### PR TITLE
SAFE-OUT v1.1: State machine, structured recovery, phased logging, entrypoint integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- SAFE-OUT v1.1 state machine with structured recovery and phase logging.
+
+### Changed
+- `_tree_of_thought` entrypoint returns phase traces and richer notes.
+
 ### Fixed
 - Remove duplicate entrypoint module; normalize imports to a single `_tree_of_thought` API.
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,37 @@ result = _tree_of_thought(
 print(result["route"], result["final_answer"])
 ```
 
+### SAFE-OUT v1.1 (State Machine & Structured Recovery)
+
+SAFE-OUT now uses a tiny deterministic state machine to assess results and, when needed, run a bounded Chain-of-Thought fallback.
+_tree_of_thought maintains backward compatibility: existing keys are unchanged; phases and enriched notes are additive.
+
+```python
+from alpha_solver_entry import _tree_of_thought
+
+result = _tree_of_thought(
+    "ambiguous prompt",
+    seed=123,
+    low_conf_threshold=0.75,
+    enable_cot_fallback=True,
+)
+
+print(result["route"])
+print(result["phases"])
+print(result["notes"])
+```
+
+Output (truncated):
+
+```json
+{
+  "final_answer": "...",
+  "route": "cot_fallback",
+  "phases": ["init", "assess", "fallback", "finalize"],
+  "notes": "path=init->assess->fallback->finalize"
+}
+```
+
 ## Telemetry Leaderboard (offline, stdlib-only)
 
 Generate a Markdown leaderboard from telemetry JSONL files:

--- a/alpha-solver-v91-python.py
+++ b/alpha-solver-v91-python.py
@@ -1,8 +1,7 @@
 """Alpha Solver v91 entrypoints."""
 
 from alpha.reasoning.tot import TreeOfThoughtSolver
-from alpha.policy.safe_out import SafeOutPolicy
-from alpha.reasoning.logging import log_safe_out_decision
+from alpha.policy.safe_out_sm import SOConfig, SafeOutStateMachine
 
 
 def _tree_of_thought(
@@ -16,6 +15,7 @@ def _tree_of_thought(
     dynamic_prune_margin: float = 0.15,
     low_conf_threshold: float = 0.60,
     enable_cot_fallback: bool = True,
+    max_cot_steps: int = 4,
 ) -> dict:
     """Solve ``query`` via deterministic Tree-of-Thought reasoning."""
     solver = TreeOfThoughtSolver(
@@ -27,15 +27,11 @@ def _tree_of_thought(
         dynamic_prune_margin=dynamic_prune_margin,
     )
     tot_result = solver.solve(query)
-    policy = SafeOutPolicy(
+    cfg = SOConfig(
         low_conf_threshold=low_conf_threshold,
         enable_cot_fallback=enable_cot_fallback,
+        max_cot_steps=max_cot_steps,
+        seed=seed,
     )
-    decision = policy.apply(tot_result, query)
-    log_safe_out_decision(
-        route=decision["route"],
-        conf=float(tot_result.get("confidence", 0.0)),
-        threshold=low_conf_threshold,
-        reason=decision["reason"],
-    )
+    decision = SafeOutStateMachine(cfg).run(tot_result, query)
     return decision

--- a/alpha/policy/safe_out.py
+++ b/alpha/policy/safe_out.py
@@ -1,69 +1,33 @@
 from __future__ import annotations
 
-"""SAFE-OUT policy for low-confidence Tree-of-Thought results."""
+"""Facade for SAFE-OUT state machine."""
 
 from typing import Any, Dict
 
-try:  # Best-effort optional CoT import
-    from alpha.reasoning.cot import run_cot  # type: ignore
-except Exception:  # pragma: no cover - fallback when CoT unavailable
-    run_cot = None  # type: ignore
+from alpha.reasoning import logging as rlog
 
-
-def _run_cot_fallback(query: str) -> Dict[str, Any]:
-    """Deterministic placeholder Chain-of-Thought response."""
-    return {"answer": f"To proceed, clarify: {query} …", "confidence": 0.50, "steps": []}
+from .safe_out_sm import SOConfig, SafeOutStateMachine
 
 
 class SafeOutPolicy:
-    """Policy that handles low-confidence ToT results."""
+    """Backward-compatible wrapper around :class:`SafeOutStateMachine`."""
 
-    def __init__(self, *, low_conf_threshold: float = 0.60, enable_cot_fallback: bool = True) -> None:
-        self.low_conf_threshold = low_conf_threshold
-        self.enable_cot_fallback = enable_cot_fallback
+    def __init__(
+        self,
+        *,
+        low_conf_threshold: float = 0.60,
+        enable_cot_fallback: bool = True,
+        max_cot_steps: int = 4,
+        seed: int = 42,
+    ) -> None:
+        self.cfg = SOConfig(
+            low_conf_threshold=low_conf_threshold,
+            enable_cot_fallback=enable_cot_fallback,
+            max_cot_steps=max_cot_steps,
+            seed=seed,
+        )
 
     def apply(self, tot_result: Dict[str, Any], original_query: str) -> Dict[str, Any]:
-        """Apply SAFE-OUT logic to ``tot_result``.
-
-        Parameters
-        ----------
-        tot_result:
-            Output from Tree-of-Thought solving.
-        original_query:
-            User query used for potential CoT fallback.
-        """
-
-        confidence = float(tot_result.get("confidence", 0.0))
-        if confidence >= self.low_conf_threshold:
-            return {
-                "final_answer": tot_result.get("answer", ""),
-                "route": "tot",
-                "confidence": confidence,
-                "reason": "ok",
-                "notes": "confidence above threshold",
-                "tot": tot_result,
-                "cot": None,
-            }
-
-        if self.enable_cot_fallback:
-            cot_fn = run_cot or _run_cot_fallback
-            cot_result: Dict[str, Any] = cot_fn(original_query)
-            return {
-                "final_answer": cot_result.get("answer", ""),
-                "route": "cot_fallback",
-                "confidence": float(cot_result.get("confidence", 0.0)),
-                "reason": "low_confidence",
-                "notes": f"Confidence below {self.low_conf_threshold:.2f}; used chain-of-thought fallback.",
-                "tot": tot_result,
-                "cot": cot_result,
-            }
-
-        return {
-            "final_answer": tot_result.get("answer", ""),
-            "route": "best_effort",
-            "confidence": confidence,
-            "reason": "low_confidence",
-            "notes": f"Confidence below {self.low_conf_threshold:.2f}; recommending clarification or narrower query.",
-            "tot": tot_result,
-            "cot": None,
-        }
+        """Apply SAFE-OUT policy to ``tot_result``."""
+        sm = SafeOutStateMachine(self.cfg, rlog)
+        return sm.run(tot_result, original_query)

--- a/alpha/policy/safe_out_sm.py
+++ b/alpha/policy/safe_out_sm.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+"""SAFE-OUT v1.1 state machine for structured recovery."""
+
+from dataclasses import dataclass, asdict
+from typing import Any, Dict, List, Literal, Optional
+
+from alpha.reasoning import logging as rlog
+
+Phase = Literal["init", "assess", "fallback", "finalize"]
+
+
+@dataclass(frozen=True)
+class SOConfig:
+    """Configuration for :class:`SafeOutStateMachine`."""
+
+    low_conf_threshold: float = 0.60
+    enable_cot_fallback: bool = True
+    max_cot_steps: int = 4
+    seed: int = 42
+
+
+try:  # Best-effort optional CoT import
+    from alpha.reasoning.cot import run_cot  # type: ignore
+except Exception:  # pragma: no cover - fallback when CoT unavailable
+    run_cot = None  # type: ignore
+
+
+def _run_cot_shim(query: str, *, seed: int, max_steps: int) -> Dict[str, Any]:
+    """Deterministic placeholder Chain-of-Thought response."""
+    steps = [f"step {i + 1}: {query}" for i in range(max_steps)]
+    return {"answer": f"To proceed, clarify: {query} …", "confidence": 0.50, "steps": steps}
+
+
+class SafeOutStateMachine:
+    """Deterministic SAFE-OUT recovery flow."""
+
+    def __init__(self, cfg: SOConfig, logger: Any = rlog) -> None:
+        self.cfg = cfg
+        self.logger = logger
+
+    def run(self, tot_result: Dict[str, Any], original_query: str) -> Dict[str, Any]:
+        """Traverse SAFE-OUT phases and return a policy envelope."""
+        phases: List[Phase] = ["init"]
+        self.logger.log_event("safe_out_config", config=asdict(self.cfg))
+        self.logger.log_safe_out_phase(
+            phase="init",
+            conf=float(tot_result.get("confidence", 0.0)),
+            threshold=self.cfg.low_conf_threshold,
+        )
+
+        conf = float(tot_result.get("confidence", 0.0))
+        tot_reason = str(tot_result.get("reason", "ok"))
+        phases.append("assess")
+        self.logger.log_safe_out_phase(
+            phase="assess",
+            conf=conf,
+            threshold=self.cfg.low_conf_threshold,
+        )
+
+        if tot_reason == "timeout":
+            phases.append("fallback")
+            if self.cfg.enable_cot_fallback:
+                cot_fn = run_cot or _run_cot_shim
+                cot_result = cot_fn(
+                    original_query, seed=self.cfg.seed, max_steps=self.cfg.max_cot_steps
+                )
+                route = "cot_fallback"
+                conf = float(cot_result.get("confidence", 0.0))
+            else:
+                cot_result = None
+                route = "best_effort"
+            reason = "timeout"
+            final_answer = (cot_result or tot_result).get("answer", "")
+            self.logger.log_safe_out_phase(
+                phase="fallback", route=route, conf=conf, threshold=self.cfg.low_conf_threshold
+            )
+        elif conf >= self.cfg.low_conf_threshold:
+            route = "tot"
+            reason = tot_reason
+            final_answer = tot_result.get("answer", "")
+            cot_result = None
+        else:
+            phases.append("fallback")
+            if self.cfg.enable_cot_fallback:
+                cot_fn = run_cot or _run_cot_shim
+                cot_result = cot_fn(
+                    original_query, seed=self.cfg.seed, max_steps=self.cfg.max_cot_steps
+                )
+                route = "cot_fallback"
+                conf = float(cot_result.get("confidence", 0.0))
+            else:
+                cot_result = None
+                route = "best_effort"
+            reason = "low_confidence"
+            final_answer = (cot_result or tot_result).get("answer", "")
+            self.logger.log_safe_out_phase(
+                phase="fallback", route=route, conf=conf, threshold=self.cfg.low_conf_threshold
+            )
+
+        phases.append("finalize")
+        self.logger.log_safe_out_phase(
+            phase="finalize", route=route, conf=conf, threshold=self.cfg.low_conf_threshold
+        )
+        notes = f"path={'->'.join(phases)}"
+        if tot_reason != "ok":
+            notes += f"; tot_reason={tot_reason}"
+        return {
+            "final_answer": final_answer,
+            "route": route,
+            "confidence": conf,
+            "reason": reason,
+            "notes": notes,
+            "tot": tot_result,
+            "cot": cot_result,
+            "phases": phases,
+        }

--- a/alpha/reasoning/logging.py
+++ b/alpha/reasoning/logging.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import time
-from typing import Any
+from typing import Any, Literal, Optional
 
 LOGGER = logging.getLogger(__name__)
 
@@ -10,6 +10,16 @@ def log_event(event: str, **data: Any) -> None:
     """Log a structured JSON event."""
     payload = {"event": event, **data, "ts": time.time()}
     LOGGER.info(json.dumps(payload))
+
+
+Phase = Literal["init", "assess", "fallback", "finalize"]
+
+
+def log_safe_out_phase(
+    *, phase: Phase, route: Optional[str] = None, conf: Optional[float] = None, threshold: Optional[float] = None
+) -> None:
+    """Log a SAFE-OUT state-machine phase transition."""
+    log_event("safe_out_phase", phase=phase, route=route, conf=conf, threshold=threshold)
 
 
 def log_safe_out_decision(*, route: str, conf: float, threshold: float, reason: str) -> None:

--- a/tests/policy/test_safe_out_sm.py
+++ b/tests/policy/test_safe_out_sm.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import Dict
+
+import pytest
+
+from alpha.policy.safe_out_sm import SOConfig, SafeOutStateMachine
+
+
+def _synthetic(confidence: float, reason: str = "ok") -> Dict[str, float | str]:
+    return {"answer": "ans", "confidence": confidence, "reason": reason}
+
+
+@pytest.mark.parametrize(
+    "confidence,enable,route,phases",
+    [
+        (0.80, True, "tot", ["init", "assess", "finalize"]),
+        (0.55, True, "cot_fallback", ["init", "assess", "fallback", "finalize"]),
+        (0.55, False, "best_effort", ["init", "assess", "fallback", "finalize"]),
+    ],
+)
+def test_state_machine_routes(confidence, enable, route, phases, caplog):
+    cfg = SOConfig(enable_cot_fallback=enable)
+    sm = SafeOutStateMachine(cfg)
+    tot = _synthetic(confidence)
+    with caplog.at_level(logging.INFO):
+        result = sm.run(tot, "q")
+    assert result["route"] == route
+    assert result["phases"] == phases
+    assert json.dumps(result)
+    assert any("safe_out_phase" in r.message for r in caplog.records)
+
+
+@pytest.mark.parametrize(
+    "confidence,reason,enable,route,expected_reason",
+    [
+        (0.80, "timeout", False, "best_effort", "timeout"),
+        (0.55, "below_threshold", True, "cot_fallback", "low_confidence"),
+    ],
+)
+def test_state_machine_edge_cases(confidence, reason, enable, route, expected_reason):
+    cfg = SOConfig(enable_cot_fallback=enable)
+    sm = SafeOutStateMachine(cfg)
+    tot = _synthetic(confidence, reason)
+    result = sm.run(tot, "q")
+    assert result["route"] == route
+    assert result["reason"] == expected_reason
+    assert reason in result["notes"]
+    assert result["phases"] == ["init", "assess", "fallback", "finalize"]
+
+
+def test_state_machine_determinism():
+    cfg = SOConfig(seed=1)
+    runs = [SafeOutStateMachine(cfg).run(_synthetic(0.55), "q") for _ in range(3)]
+    assert runs[0] == runs[1] == runs[2]
+    sample = runs[0]
+    for key in ["final_answer", "route", "confidence", "reason", "notes", "tot", "cot", "phases"]:
+        assert key in sample

--- a/tests/reasoning/test_tot_entrypoint_with_policy.py
+++ b/tests/reasoning/test_tot_entrypoint_with_policy.py
@@ -31,5 +31,7 @@ def test_tree_of_thought_policy(monkeypatch, caplog, enable_cot):
             enable_cot_fallback=enable_cot,
         )
     assert result["route"] == ("cot_fallback" if enable_cot else "best_effort")
+    assert result["phases"] == ["init", "assess", "fallback", "finalize"]
+    assert "init->assess->fallback->finalize" in result["notes"]
     assert json.dumps(result)
-    assert any("safe_out_decision" in r.message for r in caplog.records)
+    assert any("safe_out_phase" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- Implement deterministic SAFE-OUT v1.1 state machine with configurable phases and bounded CoT fallback.
- Integrate state machine with `_tree_of_thought` entrypoint and log phase transitions.
- Document SAFE-OUT v1.1 and update changelog.
- Add backward-compatibility note and edge-case tests for timeout/below-threshold routes.

## Testing
- `PYTHONPATH=. pytest tests/policy/test_safe_out.py tests/policy/test_safe_out_sm.py tests/reasoning/test_tot_entrypoint_with_policy.py`


------
https://chatgpt.com/codex/tasks/task_e_68be0bcb9a148329a68f2ff9d0d34673