### PR TITLE
docs: merge & normalize observability doc (keep lowercase; remove uppercase duplicate)

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,21 +1,98 @@
 # Observability
 
-The production compose stack wires the API with Prometheus and Grafana for quick monitoring.
+This guide covers how to **run**, **inspect**, and **evaluate** Alpha Solver’s observability: health/ready endpoints, Prometheus/Grafana, JSONL telemetry search, replay/benchmark utilities, accessibility checks, and leaderboards.
 
-## Running
+---
+
+## Run (production compose)
 
 ```bash
 docker compose -f infrastructure/docker-compose.prod.yml up
 ```
 
-The API serves requests on `http://localhost:8000` and exposes metrics on `http://localhost:9000/metrics`.
+- API: http://localhost:8000  
+- Prometheus metrics: http://localhost:9090/metrics  
+- Grafana dashboards: http://localhost:3000 (provisioned from `infrastructure/grafana/provisioning`)
+
+---
 
 ## Endpoints
 
-- `/healthz` – basic process health, returns `{"status": "ok"}` when configuration is loaded.
-- `/readyz` – readiness probe that flips with `app.state.ready`.
-- `/metrics` – Prometheus metrics including request counts, latency, rate-limit and SAFE-OUT events.
+- `GET /health` — basic process health; returns `{"status":"ok"}` when configuration is loaded.  
+- `GET /ready` — readiness probe toggled by `app_state.ready`.  
+- `GET /metrics` — Prometheus metrics (request counts, latency, rate-limit, SAFE-OUT events).
 
-## Dashboards
+---
 
-Grafana is available at `http://localhost:3000` with a Prometheus data source pre-configured. Dashboards are provisioned from `infrastructure/grafana/provisioning` and mounted read-only.
+## JSONL Search (telemetry)
+
+Filter run summaries from `telemetry/telemetry.jsonl`:
+
+```bash
+jq -r 'select(.event=="run_summary")' telemetry/telemetry.jsonl
+```
+
+---
+
+## Replay Harness
+
+Rehydrate a recorded session:
+
+```bash
+alpha-solver replay --session SESSION_ID
+```
+
+Artifacts (evidence packs) are written under `artifacts/replays/<SESSION_ID>.jsonl`.
+
+---
+
+## Benchmark
+
+Quick sanity benchmark:
+
+```bash
+alpha-solver bench --quick
+head bench_out/bench.csv
+```
+
+---
+
+## Accessibility CLI
+
+Run a11y checks on a replay and view the summary:
+
+```bash
+alpha-solver a11y-check --input artifacts/replays/SESSION_ID.jsonl
+cat artifacts/a11y/summary.json
+```
+
+---
+
+## Governance Flags (examples)
+
+Budget and breaker examples for safe runs:
+
+```bash
+alpha-solver run --queries demo --budget-max-steps 5 --budget-max-seconds 1 --breaker-max-fails 2
+```
+
+*(Tune to your scenario; these flags gate cost and failure loops.)*
+
+---
+
+## Leaderboard & Overview
+
+Generate per-query/top-k tables from telemetry:
+
+```bash
+python scripts/telemetry/leaderboard.py --paths telemetry/*.jsonl --format all
+```
+
+The overview lists run metadata and per-query leaderboards; links appear at the end.
+
+---
+
+## Notes
+
+- The production compose stack wires Prometheus & Grafana for quick monitoring.  
+- Evidence (replay/benchmark/a11y) plus metrics makes regressions easy to spot and reproduce.


### PR DESCRIPTION
## What’s changed
This PR merges the two observability docs into a single canonical guide and removes the duplicate uppercase file:

- **Kept:** `docs/observability.md` (lowercase, canonical)
- **Removed:** `docs/OBSERVABILITY.md` (uppercase duplicate)

The merged guide now covers:
- **Run (compose)**: prod docker-compose, API/metrics endpoints, Grafana
- **Endpoints**: `/health`, `/ready`, `/metrics`
- **Telemetry search**: JSONL filter examples (jq)
- **Replay harness**: rehydrate sessions and evidence packs
- **Benchmark**: quick sanity run + outputs
- **Accessibility CLI**: a11y checks and summaries
- **Governance flags**: budget/breaker examples for safe execution
- **Leaderboard**: per-query/top-k tables from telemetry

## Why
- On macOS (case-insensitive FS), having both `OBSERVABILITY.md` and `observability.md`
  caused “phantom” changes and made it hard to keep a clean working tree.
- A single, consolidated doc is simpler to maintain and easier for new contributors.

## Testing / Verification
- Open `docs/observability.md` and confirm all sections render and anchors work.
- Search the repo for links to `OBSERVABILITY.md` and update them if any remain:

git grep -n “OBSERVABILITY.md” || echo “No uppercase links found”

## Risks & Mitigations
- **Risk:** Missed links to the uppercase filename could 404.
- **Mitigation:** run the grep above; CI/docs link-check (if enabled) will pass.

## Follow-ups
- (Optional) Add a CI docs link checker if not present.
- (Optional) Add a short “Observability Quickstart” snippet to README linking here.

## Screenshots (optional)
N/A

## Release note
- Docs: unified observability guide; removed uppercase duplicate to prevent macOS case collisions.