### PR TITLE
SAFE-OUT v1.1: State machine, structured recovery, phased logging, entrypoint integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 ### Docs
 - Clarified `score_threshold` vs `low_conf_threshold` and documented SAFE-OUT output schema.
 
+## [2025-09-09]
+### Added
+- SAFE-OUT v1.1 state machine with structured recovery and phased JSONL logging.
+### Changed
+- `_tree_of_thought` entrypoint returns phases and enriched notes while preserving existing keys.
+
 ## [2025-09-07]
 ### Added
 - SAFE-OUT policy (low-confidence fallback) with JSON `safe_out_decision` logging.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,34 @@ result = _tree_of_thought(
 print(result["route"], result["final_answer"])
 ```
 
+### SAFE-OUT v1.1 (State Machine & Structured Recovery)
+
+```python
+from alpha_solver_entry import _tree_of_thought
+
+result = _tree_of_thought("unclear query")
+print(result["route"])
+print(result["phases"])
+print(result["notes"])
+```
+
+Example output:
+
+```json
+{
+  "final_answer": "To proceed, clarify: unclear query …",
+  "route": "cot_fallback",
+  "confidence": 0.5,
+  "reason": "low_confidence",
+  "notes": "Confidence below 0.60; used chain-of-thought fallback. | phases: init->assess->fallback->finalize",
+  "tot": {"confidence": 0.55, "reason": "ok", ...},
+  "cot": {"confidence": 0.5, "steps": []},
+  "phases": ["init", "assess", "fallback", "finalize"]
+}
+```
+
+_tree_of_thought maintains backward compatibility: existing keys are unchanged; phases and enriched notes are additive.
+
 ## Telemetry Leaderboard (offline, stdlib-only)
 
 Generate a Markdown leaderboard from telemetry JSONL files:

--- a/alpha/policy/safe_out.py
+++ b/alpha/policy/safe_out.py
@@ -1,69 +1,36 @@
 from __future__ import annotations
 
-"""SAFE-OUT policy for low-confidence Tree-of-Thought results."""
+"""Thin façade for SAFE-OUT state machine."""
 
 from typing import Any, Dict
 
-try:  # Best-effort optional CoT import
-    from alpha.reasoning.cot import run_cot  # type: ignore
-except Exception:  # pragma: no cover - fallback when CoT unavailable
-    run_cot = None  # type: ignore
-
-
-def _run_cot_fallback(query: str) -> Dict[str, Any]:
-    """Deterministic placeholder Chain-of-Thought response."""
-    return {"answer": f"To proceed, clarify: {query} …", "confidence": 0.50, "steps": []}
+from .safe_out_sm import SOConfig, SafeOutStateMachine
 
 
 class SafeOutPolicy:
-    """Policy that handles low-confidence ToT results."""
+    """Policy wrapper constructing and executing the state machine."""
 
-    def __init__(self, *, low_conf_threshold: float = 0.60, enable_cot_fallback: bool = True) -> None:
-        self.low_conf_threshold = low_conf_threshold
-        self.enable_cot_fallback = enable_cot_fallback
+    def __init__(
+        self,
+        *,
+        low_conf_threshold: float = 0.60,
+        enable_cot_fallback: bool = True,
+        seed: int = 42,
+        max_cot_steps: int = 4,
+    ) -> None:
+        self.config = SOConfig(
+            low_conf_threshold=low_conf_threshold,
+            enable_cot_fallback=enable_cot_fallback,
+            seed=seed,
+            max_cot_steps=max_cot_steps,
+        )
 
     def apply(self, tot_result: Dict[str, Any], original_query: str) -> Dict[str, Any]:
-        """Apply SAFE-OUT logic to ``tot_result``.
+        """Apply SAFE-OUT policy to ``tot_result``."""
 
-        Parameters
-        ----------
-        tot_result:
-            Output from Tree-of-Thought solving.
-        original_query:
-            User query used for potential CoT fallback.
-        """
+        sm = SafeOutStateMachine(self.config)
+        return sm.run(tot_result, original_query)
 
-        confidence = float(tot_result.get("confidence", 0.0))
-        if confidence >= self.low_conf_threshold:
-            return {
-                "final_answer": tot_result.get("answer", ""),
-                "route": "tot",
-                "confidence": confidence,
-                "reason": "ok",
-                "notes": "confidence above threshold",
-                "tot": tot_result,
-                "cot": None,
-            }
 
-        if self.enable_cot_fallback:
-            cot_fn = run_cot or _run_cot_fallback
-            cot_result: Dict[str, Any] = cot_fn(original_query)
-            return {
-                "final_answer": cot_result.get("answer", ""),
-                "route": "cot_fallback",
-                "confidence": float(cot_result.get("confidence", 0.0)),
-                "reason": "low_confidence",
-                "notes": f"Confidence below {self.low_conf_threshold:.2f}; used chain-of-thought fallback.",
-                "tot": tot_result,
-                "cot": cot_result,
-            }
+__all__ = ["SafeOutPolicy"]
 
-        return {
-            "final_answer": tot_result.get("answer", ""),
-            "route": "best_effort",
-            "confidence": confidence,
-            "reason": "low_confidence",
-            "notes": f"Confidence below {self.low_conf_threshold:.2f}; recommending clarification or narrower query.",
-            "tot": tot_result,
-            "cot": None,
-        }

--- a/alpha/policy/safe_out_sm.py
+++ b/alpha/policy/safe_out_sm.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+"""SAFE-OUT v1.1 state machine and configuration."""
+
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, List, Optional
+
+from alpha.reasoning.logging import log_event, log_safe_out_phase
+
+try:  # Optional deterministic CoT import
+    from alpha.reasoning.cot import run_cot  # type: ignore
+except Exception:  # pragma: no cover - fallback when CoT unavailable
+
+    def run_cot(query: str, seed: int, max_steps: int) -> Dict[str, Any]:  # type: ignore
+        return {
+            "answer": f"To proceed, clarify: {query} …",
+            "confidence": 0.50,
+            "steps": [],
+        }
+
+
+@dataclass(frozen=True)
+class SOConfig:
+    """Configuration for the SAFE-OUT state machine."""
+
+    low_conf_threshold: float = 0.60
+    enable_cot_fallback: bool = True
+    seed: int = 42
+    max_cot_steps: int = 4
+
+
+class SafeOutStateMachine:
+    """Deterministic SAFE-OUT policy state machine."""
+
+    def __init__(self, config: SOConfig) -> None:
+        self.config = config
+
+    def run(self, tot_result: Dict[str, Any], original_query: str) -> Dict[str, Any]:
+        """Execute the SAFE-OUT state machine for ``tot_result``."""
+
+        phases: List[str] = ["init"]
+        confidence = float(tot_result.get("confidence", 0.0))
+        log_event("safe_out_config", config=asdict(self.config))
+        log_safe_out_phase(
+            phase="init",
+            route="pending",
+            conf=confidence,
+            threshold=self.config.low_conf_threshold,
+        )
+
+        phases.append("assess")
+        if confidence >= self.config.low_conf_threshold:
+            route = "tot"
+            notes = "confidence above threshold"
+            cot_result: Optional[Dict[str, Any]] = None
+            log_safe_out_phase(
+                phase="assess",
+                route=route,
+                conf=confidence,
+                threshold=self.config.low_conf_threshold,
+            )
+        else:
+            log_safe_out_phase(
+                phase="assess",
+                route="below_threshold",
+                conf=confidence,
+                threshold=self.config.low_conf_threshold,
+            )
+            phases.append("fallback")
+            if self.config.enable_cot_fallback:
+                cot_result = run_cot(
+                    original_query,
+                    seed=self.config.seed,
+                    max_steps=self.config.max_cot_steps,
+                )
+                confidence = float(cot_result.get("confidence", 0.0))
+                route = "cot_fallback"
+                notes = (
+                    f"Confidence below {self.config.low_conf_threshold:.2f}; used chain-of-thought fallback."
+                )
+                log_safe_out_phase(
+                    phase="fallback",
+                    route=route,
+                    conf=confidence,
+                    threshold=self.config.low_conf_threshold,
+                )
+            else:
+                cot_result = None
+                route = "best_effort"
+                notes = (
+                    f"Confidence below {self.config.low_conf_threshold:.2f}; recommending clarification or narrower query."
+                )
+                log_safe_out_phase(
+                    phase="fallback",
+                    route=route,
+                    conf=confidence,
+                    threshold=self.config.low_conf_threshold,
+                )
+
+        phases.append("finalize")
+        log_safe_out_phase(
+            phase="finalize",
+            route=route,
+            conf=confidence,
+            threshold=self.config.low_conf_threshold,
+        )
+
+        reason = tot_result.get("reason", "ok") if route == "tot" else "low_confidence"
+        notes = f"{notes} | phases: {'->'.join(phases)}"
+        envelope = {
+            "final_answer": (cot_result or tot_result).get("answer", ""),
+            "route": route,
+            "confidence": confidence,
+            "reason": reason,
+            "notes": notes,
+            "tot": tot_result,
+            "cot": cot_result,
+            "phases": phases,
+        }
+        return envelope
+
+
+__all__ = ["SOConfig", "SafeOutStateMachine"]
+

--- a/alpha/reasoning/cot.py
+++ b/alpha/reasoning/cot.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Deterministic Chain-of-Thought guidance utilities."""
 
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 
 def guidance_score(context: Dict[str, Any]) -> float:
@@ -16,3 +16,24 @@ def guidance_score(context: Dict[str, Any]) -> float:
     keywords = ["therefore", "because", "thus"]
     matches = sum(1 for kw in keywords if kw in hint)
     return matches / len(keywords)
+
+
+def run_cot(query: str, seed: int, max_steps: int) -> Dict[str, Any]:
+    """Return a deterministic Chain-of-Thought fallback response.
+
+    Parameters
+    ----------
+    query:
+        Original user query.
+    seed:
+        Unused seed maintained for deterministic signature.
+    max_steps:
+        Maximum number of reasoning steps to emit.
+    """
+
+    steps: List[str] = [f"step_{i}: {query}" for i in range(1, max_steps + 1)]
+    return {
+        "answer": f"To proceed, consider: {query}",
+        "confidence": 0.50,
+        "steps": steps,
+    }

--- a/alpha/reasoning/logging.py
+++ b/alpha/reasoning/logging.py
@@ -15,3 +15,8 @@ def log_event(event: str, **data: Any) -> None:
 def log_safe_out_decision(*, route: str, conf: float, threshold: float, reason: str) -> None:
     """Convenience wrapper for SAFE-OUT policy decisions."""
     log_event("safe_out_decision", route=route, conf=conf, threshold=threshold, reason=reason)
+
+
+def log_safe_out_phase(*, phase: str, route: str, conf: float, threshold: float) -> None:
+    """Log a SAFE-OUT state machine phase transition."""
+    log_event("safe_out_phase", phase=phase, route=route, conf=conf, threshold=threshold)

--- a/tests/policy/test_safe_out_sm.py
+++ b/tests/policy/test_safe_out_sm.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+import pytest
+
+from alpha.policy.safe_out_sm import SOConfig, SafeOutStateMachine
+
+
+def _tot(conf: float) -> Dict[str, Any]:
+    return {
+        "answer": "ans",
+        "confidence": conf,
+        "path": [],
+        "explored_nodes": 0,
+        "config": {},
+        "reason": "ok",
+    }
+
+
+EXPECTED_KEYS = {
+    "final_answer",
+    "route",
+    "confidence",
+    "reason",
+    "notes",
+    "tot",
+    "cot",
+    "phases",
+}
+
+
+@pytest.mark.parametrize(
+    "conf, enable_cot, route, phases, reason",
+    [
+        (0.80, True, "tot", ["init", "assess", "finalize"], "ok"),
+        (0.55, True, "cot_fallback", ["init", "assess", "fallback", "finalize"], "low_confidence"),
+        (0.55, False, "best_effort", ["init", "assess", "fallback", "finalize"], "low_confidence"),
+    ],
+)
+def test_safe_out_state_machine(conf, enable_cot, route, phases, reason, caplog):
+    cfg = SOConfig(low_conf_threshold=0.60, enable_cot_fallback=enable_cot, seed=1, max_cot_steps=2)
+    sm = SafeOutStateMachine(cfg)
+    tot = _tot(conf)
+    with caplog.at_level(logging.INFO):
+        r1 = sm.run(tot, "q")
+        r2 = sm.run(tot, "q")
+        r3 = sm.run(tot, "q")
+    assert r1 == r2 == r3
+    assert r1["route"] == route
+    assert r1["phases"] == phases
+    assert r1["reason"] == reason
+    assert set(r1.keys()) == EXPECTED_KEYS
+    assert any("safe_out_phase" in rec.message for rec in caplog.records)

--- a/tests/reasoning/test_tot_entrypoint_with_policy.py
+++ b/tests/reasoning/test_tot_entrypoint_with_policy.py
@@ -31,5 +31,7 @@ def test_tree_of_thought_policy(monkeypatch, caplog, enable_cot):
             enable_cot_fallback=enable_cot,
         )
     assert result["route"] == ("cot_fallback" if enable_cot else "best_effort")
+    assert result["phases"] == ["init", "assess", "fallback", "finalize"]
+    assert "init->assess" in result["notes"]
     assert json.dumps(result)
-    assert any("safe_out_decision" in r.message for r in caplog.records)
+    assert any("safe_out_phase" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- introduce `SafeOutStateMachine` with deterministic phases, structured recovery and JSONL logging
- integrate state machine with `_tree_of_thought` entrypoint and thin `SafeOutPolicy`
- document SAFE-OUT v1.1, update changelog, and add comprehensive tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be1133ccd88329bc8babbaa8c127d4