### PR TITLE
PR-56: API hardening — API-Key auth, basic rate limit, OpenAPI polish, SDK alignment

### DIFF
--- a/clients/python/alpha_client.py
+++ b/clients/python/alpha_client.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, Optional
 class AlphaClient:
     """Minimal HTTP client for the Alpha Solver API."""
 
-    def __init__(self, api_url: str, api_key: str) -> None:
+    def __init__(self, api_url: str, api_key: Optional[str] = None) -> None:
         self.api_url = api_url.rstrip("/")
         self.api_key = api_key
 
@@ -28,7 +28,9 @@ class AlphaClient:
             payload["strategy"] = strategy
         data = json.dumps(payload).encode("utf-8")
         url = f"{self.api_url}/v1/solve"
-        headers = {"Content-Type": "application/json", "X-API-Key": self.api_key}
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["X-API-Key"] = self.api_key
         backoff = 0.5
         for attempt in range(3):
             req = urllib.request.Request(url, data=data, headers=headers)

--- a/docs/api.md
+++ b/docs/api.md
@@ -12,28 +12,33 @@ Once started the service is available at `http://localhost:8000`.
 
 ## Authentication
 
-Requests must include an API key header:
+Requests may include an API key header (default `X-API-Key`). When
+authentication is enabled, only configured keys are accepted. Set
+`SERVICE_AUTH_KEYS=key1,key2` to change the allowed keys or
+`SERVICE_AUTH_ENABLED=false` to disable the check entirely.
 
 ```
-X-API-Key: changeme
+X-API-Key: dev-secret
 ```
-
-Set `API_KEY` environment variable to change the expected key.
 
 ## Rate limiting
 
-Each key is limited to **60 requests per minute**.
+Each API key is limited to **120 requests per 60 seconds** by default. Set
+`SERVICE_RATELIMIT_ENABLED=false` to disable or tune
+`SERVICE_RATELIMIT_WINDOW_SECONDS` and `SERVICE_RATELIMIT_MAX_REQUESTS`. When
+auth is disabled the limit applies per client IP.
 
 ## Example
 
 ```bash
-curl -H "X-API-Key: changeme" \
+curl -H "X-API-Key: dev-secret" \
      -H "Content-Type: application/json" \
      -d '{"query": "hello", "strategy": "react"}' \
      http://localhost:8000/v1/solve
 ```
 
-`strategy` selects the reasoning mode: `cot` (default), `react`, or `tot`. Responses using `react` include a `trace` and `meta` block:
+`strategy` selects the reasoning mode: `cot` (default), `react`, or `tot`.
+Responses using `react` include a `trace` and `meta` block:
 
 ```json
 {
@@ -49,3 +54,4 @@ curl -H "X-API-Key: changeme" \
 * Interactive docs: `http://localhost:8000/docs`
 * OpenAPI JSON: `http://localhost:8000/openapi.json`
 * Prometheus metrics: `http://localhost:8000/metrics`
+

--- a/docs/api.md
+++ b/docs/api.md
@@ -54,4 +54,3 @@ Responses using `react` include a `trace` and `meta` block:
 * Interactive docs: `http://localhost:8000/docs`
 * OpenAPI JSON: `http://localhost:8000/openapi.json`
 * Prometheus metrics: `http://localhost:8000/metrics`
-

--- a/examples/curl/solve_react.sh
+++ b/examples/curl/solve_react.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-curl -s -H "X-API-Key: ${API_KEY:-changeme}" -H "Content-Type: application/json" \
+curl -s -H "X-API-Key: dev-secret" -H "Content-Type: application/json" \
     -d '{"query":"hi","strategy":"react"}' \
     http://localhost:8000/v1/solve | jq .

--- a/fastapi/middleware/cors.py
+++ b/fastapi/middleware/cors.py
@@ -1,0 +1,7 @@
+class CORSMiddleware:
+    def __init__(self, app, **kwargs):
+        self.app = app
+        self.kwargs = kwargs
+
+    async def __call__(self, request, call_next):
+        return await call_next(request)

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -4,3 +4,10 @@ class BaseModel:
             setattr(self, k, v)
     def dict(self):
         return self.__dict__
+
+
+def Field(default=None, **kwargs):
+    return default
+
+
+__all__ = ["BaseModel", "Field"]

--- a/tests/test_api_auth_ratelimit.py
+++ b/tests/test_api_auth_ratelimit.py
@@ -53,4 +53,3 @@ def test_rate_limit_window(monkeypatch):
     now[0] += 61
     resp = client.post("/v1/solve", json={"query": "hi"}, headers=headers)
     assert resp.status_code == 200
-

--- a/tests/test_api_auth_ratelimit.py
+++ b/tests/test_api_auth_ratelimit.py
@@ -1,0 +1,56 @@
+import uuid
+
+from fastapi.testclient import TestClient
+
+from service.app import app, time as service_time
+
+
+def _client():
+    key = str(uuid.uuid4())
+    app.state.config.api_key = key
+    app.state.config.ratelimit.window_seconds = 60
+    app.state.config.ratelimit.max_requests = 2
+    return TestClient(app), key
+
+
+def test_missing_api_key(monkeypatch):
+    client, key = _client()
+    monkeypatch.setattr("service.app._tree_of_thought", lambda *a, **k: {})
+    resp = client.post("/v1/solve", json={"query": "hi"})
+    assert resp.status_code == 401
+    assert resp.json()["final_answer"].startswith("SAFE-OUT")
+
+
+def test_invalid_api_key(monkeypatch):
+    client, key = _client()
+    monkeypatch.setattr("service.app._tree_of_thought", lambda *a, **k: {})
+    resp = client.post("/v1/solve", json={"query": "hi"}, headers={"X-API-Key": "bad"})
+    assert resp.status_code == 401
+
+
+def test_rate_limit_window(monkeypatch):
+    client, key = _client()
+    headers = {"X-API-Key": key}
+
+    # deterministic time progression
+    now = [0.0]
+
+    def _time():
+        return now[0]
+
+    monkeypatch.setattr(service_time, "time", _time)
+    monkeypatch.setattr("service.app._tree_of_thought", lambda *a, **k: {})
+
+    for _ in range(2):
+        resp = client.post("/v1/solve", json={"query": "hi"}, headers=headers)
+        assert resp.status_code == 200
+        now[0] += 1
+
+    resp = client.post("/v1/solve", json={"query": "hi"}, headers=headers)
+    assert resp.status_code == 429
+
+    # advance beyond window, should succeed
+    now[0] += 61
+    resp = client.post("/v1/solve", json={"query": "hi"}, headers=headers)
+    assert resp.status_code == 200
+

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -21,7 +21,12 @@ def test_health_ready_and_openapi():
     client, key = _client()
     assert client.get("/healthz").status_code == 200
     assert client.get("/readyz").status_code == 200
-    assert client.get("/openapi.json").status_code == 200
+    app.state.ready = False
+    assert client.get("/readyz").status_code == 503
+    app.state.ready = True
+    schema = client.get("/openapi.json").json()
+    enum_vals = schema["components"]["schemas"]["SolveRequest"]["properties"]["strategy"]["enum"]
+    assert set(enum_vals) == {"cot", "react", "tot"}
     assert client.get("/metrics").status_code == 200
 
 


### PR DESCRIPTION
## Summary
- add service configuration for API-Key auth, per-key rate limiting and CORS defaults
- enforce optional API-Key authentication and sliding window rate limits; expose health and readiness endpoints with request IDs
- align Python client and docs with X-API-Key header and strategy enum examples

## Testing
- `pytest tests/test_api_auth_ratelimit.py tests/test_api_endpoints.py tests/test_ratelimit.py tests/test_security.py tests/test_cost_tracking.py tests/test_tracing.py`

------
https://chatgpt.com/codex/tasks/task_e_68c0649f6400832995b91a86f460f63d