### PR TITLE
T5: stdlib telemetry leaderboard (Markdown/CSV) + tests + Make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,4 +18,7 @@ explain: ## Explain mode (CLI)
 	PYTHONPATH=. python -m alpha.cli --explain --regions "US" --k 3 --queries docs/queries.txt
 
 exec: ## Execute local-only (CLI)
-	PYTHONPATH=. python -m alpha.cli --execute --regions "US" --k 3 --queries docs/queries.txt
+        PYTHONPATH=. python -m alpha.cli --execute --regions "US" --k 3 --queries docs/queries.txt
+
+telemetry: ## Generate telemetry leaderboard
+	python scripts/telemetry_leaderboard.py --paths telemetry/*.jsonl --topk 5 --format md --out artifacts/leaderboard.md

--- a/README.md
+++ b/README.md
@@ -5,3 +5,17 @@ Alpha Solver is a lightweight planning and execution engine for tool selection.
 ## Quick Start
 See [docs/RUN_GUIDE.md](docs/RUN_GUIDE.md) for setup instructions and example
 commands to run the CLI.
+
+## Telemetry Leaderboard (offline, stdlib-only)
+
+Generate a Markdown leaderboard from telemetry JSONL files:
+
+```bash
+python scripts/telemetry_leaderboard.py --paths telemetry/*.jsonl --topk 5 --format md --out artifacts/leaderboard.md
+```
+
+To produce CSV output instead:
+
+```bash
+python scripts/telemetry_leaderboard.py --paths telemetry/*.jsonl --topk 5 --format csv --out artifacts/leaderboard.csv
+```

--- a/scripts/telemetry_leaderboard.py
+++ b/scripts/telemetry_leaderboard.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Iterable, Iterator
+
+
+def iter_rows(paths: Iterable[str]) -> Iterator[dict]:
+    """Yield JSON objects from provided path globs."""
+    for pattern in paths:
+        for path in glob.glob(pattern):
+            p = Path(path)
+            if not p.exists():
+                continue
+            with p.open("r", encoding="utf-8") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        yield json.loads(line)
+                    except Exception:
+                        continue
+
+
+def build_leaderboard(rows: Iterable[dict]) -> Counter:
+    counts: Counter[str] = Counter()
+    for row in rows:
+        solver = row.get("solver") or row.get("model") or row.get("id")
+        status = row.get("status")
+        if not solver:
+            continue
+        if status in ("success", "ok", True, 1):
+            counts[solver] += 1
+    return counts
+
+
+def to_markdown(counts: Counter[str], topk: int) -> str:
+    lines = ["| solver | success |", "|---|---|"]
+    for solver, cnt in counts.most_common(topk):
+        lines.append(f"| {solver} | {cnt} |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def to_csv(counts: Counter[str], topk: int) -> str:
+    rows = [("solver", "success")]
+    rows.extend(counts.most_common(topk))
+    out_lines: list[str] = []
+    for solver, cnt in rows:
+        out_lines.append(f"{solver},{cnt}")
+    out_lines.append("")
+    return "\n".join(out_lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Offline telemetry leaderboard")
+    parser.add_argument("--paths", nargs="+", required=True, help="Glob(s) for telemetry jsonl files")
+    parser.add_argument("--topk", type=int, default=5, help="Top K solvers")
+    parser.add_argument("--format", choices=["md", "csv"], default="md", help="Output format")
+    parser.add_argument("--out", help="Output file path")
+    args = parser.parse_args()
+
+    counts = build_leaderboard(iter_rows(args.paths))
+    content = to_markdown(counts, args.topk) if args.format == "md" else to_csv(counts, args.topk)
+
+    if args.out:
+        out_path = Path(args.out)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(content, encoding="utf-8")
+    else:
+        print(content)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_telemetry_leaderboard.py
+++ b/tests/test_telemetry_leaderboard.py
@@ -1,0 +1,57 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _write_sample(path: Path) -> Path:
+    rows = [
+        {"solver": "a", "status": "success"},
+        {"solver": "b", "status": "success"},
+        {"solver": "b", "status": "fail"},
+        {"solver": "a", "status": "success"},
+    ]
+    path.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+    return path
+
+
+def test_markdown_output(tmp_path: Path):
+    src = _write_sample(tmp_path / "telemetry.jsonl")
+    out = tmp_path / "out.md"
+    subprocess.check_call([
+        sys.executable,
+        "scripts/telemetry_leaderboard.py",
+        "--paths",
+        str(src),
+        "--topk",
+        "5",
+        "--format",
+        "md",
+        "--out",
+        str(out),
+    ])
+    text = out.read_text(encoding="utf-8")
+    assert "| a | 2 |" in text
+    assert "| b | 1 |" in text
+
+
+def test_csv_output(tmp_path: Path):
+    src = _write_sample(tmp_path / "telemetry.jsonl")
+    out = tmp_path / "out.csv"
+    subprocess.check_call([
+        sys.executable,
+        "scripts/telemetry_leaderboard.py",
+        "--paths",
+        str(src),
+        "--topk",
+        "5",
+        "--format",
+        "csv",
+        "--out",
+        str(out),
+    ])
+    text = out.read_text(encoding="utf-8")
+    lines = [x.strip() for x in text.splitlines() if x.strip()]
+    assert "solver,success" == lines[0]
+    assert "a,2" in lines[1:]
+    assert "b,1" in lines[1:]


### PR DESCRIPTION
## Summary
- add offline stdlib telemetry leaderboard script with Markdown/CSV outputs
- cover leaderboard script with tests
- expose telemetry leaderboard via Make target and README quick-start

## Testing
- `python scripts/telemetry_leaderboard.py --help`
- `python scripts/telemetry_leaderboard.py --paths tmp.jsonl --topk 5 --format md`


------
https://chatgpt.com/codex/tasks/task_e_68bbc3786bdc83298afc88a22626da15