### PR TITLE
Add MCP error taxonomy and tests

### DIFF
--- a/service/mcp/error_taxonomy.py
+++ b/service/mcp/error_taxonomy.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, Optional
+import asyncio
+
+
+class ErrorClass(str, Enum):
+    """Classification for MCP errors."""
+
+    TOOL_NOT_FOUND = "TOOL_NOT_FOUND"
+    SCHEMA_VALIDATION = "SCHEMA_VALIDATION"
+    AUTH = "AUTH"
+    RATE_LIMIT = "RATE_LIMIT"
+    TIMEOUT = "TIMEOUT"
+    CANCELLED = "CANCELLED"
+    CONNECTIVITY = "CONNECTIVITY"
+    RETRYABLE = "RETRYABLE"
+    NON_RETRYABLE = "NON_RETRYABLE"
+    SANDBOX_VIOLATION = "SANDBOX_VIOLATION"
+    SECURITY = "SECURITY"
+    UNKNOWN = "UNKNOWN"
+
+
+@dataclass
+class MCPError:
+    """Normalized error for MCP interactions."""
+
+    cls: ErrorClass
+    message: str
+    code: Optional[str] = None
+    retryable: bool = False
+    root: str = "Exception"
+    meta: Optional[Dict[str, Any]] = None
+
+    def to_json(self) -> Dict[str, Any]:
+        """Return a JSON-serialisable dictionary representation."""
+        return {
+            "cls": self.cls.value,
+            "message": self.message,
+            "code": self.code,
+            "retryable": self.retryable,
+            "root": self.root,
+            "meta": self.meta or {},
+        }
+
+
+def is_retryable(err: MCPError) -> bool:
+    """Return True if the error is retryable."""
+    return err.retryable
+
+
+def to_route_explain(err: MCPError) -> Dict[str, Any]:
+    """Return a minimal dict for routing/explanation purposes."""
+    return {
+        "cls": err.cls.value,
+        "message": err.message[:100],
+        "code": err.code,
+        "retryable": err.retryable,
+    }
+
+
+def map_exception(exc: Exception) -> MCPError:
+    """Map an arbitrary exception into a deterministic :class:`MCPError`."""
+
+    root = exc.__class__.__name__
+    message = str(exc) or root
+    code: Optional[str] = None
+    meta: Dict[str, Any] = {}
+
+    # HTTP-style errors
+    status = getattr(exc, "status_code", None)
+    if status is not None:
+        code = str(status)
+        if status == 429:
+            error_cls = ErrorClass.RATE_LIMIT
+            retryable = True
+        elif status in (401, 403):
+            error_cls = ErrorClass.AUTH
+            retryable = False
+        else:
+            error_cls = ErrorClass.UNKNOWN
+            retryable = False
+    elif isinstance(exc, TimeoutError):
+        error_cls = ErrorClass.TIMEOUT
+        retryable = True
+    elif isinstance(exc, ConnectionError):
+        error_cls = ErrorClass.CONNECTIVITY
+        retryable = True
+    elif isinstance(exc, asyncio.CancelledError):
+        error_cls = ErrorClass.CANCELLED
+        retryable = False
+    elif isinstance(exc, PermissionError):
+        error_cls = ErrorClass.AUTH
+        retryable = False
+    elif isinstance(exc, ValueError):
+        error_cls = ErrorClass.SCHEMA_VALIDATION
+        retryable = False
+    elif "sandbox" in root.lower():
+        error_cls = ErrorClass.SANDBOX_VIOLATION
+        retryable = False
+    else:
+        error_cls = ErrorClass.UNKNOWN
+        retryable = False
+
+    if retryable:
+        meta["secondary"] = ErrorClass.RETRYABLE.value
+
+    return MCPError(
+        cls=error_cls,
+        message=message,
+        code=code,
+        retryable=retryable,
+        root=root,
+        meta=meta or None,
+    )

--- a/tests/test_mcp_errors.py
+++ b/tests/test_mcp_errors.py
@@ -1,0 +1,85 @@
+import json
+import asyncio
+
+from service.mcp.error_taxonomy import (
+    ErrorClass,
+    map_exception,
+    to_route_explain,
+    is_retryable,
+    MCPError,
+)
+
+
+class Dummy429(Exception):
+    status_code = 429
+
+
+class DummyAuth(Exception):
+    def __init__(self, status_code):
+        self.status_code = status_code
+
+
+class SandboxViolation(Exception):
+    pass
+
+
+def test_timeout_maps_retryable():
+    err = map_exception(TimeoutError("timeout"))
+    assert err.cls == ErrorClass.TIMEOUT
+    assert is_retryable(err)
+
+
+def test_connectivity_maps_retryable():
+    err = map_exception(ConnectionError("net"))
+    assert err.cls == ErrorClass.CONNECTIVITY
+    assert is_retryable(err)
+
+
+def test_rate_limit_429_retryable():
+    err = map_exception(Dummy429("rate"))
+    assert err.cls == ErrorClass.RATE_LIMIT
+    assert err.code == "429"
+    assert is_retryable(err)
+
+
+def test_auth_nonretryable():
+    err = map_exception(DummyAuth(401))
+    assert err.cls == ErrorClass.AUTH
+    assert not is_retryable(err)
+
+
+def test_schema_validation_nonretryable():
+    err = map_exception(ValueError("bad schema"))
+    assert err.cls == ErrorClass.SCHEMA_VALIDATION
+    assert not is_retryable(err)
+
+
+def test_sandbox_violation_nonretryable():
+    err = map_exception(SandboxViolation("violate"))
+    assert err.cls == ErrorClass.SANDBOX_VIOLATION
+    assert not is_retryable(err)
+
+
+def test_cancelled_nonretryable():
+    err = map_exception(asyncio.CancelledError())
+    assert err.cls == ErrorClass.CANCELLED
+    assert not is_retryable(err)
+
+
+def test_unknown_default():
+    err = map_exception(RuntimeError("boom"))
+    assert err.cls == ErrorClass.UNKNOWN
+    assert not is_retryable(err)
+
+
+def test_to_route_explain_truncates_message():
+    long_msg = "x" * 120
+    err = MCPError(cls=ErrorClass.UNKNOWN, message=long_msg, root="R")
+    expl = to_route_explain(err)
+    assert expl["message"] == long_msg[:100]
+
+
+def test_to_json_is_serializable():
+    err = map_exception(RuntimeError("boom"))
+    json_str = json.dumps(err.to_json())
+    assert isinstance(json_str, str)


### PR DESCRIPTION
## Summary
- implement deterministic MCP error taxonomy with serialization and helpers
- normalize exceptions into structured `MCPError`
- cover mapping and serialization with unit tests

## Testing
- `pre-commit run --files service/mcp/error_taxonomy.py tests/test_mcp_errors.py` *(fails: command not found; install blocked)*
- `pytest tests/test_mcp_errors.py`


------
https://chatgpt.com/codex/tasks/task_e_68c724986668832980a7e6d2113f5a74