### PR TITLE
Integrate replay and telemetry observability with regression tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,4 +23,11 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-json
-exclude: '^(artifacts|telemetry|logs|\.venv|\.ruff_cache|\.pytest_cache)/'
+  - repo: local
+    hooks:
+      - id: regression-tests
+        name: regression tests
+        entry: pytest -q tests/regression
+        language: system
+        pass_filenames: false
+ exclude: '^(artifacts|telemetry|logs|\.venv|\.ruff_cache|\.pytest_cache)/'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,3 +5,9 @@
 - Run `ruff check alpha`.
 - Add or adjust tests for new code.
 - Follow the PR template (summary, tests, docs).
+
+## Observability workflows
+
+- Use `alpha-solver-v91-python.py --record <session>` to capture replay sessions.
+- Validate deterministic output with `--replay <session>`.
+- Benchmarks write JSON/Markdown to `artifacts/benchmarks/`.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ python -m alpha.executors.math_exec "2+2"
 
 ## Using Tree-of-Thought
 
+### Observability & Replay
+
+`alpha-solver-v91-python.py` exposes optional observability flags:
+
+```bash
+python alpha-solver-v91-python.py "demo" --record mysession
+python alpha-solver-v91-python.py "demo" --replay mysession --strict-accessibility
+```
+
+Logs can be redirected with `--log-path` and telemetry sent via `--telemetry-endpoint`.
+
 ```python
 from alpha_solver_entry import _tree_of_thought
 result = _tree_of_thought("solve x")

--- a/alpha-solver-v91-python.py
+++ b/alpha-solver-v91-python.py
@@ -1,5 +1,6 @@
 """Alpha Solver v91 entrypoints."""
 
+from alpha.core.observability import ObservabilityConfig
 from alpha.solver.observability import AlphaSolver
 
 
@@ -26,11 +27,25 @@ def _tree_of_thought(
         "checker",
         "calculator",
     ),
+    replay: str | None = None,
+    record: str | None = None,
+    strict_accessibility: bool = False,
+    log_path: str | None = None,
+    telemetry_endpoint: str | None = None,
 ) -> dict:
     """Solve ``query`` via deterministic Tree-of-Thought reasoning."""
 
-    solver = AlphaSolver()
-    return solver.solve(
+    cfg = ObservabilityConfig.load()
+    if log_path:
+        cfg.log_path = log_path
+    if telemetry_endpoint:
+        cfg.enable_telemetry = True
+        cfg.telemetry_endpoint = telemetry_endpoint
+    from alpha.core.observability import ObservabilityManager
+
+    obs = ObservabilityManager(cfg, replay_session=replay)
+    solver = AlphaSolver(observability=obs)
+    envelope = solver.solve(
         query,
         seed=seed,
         branching_factor=branching_factor,
@@ -49,6 +64,39 @@ def _tree_of_thought(
         enable_agents_v12=enable_agents_v12,
         agents_v12_order=agents_v12_order,
     )
+    a11y = solver.observability.check_text(envelope.get("solution", ""))
+    if strict_accessibility and a11y and not a11y.get("ok", True):
+        raise ValueError("accessibility check failed")
+    envelope["accessibility"] = a11y
+    session_id = solver.observability.close(record)
+    if session_id:
+        envelope.setdefault("diagnostics", {})["replay_session"] = session_id
+    return envelope
+
+
+def main() -> None:  # pragma: no cover - simple CLI
+    import argparse, json
+
+    ap = argparse.ArgumentParser()
+    ap.add_argument("query")
+    ap.add_argument("--replay")
+    ap.add_argument("--record")
+    ap.add_argument("--strict-accessibility", action="store_true")
+    ap.add_argument("--log-path")
+    ap.add_argument("--telemetry-endpoint")
+    args = ap.parse_args()
+    result = _tree_of_thought(
+        args.query,
+        replay=args.replay,
+        record=args.record,
+        strict_accessibility=args.strict_accessibility,
+        log_path=args.log_path,
+        telemetry_endpoint=args.telemetry_endpoint,
+    )
+    print(json.dumps(result))
 
 
 __all__ = ["_tree_of_thought", "AlphaSolver"]
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/alpha/core/benchmark.py
+++ b/alpha/core/benchmark.py
@@ -1,15 +1,24 @@
 from __future__ import annotations
+
+"""Simple performance benchmarking utilities."""
+
 import json
+import resource
 import time
 from pathlib import Path
-from typing import Callable, Iterable, Dict
-
-import resource
+from typing import Callable, Dict, Iterable
 
 
 def benchmark(
-    fn: Callable[[str], None], queries: Iterable[str], out_dir: str | Path = "artifacts/benchmarks"
+    fn: Callable[[str], None],
+    queries: Iterable[str],
+    out_dir: str | Path = "artifacts/benchmarks",
+    *,
+    with_replay: bool = False,
+    with_telemetry: bool = False,
 ) -> Dict[str, float]:
+    """Run ``fn`` over ``queries`` and export JSON/Markdown summaries."""
+
     out_p = Path(out_dir)
     out_p.mkdir(parents=True, exist_ok=True)
     results = []
@@ -24,6 +33,15 @@ def benchmark(
         "total_time": sum(r["elapsed"] for r in results),
         "max_mem": max((r["mem"] for r in results), default=0),
     }
-    with (out_p / "benchmark.json").open("w", encoding="utf-8") as f:
-        json.dump({"results": results, **summary}, f, indent=2)
+    data = {"results": results, **summary, "replay": with_replay, "telemetry": with_telemetry}
+    (out_p / "benchmark.json").write_text(json.dumps(data, indent=2), encoding="utf-8")
+    md = ["|query|elapsed|mem|", "|---|---|---|"]
+    for r in results:
+        md.append(f"|{r['query']}|{r['elapsed']:.4f}|{r['mem']}|")
+    md.append(f"\nTotal time: {summary['total_time']:.4f}s  Max mem: {summary['max_mem']}")
+    (out_p / "benchmark.md").write_text("\n".join(md), encoding="utf-8")
     return summary
+
+
+__all__ = ["benchmark"]
+

--- a/alpha/core/observability.py
+++ b/alpha/core/observability.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 import asyncio
 import json
+import uuid
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -32,8 +34,14 @@ class ObservabilityConfig:
 
 
 class ObservabilityManager:
-    def __init__(self, config: ObservabilityConfig | None = None):
+    def __init__(
+        self,
+        config: ObservabilityConfig | None = None,
+        *,
+        replay_session: str | None = None,
+    ):
         self.config = config or ObservabilityConfig.load()
+        self.session_id = uuid.uuid4().hex
         self.logger: Optional[JSONLLogger] = None
         if self.config.enable_logging:
             self.logger = JSONLLogger(self.config.log_path)
@@ -52,16 +60,26 @@ class ObservabilityManager:
         self.replay: Optional[ReplayHarness] = None
         if self.config.enable_replay:
             self.replay = ReplayHarness(self.config.replay_dir)
+            if replay_session:
+                self.replay.load_for_replay(replay_session)
 
         self.accessibility: Optional[AccessibilityChecker] = None
         if self.config.enable_accessibility:
             self.accessibility = AccessibilityChecker.from_config()
+        self._a11y_reports: list[Dict[str, Any]] = []
 
     def log_event(self, event: Dict[str, Any]) -> None:
-        if self.logger:
-            self.logger.log(event)
+        payload = {
+            "session_id": self.session_id,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "version": 1,
+            **event,
+        }
         if self.replay:
-            self.replay.record(event)
+            self.replay.verify(payload)
+            self.replay.record(payload)
+        if self.logger:
+            self.logger.log(payload)
 
     async def emit_telemetry(self, event: Dict[str, Any]) -> None:
         if self.telemetry:
@@ -69,15 +87,33 @@ class ObservabilityManager:
 
     def check_text(self, text: str) -> Optional[Dict[str, Any]]:
         if self.accessibility:
-            return self.accessibility.check_text(text)
+            result = self.accessibility.check_text(text)
+            self._a11y_reports.append({"text": text, **result})
+            return result
         return None
 
-    def close(self) -> Optional[str]:
+    def export_accessibility(self, base_path: str | Path = "artifacts/reports") -> None:
+        if not self._a11y_reports:
+            return
+        p = Path(base_path)
+        p.mkdir(parents=True, exist_ok=True)
+        json_path = p / "accessibility.json"
+        csv_path = p / "accessibility.csv"
+        with json_path.open("w", encoding="utf-8") as f:
+            json.dump(self._a11y_reports, f)
+        with csv_path.open("w", encoding="utf-8") as f:
+            f.write("readability,ok\n")
+            for item in self._a11y_reports:
+                f.write(f"{item['readability']},{int(item['ok'])}\n")
+
+    def close(self, session_id: str | None = None) -> Optional[str]:
         if self.logger:
             self.logger.close()
         if self.telemetry:
             asyncio.run(self.telemetry.close())
-        session_id: Optional[str] = None
         if self.replay:
-            session_id = self.replay.save()
-        return session_id
+            sid = self.replay.save(session_id)
+        else:
+            sid = None
+        self.export_accessibility()
+        return sid

--- a/alpha/core/replay.py
+++ b/alpha/core/replay.py
@@ -4,7 +4,7 @@ import json
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, Iterable, List
+from typing import Dict, Iterable, Iterator, List, Optional
 
 
 @dataclass
@@ -18,12 +18,13 @@ class ReplayHarness:
         self.base_dir = Path(base_dir)
         self.base_dir.mkdir(parents=True, exist_ok=True)
         self.events: List[Dict[str, object]] = []
+        self._replay_iter: Optional[Iterator[Dict[str, object]]] = None
 
     def record(self, event: Dict[str, object]) -> None:
         self.events.append(event)
 
-    def save(self) -> str:
-        session_id = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    def save(self, session_id: str | None = None) -> str:
+        session_id = session_id or datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
         path = self.base_dir / f"{session_id}.jsonl.gz"
         with gzip.open(path, "wt", encoding="utf-8") as f:
             for ev in self.events:
@@ -34,6 +35,24 @@ class ReplayHarness:
         path = self.base_dir / f"{session_id}.jsonl.gz"
         events = [json.loads(line) for line in gzip.open(path, "rt", encoding="utf-8")]
         return ReplaySession(session_id=session_id, events=events)
+
+    def load_for_replay(self, session_id: str) -> None:
+        session = self.load(session_id)
+        self._replay_iter = iter(session.events)
+
+    def verify(self, event: Dict[str, object]) -> None:
+        if self._replay_iter is None:
+            return
+        expected = next(self._replay_iter, None)
+        if expected is None:
+            return
+        ignore = {"timestamp", "session_id"}
+        exp = {k: v for k, v in expected.items() if k not in ignore}
+        cur = {k: v for k, v in event.items() if k not in ignore}
+        exp_norm = json.loads(json.dumps(exp, sort_keys=True))
+        cur_norm = json.loads(json.dumps(cur, sort_keys=True))
+        if exp_norm != cur_norm:
+            raise AssertionError("Replay mismatch")
 
     def replay(self, session: ReplaySession) -> Iterable[Dict[str, object]]:
         for ev in session.events:

--- a/tests/observability/conftest.py
+++ b/tests/observability/conftest.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import pytest
+
+from alpha.core.observability import ObservabilityManager
+
+
+@pytest.fixture
+def check_accessibility() -> ObservabilityManager:
+    """Provide an ObservabilityManager with accessibility checking enabled."""
+
+    cfg = ObservabilityManager().config
+    cfg.enable_accessibility = True
+    return ObservabilityManager(cfg)
+

--- a/tests/observability/test_observability.py
+++ b/tests/observability/test_observability.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+"""Regression tests for observability and replay features."""
+
+import pytest
+
+from alpha.core.telemetry import validate_event
+from alpha.policy.safe_out_sm import SOConfig, SafeOutStateMachine
+from alpha.reasoning.tot import TreeOfThoughtSolver
+from alpha_solver_entry import _tree_of_thought
+
+
+def test_safe_out_threshold_edge_case() -> None:
+    cfg = SOConfig(low_conf_threshold=0.6)
+    sm = SafeOutStateMachine(cfg)
+    env = sm.run({"answer": "ok", "confidence": 0.6}, "q")
+    assert env["route"] == "tot"
+
+
+def test_safe_out_fallback_route() -> None:
+    cfg = SOConfig(low_conf_threshold=0.8, enable_cot_fallback=False)
+    sm = SafeOutStateMachine(cfg)
+    env = sm.run({"answer": "ok", "confidence": 0.1}, "q")
+    assert env["route"] == "best_effort"
+
+
+def test_tot_pruning_max_nodes() -> None:
+    solver = TreeOfThoughtSolver(max_nodes=1, max_depth=2)
+    res = solver.solve("hi")
+    assert solver._explored_nodes <= 1
+    assert "answer" in res
+
+
+def test_replay_determinism(tmp_path) -> None:
+    env1 = _tree_of_thought("demo", record="sess", log_path=str(tmp_path / "log1.jsonl"))
+    sid = env1["diagnostics"]["replay_session"]
+    env2 = _tree_of_thought("demo", replay=sid, log_path=str(tmp_path / "log2.jsonl"))
+    assert env2["solution"] == env1["solution"]
+    assert env2["diagnostics"]["replay_session"]
+
+
+def test_telemetry_schema_validator() -> None:
+    event = {
+        "session_id": "s",
+        "event": "x",
+        "timestamp": "t",
+        "version": 1,
+        "data": {},
+    }
+    assert validate_event(event)
+
+
+def test_telemetry_schema_validator_missing() -> None:
+    with pytest.raises(ValueError):
+        validate_event({"event": "x"})
+
+
+def test_strict_accessibility_failure(monkeypatch) -> None:
+    from alpha.core.observability import ObservabilityManager
+
+    def bad_check(self, text):
+        return {"readability": 0, "ok": False}
+
+    monkeypatch.setattr(ObservabilityManager, "check_text", bad_check)
+    with pytest.raises(ValueError):
+        _tree_of_thought("demo", strict_accessibility=True)
+


### PR DESCRIPTION
## Summary
- Wire ReplayHarness and session metadata into ObservabilityManager, with optional replay verification and accessibility reporting
- Add CLI flags for replay, recording, telemetry and strict accessibility in `_tree_of_thought`
- Export benchmark summaries to JSON/Markdown and validate telemetry schema
- Expand regression tests covering SAFE-OUT edges, ToT pruning, replay determinism and telemetry schema

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be6963d3448329bf685f5d56d6734a