### PR TITLE
T4: Local executors (math, CSV) + instruction adapter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,4 +24,7 @@ telemetry: ## Generate telemetry leaderboard
 	python scripts/telemetry_leaderboard.py --paths telemetry/*.jsonl --topk 5 --format md --out artifacts/leaderboard.md
 
 quick-audit:
-	python scripts/quick_audit.py
+        python scripts/quick_audit.py
+
+exec-test:
+	pytest -q tests/test_math_exec.py tests/test_csv_exec.py tests/test_instruction_adapter.py

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ Alpha Solver is a lightweight planning and execution engine for tool selection.
 See [docs/RUN_GUIDE.md](docs/RUN_GUIDE.md) for setup instructions and example
 commands to run the CLI.
 
+## Local executors
+
+See [docs/EXECUTORS.md](docs/EXECUTORS.md) for built-in math and CSV executors.
+
+```bash
+python -m alpha.executors.math_exec "2+2"
+```
+
 ## Telemetry Leaderboard (offline, stdlib-only)
 
 Generate a Markdown leaderboard from telemetry JSONL files:

--- a/alpha/adapters/instruction_adapter.py
+++ b/alpha/adapters/instruction_adapter.py
@@ -1,0 +1,41 @@
+"""Instruction adapter for local executors."""
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from alpha.executors import math_exec, csv_exec
+
+_TRACE_PATH = Path("artifacts/exec/instructions.jsonl")
+
+
+def _log(record: Dict[str, Any]) -> None:
+    _TRACE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with open(_TRACE_PATH, "a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def run_instruction(instr: Dict[str, Any]) -> Dict[str, Any]:
+    tool_id = instr.get("tool_id")
+    action = instr.get("action")
+    args = instr.get("args", {})
+
+    if tool_id == math_exec.TOOL_ID:
+        result = math_exec.evaluate(args.get("expr", ""))
+    elif tool_id == csv_exec.TOOL_ID:
+        if action == "row_count":
+            result = csv_exec.row_count(args.get("path", ""))
+        elif action == "filter_rows":
+            result = csv_exec.filter_rows(
+                args.get("path", ""),
+                args.get("col", ""),
+                args.get("value", ""),
+                args.get("out_path", "output.csv"),
+            )
+        else:
+            result = {"ok": False, "error": "unsupported action"}
+    else:
+        result = {"ok": False, "error": "unsupported tool"}
+
+    out = {"tool_id": tool_id, "action": action, **result}
+    _log(out)
+    return out

--- a/alpha/executors/__init__.py
+++ b/alpha/executors/__init__.py
@@ -1,0 +1,2 @@
+"""Local executors package."""
+from . import math_exec, csv_exec  # noqa: F401

--- a/alpha/executors/csv_exec.py
+++ b/alpha/executors/csv_exec.py
@@ -1,0 +1,35 @@
+"""Local CSV operations."""
+import csv
+import time
+from pathlib import Path
+from typing import Dict, Any
+
+TOOL_ID = "local.csv.ops"
+
+_ARTIFACT_DIR = Path("artifacts/exec/csv")
+
+
+def _timestamp() -> str:
+    return time.strftime("%Y%m%d%H%M%S", time.gmtime())
+
+
+def row_count(path: str) -> Dict[str, Any]:
+    with open(path, newline="", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        count = sum(1 for _ in reader)
+    return {"ok": True, "rows": count}
+
+
+def filter_rows(path: str, col: str, value: str, out_name: str) -> Dict[str, Any]:
+    with open(path, newline="", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        rows = [row for row in reader if row.get(col) == value]
+        fieldnames = reader.fieldnames if reader.fieldnames else []
+
+    _ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)
+    out_path = _ARTIFACT_DIR / f"{_timestamp()}_{Path(out_name).name}"
+    with open(out_path, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+    return {"ok": True, "rows": len(rows), "out": str(out_path)}

--- a/alpha/executors/math_exec.py
+++ b/alpha/executors/math_exec.py
@@ -1,0 +1,63 @@
+"""Deterministic local math evaluator."""
+import ast
+import json
+from typing import Any, Dict
+
+TOOL_ID = "local.math.eval"
+
+_ALLOWED_BINOPS = {
+    ast.Add: lambda a, b: a + b,
+    ast.Sub: lambda a, b: a - b,
+    ast.Mult: lambda a, b: a * b,
+    ast.Div: lambda a, b: a / b,
+    ast.Pow: lambda a, b: a ** b,
+    ast.Mod: lambda a, b: a % b,
+    ast.FloorDiv: lambda a, b: a // b,
+}
+
+_ALLOWED_UNARY = {
+    ast.UAdd: lambda a: +a,
+    ast.USub: lambda a: -a,
+}
+
+def _eval(node: ast.AST) -> float:
+    if isinstance(node, ast.Expression):
+        return _eval(node.body)
+    if isinstance(node, ast.Constant):
+        if isinstance(node.value, (int, float)):
+            return float(node.value)
+        raise ValueError("unsupported constant")
+    if isinstance(node, ast.Num):  # pragma: no cover
+        return float(node.n)
+    if isinstance(node, ast.BinOp):
+        op_type = type(node.op)
+        if op_type not in _ALLOWED_BINOPS:
+            raise ValueError("unsupported operator")
+        left = _eval(node.left)
+        right = _eval(node.right)
+        return _ALLOWED_BINOPS[op_type](left, right)
+    if isinstance(node, ast.UnaryOp):
+        op_type = type(node.op)
+        if op_type not in _ALLOWED_UNARY:
+            raise ValueError("unsupported operator")
+        operand = _eval(node.operand)
+        return _ALLOWED_UNARY[op_type](operand)
+    raise ValueError("unsupported expression")
+
+
+def evaluate(expr: str) -> Dict[str, Any]:
+    """Safely evaluate a math expression."""
+    try:
+        parsed = ast.parse(expr, mode="eval")
+        result = _eval(parsed)
+        return {"ok": True, "result": result, "error": None}
+    except Exception as exc:  # pragma: no cover - deterministic message
+        return {"ok": False, "result": None, "error": str(exc)}
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI helper
+    import sys
+
+    expression = sys.argv[1] if len(sys.argv) > 1 else ""
+    out = evaluate(expression)
+    print(json.dumps(out))

--- a/docs/EXECUTORS.md
+++ b/docs/EXECUTORS.md
@@ -1,0 +1,37 @@
+# Local Executors
+
+Alpha Solver includes deterministic local executors for simple math and CSV operations. These executors run without external dependencies.
+
+## Math Evaluator
+
+- Module: `alpha.executors.math_exec`
+- Tool ID: `local.math.eval`
+- Supports `+`, `-`, `*`, `/`, `**`, `%`, `//` and parentheses.
+
+```bash
+python -m alpha.executors.math_exec "2+2"
+```
+
+## CSV Operations
+
+- Module: `alpha.executors.csv_exec`
+- Tool ID: `local.csv.ops`
+- Functions:
+  - `row_count(path)` – count rows in a CSV file.
+  - `filter_rows(path, col, value, out_path)` – write rows matching `col==value`.
+
+Outputs are stored under `artifacts/exec/csv/<timestamp>_<name>.csv`.
+
+## Instruction Adapter
+
+Use `alpha.adapters.instruction_adapter.run_instruction` to dispatch JSON instructions to the executors. Each instruction is logged to `artifacts/exec/instructions.jsonl`.
+
+Example instruction:
+
+```json
+{
+  "tool_id": "local.math.eval",
+  "action": "eval",
+  "args": {"expr": "2+2"}
+}
+```

--- a/tests/test_csv_exec.py
+++ b/tests/test_csv_exec.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+import csv
+
+from alpha.executors import csv_exec
+
+
+def _write_csv(path: Path, rows):
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def test_row_count(tmp_path):
+    src = tmp_path / "input.csv"
+    rows = [{"a": "1"}, {"a": "2"}]
+    _write_csv(src, rows)
+    res = csv_exec.row_count(str(src))
+    assert res["ok"] and res["rows"] == 2
+
+
+def test_filter_rows(tmp_path):
+    src = tmp_path / "input.csv"
+    rows = [{"a": "1"}, {"a": "2"}, {"a": "1"}]
+    _write_csv(src, rows)
+    res = csv_exec.filter_rows(str(src), "a", "1", "out.csv")
+    out_path = Path(res["out"])
+    assert res["ok"] and res["rows"] == 2
+    assert out_path.exists()
+    with open(out_path, newline="", encoding="utf-8") as fh:
+        reader = list(csv.DictReader(fh))
+        assert len(reader) == 2
+        assert all(r["a"] == "1" for r in reader)

--- a/tests/test_instruction_adapter.py
+++ b/tests/test_instruction_adapter.py
@@ -1,0 +1,37 @@
+import json
+from pathlib import Path
+
+from alpha.adapters import instruction_adapter
+from alpha.executors import math_exec, csv_exec
+
+
+def test_run_instruction_dispatch(tmp_path):
+    math_res = instruction_adapter.run_instruction({
+        "tool_id": math_exec.TOOL_ID,
+        "action": "eval",
+        "args": {"expr": "1+1"},
+    })
+    assert math_res["result"] == 2
+
+    src = tmp_path / "input.csv"
+    src.write_text("a\n1\n2\n", encoding="utf-8")
+    csv_res = instruction_adapter.run_instruction({
+        "tool_id": csv_exec.TOOL_ID,
+        "action": "row_count",
+        "args": {"path": str(src)},
+    })
+    assert csv_res["rows"] == 2
+
+
+def test_trace_file_written(tmp_path):
+    trace = Path("artifacts/exec/instructions.jsonl")
+    if trace.exists():
+        trace.unlink()
+    instruction_adapter.run_instruction({
+        "tool_id": math_exec.TOOL_ID,
+        "action": "eval",
+        "args": {"expr": "3+3"},
+    })
+    assert trace.exists()
+    lines = trace.read_text(encoding="utf-8").strip().splitlines()
+    assert lines and json.loads(lines[-1])["tool_id"] == math_exec.TOOL_ID

--- a/tests/test_math_exec.py
+++ b/tests/test_math_exec.py
@@ -1,0 +1,14 @@
+import os
+from alpha.executors import math_exec
+
+
+def test_evaluate_success():
+    res = math_exec.evaluate("2+2")
+    assert res["ok"]
+    assert res["result"] == 4
+
+
+def test_evaluate_invalid():
+    res = math_exec.evaluate("2+")
+    assert not res["ok"]
+    assert res["error"]


### PR DESCRIPTION
## Summary
- add deterministic math evaluator and CSV operations
- add instruction adapter with execution trace
- document and test local executors

## Testing
- `pytest -q tests/test_math_exec.py tests/test_csv_exec.py tests/test_instruction_adapter.py`


------
https://chatgpt.com/codex/tasks/task_e_68bbd16e4db083299c2b2ac323d34057