### PR TITLE
MVP Hardening: Scorers + Cache + Eval + Accounting + Governance + Config + Telemetry v1 + CLI + Web Viz (deterministic)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,14 @@
 - SAFE-OUT v1.2 with reasons, evidence and recovery notes.
 - Config defaults and loader with env/CLI layering.
 - Telemetry schema v1 with validation helper and tiny web viz.
+- Pluggable path scorers with registry and composite weights.
+- Persistent JSON cache for Tree-of-Thought.
+- Lightweight accounting of expansions and simulated tokens.
 
 ### Changed
 - `_tree_of_thought` entrypoint now surfaces router and agent diagnostics and exposes new flags.
 - AlphaSolver v2.2.6 P3 moved to `alpha.solver.observability` and is wrapped by the single `alpha-solver-v91-python` entrypoint.
+- Diagnostics now include scorer details, config snapshot and accounting summary.
 
 ## [2025-09-09]
 ### Added

--- a/README.md
+++ b/README.md
@@ -90,8 +90,21 @@ _tree_of_thought(
     router_min_progress: float = 0.3,
     enable_agents_v12: bool = False,
     agents_v12_order: tuple[str, ...] = ("decomposer", "checker", "calculator"),
+    scorer: str = "composite",
+    scorer_weights: dict[str, float] | None = None,
+    enable_cache: bool = True,
+    cache_path: str | None = None,
 ) -> dict
 ```
+
+Configuration highlights:
+
+| key | default | description |
+|---|---|---|
+| `scorer` | `"composite"` | Path scoring strategy (`lexical`, `constraint`, `composite`). |
+| `scorer_weights` | `{\"lexical\": 0.6, \"constraint\": 0.4}` | Weights for composite scorer. |
+| `enable_cache` | `True` | Enable persistent ToT cache. |
+| `cache_path` | `artifacts/cache/tot_cache.json` | Location for cache file. |
 
 ### Safety: Low-Confidence Fallback (SAFE-OUT)
 

--- a/alpha/config/defaults.py
+++ b/alpha/config/defaults.py
@@ -24,5 +24,9 @@ DEFAULT_CONFIG: Dict[str, Any] = {
     "router_escalation": ("basic", "structured", "constrained"),
     "enable_agents_v12": False,
     "agents_v12_order": ("decomposer", "checker", "calculator"),
+    "scorer": "composite",
+    "scorer_weights": {"lexical": 0.6, "constraint": 0.4},
+    "enable_cache": True,
+    "cache_path": "artifacts/cache/tot_cache.json",
 }
 

--- a/alpha/config/loader.py
+++ b/alpha/config/loader.py
@@ -18,6 +18,13 @@ def _coerce(value: str, target: Any) -> Any:
         return value.lower() in {"1", "true", "yes"}
     if isinstance(target, tuple):
         return tuple(v.strip() for v in value.split(",") if v.strip())
+    if isinstance(target, dict):
+        import json
+
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            return target
     return type(target)(value)
 
 

--- a/alpha/observability/__init__.py
+++ b/alpha/observability/__init__.py
@@ -1,0 +1,1 @@
+"""Observability helpers."""

--- a/alpha/observability/accounting.py
+++ b/alpha/observability/accounting.py
@@ -1,0 +1,37 @@
+"""Lightweight deterministic accounting utilities."""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass
+
+_DETERMINISTIC = os.getenv("ALPHA_DETERMINISM") == "1"
+
+
+@dataclass
+class Accountant:
+    """Track expansions and simulated token counts."""
+
+    expansions: int = 0
+    sim_tokens: int = 0
+    start: float = 0.0 if _DETERMINISTIC else time.time()
+
+    def record(self, text: str) -> None:
+        """Record an expansion for ``text``."""
+
+        self.expansions += 1
+        self.sim_tokens += len(text.split())
+
+    def summary(self) -> dict:
+        """Return a summary dictionary."""
+
+        elapsed = 0.0 if _DETERMINISTIC else time.time() - self.start
+        return {
+            "expansions": self.expansions,
+            "sim_tokens": self.sim_tokens,
+            "elapsed_ms": int(elapsed * 1000),
+        }
+
+
+__all__ = ["Accountant"]

--- a/alpha/reasoning/cache.py
+++ b/alpha/reasoning/cache.py
@@ -1,0 +1,52 @@
+"""Deterministic JSON-backed cache for Tree-of-Thought."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Dict, Any
+
+_DETERMINISTIC = os.getenv("ALPHA_DETERMINISM") == "1"
+
+
+def load_cache(path: str) -> Dict[str, Any]:
+    """Load cache from ``path`` if it exists."""
+
+    p = Path(path)
+    if p.exists():
+        try:
+            with p.open("r", encoding="utf-8") as fh:
+                return json.load(fh)
+        except json.JSONDecodeError:  # pragma: no cover - corrupt file
+            return {}
+    return {}
+
+
+def save_cache(cache: Dict[str, Any], path: str) -> None:
+    """Persist ``cache`` to ``path`` creating directories as needed."""
+
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("w", encoding="utf-8") as fh:
+        json.dump(cache, fh, indent=2, sort_keys=True)
+        fh.write("\n")
+
+
+def make_key(query: str, depth: int, branch_path: tuple[str, ...], context_hash: str) -> str:
+    """Return a deterministic cache key."""
+
+    stable = json.dumps([query, depth, list(branch_path), context_hash], sort_keys=True)
+    return hashlib.sha256(stable.encode("utf-8")).hexdigest()
+
+
+def get(cache: Dict[str, Any], key: str) -> Any:
+    return cache.get(key)
+
+
+def put(cache: Dict[str, Any], key: str, value: Any) -> None:
+    cache[key] = value
+
+
+__all__ = ["load_cache", "save_cache", "make_key", "get", "put"]

--- a/alpha/reasoning/scoring.py
+++ b/alpha/reasoning/scoring.py
@@ -1,0 +1,76 @@
+"""Deterministic path scoring utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Protocol, Callable
+
+
+class PathScorer(Protocol):
+    """Protocol for pluggable path scorers."""
+
+    def score(self, *, node_text: str, context: Dict[str, object]) -> float:  # pragma: no cover - protocol
+        ...
+
+
+@dataclass
+class LexicalScorer:
+    """Simple lexical keyword based scorer.
+
+    The score combines relevance of ``node_text`` to ``context['query_tokens']``
+    and a depth based progress term.  The combined score is normalised to
+    ``[0, 1]``.
+    """
+
+    def score(self, *, node_text: str, context: Dict[str, object]) -> float:
+        tokens = set(str(node_text).lower().split())
+        query_tokens = set(context.get("query_tokens", set()))
+        relevance = len(tokens & query_tokens) / max(len(query_tokens), 1)
+        depth = int(context.get("depth", 0))
+        max_depth = int(context.get("max_depth", 1))
+        progress = max(0.0, 1 - (depth / max(max_depth, 1)))
+        raw = 0.4 * relevance + 0.3 * progress
+        return round(max(0.0, min(1.0, raw / 0.7 if 0.7 else raw)), 3)
+
+
+@dataclass
+class ConstraintScorer:
+    """Penalty scorer that checks for obvious contradictions."""
+
+    negatives: tuple[str, ...] = ("contradiction", "inconsistent", "impossible")
+
+    def score(self, *, node_text: str, context: Dict[str, object]) -> float:
+        text = str(node_text).lower()
+        return 0.0 if any(term in text for term in self.negatives) else 1.0
+
+
+@dataclass
+class CompositeScorer:
+    """Weighted composite over registered scorers."""
+
+    weights: Dict[str, float]
+
+    def score(self, *, node_text: str, context: Dict[str, object]) -> float:
+        total = 0.0
+        for name, weight in self.weights.items():
+            if name == "composite":
+                continue
+            factory = SCORERS.get(name)
+            if not factory:
+                continue
+            scorer = factory() if callable(factory) else factory
+            total += weight * scorer.score(node_text=node_text, context=context)
+        return round(max(0.0, min(1.0, total)), 3)
+
+
+# Registry of scorer factories
+SCORERS: Dict[str, Callable[..., PathScorer]] = {
+    "lexical": LexicalScorer,
+    "constraint": ConstraintScorer,
+    "composite": lambda weights=None: CompositeScorer(
+        weights or {"lexical": 0.6, "constraint": 0.4}
+    ),
+}
+
+
+__all__ = ["PathScorer", "SCORERS", "LexicalScorer", "ConstraintScorer", "CompositeScorer"]

--- a/tests/observability/test_accounting.py
+++ b/tests/observability/test_accounting.py
@@ -1,0 +1,9 @@
+from alpha_solver_entry import _tree_of_thought
+
+
+def test_accounting_summary_present():
+    res = _tree_of_thought("impossible question", score_threshold=0.9)
+    summary = res.get("run_summary", {}).get("accounting", {})
+    assert summary["expansions"] >= 0
+    assert summary["sim_tokens"] >= 0
+    assert "elapsed_ms" in summary

--- a/tests/reasoning/test_scorers.py
+++ b/tests/reasoning/test_scorers.py
@@ -1,0 +1,26 @@
+from alpha.reasoning.scoring import SCORERS, CompositeScorer
+
+
+def test_lexical_scorer_deterministic():
+    scorer = SCORERS["lexical"]()
+    ctx = {"query_tokens": {"solve", "x"}, "depth": 1, "max_depth": 5}
+    s1 = scorer.score(node_text="solve x", context=ctx)
+    s2 = scorer.score(node_text="solve x", context=ctx)
+    assert 0 <= s1 <= 1
+    assert s1 == s2
+
+
+def test_constraint_scorer_penalty():
+    scorer = SCORERS["constraint"]()
+    ctx = {}
+    ok = scorer.score(node_text="all good", context=ctx)
+    bad = scorer.score(node_text="impossible case", context=ctx)
+    assert ok == 1.0 and bad == 0.0
+
+
+def test_composite_weights_and_rounding():
+    comp = CompositeScorer({"lexical": 0.5, "constraint": 0.5})
+    ctx = {"query_tokens": {"a"}, "depth": 0, "max_depth": 1}
+    score = comp.score(node_text="a", context=ctx)
+    assert isinstance(score, float)
+    assert round(score, 3) == score

--- a/tests/reasoning/test_tot_cache.py
+++ b/tests/reasoning/test_tot_cache.py
@@ -1,0 +1,19 @@
+from alpha_solver_entry import _tree_of_thought
+
+
+def test_tot_cache_reduces_exploration(tmp_path):
+    cache_file = tmp_path / "cache.json"
+    result1 = _tree_of_thought(
+        "impossible question",
+        score_threshold=0.9,
+        cache_path=str(cache_file),
+    )
+    explored1 = result1["diagnostics"]["tot"]["explored_nodes"]
+    result2 = _tree_of_thought(
+        "impossible question",
+        score_threshold=0.9,
+        cache_path=str(cache_file),
+    )
+    explored2 = result2["diagnostics"]["tot"]["explored_nodes"]
+    assert explored1 > explored2
+    assert cache_file.exists()

--- a/tests/reasoning/test_tot_scorer_integration.py
+++ b/tests/reasoning/test_tot_scorer_integration.py
@@ -1,0 +1,14 @@
+from alpha.reasoning.tot import TreeOfThoughtSolver
+
+
+def test_tot_default_composite():
+    solver = TreeOfThoughtSolver()
+    res = solver.solve("solve x")
+    assert res["answer"] == "solve x"
+    assert res["confidence"] == 1.0
+
+
+def test_tot_lexical_only():
+    solver = TreeOfThoughtSolver(scorer="lexical")
+    res = solver.solve("impossible question")
+    assert res["confidence"] <= 1.0


### PR DESCRIPTION
## Summary
- add pluggable deterministic path scorers with composite weighting
- introduce persistent JSON cache and lightweight accounting
- wire scorer diagnostics and caching/config flags into entrypoint and solver

## Testing
- `ruff check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be8d9c6574832993e8a80a4ca0935d