### PR TITLE
T3: Governance MVP — budget caps, circuit breaker, dry-run audit, data policy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,10 @@ run:
 	python -m alpha.cli run --queries "demo query" --regions US --plan-only --seed 1234 || true
 
 sweep:
-	python -m alpha.cli run --queries-file docs/queries.sample.txt --regions US EU --explain || true
+        python -m alpha.cli run --queries-file docs/queries.sample.txt --regions US EU --explain || true
+
+policy-dry-run:
+	python -m alpha.cli run --queries "demo" --policy-dry-run --budget-max-steps 3 --breaker-max-fails 1 || true
 
 telemetry:
         python scripts/telemetry_leaderboard.py --paths telemetry/*.jsonl --format all || true

--- a/README.md
+++ b/README.md
@@ -134,6 +134,24 @@ python scripts/preflight.py --fix-ids
 Set `ALPHA_DETERMINISM=1` to lock a global seed and a single UTC
 timestamp in session traces for reproducible runs.
 
+## Governance (MVP)
+
+The lightweight policy engine enforces step/time budgets and a simple
+circuit breaker, with optional data classification.  Decisions are logged to
+`artifacts/policy_audit.jsonl`.
+
+CLI flags:
+
+```bash
+--policy-dry-run
+--budget-max-steps INT
+--budget-max-seconds FLOAT
+--breaker-max-fails INT
+--data-policy PATH
+```
+
+See [docs/POLICY.md](docs/POLICY.md) for details.
+
 ## Governance v1
 
 ```bash

--- a/alpha/cli.py
+++ b/alpha/cli.py
@@ -39,6 +39,29 @@ def _add_common_args(p: argparse.ArgumentParser) -> None:
     mode.add_argument("--plan-only", action="store_true", help="Emit plan and exit (no execution).")
     mode.add_argument("--explain", action="store_true", help="Emit plan + explanations, no execution.")
     mode.add_argument("--execute", action="store_true", help="Execute actions (default).")
+    p.add_argument("--policy-dry-run", action="store_true", help="Log policy warnings but never block.")
+    p.add_argument(
+        "--budget-max-steps",
+        type=int,
+        default=0,
+        help="Maximum allowed steps (0 = unlimited).",
+    )
+    p.add_argument(
+        "--budget-max-seconds",
+        type=float,
+        default=0.0,
+        help="Maximum wall-clock seconds (0 = unlimited).",
+    )
+    p.add_argument(
+        "--breaker-max-fails",
+        type=int,
+        default=0,
+        help="Consecutive failures before breaker trips (0 = disabled).",
+    )
+    p.add_argument(
+        "--data-policy",
+        help="Path to data_policy.json controlling family/tag allow/deny.",
+    )
 
 
 def _resolve_version() -> str:
@@ -104,6 +127,11 @@ def main(argv: List[str] | None = None) -> int:
                 seed=args.seed,
                 topk=args.topk,
                 mode=mode,
+                policy_dry_run=args.policy_dry_run,
+                budget_max_steps=args.budget_max_steps,
+                budget_max_seconds=args.budget_max_seconds,
+                breaker_max_fails=args.breaker_max_fails,
+                data_policy=args.data_policy,
             )
         if args.cmd == "telemetry":
             import subprocess, sys as _sys

--- a/alpha/policy/engine.py
+++ b/alpha/policy/engine.py
@@ -1,0 +1,179 @@
+import json
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+@dataclass
+class Decision:
+    decision: str  # "allow" | "block" | "warn"
+    reason: str
+
+
+class PolicyEngine:
+    """Minimal governance engine with deterministic budgets and audit logging."""
+
+    def __init__(
+        self,
+        *,
+        max_steps: int = 0,
+        max_seconds: float = 0.0,
+        breaker_max_fails: int = 0,
+        dry_run: bool = False,
+        data_policy_path: Optional[str] = None,
+        run_id: Optional[str] = None,
+        audit_path: str = "artifacts/policy_audit.jsonl",
+    ) -> None:
+        self.max_steps = int(max_steps)
+        self.max_seconds = float(max_seconds)
+        self.breaker_max_fails = int(breaker_max_fails)
+        self.dry_run = bool(dry_run)
+        self.run_id = run_id or uuid.uuid4().hex
+        self.audit_path = Path(audit_path)
+        self.audit_path.parent.mkdir(parents=True, exist_ok=True)
+
+        self.start_time = time.time()
+        self.steps = 0
+        self.fails = 0
+
+        self.now_utc = (
+            datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        )
+        self._header_written = False
+
+        self.data_policy = {
+            "deny": {"families": [], "tags": []},
+            "allow": {"families": [], "tags": []},
+        }
+        path = Path(data_policy_path or "data_policy.json")
+        if path.exists():
+            try:
+                with path.open("r", encoding="utf-8") as f:
+                    dp = json.load(f)
+                if isinstance(dp, dict):
+                    deny = dp.get("deny", {}) or {}
+                    allow = dp.get("allow", {}) or {}
+                    self.data_policy = {
+                        "deny": {
+                            "families": list(deny.get("families", [])),
+                            "tags": list(deny.get("tags", [])),
+                        },
+                        "allow": {
+                            "families": list(allow.get("families", [])),
+                            "tags": list(allow.get("tags", [])),
+                        },
+                    }
+            except Exception:
+                pass
+
+        self._write_header()
+
+    # ------------------------------------------------------------------
+    # internal helpers
+    def _write_header(self) -> None:
+        if self._header_written:
+            return
+        rec = {"run_id": self.run_id, "now_utc": self.now_utc}
+        # attempt to include code version; ignore on failure
+        try:
+            import subprocess
+
+            rec["code_version"] = (
+                subprocess.check_output(["git", "rev-parse", "HEAD"], text=True)
+                .strip()
+            )
+        except Exception:
+            pass
+        with self.audit_path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(rec, ensure_ascii=False) + "\n")
+        self._header_written = True
+
+    def _log(self, rec: Dict[str, object]) -> None:
+        rec = dict(rec)
+        rec["timestamp"] = datetime.now(timezone.utc).isoformat().replace(
+            "+00:00", "Z"
+        )
+        with self.audit_path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(rec, ensure_ascii=False) + "\n")
+
+    # ------------------------------------------------------------------
+    def decide(
+        self,
+        *,
+        query: str = "",
+        region: str = "",
+        tool_id: str = "",
+        family: str = "",
+        tags: Optional[List[str]] = None,
+    ) -> Decision:
+        """Return policy decision for the next step and audit it."""
+
+        step_index = self.steps + 1
+        tags = tags or []
+        elapsed = time.time() - self.start_time
+
+        data_status = "allow"
+        if family in self.data_policy["deny"]["families"] or any(
+            t in self.data_policy["deny"]["tags"] for t in tags
+        ):
+            data_status = "deny"
+
+        budget = {
+            "steps": step_index,
+            "max_steps": self.max_steps,
+            "elapsed_s": round(elapsed, 3),
+            "max_seconds": self.max_seconds,
+        }
+        breaker_state = {
+            "fails": self.fails,
+            "max_fails": self.breaker_max_fails,
+            "tripped": self.breaker_max_fails > 0
+            and self.fails >= self.breaker_max_fails,
+        }
+        data_class = {"family": family, "tags": tags, "status": data_status}
+
+        decision = "allow"
+        reason = ""
+        if self.max_steps and step_index > self.max_steps:
+            decision = "block"
+            reason = "max_steps exceeded"
+        elif self.max_seconds and elapsed > self.max_seconds:
+            decision = "block"
+            reason = "max_seconds exceeded"
+        elif breaker_state["tripped"]:
+            decision = "block"
+            reason = "circuit breaker tripped"
+        elif data_status == "deny":
+            decision = "block"
+            reason = "data policy deny"
+
+        audit_decision = decision
+        if self.dry_run and decision == "block":
+            audit_decision = "warn"
+            decision = "allow"
+
+        rec = {
+            "run_id": self.run_id,
+            "step_index": step_index,
+            "query": query,
+            "region": region,
+            "tool_id": tool_id,
+            "decision": audit_decision,
+            "reason": reason,
+            "budget": budget,
+            "breaker": breaker_state,
+            "data_class": data_class,
+        }
+        self._log(rec)
+        return Decision(audit_decision if self.dry_run else decision, reason)
+
+    def record_step_result(self, success: bool) -> None:
+        """Update counters based on step success or failure."""
+        if success:
+            self.fails = 0
+        else:
+            self.fails += 1
+        self.steps += 1

--- a/docs/POLICY.md
+++ b/docs/POLICY.md
@@ -1,0 +1,59 @@
+# Policy & Governance (MVP)
+
+Alpha Solver ships with a minimal governance layer that runs entirely in
+stdlib-only mode and works offline.  The *policy engine* enforces simple
+budget caps, a circuit breaker, optional data classification and emits an
+audit log for every decision.
+
+## Budget caps
+
+Two optional limits protect a run from runaway executions:
+
+- `max_steps` – maximum number of steps allowed.
+- `max_seconds` – maximum wall clock seconds since the policy engine was
+  created.
+
+When a limit is exceeded the decision becomes **block** (or **warn** in
+`--policy-dry-run` mode).
+
+## Circuit breaker
+
+`breaker_max_fails` counts consecutive step failures.  Once the threshold is
+reached subsequent steps are blocked (or warned in dry-run).  A successful
+step resets the counter.
+
+## Dry-run mode
+
+`--policy-dry-run` never blocks execution.  Any would-be block is recorded as a
+`warn` decision in the audit log and the run continues.
+
+## Audit JSONL
+
+Decisions are appended to `artifacts/policy_audit.jsonl` with RFC3339Z
+timestamps.  The first line contains deterministic run metadata.  Each
+subsequent line includes the decision and policy state:
+
+```json
+{"run_id":"abc","step_index":1,"query":"demo","region":"US","tool_id":"t1","decision":"warn","reason":"max_steps exceeded","budget":{"steps":3,"max_steps":2,"elapsed_s":0.1,"max_seconds":0},"breaker":{"fails":0,"max_fails":0,"tripped":false},"data_class":{"family":"","tags":[],"status":"allow"}}
+```
+
+## Data policy JSON
+
+A optional `data_policy.json` file can deny tools by family or tag:
+
+```json
+{
+  "deny": { "families": ["x"], "tags": ["pii"] },
+  "allow": { "families": [], "tags": [] }
+}
+```
+
+A candidate tool matching a denied family or tag is blocked (or warned in
+`--policy-dry-run` mode).
+
+## Quickstart
+
+```bash
+python -m alpha.cli run --queries "demo" \
+  --policy-dry-run --budget-max-steps 5 --breaker-max-fails 2
+```

--- a/tests/test_policy_audit_schema.py
+++ b/tests/test_policy_audit_schema.py
@@ -1,0 +1,31 @@
+import json
+import re
+
+from alpha.policy.engine import PolicyEngine
+
+
+def test_policy_audit_schema(tmp_path):
+    audit = tmp_path / "audit.jsonl"
+    engine = PolicyEngine(audit_path=str(audit))
+    engine.decide(query="q", region="r", tool_id="t")
+    lines = audit.read_text().strip().splitlines()
+    assert len(lines) >= 2
+    header = json.loads(lines[0])
+    assert header["run_id"]
+    assert header["now_utc"].endswith("Z")
+    rec = json.loads(lines[1])
+    for field in [
+        "run_id",
+        "step_index",
+        "query",
+        "region",
+        "tool_id",
+        "decision",
+        "reason",
+        "budget",
+        "breaker",
+        "data_class",
+        "timestamp",
+    ]:
+        assert field in rec
+    assert re.match(r"\d{4}-\d{2}-\d{2}T.*Z", rec["timestamp"])

--- a/tests/test_policy_breaker.py
+++ b/tests/test_policy_breaker.py
@@ -1,0 +1,17 @@
+import json
+
+from alpha.policy.engine import PolicyEngine
+
+
+def test_policy_breaker_trips(tmp_path):
+    audit = tmp_path / "audit.jsonl"
+    engine = PolicyEngine(breaker_max_fails=2, audit_path=str(audit))
+    for _ in range(2):
+        dec = engine.decide(query="q", region="r", tool_id="t")
+        assert dec.decision == "allow"
+        engine.record_step_result(False)
+    dec = engine.decide(query="q", region="r", tool_id="t")
+    assert dec.decision == "block"
+    lines = audit.read_text().strip().splitlines()
+    rec = json.loads(lines[-1])
+    assert rec["breaker"]["tripped"] is True

--- a/tests/test_policy_budget.py
+++ b/tests/test_policy_budget.py
@@ -1,0 +1,17 @@
+import json
+
+from alpha.policy.engine import PolicyEngine
+
+
+def test_policy_budget_blocks(tmp_path):
+    audit = tmp_path / "audit.jsonl"
+    engine = PolicyEngine(max_steps=2, audit_path=str(audit))
+    for _ in range(3):
+        dec = engine.decide(query="q", region="r", tool_id="t")
+        if dec.decision == "block":
+            break
+        engine.record_step_result(True)
+    lines = audit.read_text().strip().splitlines()
+    rec = json.loads(lines[-1])
+    assert rec["decision"] == "block"
+    assert rec["reason"] == "max_steps exceeded"

--- a/tests/test_policy_data_class.py
+++ b/tests/test_policy_data_class.py
@@ -1,0 +1,27 @@
+import json
+
+from alpha.policy.engine import PolicyEngine
+
+
+def test_policy_data_class(tmp_path):
+    policy_path = tmp_path / "data_policy.json"
+    policy_path.write_text(
+        json.dumps(
+            {
+                "deny": {"families": ["denyfam"], "tags": ["pii"]},
+                "allow": {"families": [], "tags": []},
+            }
+        )
+    )
+    audit = tmp_path / "audit.jsonl"
+    engine = PolicyEngine(data_policy_path=str(policy_path), audit_path=str(audit))
+    dec = engine.decide(
+        query="q",
+        region="r",
+        tool_id="t",
+        family="denyfam",
+        tags=["pii"],
+    )
+    assert dec.decision == "block"
+    rec = json.loads(audit.read_text().strip().splitlines()[-1])
+    assert rec["data_class"]["status"] == "deny"


### PR DESCRIPTION
## Summary
- Add deterministic PolicyEngine with step/time budgets, circuit breaker, data policy checks and audit JSONL
- Wire policy controls into runner and CLI with dry-run option
- Document governance features and provide sample Makefile target and tests

## Testing
- `pytest tests/test_policy_budget.py tests/test_policy_breaker.py tests/test_policy_audit_schema.py tests/test_policy_data_class.py -q`

## Notes
- Deterministic, stdlib-only implementation; no new dependencies

------
https://chatgpt.com/codex/tasks/task_e_68bc081bd1788329bee3dc07f320f9cd