### PR TITLE
PR-57: Observability hardening — health/ready, Prom metrics, structured logs, prod compose tune

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,19 @@
+# Observability
+
+Run the production stack with Docker Compose:
+
+```bash
+docker compose -f infrastructure/docker-compose.prod.yml up --build
+```
+
+The API exposes health, readiness and Prometheus metrics:
+
+- `curl localhost:9000/healthz`
+- `curl localhost:9000/readyz`
+- `curl localhost:9000/metrics`
+
+Prometheus scrapes the API automatically. Grafana boots with a pre-provisioned
+Prometheus data source and example dashboard. Access them at:
+
+- Prometheus: http://localhost:9090
+- Grafana: http://localhost:3000 (default credentials `admin`/`admin`)

--- a/fastapi/responses.py
+++ b/fastapi/responses.py
@@ -1,3 +1,12 @@
 from . import JSONResponse
 
-__all__ = ["JSONResponse"]
+
+class Response:
+    def __init__(self, content: bytes, media_type: str = "text/plain", status_code: int = 200, headers=None):
+        self.body = content
+        self.media_type = media_type
+        self.status_code = status_code
+        self.headers = headers or {}
+
+
+__all__ = ["JSONResponse", "Response"]

--- a/fastapi/testclient.py
+++ b/fastapi/testclient.py
@@ -12,6 +12,12 @@ class TestResponse:
         if hasattr(self._response, "json"):
             return self._response.json()
         return self._response
+    @property
+    def text(self):  # pragma: no cover - helper for tests
+        body = getattr(self._response, "body", b"")
+        if isinstance(body, (bytes, bytearray)):
+            return body.decode()
+        return str(body)
 
 class TestClient:
     def __init__(self, app: FastAPI):

--- a/infrastructure/docker-compose.prod.yml
+++ b/infrastructure/docker-compose.prod.yml
@@ -8,7 +8,7 @@ services:
       - RATE_LIMIT_PER_MINUTE=60
       - OTEL_ENDPOINT=http://otel-collector:4317
     ports:
-      - "8000:8000"
+      - "9000:8000"
     volumes:
       - ../artifacts:/app/artifacts
       - ../logs:/app/logs
@@ -25,7 +25,7 @@ services:
   prometheus:
     image: prom/prometheus:latest
     volumes:
-      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
     ports:
       - "9090:9090"
   grafana:
@@ -33,6 +33,7 @@ services:
     ports:
       - "3000:3000"
     volumes:
-      - ./grafana/provisioning:/etc/grafana/provisioning
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
     depends_on:
       - prometheus

--- a/infrastructure/grafana/dashboards/alpha.json
+++ b/infrastructure/grafana/dashboards/alpha.json
@@ -1,0 +1,5 @@
+{
+  "title": "Alpha Solver",
+  "panels": [],
+  "uid": "alpha-solver"
+}

--- a/prometheus_client/__init__.py
+++ b/prometheus_client/__init__.py
@@ -1,0 +1,91 @@
+"""Very small subset of the ``prometheus_client`` API used for tests.
+
+This module implements ``Counter`` and ``Histogram`` collectors and a
+``generate_latest`` helper to expose metrics in the Prometheus text format.
+It is intentionally tiny to avoid pulling the real dependency.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List, Tuple
+
+CONTENT_TYPE_LATEST = "text/plain; version=0.0.4; charset=utf-8"
+
+
+_METRICS: List["_Metric"] = []
+
+
+class _Metric:
+    def __init__(self, name: str, doc: str, labelnames: Iterable[str] | None = None):
+        self.name = name
+        self.doc = doc
+        self.labelnames = tuple(labelnames or [])
+        self.samples: Dict[Tuple[str, ...], object] = {}
+        _METRICS.append(self)
+
+    def labels(self, **kwargs):
+        key = tuple(str(kwargs.get(lbl, "")) for lbl in self.labelnames)
+        if key not in self.samples:
+            self.samples[key] = self._init_value()
+        return self._child(self, key)
+
+    def _init_value(self):  # pragma: no cover - overridden
+        return 0
+
+    def _child(self, parent, key):  # pragma: no cover - overridden
+        raise NotImplementedError
+
+
+class Counter(_Metric):
+    class _Child:
+        def __init__(self, parent: "Counter", key: Tuple[str, ...]):
+            self.parent = parent
+            self.key = key
+
+        def inc(self, amount: int = 1) -> None:
+            self.parent.samples[self.key] += amount
+
+    def _child(self, parent, key):
+        return Counter._Child(parent, key)
+
+
+class Histogram(_Metric):
+    class _Child:
+        def __init__(self, parent: "Histogram", key: Tuple[str, ...]):
+            self.parent = parent
+            self.key = key
+
+        def observe(self, value: float) -> None:
+            self.parent.samples[self.key].append(value)
+
+    def _init_value(self):
+        return []
+
+    def _child(self, parent, key):
+        return Histogram._Child(parent, key)
+
+
+def generate_latest() -> bytes:
+    lines: List[str] = []
+    for metric in _METRICS:
+        mtype = "counter" if isinstance(metric, Counter) else "histogram"
+        lines.append(f"# HELP {metric.name} {metric.doc}")
+        lines.append(f"# TYPE {metric.name} {mtype}")
+        for key, value in metric.samples.items():
+            labels = []
+            for name, val in zip(metric.labelnames, key):
+                if val:
+                    labels.append(f'{name}="{val}"')
+            label_str = f"{{{','.join(labels)}}}" if labels else ""
+            val = value if isinstance(metric, Counter) else sum(value)
+            lines.append(f"{metric.name}{label_str} {val}")
+    return "\n".join(lines).encode("utf-8")
+
+
+__all__ = [
+    "Counter",
+    "Histogram",
+    "generate_latest",
+    "CONTENT_TYPE_LATEST",
+]
+

--- a/prometheus_fastapi_instrumentator/__init__.py
+++ b/prometheus_fastapi_instrumentator/__init__.py
@@ -1,13 +1,14 @@
-from fastapi import JSONResponse
+from fastapi.responses import Response
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 
 class Instrumentator:
     def instrument(self, app):
         self.app = app
         return self
-    def expose(self, app):
-        @app.get("/metrics")
+    def expose(self, app, endpoint: str = "/metrics"):
+        @app.get(endpoint)
         async def metrics():
-            return JSONResponse({})
+            return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
         return self
 
 __all__ = ["Instrumentator"]

--- a/tests/test_health_ready.py
+++ b/tests/test_health_ready.py
@@ -1,0 +1,14 @@
+from fastapi.testclient import TestClient
+from service.app import app
+
+
+def test_health_and_ready():
+    client = TestClient(app)
+    r = client.get("/healthz")
+    assert r.status_code == 200
+    app.state.ready = False
+    r = client.get("/readyz")
+    assert r.status_code == 503
+    app.state.ready = True
+    r = client.get("/readyz")
+    assert r.status_code == 200

--- a/tests/test_metrics_smoke.py
+++ b/tests/test_metrics_smoke.py
@@ -1,0 +1,14 @@
+from fastapi.testclient import TestClient
+from service.app import app
+
+
+def test_metrics_smoke():
+    client = TestClient(app)
+    client.get("/healthz")
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+    data = resp.text
+    assert "alpha_request_total" in data
+    assert "alpha_request_latency_ms" in data
+    assert "alpha_rate_limit_total" in data
+    assert "alpha_safe_out_total" in data


### PR DESCRIPTION
## Summary
- instrument telemetry helpers with Prometheus counters and histograms
- emit structured JSON logs and record request/latency/SAFE-OUT metrics in API
- wire compose-prod with Prometheus/Grafana and document health and metrics endpoints

## Testing
- `pytest tests/test_health_ready.py tests/test_metrics_smoke.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c070e8b6808329a8155fd312d66699