### PR TITLE
Implement MCP retry backoff

### DIFF
--- a/service/mcp/retry_backoff.py
+++ b/service/mcp/retry_backoff.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import asyncio
+import random
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
+
+from .error_taxonomy import map_exception, is_retryable
+
+
+async def _call_maybe_async(func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+    """Invoke ``func`` which may be sync or async."""
+    result = func(*args, **kwargs)
+    if asyncio.iscoroutine(result) or isinstance(result, Awaitable):
+        return await result  # type: ignore[arg-type]
+    return result
+
+
+async def call_with_retries(
+    func: Callable[..., Any],
+    *args: Any,
+    timeout: float,
+    base: float = 0.2,
+    factor: float = 2.0,
+    jitter: float = 0.2,
+    max_retries: int = 2,
+    max_delay: float = 2.0,
+    seed: Optional[int] = None,
+    idempotency_key: Optional[str] = None,
+    **kwargs: Any,
+) -> Tuple[Any, Dict[str, Any]]:
+    """Execute ``func`` with retries and backoff.
+
+    Returns a tuple of ``(result, retry_metadata)``. ``retry_metadata`` contains
+    the number of attempts, the list of delays between attempts, and the error
+    classification for the last encountered error if any.
+    """
+
+    rng = random.Random(seed)
+    attempts = 0
+    delays: List[float] = []
+    last_err = None
+
+    delay = base
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + timeout if timeout is not None else None
+
+    while True:
+        attempts += 1
+        try:
+            call_kwargs = dict(kwargs)
+            if idempotency_key is not None:
+                call_kwargs.setdefault("idempotency_key", idempotency_key)
+
+            if deadline is not None:
+                remaining = deadline - loop.time()
+                if remaining <= 0:
+                    raise TimeoutError("timeout budget exceeded")
+                result = await asyncio.wait_for(
+                    _call_maybe_async(func, *args, **call_kwargs),
+                    timeout=remaining,
+                )
+            else:
+                result = await _call_maybe_async(func, *args, **call_kwargs)
+
+            meta = {
+                "attempts": attempts,
+                "delays": delays,
+                "last_error_class": last_err.cls.value if last_err else None,
+                "last_error_code": last_err.code if last_err else None,
+            }
+            return result, meta
+        except Exception as exc:  # pragma: no cover - broad for mapping
+            last_err = map_exception(exc)
+            retryable = is_retryable(last_err)
+            if attempts > max_retries or not retryable:
+                meta = {
+                    "attempts": attempts,
+                    "delays": delays,
+                    "last_error_class": last_err.cls.value,
+                    "last_error_code": last_err.code,
+                }
+                setattr(exc, "retry_meta", meta)
+                raise
+
+            candidate = min(max_delay, delay * factor)
+            jitter_range = candidate * jitter
+            next_delay = rng.uniform(
+                max(base, candidate - jitter_range),
+                min(max_delay, candidate + jitter_range),
+            )
+
+            if deadline is not None:
+                remaining = deadline - loop.time()
+                if next_delay > remaining:
+                    meta = {
+                        "attempts": attempts,
+                        "delays": delays,
+                        "last_error_class": last_err.cls.value,
+                        "last_error_code": last_err.code,
+                    }
+                    setattr(exc, "retry_meta", meta)
+                    raise
+
+            delays.append(next_delay)
+            delay = next_delay
+            await asyncio.sleep(next_delay)

--- a/tests/test_mcp_retry.py
+++ b/tests/test_mcp_retry.py
@@ -1,0 +1,129 @@
+import asyncio
+import pytest
+
+from service.mcp.retry_backoff import call_with_retries
+from service.mcp.error_taxonomy import ErrorClass
+
+
+def test_retry_on_retryable_errors():
+    class FlakyTool:
+        def __init__(self):
+            self.calls = 0
+
+        async def __call__(self, *, idempotency_key=None):
+            self.calls += 1
+            if self.calls < 2:
+                raise TimeoutError("temp")
+            return "ok"
+
+    tool = FlakyTool()
+    result, meta = asyncio.run(call_with_retries(tool, timeout=5, seed=1))
+    assert result == "ok"
+    assert meta["attempts"] == 2
+    assert len(meta["delays"]) == 1
+
+
+def test_no_retry_on_nonretryable():
+    def fail(*, idempotency_key=None):
+        raise ValueError("bad")
+
+    async def run():
+        await call_with_retries(fail, timeout=1)
+
+    with pytest.raises(ValueError) as exc:
+        asyncio.run(run())
+    assert exc.value.retry_meta["attempts"] == 1
+
+
+def test_respects_max_retries():
+    class AlwaysFail:
+        def __init__(self):
+            self.calls = 0
+
+        async def __call__(self, *, idempotency_key=None):
+            self.calls += 1
+            raise TimeoutError("fail")
+
+    tool = AlwaysFail()
+
+    async def run():
+        await call_with_retries(tool, timeout=5, max_retries=1, seed=0)
+
+    with pytest.raises(TimeoutError) as exc:
+        asyncio.run(run())
+    assert tool.calls == 2
+    assert exc.value.retry_meta["attempts"] == 2
+
+
+def test_deterministic_delays_with_seed():
+    class FailTwice:
+        def __init__(self):
+            self.calls = 0
+
+        async def __call__(self, *, idempotency_key=None):
+            self.calls += 1
+            if self.calls < 3:
+                raise TimeoutError("temp")
+            return "ok"
+
+    tool1 = FailTwice()
+    res1, meta1 = asyncio.run(
+        call_with_retries(tool1, timeout=10, seed=42, max_retries=5)
+    )
+    tool2 = FailTwice()
+    res2, meta2 = asyncio.run(
+        call_with_retries(tool2, timeout=10, seed=42, max_retries=5)
+    )
+    assert meta1["delays"] == meta2["delays"]
+
+
+def test_honors_timeout_budget():
+    async def slow(*, idempotency_key=None):
+        await asyncio.sleep(1)
+        return "ok"
+
+    with pytest.raises(TimeoutError) as exc:
+        asyncio.run(call_with_retries(slow, timeout=0.5))
+    assert exc.value.retry_meta["attempts"] == 1
+    assert exc.value.retry_meta["delays"] == []
+
+
+def test_route_explain_fields_present():
+    class FlakyTool:
+        def __init__(self):
+            self.calls = 0
+
+        async def __call__(self, *, idempotency_key=None):
+            self.calls += 1
+            if self.calls < 2:
+                raise TimeoutError("temp")
+            return "ok"
+
+    result, meta = asyncio.run(call_with_retries(FlakyTool(), timeout=5, seed=0))
+    for key in ("attempts", "delays", "last_error_class", "last_error_code"):
+        assert key in meta
+    assert meta["last_error_class"] == ErrorClass.TIMEOUT.value
+    assert meta["last_error_code"] is None
+
+
+def test_idempotency_guard():
+    class CounterTool:
+        def __init__(self):
+            self.counter = 0
+            self.seen = set()
+
+        async def __call__(self, *, idempotency_key=None):
+            if idempotency_key not in self.seen:
+                self.counter += 1
+                self.seen.add(idempotency_key)
+                if self.counter == 1:
+                    raise TimeoutError("fail once")
+            return self.counter
+
+    tool = CounterTool()
+    result, meta = asyncio.run(
+        call_with_retries(tool, timeout=5, idempotency_key="k1", seed=0)
+    )
+    assert tool.counter == 1
+    assert result == 1
+    assert meta["attempts"] == 2


### PR DESCRIPTION
## Summary
- add `call_with_retries` helper providing exponential backoff with ±20% jitter
- surface retry metadata and honor timeout budgets
- support idempotency keys and deterministic delays

## Testing
- `pytest tests/test_mcp_errors.py tests/test_mcp_retry.py`

------
https://chatgpt.com/codex/tasks/task_e_68c7269c98ec8329af312a4c89c19f72