### PR TITLE
Add deterministic Tree-of-Thought solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+- Add deterministic Tree-of-Thought solver and reasoning package.
+- Introduce entrypoint `_tree_of_thought` and tests for solver components.
+- Improve solver with heap-based traversal, structured branch/prune logs,
+  dynamic pruning thresholds, context-aware scoring, and timeout/max_nodes
+  safeguards.
+
 ## [1.0.0b1]
 - Initial packaging metadata and console entry point.
 - Added release workflow attaching build artifacts to GitHub Releases.

--- a/alpha-solver-v91-python.py
+++ b/alpha-solver-v91-python.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+"""Alpha Solver v91 entrypoints."""
+
+from alpha.reasoning.tot import TreeOfThoughtSolver
+
+
+def _tree_of_thought(
+    query: str,
+    *,
+    timeout: float = 1.0,
+    max_nodes: int = 100,
+    **kwargs,
+):
+    """Solve ``query`` using the deterministic Tree-of-Thought solver.
+
+    Parameters ``timeout`` and ``max_nodes`` provide safeguards against runaway
+    searches and are forwarded to :class:`TreeOfThoughtSolver`.
+    """
+
+    solver = TreeOfThoughtSolver(timeout=timeout, max_nodes=max_nodes, **kwargs)
+    return solver.solve(query)

--- a/alpha/reasoning/__init__.py
+++ b/alpha/reasoning/__init__.py
@@ -1,0 +1,5 @@
+"""Reasoning utilities including deterministic Tree-of-Thought solver."""
+
+from .tot import Node, TreeOfThoughtSolver
+
+__all__ = ["Node", "TreeOfThoughtSolver"]

--- a/alpha/reasoning/cot.py
+++ b/alpha/reasoning/cot.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+"""Deterministic Chain-of-Thought guidance utilities."""
+
+from typing import Any, Dict
+
+
+def guidance_score(context: Dict[str, Any]) -> float:
+    """Return a normalized guidance score based on ``context``.
+
+    The score counts the presence of reasoning keywords inside the optional
+    ``hint`` field of ``context`` and normalizes the result to ``[0, 1]``.
+    """
+
+    hint = context.get("hint", "").lower()
+    keywords = ["therefore", "because", "thus"]
+    matches = sum(1 for kw in keywords if kw in hint)
+    return matches / len(keywords)

--- a/alpha/reasoning/tot.py
+++ b/alpha/reasoning/tot.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+"""Deterministic Tree-of-Thought reasoning utilities."""
+
+from dataclasses import dataclass, field, replace
+from types import MappingProxyType
+from typing import Any, Dict, List, Mapping, Tuple
+import heapq
+import logging
+import time
+
+from .cot import guidance_score
+
+
+@dataclass(frozen=True)
+class Node:
+    """Represents a node in the reasoning tree."""
+
+    id: int
+    subquery: str
+    path: Tuple[str, ...]
+    score: float
+    depth: int
+    context: Mapping[str, Any] = field(default_factory=dict, compare=False)
+
+    def __post_init__(self) -> None:  # pragma: no cover - trivial
+        object.__setattr__(self, "context", MappingProxyType(dict(self.context)))
+
+
+class TreeOfThoughtSolver:
+    """Simple deterministic Tree-of-Thought solver.
+
+    The solver performs a greedy best-first traversal of a reasoning tree with
+    deterministic branching and scoring. It stops when the score threshold,
+    maximum depth, or timeout is reached.
+    """
+
+    def __init__(
+        self,
+        *,
+        branching_factor: int = 2,
+        score_threshold: float = 0.9,
+        max_depth: int = 3,
+        timeout: float = 1.0,
+        max_nodes: int = 100,
+        prune_ratio: float = 0.8,
+    ) -> None:
+        self.branching_factor = branching_factor
+        self.score_threshold = score_threshold
+        self.max_depth = max_depth
+        self.timeout = timeout
+        self.max_nodes = max_nodes
+        self.prune_ratio = prune_ratio
+        self.visited: set[tuple[str, Tuple[Tuple[str, Any], ...]]] = set()
+        self.logger = logging.getLogger(__name__)
+        self._counter = 0
+
+    def _next_id(self) -> int:
+        self._counter += 1
+        return self._counter
+
+    # ------------------------------------------------------------------
+    # Core components
+    # ------------------------------------------------------------------
+    def branch_generator(self, node: Node) -> List[Node]:
+        """Generate deterministic child branches for ``node``."""
+
+        branches: List[Node] = []
+        for i in range(self.branching_factor):
+            subquery = f"{node.subquery}.{i + 1}"
+            child = Node(
+                id=self._next_id(),
+                subquery=subquery,
+                path=node.path + (subquery,),
+                score=0.0,
+                depth=node.depth + 1,
+                context=dict(node.context),
+            )
+            score = self.path_scorer(child)
+            child = replace(child, score=score)
+            self.logger.info(
+                {
+                    "event": "branch",
+                    "parent": node.id,
+                    "child": child.id,
+                    "step": i,
+                    "subquery": child.subquery,
+                    "score": child.score,
+                }
+            )
+            branches.append(child)
+        return branches
+
+    def path_scorer(self, node: Node) -> float:
+        """Score ``node`` using path and context guidance.
+
+        The score combines deterministic path metrics, depth, path length, and
+        Chain-of-Thought guidance hints stored in ``node.context``. The result is
+        normalized to ``[0, 1]``.
+        """
+
+        path_total = sum((i + 1) * ord(ch) for i, ch in enumerate("".join(node.path)))
+        path_score = (path_total % 50) / 50
+        depth_score = 1.0 - (node.depth / max(self.max_depth, 1))
+        length_score = len(node.path) / (self.max_depth + 1)
+        guidance = guidance_score(node.context)
+        return max(0.0, min(1.0, (path_score + depth_score + length_score + guidance) / 4))
+
+    def best_path_selector(self, frontier: List[Tuple[float, Tuple[str, ...], int, Node]]) -> Node:
+        """Pop and return the highest scoring node from ``frontier``."""
+
+        return heapq.heappop(frontier)[3]
+
+    def _retrace_and_prune(
+        self, node: Node, best_score: float, *, threshold: float | None = None
+    ) -> bool:
+        """Return ``True`` if ``node`` should be pruned.
+
+        ``threshold`` is the multiplier applied to ``best_score`` for pruning. If not
+        provided, ``self.prune_ratio`` is used. Paths already visited are also
+        pruned.
+        """
+
+        key = (node.subquery, tuple(sorted(node.context.items())))
+        if key in self.visited:
+            self.logger.info(
+                {
+                    "event": "prune",
+                    "reason": "visited",
+                    "node": node.id,
+                    "score": node.score,
+                }
+            )
+            return True
+
+        ratio = threshold if threshold is not None else self.prune_ratio
+        if node.score < best_score * ratio:
+            self.logger.info(
+                {
+                    "event": "prune",
+                    "reason": "threshold",
+                    "node": node.id,
+                    "score": node.score,
+                    "best": best_score,
+                    "ratio": ratio,
+                }
+            )
+            return True
+
+        self.visited.add(key)
+        return False
+
+    # ------------------------------------------------------------------
+    # Solver entry point
+    # ------------------------------------------------------------------
+    def solve(self, query: str) -> Dict[str, Any]:
+        """Solve ``query`` using deterministic Tree-of-Thought reasoning."""
+
+        start = time.monotonic()
+        root = Node(id=self._next_id(), subquery=query, path=(query,), score=0.0, depth=0)
+        root = replace(root, score=self.path_scorer(root))
+        frontier: List[Tuple[float, Tuple[str, ...], int, Node]] = [
+            (-root.score, root.path, root.id, root)
+        ]
+        best = root
+        nodes_expanded = 0
+
+        while frontier:
+            if time.monotonic() - start > self.timeout:
+                self.logger.warning(
+                    {"event": "abort", "reason": "timeout", "nodes": nodes_expanded}
+                )
+                break
+            if nodes_expanded >= self.max_nodes:
+                self.logger.warning(
+                    {"event": "abort", "reason": "max_nodes", "nodes": nodes_expanded}
+                )
+                break
+
+            current = self.best_path_selector(frontier)
+            best = current
+
+            if current.score >= self.score_threshold or current.depth >= self.max_depth:
+                break
+
+            for child in self.branch_generator(current):
+                if self._retrace_and_prune(child, best.score):
+                    continue
+                heapq.heappush(frontier, (-child.score, child.path, child.id, child))
+
+            nodes_expanded += 1
+
+        return {"solution": best.subquery, "path": list(best.path), "score": best.score}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,14 @@ dependencies = []
 alpha-solver = "alpha.cli:main"
 
 [tool.setuptools]
-packages = ["alpha", "alpha.core", "alpha.adapters", "alpha.executors", "scripts"]
+packages = [
+    "alpha",
+    "alpha.core",
+    "alpha.adapters",
+    "alpha.executors",
+    "alpha.reasoning",
+    "scripts",
+]
 
 [tool.setuptools.package-data]
 alpha = ["**/*.json", "**/*.md"]

--- a/tests/reasoning/test_best_path_selector.py
+++ b/tests/reasoning/test_best_path_selector.py
@@ -1,0 +1,18 @@
+import heapq
+
+from alpha.reasoning.tot import TreeOfThoughtSolver, Node
+
+
+def test_best_path_selector():
+    solver = TreeOfThoughtSolver()
+    frontier = []
+    nodes = [
+        Node(id=1, subquery="a", path=("a",), score=0.2, depth=1),
+        Node(id=2, subquery="b", path=("b",), score=0.8, depth=1),
+        Node(id=3, subquery="c", path=("c",), score=0.5, depth=1),
+    ]
+    for node in nodes:
+        heapq.heappush(frontier, (-node.score, node.path, node.id, node))
+
+    best = solver.best_path_selector(frontier)
+    assert best.subquery == "b"

--- a/tests/reasoning/test_branch_generator.py
+++ b/tests/reasoning/test_branch_generator.py
@@ -1,0 +1,10 @@
+from alpha.reasoning.tot import TreeOfThoughtSolver, Node
+
+
+def test_branch_generator():
+    solver = TreeOfThoughtSolver(branching_factor=2)
+    root = Node(id=0, subquery="q", path=("q",), score=0.0, depth=0)
+    branches = solver.branch_generator(root)
+    assert [b.subquery for b in branches] == ["q.1", "q.2"]
+    assert all(b.depth == 1 for b in branches)
+    assert all(0 <= b.score <= 1 for b in branches)

--- a/tests/reasoning/test_path_scorer.py
+++ b/tests/reasoning/test_path_scorer.py
@@ -1,0 +1,26 @@
+from alpha.reasoning.tot import TreeOfThoughtSolver, Node
+
+
+def test_path_scorer_context_and_normalization():
+    solver = TreeOfThoughtSolver()
+    base = Node(id=0, subquery="q", path=("q",), score=0.0, depth=0)
+    hinted = Node(
+        id=1,
+        subquery="q",
+        path=("q",),
+        score=0.0,
+        depth=0,
+        context={"hint": "because"},
+    )
+    base_score = solver.path_scorer(base)
+    hinted_score = solver.path_scorer(hinted)
+    assert 0 <= base_score <= 1
+    assert 0 <= hinted_score <= 1
+    assert hinted_score > base_score
+
+
+def test_path_scorer_deterministic_with_context():
+    solver = TreeOfThoughtSolver()
+    node1 = Node(id=0, subquery="q", path=("q",), score=0.0, depth=0, context={"hint": "thus"})
+    node2 = Node(id=1, subquery="q", path=("q",), score=0.0, depth=0, context={"hint": "thus"})
+    assert solver.path_scorer(node1) == solver.path_scorer(node2)

--- a/tests/reasoning/test_pruning.py
+++ b/tests/reasoning/test_pruning.py
@@ -1,0 +1,19 @@
+from alpha.reasoning.tot import TreeOfThoughtSolver, Node
+
+
+def test_default_prune_threshold():
+    solver = TreeOfThoughtSolver()
+    best = 0.9
+    low = Node(id=1, subquery="a", path=("a",), score=0.6, depth=1)
+    high = Node(id=2, subquery="b", path=("b",), score=0.8, depth=1)
+    assert solver._retrace_and_prune(low, best) is True
+    assert solver._retrace_and_prune(high, best) is False
+
+
+def test_custom_prune_threshold():
+    solver = TreeOfThoughtSolver()
+    best = 0.9
+    node = Node(id=3, subquery="c", path=("c",), score=0.7, depth=1)
+    assert solver._retrace_and_prune(node, best, threshold=0.9) is True
+    node2 = Node(id=4, subquery="d", path=("d",), score=0.7, depth=1)
+    assert solver._retrace_and_prune(node2, best, threshold=0.5) is False

--- a/tests/reasoning/test_tot_solver.py
+++ b/tests/reasoning/test_tot_solver.py
@@ -1,0 +1,25 @@
+from alpha.reasoning.tot import TreeOfThoughtSolver
+
+
+def test_tot_solver_end_to_end():
+    solver = TreeOfThoughtSolver(branching_factor=2, max_depth=2, score_threshold=0.95)
+    result = solver.solve("start")
+    assert result["solution"] == "start.2.1"
+    assert result["path"] == ["start", "start.2", "start.2.1"]
+    assert 0 <= result["score"] <= 1
+
+
+def test_timeout_abort(caplog):
+    solver = TreeOfThoughtSolver(timeout=0.0)
+    with caplog.at_level("WARNING"):
+        result = solver.solve("start")
+    assert result["path"] == ["start"]
+    assert any(rec.msg.get("reason") == "timeout" for rec in caplog.records)
+
+
+def test_max_nodes_abort(caplog):
+    solver = TreeOfThoughtSolver(max_nodes=0)
+    with caplog.at_level("WARNING"):
+        result = solver.solve("start")
+    assert result["path"] == ["start"]
+    assert any(rec.msg.get("reason") == "max_nodes" for rec in caplog.records)


### PR DESCRIPTION
## Summary
- use heap-based priority queue with configurable pruning and resource limits
- implement context-aware scoring and emit structured logs
- add tests for pruning, context scoring, and solver limits

## Testing
- `python -m ruff check alpha/reasoning alpha-solver-v91-python.py tests/reasoning`
- `python -m ruff format alpha/reasoning alpha-solver-v91-python.py tests/reasoning`
- `python -m black alpha/reasoning alpha-solver-v91-python.py tests/reasoning`
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pre-commit run --files alpha/reasoning/__init__.py alpha/reasoning/cot.py alpha/reasoning/tot.py alpha-solver-v91-python.py pyproject.toml CHANGELOG.md tests/reasoning/test_branch_generator.py tests/reasoning/test_path_scorer.py tests/reasoning/test_best_path_selector.py tests/reasoning/test_tot_solver.py tests/reasoning/test_pruning.py tests/reasoning/__init__.py` *(command not found)*
- `pytest tests/reasoning -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdb91c83448329a153a87c73d0488d