### PR TITLE
chore(devcontainer): install pre-commit reliably in Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,8 +7,8 @@
     "NO_PROXY": "localhost,127.0.0.1"
   },
   "postCreateCommand": "bash .devcontainer/postCreate.sh",
-  "postAttachCommand": "bash .devcontainer/postCreate.sh",
-  "remoteEnv": { "PATH": "${containerEnv:PATH}:/home/codespace/.local/bin:/home/codespace/.venvs/precommit/bin" },
+  "postAttachCommand": "pre-commit --version >/dev/null 2>&1 || true",
+  "remoteEnv": { "PATH": "/home/codespace/.venvs/precommit/bin:/home/codespace/.local/bin:${containerEnv:PATH}" },
   "customizations": {
     "vscode": {
       "settings": {

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -1,31 +1,52 @@
 #!/usr/bin/env bash
-# Safe, idempotent setup for pre-commit via an isolated venv
+# Reliable, idempotent setup for pre-commit via an isolated venv
 set -u  # don't use -e so Codespaces won't fall into recovery on transient errors
 
-# Ensure PATH includes our shims/venv now and later
-export PATH="$HOME/.local/bin:$HOME/.venvs/precommit/bin:$PATH"
-grep -qxF 'export PATH="$HOME/.local/bin:$HOME/.venvs/precommit/bin:$PATH"' ~/.bashrc  || echo 'export PATH="$HOME/.local/bin:$HOME/.venvs/precommit/bin:$PATH"' >> ~/.bashrc
-grep -qxF 'export PATH="$HOME/.local/bin:$HOME/.venvs/precommit/bin:$PATH"' ~/.profile || echo 'export PATH="$HOME/.local/bin:$HOME/.venvs/precommit/bin:$PATH"' >> ~/.profile
+VENV="$HOME/.venvs/precommit"
+STAMP=".devcontainer/last_setup.txt"
+
+# Ensure PATH includes our venv and user bin directories now and later
+export PATH="$VENV/bin:$HOME/.local/bin:$PATH"
+grep -qxF "export PATH=\"$VENV/bin:$HOME/.local/bin:\$PATH\"" ~/.bashrc  || echo "export PATH=\"$VENV/bin:$HOME/.local/bin:\$PATH\"" >> ~/.bashrc
+grep -qxF "export PATH=\"$VENV/bin:$HOME/.local/bin:\$PATH\"" ~/.profile || echo "export PATH=\"$VENV/bin:$HOME/.local/bin:\$PATH\"" >> ~/.profile
 
 # Avoid pip env quirks that break console_scripts
 unset PIP_TARGET PIP_PREFIX PYTHONUSERBASE || true
 
-# Create the venv if missing and install/upgrade pre-commit
-if [ ! -x "$HOME/.venvs/precommit/bin/python" ]; then
-  python -m venv "$HOME/.venvs/precommit" || true
+# Proxy-aware pip config
+if [ -n "${HTTPS_PROXY:-${HTTP_PROXY:-}}" ]; then
+  mkdir -p "$HOME/.pip"
+  {
+    echo "[global]"
+    echo "proxy = ${HTTPS_PROXY:-${HTTP_PROXY}}"
+  } > "$HOME/.pip/pip.conf"
 fi
-"$HOME/.venvs/precommit/bin/python" -m pip install --upgrade pip wheel pre-commit >/dev/null 2>&1 || true
+
+# Install pre-commit if needed with wheel fallbacks
+if ! "$VENV/bin/pre-commit" --version 2>/dev/null | grep -q '^pre-commit 4.3.0'; then
+  python -m venv "$VENV" >/dev/null 2>&1 || true
+  "$VENV/bin/python" -m pip install --upgrade pip wheel >/dev/null 2>&1 || true
+  if ! "$VENV/bin/python" -m pip install pre-commit==4.3.0 >/dev/null 2>&1; then
+    if ! "$VENV/bin/python" -m pip install ".devcontainer/assets/pre_commit-4.3.0-py3-none-any.whl" >/dev/null 2>&1; then
+      "$VENV/bin/python" -m pip install "https://github.com/pre-commit/pre-commit/releases/download/v4.3.0/pre_commit-4.3.0-py3-none-any.whl" >/dev/null 2>&1 || true
+    fi
+  fi
+fi
 
 # Shim (idempotent)
 mkdir -p "$HOME/.local/bin"
-ln -sf "$HOME/.venvs/precommit/bin/pre-commit" "$HOME/.local/bin/pre-commit"
+ln -sf "$VENV/bin/pre-commit" "$HOME/.local/bin/pre-commit"
 
-# Register hooks; don't fail the container on lint issues
-"$HOME/.venvs/precommit/bin/pre-commit" install >/dev/null 2>&1 || true
-"$HOME/.venvs/precommit/bin/pre-commit" run --files README.md >/dev/null 2>&1 || true
+# Final checks and hook setup (safe on reruns)
+python -m pre_commit --version || true
+"$VENV/bin/pre-commit" --version || true
+pre-commit install && pre-commit run --files README.md || true
 
 # Breadcrumb
-"$HOME/.venvs/precommit/bin/pre-commit" --version > .devcontainer/last_setup.txt 2>/dev/null || echo "pre-commit not installed" > .devcontainer/last_setup.txt
-echo "setup-complete" >> .devcontainer/last_setup.txt
+{
+  "$VENV/bin/pre-commit" --version 2>/dev/null || echo "pre-commit missing"
+  echo "setup-complete"
+} > "$STAMP"
 
 exit 0
+


### PR DESCRIPTION
## Summary
- ensure PATH includes pre-commit venv
- add proxy-aware, idempotent post-create script with wheel fallback

## Testing
- `pre-commit --version`
- `python -m pre_commit --version`
- `pre-commit run --files README.md`
- `pytest -q`
- `git lfs version`


------
https://chatgpt.com/codex/tasks/task_e_68bfb0d10bc48329891642c3cb027a2f