### PR TITLE
PR-58: Docs & DevEx polish — Postman, README quickstart, SDK packaging, Release checklist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ telemetry/*.jsonl
 .DS_Store
 bench_out/
 .codespaces/
+clients/python/dist/
+clients/python/*.egg-info/

--- a/README.md
+++ b/README.md
@@ -3,27 +3,32 @@
 Alpha Solver is a lightweight planning and execution engine for tool selection.
 
 
-## MVP Quickstart
+## MVP Quickstart (5 minutes)
 
+### 1) CLI (local)
 ```bash
-# CLI
-pip install -e .
-alpha-solver run --queries "2+2?" --strategy react
+python -m alpha.cli.main solve --strategy react --seed 1337 --prompt "Explain 21*3 with brief rationale and answer."
+```
 
-# SDK
+### 2) Python SDK (local)
+```bash
 pip install -e clients/python
 python - <<'PY'
-from alpha_solver_sdk import AlphaClient
+from alpha_client import AlphaClient
 client = AlphaClient("http://localhost:8000")
-print(client.solve("2+2?", strategy="react"))
+print(client.solve(prompt="Explain 21*3 with brief rationale and answer.", strategy="react"))
 PY
+```
 
-# API
-curl -H "Content-Type: application/json" \
-     -d '{"query":"2+2?","strategy":"react"}' \
-     http://localhost:8000/v1/solve
+### 3) API (HTTP)
+```bash
+curl -X POST http://localhost:8000/v1/solve \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "Explain 21*3 with brief rationale and answer.", "strategy": "react"}'
+```
 
-# Checks
+### 4) Quality gates
+```bash
 make gates
 ```
 

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -9,7 +9,8 @@ pip install -e .
 Usage:
 
 ```python
-from alpha_solver_sdk import AlphaClient
-client = AlphaClient("http://localhost:8000", api_key="changeme")
-print(client.solve("2+2?", strategy="react"))
+from alpha_client import AlphaClient
+
+client = AlphaClient("http://localhost:8000")
+print(client.solve(prompt="Explain 21*3 with brief rationale and answer.", strategy="react"))
 ```

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,15 +1,14 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=67"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "alpha-solver-sdk"
-version = "0.1.0"
-description = "Python client SDK for Alpha Solver"
+version = "0.0.0"
+description = "Alpha Solver Python SDK"
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = ["requests"]
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["alpha_solver_sdk"]

--- a/docs/postman/alpha_solver.postman_collection.json
+++ b/docs/postman/alpha_solver.postman_collection.json
@@ -1,48 +1,40 @@
 {
   "info": {
-    "name": "Alpha Solver",
+    "name": "Alpha Solver (MVP)",
+    "_postman_id": "7e0e5b1a-1c2d-4a6e-bc99-aaaaaaaaaaaa",
+    "description": "Postman collection for Alpha Solver MVP endpoints.",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "item": [
     {
-      "name": "Solve",
+      "name": "Solve (no API key)",
       "request": {
         "method": "POST",
         "header": [
-          {"key": "Content-Type", "value": "application/json"},
-          {"key": "X-API-Key", "value": "{{api_key}}"}
+          { "key": "Content-Type", "value": "application/json" }
         ],
+        "url": { "raw": "{{baseUrl}}/v1/solve", "host": ["{{baseUrl}}"], "path": ["v1","solve"] },
         "body": {
           "mode": "raw",
-          "raw": "{\n  \"query\": \"2+2?\",\n  \"strategy\": \"react\"\n}"
-        },
-        "url": {
-          "raw": "{{base_url}}/v1/solve",
-          "host": ["{{base_url}}"],
-          "path": ["v1", "solve"]
+          "raw": "{\n  \"prompt\": \"Explain 21*3 with brief rationale and answer.\",\n  \"strategy\": \"react\"\n}\n"
         }
-      },
-      "response": []
-    }
-  ],
-  "variable": [
-    {"key": "base_url", "value": "http://localhost:8000"},
-    {"key": "api_key", "value": ""}
-  ],
-  "environments": [
-    {
-      "name": "local",
-      "values": [
-        {"key": "base_url", "value": "http://localhost:8000"},
-        {"key": "api_key", "value": ""}
-      ]
+      }
     },
     {
-      "name": "prod",
-      "values": [
-        {"key": "base_url", "value": "https://api.alpha-solver.com"},
-        {"key": "api_key", "value": "changeme"}
-      ]
+      "name": "Solve (with API key)",
+      "request": {
+        "method": "POST",
+        "header": [
+          { "key": "Content-Type", "value": "application/json" },
+          { "key": "X-API-Key", "value": "{{apiKey}}", "type": "text" }
+        ],
+        "url": { "raw": "{{baseUrl}}/v1/solve", "host": ["{{baseUrl}}"], "path": ["v1","solve"] },
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"prompt\": \"Explain 21*3 with brief rationale and answer.\",\n  \"strategy\": \"react\"\n}\n"
+        }
+      }
     }
-  ]
+  ],
+  "event": []
 }

--- a/docs/postman/env.local.postman_environment.json
+++ b/docs/postman/env.local.postman_environment.json
@@ -1,0 +1,10 @@
+{
+  "id": "1f111111-2222-3333-4444-555555555555",
+  "name": "local",
+  "values": [
+    { "key": "baseUrl", "value": "http://localhost:8000", "enabled": true },
+    { "key": "apiKey", "value": "", "enabled": true }
+  ],
+  "_postman_variable_scope": "environment",
+  "_postman_exported_using": "Postman/10.24.0"
+}

--- a/docs/postman/env.prod.postman_environment.json
+++ b/docs/postman/env.prod.postman_environment.json
@@ -1,0 +1,10 @@
+{
+  "id": "9f999999-8888-7777-6666-555555555555",
+  "name": "prod",
+  "values": [
+    { "key": "baseUrl", "value": "https://YOUR-PROD-URL", "enabled": true },
+    { "key": "apiKey", "value": "REPLACE_WITH_REAL_API_KEY", "enabled": true }
+  ],
+  "_postman_variable_scope": "environment",
+  "_postman_exported_using": "Postman/10.24.0"
+}

--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -1,7 +1,7 @@
 # Release Checklist
 
 1. Run `make gates`.
-2. Tag the release.
-3. Generate changelog.
-4. Push image (optional).
-5. Verify dashboards.
+2. Update and commit `CHANGELOG.md`.
+3. Bump version numbers as needed.
+4. Tag the release and push to origin.
+5. Verify dashboards after deployment.


### PR DESCRIPTION
## Summary
- add Postman collection and local/prod environments for `/v1/solve`
- tighten README with 5-minute MVP quickstart for CLI, SDK, and API
- make Python SDK pip-installable with `pyproject.toml` and minimal README
- include simple release checklist and ignore SDK build artifacts

## Testing
- `pre-commit run --files README.md docs/postman/alpha_solver.postman_collection.json docs/postman/env.local.postman_environment.json docs/postman/env.prod.postman_environment.json clients/python/pyproject.toml clients/python/README.md docs/release_checklist.md .gitignore` *(fails: pre-commit not installed)*
- `pytest`
- `python -m alpha.eval.harness --dataset datasets/mvp_golden.jsonl --seed 42 --compare-baseline`

Labels: mvp, docs, devex, sdk, release

------
https://chatgpt.com/codex/tasks/task_e_68c1c23b7b308329bf900e4f5554b33a