### PR TITLE
SAFE-OUT cleanup: remove duplicate entrypoint, normalize imports, clarify README, update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,19 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- Remove duplicate entrypoint module; normalize imports to a single `_tree_of_thought` API.
 
-- Added: ToT v1 deterministic pipeline, public entrypoint, tests & logging.
+### Docs
+- Clarified `score_threshold` vs `low_conf_threshold` and documented SAFE-OUT output schema.
+
+## [2025-09-07]
+### Added
+- SAFE-OUT policy (low-confidence fallback) with JSON `safe_out_decision` logging.
+- Public `_tree_of_thought(...)` returns routed policy output.
+
+### Changed
+- ToT v1 deterministic pipeline (branching, scoring, selection, pruning).
 
 ## [1.0.0b1]
 - Initial packaging metadata and console entry point.

--- a/alpha/policy/safe_out.py
+++ b/alpha/policy/safe_out.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+"""SAFE-OUT policy for low-confidence Tree-of-Thought results."""
+
+from typing import Any, Dict
+
+try:  # Best-effort optional CoT import
+    from alpha.reasoning.cot import run_cot  # type: ignore
+except Exception:  # pragma: no cover - fallback when CoT unavailable
+    run_cot = None  # type: ignore
+
+
+def _run_cot_fallback(query: str) -> Dict[str, Any]:
+    """Deterministic placeholder Chain-of-Thought response."""
+    return {"answer": f"To proceed, clarify: {query} …", "confidence": 0.50, "steps": []}
+
+
+class SafeOutPolicy:
+    """Policy that handles low-confidence ToT results."""
+
+    def __init__(self, *, low_conf_threshold: float = 0.60, enable_cot_fallback: bool = True) -> None:
+        self.low_conf_threshold = low_conf_threshold
+        self.enable_cot_fallback = enable_cot_fallback
+
+    def apply(self, tot_result: Dict[str, Any], original_query: str) -> Dict[str, Any]:
+        """Apply SAFE-OUT logic to ``tot_result``.
+
+        Parameters
+        ----------
+        tot_result:
+            Output from Tree-of-Thought solving.
+        original_query:
+            User query used for potential CoT fallback.
+        """
+
+        confidence = float(tot_result.get("confidence", 0.0))
+        if confidence >= self.low_conf_threshold:
+            return {
+                "final_answer": tot_result.get("answer", ""),
+                "route": "tot",
+                "confidence": confidence,
+                "reason": "ok",
+                "notes": "confidence above threshold",
+                "tot": tot_result,
+                "cot": None,
+            }
+
+        if self.enable_cot_fallback:
+            cot_fn = run_cot or _run_cot_fallback
+            cot_result: Dict[str, Any] = cot_fn(original_query)
+            return {
+                "final_answer": cot_result.get("answer", ""),
+                "route": "cot_fallback",
+                "confidence": float(cot_result.get("confidence", 0.0)),
+                "reason": "low_confidence",
+                "notes": f"Confidence below {self.low_conf_threshold:.2f}; used chain-of-thought fallback.",
+                "tot": tot_result,
+                "cot": cot_result,
+            }
+
+        return {
+            "final_answer": tot_result.get("answer", ""),
+            "route": "best_effort",
+            "confidence": confidence,
+            "reason": "low_confidence",
+            "notes": f"Confidence below {self.low_conf_threshold:.2f}; recommending clarification or narrower query.",
+            "tot": tot_result,
+            "cot": None,
+        }

--- a/alpha/reasoning/logging.py
+++ b/alpha/reasoning/logging.py
@@ -10,3 +10,8 @@ def log_event(event: str, **data: Any) -> None:
     """Log a structured JSON event."""
     payload = {"event": event, **data, "ts": time.time()}
     LOGGER.info(json.dumps(payload))
+
+
+def log_safe_out_decision(*, route: str, conf: float, threshold: float, reason: str) -> None:
+    """Convenience wrapper for SAFE-OUT policy decisions."""
+    log_event("safe_out_decision", route=route, conf=conf, threshold=threshold, reason=reason)

--- a/alpha_solver_entry.py
+++ b/alpha_solver_entry.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+ENTRY = Path(__file__).with_name("alpha-solver-v91-python.py")
+if not ENTRY.exists():
+    raise ImportError(f"Expected entrypoint file not found: {ENTRY}")
+
+_spec = importlib.util.spec_from_file_location("alpha_solver_v91_impl", ENTRY)
+if _spec is None or _spec.loader is None:
+    raise ImportError("Could not load alpha-solver-v91-python.py via importlib")
+
+_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_module)  # type: ignore[attr-defined]
+
+_tree_of_thought = _module._tree_of_thought  # type: ignore[attr-defined]
+
+__all__ = ["_tree_of_thought"]

--- a/scripts/benchmark_tot.py
+++ b/scripts/benchmark_tot.py
@@ -1,4 +1,4 @@
-from alpha_solver_v91_python import _tree_of_thought
+from alpha_solver_entry import _tree_of_thought
 
 
 def main() -> None:
@@ -7,7 +7,7 @@ def main() -> None:
     total_conf = 0.0
     for q in queries:
         result = _tree_of_thought(q)
-        total_nodes += result["explored_nodes"]
+        total_nodes += result["tot"]["explored_nodes"]
         total_conf += result["confidence"]
     avg_conf = total_conf / len(queries)
     print(f"explored_nodes={total_nodes}")

--- a/tests/policy/test_safe_out.py
+++ b/tests/policy/test_safe_out.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+
+from alpha.policy.safe_out import SafeOutPolicy
+
+
+def _synthetic(confidence: float) -> dict:
+    return {
+        "answer": "ans",
+        "confidence": confidence,
+        "path": [],
+        "explored_nodes": 0,
+        "config": {},
+        "reason": "ok",
+    }
+
+
+def test_safe_out_pass_through():
+    policy = SafeOutPolicy()
+    tot = _synthetic(0.80)
+    result = policy.apply(tot, "q")
+    assert result["route"] == "tot"
+    assert result["reason"] == "ok"
+    assert json.dumps(result)
+
+
+def test_safe_out_cot_fallback():
+    policy = SafeOutPolicy(enable_cot_fallback=True)
+    tot = _synthetic(0.55)
+    result = policy.apply(tot, "q")
+    assert result["route"] == "cot_fallback"
+    assert result["reason"] == "low_confidence"
+    assert result["cot"] is not None
+    assert json.dumps(result)
+
+
+def test_safe_out_best_effort():
+    policy = SafeOutPolicy(enable_cot_fallback=False)
+    tot = _synthetic(0.55)
+    result = policy.apply(tot, "q")
+    assert result["route"] == "best_effort"
+    assert result["reason"] == "low_confidence"
+    assert result["cot"] is None
+    assert json.dumps(result)

--- a/tests/reasoning/test_tot_entrypoint_with_policy.py
+++ b/tests/reasoning/test_tot_entrypoint_with_policy.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict
+
+import pytest
+
+from alpha.reasoning.tot import TreeOfThoughtSolver
+from alpha_solver_entry import _tree_of_thought
+
+
+def _low_confidence(self, query: str) -> Dict[str, Any]:  # pragma: no cover - used in tests
+    return {
+        "answer": "low",
+        "confidence": 0.55,
+        "path": [],
+        "explored_nodes": 0,
+        "config": {},
+        "reason": "ok",
+    }
+
+
+@pytest.mark.parametrize("enable_cot", [True, False])
+def test_tree_of_thought_policy(monkeypatch, caplog, enable_cot):
+    monkeypatch.setattr(TreeOfThoughtSolver, "solve", _low_confidence)
+    with caplog.at_level(logging.INFO):
+        result = _tree_of_thought(
+            "query",
+            low_conf_threshold=0.60,
+            enable_cot_fallback=enable_cot,
+        )
+    assert result["route"] == ("cot_fallback" if enable_cot else "best_effort")
+    assert json.dumps(result)
+    assert any("safe_out_decision" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- remove legacy `alpha_solver_v91_python.py` and expose `_tree_of_thought` via a small import shim that validates the canonical entrypoint
- document SAFE-OUT parameters and output schema with clarified thresholds, noting the shim import
- log changelog fixes for entrypoint cleanup and docs

## Testing
- `ruff check alpha_solver_entry.py`
- `PYTHONPATH=. pytest tests/policy/test_safe_out.py tests/reasoning/test_tot_entrypoint_with_policy.py -q`
- `PYTHONPATH=. pytest tests/reasoning/test_tot_solver.py -q`
- `rg alpha_solver_v91_python`


------
https://chatgpt.com/codex/tasks/task_e_68bdf72df4bc8329b956f5c091bcae5a