### PR TITLE
fix quality gate CLI test

### DIFF
--- a/tests/test_quality_gate_cli.py
+++ b/tests/test_quality_gate_cli.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# Compute the repository root without resolving symlinks
+ROOT = Path(__file__).parent.parent
+
+
+def _run(code: str) -> str:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(ROOT)
+    cmd = [sys.executable, "-c", code]
+    return subprocess.check_output(cmd, env=env, text=True)
+
+
+def test_quality_gate_cli_imports_alpha() -> None:
+    out = _run("import alpha.core.config as c; print(c.__name__)")
+    assert out.strip() == "alpha.core.config"


### PR DESCRIPTION
## Summary
- add quality gate CLI test that computes repository root without resolving symlinks
- ensure helper uses stringified root in PYTHONPATH

## Testing
- `pytest -q`
- `pytest tests/cli/test_alpha_solver_cli.py -q`
- `python test_alpha_solver_smoke.py > /tmp/smoke.log && tail -n 20 /tmp/smoke.log`


------
https://chatgpt.com/codex/tasks/task_e_68bf478c80608329bb2206deaa86f634