### PR TITLE
Handle missing PyYAML for quality gate configuration

### DIFF
--- a/alpha/core/config.py
+++ b/alpha/core/config.py
@@ -3,7 +3,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
 import os
+
+try:  # pragma: no cover - exercised in tests
+    import yaml  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover
+    yaml = None
 
 
 @dataclass
@@ -23,4 +30,59 @@ class APISettings:
     version: str = os.getenv("ALPHA_SOLVER_VERSION", "0.0.0")
 
 
-__all__ = ["APISettings"]
+@dataclass
+class QualityGateConfig:
+    """Simple configuration used for quality gating."""
+
+    min_score: float = 0.0
+    max_latency_ms: int = 1000
+
+
+def _parse_simple_yaml(text: str) -> dict[str, Any]:
+    """Parse a minimal subset of YAML (``key: value`` pairs)."""
+
+    data: dict[str, Any] = {}
+    for raw in text.splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line or ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        value = value.strip().strip('"\'')
+        if value.lower() in {"true", "false"}:
+            parsed: Any = value.lower() == "true"
+        else:
+            try:
+                parsed = int(value)
+            except ValueError:
+                try:
+                    parsed = float(value)
+                except ValueError:
+                    parsed = value
+        data[key.strip()] = parsed
+    return data
+
+
+def get_quality_gate(path: Path | str = Path("config/quality_gate.yaml")) -> QualityGateConfig:
+    """Load the quality gate configuration.
+
+    Falls back to a minimal parser if :mod:`yaml` is unavailable. Missing files
+    or parsing errors simply return the default configuration.
+    """
+
+    path = Path(path)
+    defaults = QualityGateConfig()
+    try:
+        text = path.read_text(encoding="utf-8")
+        if yaml is not None:
+            loaded = yaml.safe_load(text) or {}
+        else:
+            loaded = _parse_simple_yaml(text)
+    except Exception:
+        loaded = {}
+    return QualityGateConfig(
+        min_score=float(loaded.get("min_score", defaults.min_score)),
+        max_latency_ms=int(loaded.get("max_latency_ms", defaults.max_latency_ms)),
+    )
+
+
+__all__ = ["APISettings", "QualityGateConfig", "get_quality_gate"]

--- a/config/quality_gate.yaml
+++ b/config/quality_gate.yaml
@@ -1,0 +1,2 @@
+min_score: 0.75
+max_latency_ms: 500

--- a/tests/test_quality_gate_config.py
+++ b/tests/test_quality_gate_config.py
@@ -1,0 +1,33 @@
+import importlib
+import builtins
+
+import pytest
+
+from alpha.core.config import get_quality_gate, QualityGateConfig
+
+
+def test_get_quality_gate_with_yaml():
+    pytest.importorskip('yaml')
+    cfg = get_quality_gate()
+    assert isinstance(cfg, QualityGateConfig)
+    assert cfg.min_score == pytest.approx(0.75)
+    assert cfg.max_latency_ms == 500
+
+
+def test_get_quality_gate_without_yaml(monkeypatch):
+    import alpha.core.config as cfg_module
+
+    original_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == 'yaml':
+            raise ModuleNotFoundError
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, '__import__', fake_import)
+    cfg_module = importlib.reload(cfg_module)
+    assert cfg_module.yaml is None
+    cfg = cfg_module.get_quality_gate()
+    assert isinstance(cfg, cfg_module.QualityGateConfig)
+    assert cfg.min_score == pytest.approx(0.75)
+    assert cfg.max_latency_ms == 500


### PR DESCRIPTION
## Summary
- add fallback import for `yaml` in config module
- parse `config/quality_gate.yaml` even when PyYAML is missing
- cover quality gate configuration with unit tests for both import scenarios

## Testing
- `pytest tests/test_quality_gate_config.py`

------
https://chatgpt.com/codex/tasks/task_e_68bf381f385c8329beefab271e33de2d