### PR TITLE
feat(policy): add PII gateway with redaction

### DIFF
--- a/service/policy/policy_gateway.py
+++ b/service/policy/policy_gateway.py
@@ -1,0 +1,55 @@
+from dataclasses import dataclass, field
+from typing import Dict, Tuple
+
+from . import redaction
+
+
+@dataclass
+class PolicyConfig:
+    enable_input_redaction: bool = True
+    detectors: Dict[str, bool] = field(default_factory=lambda: {"email": True, "phone": True})
+    latency_budget_ms_p95: int = 50
+    ner_provider: str = "none"
+    fail_closed: bool = True
+
+
+class PolicyGateway:
+    """Gateway applying PII policy before logging and model input."""
+
+    def __init__(self, config: PolicyConfig | None = None):
+        self.config = config or PolicyConfig()
+
+    def process(self, message: str, route_explain: Dict, *, for_model: bool = False) -> Tuple[str, str]:
+        """Redact *message* for logging and optionally for model input.
+
+        Parameters
+        ----------
+        message: str
+            The raw incoming message.
+        route_explain: Dict
+            Mutable dict augmented with policy information.
+        for_model: bool
+            Whether the processed message will be sent to the model.
+
+        Returns
+        -------
+        (log_text, model_text)
+            Text for logging and for model consumption respectively.
+        """
+        try:
+            redacted, stats = redaction.redact(message, self.config.detectors)
+            route_explain["policy_verdict"] = "pass"
+            route_explain["redaction_stats"] = stats
+            log_text = redacted
+            if for_model and self.config.enable_input_redaction:
+                model_text = redacted
+            else:
+                model_text = message
+            return log_text, model_text
+        except Exception as exc:
+            if self.config.fail_closed:
+                route_explain["policy_verdict"] = "error"
+                route_explain["redaction_stats"] = {"error": str(exc)}
+                masked = "[REDACTED]"
+                return masked, masked if (for_model and self.config.enable_input_redaction) else ""
+            raise

--- a/service/policy/redaction.py
+++ b/service/policy/redaction.py
@@ -1,0 +1,68 @@
+import re
+import time
+from typing import Dict, Tuple
+
+EMAIL_REGEX = re.compile(r"(?P<local>[A-Za-z0-9._%+-]+)@(?P<domain>[A-Za-z0-9.-]+\.[A-Za-z]{2,})")
+PHONE_REGEX = re.compile(r"\+?\d[\d\s\-]{8,}\d")
+
+
+def _mask_email(local: str, domain: str) -> str:
+    local_masked = local[0] + "***" if local else "***"
+    domain_parts = domain.split('.')
+    first = domain_parts[0]
+    domain_parts[0] = (first[0] + "***") if first else "***"
+    return f"{local_masked}@{'.'.join(domain_parts)}"
+
+
+def _mask_phone(s: str) -> str:
+    digits = [c for c in s if c.isdigit()]
+    last_four = digits[-4:]
+    result = []
+    digit_index = 0
+    for c in s:
+        if c.isdigit():
+            if digit_index < len(digits) - 4:
+                result.append('*')
+            else:
+                result.append(last_four[digit_index - (len(digits) - 4)])
+            digit_index += 1
+        else:
+            result.append(c)
+    return ''.join(result)
+
+
+def redact(text: str, detectors: Dict[str, bool]) -> Tuple[str, Dict[str, float]]:
+    """Redact PII in *text* according to *detectors* configuration.
+
+    Returns redacted text and stats including latency_ms and hit counts.
+    """
+    start = time.perf_counter()
+    stats: Dict[str, float] = {"email": 0, "phone": 0}
+
+    def repl_email(match: re.Match) -> str:
+        local = match.group('local')
+        domain = match.group('domain')
+        stats['email'] += 1
+        return _mask_email(local, domain)
+
+    def repl_phone(match: re.Match) -> str:
+        s = match.group(0)
+        digits = [c for c in s if c.isdigit()]
+        # basic E.164 length check 10-15 digits
+        if not (10 <= len(digits) <= 15):
+            return s
+        stats['phone'] += 1
+        return _mask_phone(s)
+
+    try:
+        if detectors.get('email', True):
+            text = EMAIL_REGEX.sub(repl_email, text)
+        if detectors.get('phone', True):
+            text = PHONE_REGEX.sub(repl_phone, text)
+    except Exception as exc:  # fail-closed on detector errors
+        stats['error'] = str(exc)
+        text = '[REDACTED]'
+    finally:
+        stats['latency_ms'] = (time.perf_counter() - start) * 1000.0
+
+    return text, stats

--- a/tests/test_policy_pii_gateway.py
+++ b/tests/test_policy_pii_gateway.py
@@ -1,0 +1,70 @@
+from service.policy.policy_gateway import PolicyGateway, PolicyConfig
+
+
+def test_email_masking():
+    cfg = PolicyConfig(enable_input_redaction=True, detectors={"email": True, "phone": False})
+    gw = PolicyGateway(cfg)
+    route = {}
+    log_text, model_text = gw.process("Reach me at alice@example.com", route, for_model=True)
+    assert "alice@example.com" not in log_text
+    assert log_text == model_text
+    assert route["redaction_stats"]["email"] == 1
+
+    route = {}
+    log_text, model_text = gw.process("No emails here", route, for_model=True)
+    assert log_text == "No emails here"
+    assert route["redaction_stats"]["email"] == 0
+
+
+def test_phone_masking():
+    cfg = PolicyConfig(enable_input_redaction=True, detectors={"email": False, "phone": True})
+    gw = PolicyGateway(cfg)
+    route = {}
+    log_text, model_text = gw.process("Call +1-234-567-1234 now", route, for_model=True)
+    assert "+1-234-567-1234" not in log_text
+    assert log_text == model_text
+    assert route["redaction_stats"]["phone"] == 1
+
+    route = {}
+    log_text, model_text = gw.process("Number 123 is short", route, for_model=True)
+    assert "Number 123 is short" == log_text
+    assert route["redaction_stats"]["phone"] == 0
+
+
+def test_fail_closed_blocks_raw_logging(monkeypatch):
+    cfg = PolicyConfig()
+    gw = PolicyGateway(cfg)
+
+    def boom(text, detectors):
+        raise RuntimeError("detector fail")
+
+    from service.policy import redaction
+
+    monkeypatch.setattr(redaction, "redact", boom)
+    route = {}
+    log_text, model_text = gw.process("secret text", route, for_model=True)
+    assert "secret text" not in log_text
+    assert route["policy_verdict"] == "error"
+    assert "error" in route["redaction_stats"]
+
+
+def test_latency_budget_p95_under_50ms():
+    cfg = PolicyConfig()
+    gw = PolicyGateway(cfg)
+    latencies = []
+    for _ in range(1000):
+        route = {}
+        gw.process("Hello there", route, for_model=False)
+        latencies.append(route["redaction_stats"]["latency_ms"])
+    latencies.sort()
+    p95 = latencies[int(len(latencies) * 0.95)]
+    assert p95 < 50
+
+
+def test_route_explain_fields_present():
+    cfg = PolicyConfig()
+    gw = PolicyGateway(cfg)
+    route = {}
+    gw.process("hi", route, for_model=True)
+    assert "policy_verdict" in route
+    assert "redaction_stats" in route


### PR DESCRIPTION
## Summary
- add regex-based PII redaction with format-preserving masking
- introduce policy gateway to redact messages before logging and model input
- cover email/phone masking, fail-closed behavior, latency budget, and telemetry in route_explain tests

## Testing
- `pytest tests/test_policy_pii_gateway.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7222cf0288329a5269041e2e4b17d