### PR TITLE
T2: Reasons & confidence + region weights (opt-in) + golden smoke test

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,27 @@ artifacts/shortlists/<region>/<query_hash>.json
 
 contains rank, tool_id, score, prior; useful for audits and diffs
 ```
+
+## Reasons & Confidence
+
+Each shortlist item now includes:
+
+- `confidence`: normalized 0-1 score relative to other items in the shortlist.
+- `explain`: component scores (lexical, semantic, priors, recency, total).
+- `reason`: plain text summary of the score parts.
+
+## Optional region weights
+
+Provide a JSON file mapping region codes to multipliers:
+
+```bash
+export ALPHA_REGION_WEIGHTS_PATH=registries/region_weights.sample.json
+python scripts/preflight.py  # validates file if set
+```
+
+Weights (if any) are applied to scores before tie-breaks.
+
+## Audit reminder
+
+Keep shortlist snapshots under `artifacts/shortlists/` and run `make telemetry`
+to collect usage logs for later review.

--- a/registries/region_weights.sample.json
+++ b/registries/region_weights.sample.json
@@ -1,0 +1,6 @@
+{
+  "_comment": "Optional region multipliers applied to final score before tie-breaks.",
+  "US": 1.00,
+  "EU": 0.95,
+  "APAC": 0.92
+}

--- a/scripts/preflight.py
+++ b/scripts/preflight.py
@@ -102,6 +102,21 @@ def main() -> int:
             if missing:
                 parts.append("unknown tool_ids: " + ", ".join(missing))
             raise SystemExit("[preflight] recency priors invalid: " + "; ".join(parts))
+    region_path = os.getenv("ALPHA_REGION_WEIGHTS_PATH")
+    if region_path:
+        try:
+            raw = json.loads(Path(region_path).read_text(encoding="utf-8"))
+        except Exception:
+            raise SystemExit(f"[preflight] cannot read region weights: {region_path}")
+        if not isinstance(raw, dict):
+            raise SystemExit("[preflight] region weights must be a JSON object")
+        for k, v in raw.items():
+            if isinstance(k, str) and k.startswith("_"):
+                continue
+            try:
+                float(v)
+            except Exception:
+                raise SystemExit(f"[preflight] non-numeric weight for region {k}: {v}")
     ids_canon = []
     canon = ART_DIR / "tools_canon.csv"
     if canon.exists():

--- a/tests/test_ranker_golden.py
+++ b/tests/test_ranker_golden.py
@@ -1,0 +1,10 @@
+from alpha.core.registry_provider import RegistryProvider
+
+
+def test_golden_ranker_output_smoke():
+    rp = RegistryProvider()
+    res = rp.shortlist(query="golden smoke test", region="US", k=3)
+    assert len(res) >= 1
+    r0 = res[0]
+    assert "tool_id" in r0 and "score" in r0 and "confidence" in r0
+    assert "explain" in r0 and "total" in r0["explain"]


### PR DESCRIPTION
## Summary
- Enrich registry shortlist with deterministic score parts, reasons, confidence, and optional region weighting
- Add sample region weight file and preflight validation for ALPHA_REGION_WEIGHTS_PATH
- Document reasons/confidence and opt-in region weights, plus golden shortlist smoke test

## Testing
- `python -m pytest -q`
- `python scripts/preflight.py`
- `ALPHA_REGION_WEIGHTS_PATH=registries/region_weights.sample.json python scripts/preflight.py`


------
https://chatgpt.com/codex/tasks/task_e_68bbc921a9a08329a383414ec98a82a2