### PR TITLE
T2: recency priors (file-based, opt-in) + shortlist snapshots + tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,22 @@ To produce CSV output instead:
 ```bash
 python scripts/telemetry_leaderboard.py --paths telemetry/*.jsonl --topk 5 --format csv --out artifacts/leaderboard.csv
 ```
+
+## Recency priors (optional)
+
+```markdown
+optional recency signal via dated priors
+export ALPHA_RECENCY_PRIORS_PATH=registries/priors/dated_priors.sample.json
+export ALPHA_RECENCY_WEIGHT=0.15
+export ALPHA_RECENCY_HALFLIFE_DAYS=90
+python scripts/preflight.py # validates priors & registry IDs
+```
+
+## Shortlist snapshots
+
+```vbnet
+produced by runner / overnight sweep
+artifacts/shortlists/<region>/<query_hash>.json
+
+contains rank, tool_id, score, prior; useful for audits and diffs
+```

--- a/alpha/core/freshness.py
+++ b/alpha/core/freshness.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import json, os
+from datetime import datetime, timezone
+from typing import Dict, Optional
+
+RFC3339_FALLBACKS = ("%Y-%m-%d", "%Y-%m-%dT%H:%M:%S%z", "%Y-%m-%dT%H:%M:%SZ")
+
+def _parse_dt(s: str) -> Optional[datetime]:
+    s = str(s).strip()
+    for fmt in RFC3339_FALLBACKS:
+        try:
+            if fmt.endswith("Z"):
+                if s.endswith("Z"):
+                    return datetime.strptime(s, fmt).replace(tzinfo=timezone.utc)
+                continue
+            dt = datetime.strptime(s, fmt)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt.astimezone(timezone.utc)
+        except Exception:
+            continue
+    try:
+        # last resort: fromisoformat with Z→+00:00
+        return datetime.fromisoformat(s.replace("Z", "+00:00")).astimezone(timezone.utc)
+    except Exception:
+        return None
+
+def load_dated_priors(path: Optional[str]) -> Dict[str, datetime]:
+    """Load tool_id -> last_updated datetime map. Returns empty on None/missing/invalid."""
+    if not path or not os.path.exists(path):
+        return {}
+    with open(path, "r", encoding="utf-8") as f:
+        raw = json.load(f)
+    out: Dict[str, datetime] = {}
+    if isinstance(raw, dict):
+        it = raw.items()
+    else:
+        # also allow list of {tool_id, last_updated}
+        it = ((r.get("tool_id"), r.get("last_updated")) for r in raw if isinstance(r, dict))
+    for tid, date_s in it:
+        if not tid or not date_s:
+            continue
+        dt = _parse_dt(date_s)
+        if dt:
+            out[str(tid)] = dt
+    return out
+
+def recency_factor(last_updated: datetime, now: Optional[datetime]=None, half_life_days: float=90.0) -> float:
+    """Return [0,1] where 1.0 is very recent; simple exponential decay by half-life."""
+    now = now or datetime.now(timezone.utc)
+    age_days = max(0.0, (now - last_updated).total_seconds() / 86400.0)
+    # factor = 0.5 ** (age / half_life)
+    return float(0.5 ** (age_days / max(1e-6, half_life_days)))
+
+def blend(base_score: float, recency: float, weight: float) -> float:
+    """Deterministic convex blend; weight in [0,1]."""
+    w = min(1.0, max(0.0, weight))
+    return (1.0 - w) * float(base_score) + w * float(recency)

--- a/registries/priors/dated_priors.sample.json
+++ b/registries/priors/dated_priors.sample.json
@@ -1,0 +1,6 @@
+{
+  "_comment": "Sample dated priors: tool_id -> last_updated date (ISO). Copy & edit; wire via ALPHA_RECENCY_PRIORS_PATH.",
+  "zapier.actions": "2025-08-15",
+  "sheets.local.csv": "2025-07-20",
+  "github.local.repo": "2025-06-30"
+}

--- a/tests/test_recency_priors.py
+++ b/tests/test_recency_priors.py
@@ -1,0 +1,19 @@
+import os, json
+from datetime import datetime, timedelta, timezone
+from alpha.core import freshness
+
+
+def test_parse_and_factor_and_blend(tmp_path):
+    p = tmp_path / "priors.json"
+    data = {"tool.x":"2025-08-15","tool.y":"2024-08-15T00:00:00Z","bad":"not-a-date"}
+    p.write_text(json.dumps(data), encoding="utf-8")
+    mp = freshness.load_dated_priors(str(p))
+    assert "tool.x" in mp and "tool.y" in mp and "bad" not in mp
+
+    now = datetime(2025, 9, 6, tzinfo=timezone.utc)
+    fx_recent = freshness.recency_factor(now - timedelta(days=10), now=now, half_life_days=90)
+    fx_old = freshness.recency_factor(now - timedelta(days=365), now=now, half_life_days=90)
+    assert 0.0 <= fx_old < fx_recent <= 1.0
+
+    b = freshness.blend(0.6, fx_recent, 0.2)
+    assert 0.6 <= b <= 1.0

--- a/tests/test_shortlist_snapshots.py
+++ b/tests/test_shortlist_snapshots.py
@@ -1,0 +1,21 @@
+import os, json
+from pathlib import Path
+from alpha.core import runner
+
+
+def test_snapshot_shortlist(tmp_path, monkeypatch):
+    monkeypatch.setenv('ALPHA_ARTIFACTS_DIR', str(tmp_path))
+    monkeypatch.setenv('ALPHA_SNAPSHOT_TOPK', '2')
+    shortlist = [
+        {'id': 'tool.a', 'score': 0.9, 'prior': 0.1},
+        {'id': 'tool.b', 'score': 0.8, 'prior': 0.2},
+        {'id': 'tool.c', 'score': 0.7, 'prior': 0.0},
+    ]
+    path = runner.snapshot_shortlist('US', 'abc123', shortlist)
+    p = Path(path)
+    assert p.is_file()
+    data = json.loads(p.read_text(encoding='utf-8'))
+    assert data['region'] == 'US' and data['query_hash'] == 'abc123'
+    ids = [it['tool_id'] for it in data['items']]
+    assert ids == ['tool.a', 'tool.b']
+    assert data['items'][0]['rank'] == 1


### PR DESCRIPTION
## Summary
- add stdlib-only freshness helpers to parse dated priors and compute recency blend
- weave optional recency factors into registry provider scoring with env controls
- persist deterministic shortlist snapshots for audits

## Testing
- `ALPHA_RECENCY_PRIORS_PATH=/tmp/priors_valid.json python scripts/preflight.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbc53b50448329a9b1708661252d26