### PR TITLE
Add deterministic decision rule scoring and ranking

### DIFF
--- a/config/decision_rules.yaml
+++ b/config/decision_rules.yaml
@@ -1,0 +1,16 @@
+weights:
+  confidence: 1.0
+  tool_first: 0.2
+  cost_tokens: 0.0005   # penalty per token
+  steps: 0.05           # penalty per step
+  risk: 0.7             # penalty for risk
+  latency_ms: 0.002     # penalty per ms
+norms:
+  cost_tokens_div: 1000
+  steps_div: 10
+  latency_ms_div: 1000
+tiebreak:
+  - "confidence:desc"
+  - "latency_ms:asc"
+  - "cost_tokens:asc"
+  - "id:asc"

--- a/service/scoring/decision_rules.py
+++ b/service/scoring/decision_rules.py
@@ -1,0 +1,157 @@
+"""Decision rules for scoring and ranking plans.
+
+This module provides small, deterministic helpers for scoring candidate
+plans and ranking them with a deterministic tiebreak chain.  The weights
+and normalisation factors are loaded from a YAML configuration file.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Tuple
+
+import yaml
+
+
+# ---------------------------------------------------------------------------
+# Configuration helpers
+# ---------------------------------------------------------------------------
+
+def load_weights(path: str = "config/decision_rules.yaml") -> Dict[str, Any]:
+    """Load weights configuration from *path*.
+
+    Parameters
+    ----------
+    path:
+        Path to a YAML file containing the weights, normalisation factors and
+        tiebreak configuration.
+    """
+    with open(Path(path), "r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+    validate_weights(data)
+    return data
+
+
+def validate_weights(weights: Dict[str, Any]) -> None:
+    """Validate the shape of a weights configuration.
+
+    Raises
+    ------
+    ValueError
+        If required keys are missing or malformed.
+    """
+    if not isinstance(weights, dict):
+        raise ValueError("weights must be a dict")
+
+    required_top = {"weights", "norms", "tiebreak"}
+    if not required_top.issubset(weights):
+        raise ValueError("weights config missing sections")
+
+    w = weights["weights"]
+    n = weights["norms"]
+    tb = weights["tiebreak"]
+
+    required_weights = {
+        "confidence",
+        "tool_first",
+        "cost_tokens",
+        "steps",
+        "risk",
+        "latency_ms",
+    }
+    required_norms = {"cost_tokens_div", "steps_div", "latency_ms_div"}
+
+    if not required_weights.issubset(w):
+        raise ValueError("weights section missing fields")
+    if not required_norms.issubset(n):
+        raise ValueError("norms section missing fields")
+    if not isinstance(tb, list) or not tb:
+        raise ValueError("tiebreak must be a non-empty list")
+    for rule in tb:
+        if not isinstance(rule, str) or ":" not in rule:
+            raise ValueError("invalid tiebreak rule")
+        field, direction = rule.split(":", 1)
+        if direction not in {"asc", "desc"} or not field:
+            raise ValueError("invalid tiebreak rule")
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+def _normalise(value: float, div: float) -> float:
+    """Simple min/div normalisation capped at 1.0."""
+    if div <= 0:
+        return 0.0
+    return min(value / div, 1.0)
+
+
+def score_plan(plan: Dict[str, Any], weights: Dict[str, Any]) -> Tuple[float, Dict[str, Any]]:
+    """Score a plan according to configured weights.
+
+    Returns the numeric score and an explanation dictionary.
+    """
+    w = weights["weights"]
+    n = weights["norms"]
+    tiebreak_fields = [rule.split(":", 1)[0] for rule in weights["tiebreak"]]
+
+    confidence = float(plan.get("confidence", 0.0))
+    tool_first = 1.0 if plan.get("tool_first") else 0.0
+    cost_norm = _normalise(float(plan.get("cost_tokens", 0)), float(n["cost_tokens_div"]))
+    steps_norm = _normalise(float(plan.get("steps", 0)), float(n["steps_div"]))
+    risk = float(plan.get("risk", 0.0))
+    latency_norm = _normalise(float(plan.get("latency_ms", 0)), float(n["latency_ms_div"]))
+
+    components = {
+        "confidence": w["confidence"] * confidence,
+        "tool_first": w["tool_first"] * tool_first,
+        "cost_tokens": -w["cost_tokens"] * cost_norm,
+        "steps": -w["steps"] * steps_norm,
+        "risk": -w["risk"] * risk,
+        "latency_ms": -w["latency_ms"] * latency_norm,
+    }
+
+    score = sum(components.values())
+    explain = {
+        "score": score,
+        "components": components,
+        "tiebreak_chain": tiebreak_fields,
+    }
+    return score, explain
+
+
+# ---------------------------------------------------------------------------
+# Ranking
+# ---------------------------------------------------------------------------
+
+def _tiebreak_key(plan: Dict[str, Any], tiebreak: Iterable[str]) -> Tuple[Any, ...]:
+    key: List[Any] = [-plan["_score"]]
+    for rule in tiebreak:
+        field, direction = rule.split(":", 1)
+        value = plan.get(field)
+        if isinstance(value, bool):
+            value = 1 if value else 0
+        if isinstance(value, (int, float)):
+            key.append(-value if direction == "desc" else value)
+        else:
+            value = "" if value is None else str(value)
+            if direction == "desc":
+                # Simple string inversion for descending order
+                value = "".join(chr(255 - ord(c)) for c in value)
+            key.append(value)
+    return tuple(key)
+
+
+def rank_plans(plans: List[Dict[str, Any]], weights: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Return a new list of plans sorted by score and tiebreak chain."""
+    ranked: List[Dict[str, Any]] = []
+    for plan in plans:
+        score, explain = score_plan(plan, weights)
+        new_plan = dict(plan)
+        new_plan["_score"] = score
+        new_plan["_explain"] = explain
+        ranked.append(new_plan)
+
+    tiebreak = weights["tiebreak"]
+    ranked.sort(key=lambda p: _tiebreak_key(p, tiebreak))
+    return ranked
+

--- a/tests/test_decision_rules.py
+++ b/tests/test_decision_rules.py
@@ -1,0 +1,145 @@
+import time
+
+import pytest
+
+from service.scoring.decision_rules import (
+    load_weights,
+    validate_weights,
+    score_plan,
+    rank_plans,
+)
+
+
+def test_load_and_validate_weights_ok():
+    weights = load_weights("config/decision_rules.yaml")
+    validate_weights(weights)
+
+
+def test_validate_weights_rejects_bad_shape():
+    bad = {"weights": {}, "norms": {}, "tiebreak": []}
+    with pytest.raises(ValueError):
+        validate_weights(bad)
+
+
+def test_score_is_deterministic():
+    weights = load_weights()
+    plan = {
+        "id": "p",
+        "confidence": 0.5,
+        "tool_first": True,
+        "cost_tokens": 100,
+        "steps": 1,
+        "risk": 0.1,
+        "latency_ms": 200,
+    }
+    scores = [score_plan(plan, weights)[0] for _ in range(5)]
+    assert all(s == scores[0] for s in scores)
+
+
+def test_rank_orders_expected_top1_on_sample():
+    weights = load_weights()
+    plans = [
+        {
+            "id": "plan_tool_confident",
+            "confidence": 0.9,
+            "tool_first": True,
+            "cost_tokens": 100,
+            "steps": 2,
+            "risk": 0.1,
+            "latency_ms": 100,
+        },
+        {
+            "id": "plan_confident_no_tool",
+            "confidence": 0.9,
+            "tool_first": False,
+            "cost_tokens": 50,
+            "steps": 1,
+            "risk": 0.1,
+            "latency_ms": 100,
+        },
+        {
+            "id": "plan_tool_low_conf",
+            "confidence": 0.2,
+            "tool_first": True,
+            "cost_tokens": 50,
+            "steps": 1,
+            "risk": 0.1,
+            "latency_ms": 100,
+        },
+    ]
+    ranked = rank_plans(plans, weights)
+    assert ranked[0]["id"] == "plan_tool_confident"
+
+
+def test_ties_are_broken_deterministically():
+    weights = load_weights()
+    plan1 = {
+        "id": "p1",
+        "confidence": 0.9,
+        "cost_tokens": 500,
+        "tool_first": False,
+        "risk": 0,
+        "steps": 0,
+        "latency_ms": 0,
+    }
+    plan2 = {
+        "id": "p2",
+        "confidence": 0.85,
+        "tool_first": True,
+        "risk": 0.21464285714285714,
+        "cost_tokens": 0,
+        "steps": 0,
+        "latency_ms": 0,
+    }
+    plan3 = dict(plan2, id="p3")
+    ranked = rank_plans([plan3, plan2, plan1], weights)
+    ids = [p["id"] for p in ranked]
+    assert ids == ["p1", "p2", "p3"]
+
+
+def test_p95_ranking_under_50ms_for_50_plans():
+    weights = load_weights()
+
+    def make_plan(i: int) -> dict:
+        return {
+            "id": f"p{i}",
+            "confidence": (i % 10) / 10,
+            "cost_tokens": i * 10,
+            "steps": i % 5,
+            "risk": (i % 3) / 3,
+            "tool_first": i % 2 == 0,
+            "latency_ms": i * 5,
+        }
+
+    plans = [make_plan(i) for i in range(50)]
+    durations = []
+    for _ in range(20):
+        start = time.monotonic()
+        rank_plans(plans, weights)
+        durations.append(time.monotonic() - start)
+    durations.sort()
+    idx = int(len(durations) * 0.95)
+    if idx == len(durations):
+        idx -= 1
+    assert durations[idx] < 0.05
+
+
+def test_explain_contains_expected_fields():
+    weights = load_weights()
+    plan = {
+        "id": "p",
+        "confidence": 0.5,
+        "tool_first": True,
+        "cost_tokens": 100,
+        "steps": 1,
+        "risk": 0.1,
+        "latency_ms": 200,
+    }
+    ranked = rank_plans([plan], weights)
+    expl = ranked[0]["_explain"]
+    assert set(expl.keys()) == {"score", "components", "tiebreak_chain"}
+    components = expl["components"]
+    assert {"confidence", "tool_first", "cost_tokens", "steps", "risk", "latency_ms"} <= set(
+        components.keys()
+    )
+    assert expl["tiebreak_chain"] == ["confidence", "latency_ms", "cost_tokens", "id"]


### PR DESCRIPTION
## Summary
- implement deterministic plan scoring and ranking utilities
- load scoring weights and norms from `config/decision_rules.yaml`
- add thorough tests for scoring logic, tie-breaking, and performance

## Testing
- `pytest tests/test_decision_rules.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c729e3c66483299d44c350761b6374