### PR TITLE
feat: add MCP registry loader

### DIFF
--- a/registries/mcp/loader.py
+++ b/registries/mcp/loader.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+"""MCP registry loader and helpers."""
+
+import copy
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Tuple, Union
+
+import yaml
+try:  # pragma: no cover - prefer real jsonschema
+    from jsonschema import Draft7Validator, ValidationError
+except Exception:  # pragma: no cover - fallback to stub
+    from jsonschema import validate  # type: ignore
+
+    class ValidationError(Exception):
+        """Raised on registry validation failures."""
+
+        def __init__(self, message: str):
+            super().__init__(message)
+            self.message = message
+
+    class _Err:
+        def __init__(self, message: str):
+            self.message = message
+
+    class Draft7Validator:  # minimal stub
+        def __init__(self, schema: Dict[str, Any]):
+            self.schema = schema
+
+        def iter_errors(self, instance: Dict[str, Any]):
+            try:
+                validate(instance, self.schema)
+                return []
+            except Exception as exc:  # pylint: disable=broad-except
+                return [_Err(str(exc))]
+
+# ---------------------------------------------------------------------------
+# Schema definition
+# ---------------------------------------------------------------------------
+
+TOOL_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "required": ["name", "type", "entry"],
+    "additionalProperties": False,
+    "properties": {
+        "name": {"type": "string", "pattern": r"^[a-z0-9]+(-[a-z0-9]+)*$"},
+        "type": {"type": "string", "enum": ["http", "script", "remote"]},
+        "entry": {"type": "string"},
+        "timeout_ms": {"type": "integer", "minimum": 0, "default": 15000},
+        "enabled": {"type": "boolean", "default": True},
+        "retry": {
+            "type": "object",
+            "required": ["max_retries", "base_ms", "factor", "jitter"],
+            "additionalProperties": False,
+            "properties": {
+                "max_retries": {"type": "integer", "minimum": 0, "maximum": 2},
+                "base_ms": {"type": "integer", "minimum": 0},
+                "factor": {"type": "number"},
+                "jitter": {"type": "number"},
+            },
+        },
+        "secrets": {
+            "type": "object",
+            "additionalProperties": {"type": "string"},
+        },
+    },
+}
+
+REGISTRY_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "required": ["tool"],
+    "additionalProperties": False,
+    "properties": {
+        "version": {"type": "string"},
+        "tool": {"type": "array", "items": TOOL_SCHEMA},
+    },
+}
+
+
+class SecretStr(str):
+    """String subclass that redacts its value in representations."""
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        return "****"
+
+    __str__ = __repr__
+
+
+Registry = Dict[str, Any]
+
+
+def _apply_defaults(registry: Registry) -> None:
+    for tool in registry.get("tool", []):
+        tool.setdefault("timeout_ms", 15000)
+        tool.setdefault("enabled", True)
+
+
+def validate_registry(obj: Registry) -> Tuple[bool, List[str]]:
+    """Validate the registry object against the schema."""
+    validator = Draft7Validator(REGISTRY_SCHEMA)
+    errors = [e.message for e in validator.iter_errors(obj)]
+    if not errors:
+        # ensure unique tool names
+        names = [t["name"] for t in obj.get("tool", [])]
+        seen = set()
+        duplicates = [n for n in names if n in seen or seen.add(n)]
+        if duplicates:
+            errors.append(f"duplicate tool names: {', '.join(sorted(set(duplicates)))}")
+    return (len(errors) == 0, errors)
+
+
+def load_registry(path_or_obj: Union[str, Path, Registry], *, resolve_env: bool = True) -> Registry:
+    """Load and validate a registry from a path or pre-parsed object."""
+    if isinstance(path_or_obj, (str, Path)):
+        path = Path(path_or_obj)
+        if not path.exists():
+            raise FileNotFoundError(str(path))
+        suffix = path.suffix.lower()
+        with path.open("r", encoding="utf-8") as fh:
+            if suffix == ".json":
+                obj = json.load(fh)
+            elif suffix in {".yaml", ".yml"}:
+                obj = yaml.safe_load(fh)
+            else:
+                raise ValueError(f"unsupported registry format: {suffix}")
+    else:
+        obj = copy.deepcopy(path_or_obj)
+
+    ok, errs = validate_registry(obj)
+    if not ok:
+        raise ValidationError("; ".join(errs))
+
+    _apply_defaults(obj)
+
+    if resolve_env:
+        for tool in obj.get("tool", []):
+            secrets = tool.get("secrets", {})
+            resolved: Dict[str, Any] = {}
+            for key in secrets:
+                value = os.environ.get(key)
+                if value is not None:
+                    resolved[key] = SecretStr(value)
+                else:
+                    resolved[key] = None
+            if resolved:
+                tool["secrets"] = resolved
+
+    return obj
+
+
+def list_tools(registry: Registry) -> List[str]:
+    """Return a list of enabled tool names."""
+    return [t["name"] for t in registry.get("tool", []) if t.get("enabled", True)]
+
+
+def get_tool(registry: Registry, name: str) -> Dict[str, Any] | None:
+    """Return a deep copy of the named tool if enabled, else ``None``."""
+    for tool in registry.get("tool", []):
+        if tool.get("name") == name and tool.get("enabled", True):
+            return copy.deepcopy(tool)
+    return None
+

--- a/service/mcp/wiring.py
+++ b/service/mcp/wiring.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""MCP wiring helpers."""
+
+from dataclasses import dataclass
+import time
+from typing import Any, Dict, Union
+
+from registries.mcp.loader import load_registry
+
+
+@dataclass
+class MCPContext:
+    """Runtime context for loaded MCP registry."""
+
+    registry: Dict[str, Any]
+    version: str
+    loaded_at: float
+
+
+def init_mcp(path_or_obj: Union[str, Dict[str, Any]]) -> MCPContext:
+    """Load the registry and return an :class:`MCPContext` instance."""
+    registry = load_registry(path_or_obj)
+    version = str(registry.get("version", "unknown"))
+    return MCPContext(registry=registry, version=version, loaded_at=time.time())
+
+
+def tool_summary(ctx: MCPContext) -> Dict[str, Any]:
+    """Return counts of tools by type and enabled/disabled."""
+    summary_by_type = {"http": 0, "script": 0, "remote": 0}
+    enabled = disabled = 0
+    for tool in ctx.registry.get("tool", []):
+        t_type = tool["type"]
+        summary_by_type[t_type] = summary_by_type.get(t_type, 0) + 1
+        if tool.get("enabled", True):
+            enabled += 1
+        else:
+            disabled += 1
+    return {"by_type": summary_by_type, "enabled": enabled, "disabled": disabled}
+
+
+def to_route_explain(ctx: MCPContext) -> Dict[str, Any]:
+    """Return a minimal dict for routing/explanation purposes."""
+    return {"registry_version": ctx.version, "tools": tool_summary(ctx)}

--- a/tests/test_mcp_loader.py
+++ b/tests/test_mcp_loader.py
@@ -1,0 +1,89 @@
+import pytest
+
+from registries.mcp.loader import (
+    ValidationError,
+    get_tool,
+    list_tools,
+    load_registry,
+)
+from service.mcp.wiring import init_mcp, tool_summary
+
+
+def _sample_registry():
+    return {
+        "version": "1.0",
+        "tool": [
+            {"name": "alpha-tool", "type": "script", "entry": "mod:func"},
+            {"name": "beta-tool", "type": "http", "entry": "http://x"},
+        ],
+    }
+
+
+def test_valid_registry_loads_and_lists():
+    registry = load_registry(_sample_registry())
+    assert list_tools(registry) == ["alpha-tool", "beta-tool"]
+    tool = get_tool(registry, "alpha-tool")
+    assert tool["timeout_ms"] == 15000
+    assert tool["enabled"] is True
+
+
+def test_disabled_tools_are_excluded():
+    registry = {
+        "tool": [
+            {"name": "t1", "type": "script", "entry": "a:b", "enabled": False},
+            {"name": "t2", "type": "http", "entry": "http://"},
+        ]
+    }
+    loaded = load_registry(registry)
+    assert list_tools(loaded) == ["t2"]
+    assert get_tool(loaded, "t1") is None
+
+
+def test_secret_env_is_resolved_but_not_logged(monkeypatch, capfd):
+    monkeypatch.setenv("MY_SECRET", "shh")
+    registry = {
+        "tool": [
+            {
+                "name": "secret-tool",
+                "type": "script",
+                "entry": "m:f",
+                "secrets": {"MY_SECRET": "REDACTED"},
+            }
+        ]
+    }
+    loaded = load_registry(registry)
+    tool = get_tool(loaded, "secret-tool")
+    captured = capfd.readouterr()
+    assert "shh" not in captured.out
+    assert "shh" not in captured.err
+    assert tool["secrets"]["MY_SECRET"] == "shh"
+
+
+def test_validation_fails_on_bad_schema():
+    bad = {"tool": [{"name": "bad", "type": "http"}]}  # missing entry
+    with pytest.raises(ValidationError):
+        load_registry(bad)
+
+
+def test_get_tool_deterministic():
+    reg = load_registry(_sample_registry())
+    tool1 = get_tool(reg, "alpha-tool")
+    tool1["entry"] = "changed"
+    tool2 = get_tool(reg, "alpha-tool")
+    assert tool2["entry"] == "mod:func"
+
+
+def test_tool_summary_counts():
+    reg = {
+        "version": "1",
+        "tool": [
+            {"name": "h1", "type": "http", "entry": "http://a"},
+            {"name": "s1", "type": "script", "entry": "m:f", "enabled": False},
+            {"name": "r1", "type": "remote", "entry": "remote:run"},
+        ],
+    }
+    ctx = init_mcp(reg)
+    summary = tool_summary(ctx)
+    assert summary["enabled"] == 2
+    assert summary["disabled"] == 1
+    assert summary["by_type"] == {"http": 1, "script": 1, "remote": 1}


### PR DESCRIPTION
## Summary
- add JSON/YAML loader for MCP tool registries with validation, defaults, and secret resolution
- provide MCP wiring helpers and context summary
- cover loader behaviors with unit tests

## Testing
- `pytest tests/test_mcp_loader.py tests/test_mcp_errors.py`

------
https://chatgpt.com/codex/tasks/task_e_68c7276651cc8329ab23b06d072faf02