### PR TITLE
T1/T2: Plan Spine + Transparency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,5 +39,8 @@ lint:
         ruff check alpha
 
 artifacts:
-	python scripts/env_snapshot.py >/dev/null || true
-	python scripts/bundle_artifacts.py
+        python scripts/env_snapshot.py >/dev/null || true
+        python scripts/bundle_artifacts.py
+
+plan:
+	python -m alpha.core.runner --plan-only --query "demo query" || true

--- a/README.md
+++ b/README.md
@@ -39,6 +39,19 @@ python scripts/env_snapshot.py
 python scripts/bundle_artifacts.py
 ```
 
+## Plan Spine & Transparency
+
+The runner can emit a minimal *plan spine* showing how a query will be solved.
+
+```bash
+python -m alpha.core.runner --plan-only --query "Test"
+python -m alpha.core.runner --explain --query "Test"
+```
+
+`--plan-only` writes `artifacts/last_plan.json` without executing any steps.
+`--explain` adds human readable summaries; omit both flags (or use `--execute`)
+to run the plan and emit the same artifact with results.
+
 ## Recency priors (optional)
 
 ```markdown

--- a/alpha/core/plan.py
+++ b/alpha/core/plan.py
@@ -1,7 +1,8 @@
 """Plan data structures"""
 from __future__ import annotations
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 
 @dataclass
@@ -14,9 +15,15 @@ class PlanStep:
     estimated_cost_usd: float = 0.0
     mode: str = "execute"
     enrichment: Dict[str, Any] = field(default_factory=dict)
+    # --- plan spine fields ---
+    step_id: str = ""
+    description: str = ""
+    contract: Dict[str, Any] = field(default_factory=dict)
+    result: Dict[str, Any] = field(default_factory=dict)
+    status: str = "pending"
 
     def to_dict(self) -> Dict[str, Any]:
-        return {
+        data = {
             "tool_id": self.tool_id,
             "prompt": self.prompt,
             "adapter": self.adapter,
@@ -26,6 +33,17 @@ class PlanStep:
             "mode": self.mode,
             "enrichment": self.enrichment,
         }
+        if self.step_id:
+            data["step_id"] = self.step_id
+        if self.description:
+            data["description"] = self.description
+        if self.contract:
+            data["contract"] = self.contract
+        if self.result:
+            data["result"] = self.result
+        if self.status != "pending":
+            data["status"] = self.status
+        return data
 
 
 @dataclass
@@ -68,6 +86,16 @@ class Plan:
     fallbacks: List[Fallback] = field(default_factory=list)
     artifacts: Dict[str, Any] = field(default_factory=dict)
     estimated_cost_usd: float = 0.0
+    # --- plan spine fields ---
+    run_id: str = ""
+    query: str = ""
+    region: str = ""
+    retries: int = 0
+    created_at: str = field(
+        default_factory=lambda: datetime.now(timezone.utc)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -81,10 +109,60 @@ class Plan:
             "estimated_cost_usd": self.estimated_cost_usd,
         }
 
+    def to_json(self) -> Dict[str, Any]:
+        """Emit minimal JSON representation with schema_version."""
+        return {
+            "schema_version": "v1",
+            "run_id": self.run_id,
+            "query": self.query or self.inputs.get("query"),
+            "region": self.region or self.inputs.get("region"),
+            "retries": self.retries,
+            "created_at": self.created_at,
+            "steps": [s.to_dict() for s in self.steps],
+        }
+
     def human_summary(self) -> str:
-        q = self.inputs.get("query", "")
-        region = self.inputs.get("region", "")
+        q = self.inputs.get("query", self.query)
+        region = self.inputs.get("region", self.region)
         return (
             f"Plan for '{q}' in region '{region}' with {len(self.steps)} steps; "
             f"estimated cost ${self.estimated_cost_usd:.2f}"
         )
+
+
+def validate_contract(step: PlanStep, result: Dict[str, Any]) -> Tuple[bool, str]:
+    """Validate result against the step contract."""
+    contract = step.contract or {}
+    for key, expected in contract.items():
+        actual = result.get(key)
+        if actual != expected:
+            critique = (
+                f"contract mismatch for '{key}': expected {expected!r} got {actual!r}"
+            )
+            return False, critique
+    return True, ""
+
+
+def bounded_retry(
+    step: PlanStep,
+    func: Callable[[], Dict[str, Any]],
+    max_retries: int = 0,
+    logger: Optional[Callable[[str], None]] = None,
+) -> None:
+    """Execute func until contract passes or retries exhausted."""
+    attempts = 0
+    while True:
+        result = func()
+        ok, critique = validate_contract(step, result)
+        step.result = result
+        if ok:
+            step.status = "ok"
+            return
+        step.status = "failed"
+        if critique:
+            step.result.setdefault("critique", critique)
+            if logger:
+                logger(critique)
+        attempts += 1
+        if attempts > max_retries:
+            return

--- a/docs/PLAN_SPINE.md
+++ b/docs/PLAN_SPINE.md
@@ -1,0 +1,69 @@
+# Plan Spine Architecture
+
+The *plan spine* records how Alpha-Solver answers a query.  Each run produces
+an ordered list of steps and a minimal JSON artifact describing the run.
+
+## Data Model
+
+```python
+from alpha.core.plan import Plan, PlanStep
+```
+
+`PlanStep` captures:
+
+* `step_id` – identifier
+* `description` – human readable summary
+* `contract` – expectations for a successful run
+* `result` – output from execution
+* `status` – `ok` or `failed`
+
+`Plan` tracks the overall run:
+
+* `run_id`, `query`, `region`
+* list of `steps`
+* `retries` – maximum retries per step
+* `created_at`
+
+`plan.to_json()` emits a dictionary with `schema_version="v1"` suitable for
+serialization.
+
+## Contracts and Retries
+
+`validate_contract(step, result)` checks a step's contract against its result
+and returns `(ok, critique)`.  `bounded_retry(step, fn, max_retries)` executes a
+callable until the contract passes or retries are exhausted.  Critiques from
+failed attempts are logged on the step's result.
+
+## CLI Usage
+
+```bash
+python -m alpha.core.runner --plan-only --query "demo"
+python -m alpha.core.runner --explain --query "demo"
+python -m alpha.core.runner --execute --query "demo"
+```
+
+The `--plan-only` flag writes `artifacts/last_plan.json` and exits.  `--explain`
+adds a short human‑readable explanation.  `--execute` (the default) also runs
+steps with retry logic and updates the artifact with results.
+
+## Example `last_plan.json`
+
+```json
+{
+  "schema_version": "v1",
+  "run_id": "1234",
+  "query": "demo",
+  "region": "US",
+  "retries": 1,
+  "created_at": "2024-01-01T00:00:00Z",
+  "steps": [
+    {
+      "step_id": "step-1",
+      "description": "demo step for demo",
+      "contract": {"ok": true},
+      "result": {"ok": true},
+      "status": "ok"
+    }
+  ]
+}
+```

--- a/tests/golden/aggregator_output.json
+++ b/tests/golden/aggregator_output.json
@@ -1,0 +1,62 @@
+[
+  {
+    "tool_id": "tool.cdp.mparticle",
+    "name": "mParticle",
+    "score": 0.18357142857142855,
+    "_parts": {
+      "lexical": 1.0,
+      "semantic": 0.6119047619047618,
+      "priors": 0.3,
+      "recency": 0.0
+    },
+    "confidence": 0.0,
+    "explain": {
+      "lexical": 1.0,
+      "semantic": 0.611905,
+      "priors": 0.3,
+      "recency": 0.0,
+      "total": 0.183571
+    },
+    "reason": "lex 1.00 + sem 0.61 + pri 0.30 + rec 0.00"
+  },
+  {
+    "tool_id": "tool.cdp.rudderstack",
+    "name": "RudderStack",
+    "score": 0.18357142857142855,
+    "_parts": {
+      "lexical": 1.0,
+      "semantic": 0.6119047619047618,
+      "priors": 0.3,
+      "recency": 0.0
+    },
+    "confidence": 0.0,
+    "explain": {
+      "lexical": 1.0,
+      "semantic": 0.611905,
+      "priors": 0.3,
+      "recency": 0.0,
+      "total": 0.183571
+    },
+    "reason": "lex 1.00 + sem 0.61 + pri 0.30 + rec 0.00"
+  },
+  {
+    "tool_id": "tool.cdp.segment",
+    "name": "Segment",
+    "score": 0.18357142857142855,
+    "_parts": {
+      "lexical": 1.0,
+      "semantic": 0.6119047619047618,
+      "priors": 0.3,
+      "recency": 0.0
+    },
+    "confidence": 0.0,
+    "explain": {
+      "lexical": 1.0,
+      "semantic": 0.611905,
+      "priors": 0.3,
+      "recency": 0.0,
+      "total": 0.183571
+    },
+    "reason": "lex 1.00 + sem 0.61 + pri 0.30 + rec 0.00"
+  }
+]

--- a/tests/test_plan_spine.py
+++ b/tests/test_plan_spine.py
@@ -1,0 +1,34 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from alpha.core.plan import PlanStep, bounded_retry
+
+
+def test_plan_only_creates_last_plan(tmp_path):
+    env = os.environ.copy()
+    env["ALPHA_ARTIFACTS_DIR"] = str(tmp_path)
+    cmd = [sys.executable, "-m", "alpha.core.runner", "--plan-only", "--query", "Demo"]
+    subprocess.check_call(cmd, env=env)
+    path = tmp_path / "last_plan.json"
+    assert path.is_file()
+    data = json.loads(path.read_text())
+    assert data.get("schema_version") == "v1"
+
+
+def test_bounded_retry_logs(capsys):
+    step = PlanStep(tool_id="noop", step_id="s1", contract={"ok": True})
+    attempts = {"n": 0}
+
+    def fn():
+        attempts["n"] += 1
+        return {"ok": False}
+
+    bounded_retry(step, fn, max_retries=2, logger=lambda m: print(m))
+    captured = capsys.readouterr()
+    assert attempts["n"] == 3  # initial try + 2 retries
+    assert step.status == "failed"
+    assert "critique" in step.result
+    assert "contract mismatch" in captured.out

--- a/tests/test_transparency.py
+++ b/tests/test_transparency.py
@@ -1,0 +1,45 @@
+import json
+from pathlib import Path
+
+from alpha.core.registry_provider import RegistryProvider
+from alpha.core.freshness import blend
+
+
+def final_score(lex, jw, sr, prior, rec, weights, rec_w):
+    w1, w2, w3 = weights
+    hybrid = max(0.0, min(1.0, w1 * lex + w2 * jw + w3 * sr))
+    base = hybrid * prior
+    return blend(base, rec, rec_w)
+
+
+def test_aggregator_output_matches_golden():
+    rp = RegistryProvider()
+    rp.load()
+    res = rp.shortlist("analytics", region="US", k=3)
+    golden = json.loads(Path("tests/golden/aggregator_output.json").read_text())
+    assert res == golden
+
+
+def test_hybrid_ranker_monotonic():
+    a = dict(lex=1.0, jw=0.0, sr=0.0, prior=0.2, rec=0.2)
+    b = dict(lex=0.0, jw=1.0, sr=1.0, prior=0.8, rec=0.8)
+
+    # lexical emphasis
+    sa = final_score(**a, weights=(1.0, 0.0, 0.0), rec_w=0.0)
+    sb = final_score(**b, weights=(1.0, 0.0, 0.0), rec_w=0.0)
+    assert sa > sb
+
+    # semantic emphasis
+    sa = final_score(**a, weights=(0.0, 0.5, 0.5), rec_w=0.0)
+    sb = final_score(**b, weights=(0.0, 0.5, 0.5), rec_w=0.0)
+    assert sb > sa
+
+    # recency emphasis
+    sa = final_score(**a, weights=(0.6, 0.25, 0.15), rec_w=1.0)
+    sb = final_score(**b, weights=(0.6, 0.25, 0.15), rec_w=1.0)
+    assert sb > sa
+
+    # priors influence
+    low = final_score(1, 1, 1, 0.2, 0.0, weights=(0.6, 0.25, 0.15), rec_w=0.0)
+    high = final_score(1, 1, 1, 0.8, 0.0, weights=(0.6, 0.25, 0.15), rec_w=0.0)
+    assert high > low


### PR DESCRIPTION
## Summary
- add PlanStep/Plan dataclasses with contract validation and bounded retry
- extend runner with plan-only/explain/execute modes and plan artifact emission
- merge canonical registry metadata, optional online signals, and richer reasons
- document plan spine and add transparency regression tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbf7a849488329ab4df95536e6bcb9