### PR TITLE
Add scenario runner with rubric and replay tests

### DIFF
--- a/scenarios/pack.yaml
+++ b/scenarios/pack.yaml
@@ -1,0 +1,652 @@
+scenarios:
+- id: web-to-sheet-01
+  steps:
+  - tool: playwright
+    action: get_text
+    input:
+      url: https://example.com
+      selector: '#title'
+    expect:
+      contains: Example
+  - tool: gsheets
+    action: append
+    input:
+      sheet: demo
+      values:
+      - - row1
+        - ok
+    expect:
+      equals: 1
+  tags:
+  - showcase
+  - deterministic
+- id: web-to-sheet-02
+  steps:
+  - tool: playwright
+    action: get_text
+    input:
+      url: https://site02.local
+      selector: '#title'
+    expect:
+      equals: ''
+  - tool: gsheets
+    action: append
+    input:
+      sheet: demo
+      values:
+      - - row2
+        - ok
+    expect:
+      equals: 1
+  tags:
+  - showcase
+  - deterministic
+- id: web-to-sheet-03
+  steps:
+  - tool: playwright
+    action: get_text
+    input:
+      url: https://site03.local
+      selector: '#title'
+    expect:
+      equals: ''
+  - tool: gsheets
+    action: append
+    input:
+      sheet: demo
+      values:
+      - - row3
+        - ok
+    expect:
+      equals: 1
+  tags:
+  - showcase
+  - deterministic
+- id: web-to-sheet-04
+  steps:
+  - tool: playwright
+    action: get_text
+    input:
+      url: https://site04.local
+      selector: '#title'
+    expect:
+      equals: ''
+  - tool: gsheets
+    action: append
+    input:
+      sheet: demo
+      values:
+      - - row4
+        - ok
+    expect:
+      equals: 1
+  tags:
+  - showcase
+  - deterministic
+- id: web-to-sheet-05
+  steps:
+  - tool: playwright
+    action: get_text
+    input:
+      url: https://site05.local
+      selector: '#title'
+    expect:
+      equals: ''
+  - tool: gsheets
+    action: append
+    input:
+      sheet: demo
+      values:
+      - - row5
+        - ok
+    expect:
+      equals: 1
+  tags:
+  - showcase
+  - deterministic
+- id: web-to-sheet-06
+  steps:
+  - tool: playwright
+    action: get_text
+    input:
+      url: https://site06.local
+      selector: '#title'
+    expect:
+      equals: ''
+  - tool: gsheets
+    action: append
+    input:
+      sheet: demo
+      values:
+      - - row6
+        - ok
+    expect:
+      equals: 1
+  tags:
+  - showcase
+  - deterministic
+- id: web-to-sheet-07
+  steps:
+  - tool: playwright
+    action: get_text
+    input:
+      url: https://site07.local
+      selector: '#title'
+    expect:
+      equals: ''
+  - tool: gsheets
+    action: append
+    input:
+      sheet: demo
+      values:
+      - - row7
+        - ok
+    expect:
+      equals: 1
+  tags:
+  - showcase
+  - deterministic
+- id: web-to-sheet-08
+  steps:
+  - tool: playwright
+    action: get_text
+    input:
+      url: https://site08.local
+      selector: '#title'
+    expect:
+      equals: ''
+  - tool: gsheets
+    action: append
+    input:
+      sheet: demo
+      values:
+      - - row8
+        - ok
+    expect:
+      equals: 1
+  tags:
+  - showcase
+  - deterministic
+- id: web-to-sheet-09
+  steps:
+  - tool: playwright
+    action: get_text
+    input:
+      url: https://site09.local
+      selector: '#title'
+    expect:
+      equals: ''
+  - tool: gsheets
+    action: append
+    input:
+      sheet: demo
+      values:
+      - - row9
+        - ok
+    expect:
+      equals: 1
+  tags:
+  - showcase
+  - deterministic
+- id: web-to-sheet-10
+  steps:
+  - tool: playwright
+    action: get_text
+    input:
+      url: https://site10.local
+      selector: '#title'
+    expect:
+      equals: ''
+  - tool: gsheets
+    action: append
+    input:
+      sheet: demo
+      values:
+      - - row10
+        - ok
+    expect:
+      equals: 1
+  tags:
+  - showcase
+  - deterministic
+- id: web-to-sheet-11
+  steps:
+  - tool: playwright
+    action: click
+    input:
+      url: https://click11.local
+      selector: '#btn'
+    expect:
+      equals: 1
+  - tool: gsheets
+    action: append
+    input:
+      sheet: demo
+      values:
+      - - row11
+        - ok
+    expect:
+      equals: 1
+  tags:
+  - showcase
+  - deterministic
+- id: web-to-sheet-12
+  steps:
+  - tool: playwright
+    action: click
+    input:
+      url: https://click12.local
+      selector: '#btn'
+    expect:
+      equals: 1
+  - tool: gsheets
+    action: append
+    input:
+      sheet: demo
+      values:
+      - - row12
+        - ok
+    expect:
+      equals: 1
+  tags:
+  - showcase
+  - deterministic
+- id: web-to-sheet-13
+  steps:
+  - tool: playwright
+    action: click
+    input:
+      url: https://click13.local
+      selector: '#btn'
+    expect:
+      equals: 1
+  - tool: gsheets
+    action: append
+    input:
+      sheet: demo
+      values:
+      - - row13
+        - ok
+    expect:
+      equals: 1
+  tags:
+  - showcase
+  - deterministic
+- id: web-to-sheet-14
+  steps:
+  - tool: playwright
+    action: click
+    input:
+      url: https://click14.local
+      selector: '#btn'
+    expect:
+      equals: 1
+  - tool: gsheets
+    action: append
+    input:
+      sheet: demo
+      values:
+      - - row14
+        - ok
+    expect:
+      equals: 1
+  tags:
+  - showcase
+  - deterministic
+- id: web-to-sheet-15
+  steps:
+  - tool: playwright
+    action: click
+    input:
+      url: https://click15.local
+      selector: '#btn'
+    expect:
+      equals: 1
+  - tool: gsheets
+    action: append
+    input:
+      sheet: demo
+      values:
+      - - row15
+        - ok
+    expect:
+      equals: 1
+  tags:
+  - showcase
+  - deterministic
+- id: web-to-sheet-16
+  steps:
+  - tool: playwright
+    action: click
+    input:
+      url: https://click16.local
+      selector: '#btn'
+    expect:
+      equals: 1
+  - tool: gsheets
+    action: append
+    input:
+      sheet: demo
+      values:
+      - - row16
+        - ok
+    expect:
+      equals: 1
+  tags:
+  - showcase
+  - deterministic
+- id: web-to-sheet-17
+  steps:
+  - tool: playwright
+    action: click
+    input:
+      url: https://click17.local
+      selector: '#btn'
+    expect:
+      equals: 1
+  - tool: gsheets
+    action: append
+    input:
+      sheet: demo
+      values:
+      - - row17
+        - ok
+    expect:
+      equals: 1
+  tags:
+  - showcase
+  - deterministic
+- id: web-to-sheet-18
+  steps:
+  - tool: playwright
+    action: click
+    input:
+      url: https://click18.local
+      selector: '#btn'
+    expect:
+      equals: 1
+  - tool: gsheets
+    action: append
+    input:
+      sheet: demo
+      values:
+      - - row18
+        - ok
+    expect:
+      equals: 1
+  tags:
+  - showcase
+  - deterministic
+- id: web-to-sheet-19
+  steps:
+  - tool: playwright
+    action: click
+    input:
+      url: https://click19.local
+      selector: '#btn'
+    expect:
+      equals: 1
+  - tool: gsheets
+    action: append
+    input:
+      sheet: demo
+      values:
+      - - row19
+        - ok
+    expect:
+      equals: 1
+  tags:
+  - showcase
+  - deterministic
+- id: web-to-sheet-20
+  steps:
+  - tool: playwright
+    action: click
+    input:
+      url: https://click20.local
+      selector: '#btn'
+    expect:
+      equals: 1
+  - tool: gsheets
+    action: append
+    input:
+      sheet: demo
+      values:
+      - - row20
+        - ok
+    expect:
+      equals: 1
+  tags:
+  - showcase
+  - deterministic
+- id: web-to-sheet-21
+  steps:
+  - tool: playwright
+    action: screenshot
+    input:
+      url: https://shot21.local
+      selector: body
+    expect:
+      regex: '^screenshot:'
+  - tool: gsheets
+    action: append
+    input:
+      sheet: demo
+      values:
+      - - row21
+        - ok
+    expect:
+      equals: 1
+  tags:
+  - showcase
+  - deterministic
+- id: web-to-sheet-22
+  steps:
+  - tool: playwright
+    action: screenshot
+    input:
+      url: https://shot22.local
+      selector: body
+    expect:
+      regex: '^screenshot:'
+  - tool: gsheets
+    action: append
+    input:
+      sheet: demo
+      values:
+      - - row22
+        - ok
+    expect:
+      equals: 1
+  tags:
+  - showcase
+  - deterministic
+- id: web-to-sheet-23
+  steps:
+  - tool: playwright
+    action: screenshot
+    input:
+      url: https://shot23.local
+      selector: body
+    expect:
+      regex: '^screenshot:'
+  - tool: gsheets
+    action: append
+    input:
+      sheet: demo
+      values:
+      - - row23
+        - ok
+    expect:
+      equals: 1
+  tags:
+  - showcase
+  - deterministic
+- id: web-to-sheet-24
+  steps:
+  - tool: playwright
+    action: screenshot
+    input:
+      url: https://shot24.local
+      selector: body
+    expect:
+      regex: '^screenshot:'
+  - tool: gsheets
+    action: append
+    input:
+      sheet: demo
+      values:
+      - - row24
+        - ok
+    expect:
+      equals: 1
+  tags:
+  - showcase
+  - deterministic
+- id: web-to-sheet-25
+  steps:
+  - tool: playwright
+    action: screenshot
+    input:
+      url: https://shot25.local
+      selector: body
+    expect:
+      regex: '^screenshot:'
+  - tool: gsheets
+    action: append
+    input:
+      sheet: demo
+      values:
+      - - row25
+        - ok
+    expect:
+      equals: 1
+  tags:
+  - showcase
+  - deterministic
+- id: web-to-sheet-26
+  steps:
+  - tool: playwright
+    action: screenshot
+    input:
+      url: https://shot26.local
+      selector: body
+    expect:
+      regex: '^screenshot:'
+  - tool: gsheets
+    action: append
+    input:
+      sheet: demo
+      values:
+      - - row26
+        - ok
+    expect:
+      equals: 1
+  tags:
+  - showcase
+  - deterministic
+- id: web-to-sheet-27
+  steps:
+  - tool: playwright
+    action: screenshot
+    input:
+      url: https://shot27.local
+      selector: body
+    expect:
+      regex: '^screenshot:'
+  - tool: gsheets
+    action: append
+    input:
+      sheet: demo
+      values:
+      - - row27
+        - ok
+    expect:
+      equals: 1
+  tags:
+  - showcase
+  - deterministic
+- id: web-to-sheet-28
+  steps:
+  - tool: playwright
+    action: screenshot
+    input:
+      url: https://shot28.local
+      selector: body
+    expect:
+      regex: '^screenshot:'
+  - tool: gsheets
+    action: append
+    input:
+      sheet: demo
+      values:
+      - - row28
+        - ok
+    expect:
+      equals: 1
+  tags:
+  - showcase
+  - deterministic
+- id: web-to-sheet-29
+  steps:
+  - tool: playwright
+    action: screenshot
+    input:
+      url: https://shot29.local
+      selector: body
+    expect:
+      regex: '^screenshot:'
+  - tool: gsheets
+    action: append
+    input:
+      sheet: demo
+      values:
+      - - row29
+        - ok
+    expect:
+      equals: 1
+  tags:
+  - showcase
+  - deterministic
+- id: web-to-sheet-30
+  steps:
+  - tool: playwright
+    action: screenshot
+    input:
+      url: https://shot30.local
+      selector: body
+    expect:
+      regex: '^screenshot:'
+  - tool: gsheets
+    action: append
+    input:
+      sheet: demo
+      values:
+      - - row30
+        - ok
+    expect:
+      equals: 1
+  tags:
+  - showcase
+  - deterministic
+- id: web-to-sheet-31
+  steps:
+  - tool: playwright
+    action: screenshot
+    input:
+      url: https://shot31.local
+      selector: body
+    expect:
+      regex: '^screenshot:'
+  - tool: gsheets
+    action: append
+    input:
+      sheet: demo
+      values:
+      - - row31
+        - ok
+    expect:
+      equals: 1
+  tags:
+  - showcase
+  - deterministic

--- a/service/scenarios/rubric.py
+++ b/service/scenarios/rubric.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+"""Rubric for judging step expectations."""
+
+import re
+from typing import Any, Dict, Tuple
+
+
+class Rubric:
+    """Deterministic judging of adapter values against expectations."""
+
+    def judge(self, expect: Dict[str, Any], value: Any) -> Tuple[bool, str]:
+        """Return verdict and reason for value against expectations."""
+        if not expect:
+            return True, ""
+
+        # equality -------------------------------------------------------
+        if "equals" in expect:
+            if value != expect["equals"]:
+                return False, f"expected {expect['equals']!r} got {value!r}"
+
+        if "contains" in expect:
+            target = expect["contains"]
+            if isinstance(value, (str, list, tuple)):
+                if target not in value:
+                    return False, f"{target!r} not in {value!r}"
+            else:
+                return False, f"value {value!r} has no containment"
+
+        if "regex" in expect:
+            pattern = expect["regex"]
+            if not isinstance(value, str) or re.search(pattern, value) is None:
+                return False, f"{value!r} does not match {pattern!r}"
+
+        if "type" in expect:
+            t = expect["type"]
+            if t == "number":
+                if not isinstance(value, (int, float)):
+                    return False, f"{value!r} is not number"
+            elif t == "string":
+                if not isinstance(value, str):
+                    return False, f"{value!r} is not string"
+
+        if "approx" in expect:
+            try:
+                target = float(expect["approx"])
+                epsilon = float(expect.get("epsilon", 1e-6))
+                if not isinstance(value, (int, float)) or abs(value - target) > epsilon:
+                    return False, f"{value!r} not within {epsilon} of {target}"
+            except Exception:
+                return False, "approx expects numeric value"
+
+        return True, ""
+
+    def to_route_explain(self, verdict: bool, reason: str) -> Dict[str, Any]:
+        data = {"judged": bool(verdict)}
+        if not verdict and reason:
+            data["policy_verdict"] = reason
+        return data

--- a/service/scenarios/runner.py
+++ b/service/scenarios/runner.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+"""Simple scenario runner with record/replay support."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from time import perf_counter
+from typing import Any, Dict, Iterable, List, Mapping
+
+import yaml
+
+from .rubric import Rubric
+
+
+# ---------------------------------------------------------------------------
+# Loading
+# ---------------------------------------------------------------------------
+
+def load_pack(path: str = "scenarios/pack.yaml") -> List[Dict[str, Any]]:
+    """Load a scenario pack from ``path``.
+
+    Parameters
+    ----------
+    path:
+        Path to the YAML file containing a top-level ``scenarios`` list.
+    """
+    data: Dict[str, Any] = yaml.safe_load(Path(path).read_text()) or {}
+    scenarios = data.get("scenarios", [])
+    return list(scenarios)
+
+
+# ---------------------------------------------------------------------------
+# Step / Scenario execution
+# ---------------------------------------------------------------------------
+
+def _build_payload(step: Mapping[str, Any]) -> Dict[str, Any]:
+    """Create adapter payload from step data."""
+    payload = dict(step.get("input", {}))
+    action = step.get("action")
+    tool = step.get("tool")
+    if tool == "gsheets":
+        payload["op"] = action
+    else:
+        payload["action"] = action
+    return payload
+
+
+def run_step(
+    step: Mapping[str, Any],
+    *,
+    adapters: Mapping[str, Any],
+    rubric: Rubric,
+) -> Dict[str, Any]:
+    """Execute a single step via an adapter and judge the result."""
+    tool = step.get("tool")
+    adapter = adapters[tool]
+    payload = _build_payload(step)
+    start = perf_counter()
+    res = adapter.run(payload)
+    latency_ms = float(res.get("meta", {}).get("latency_ms", (perf_counter() - start) * 1000))
+    value = res.get("value")
+    verdict, reason = rubric.judge(step.get("expect", {}), value)
+    route_explain = {
+        "decision": "run",
+        "adapter": tool,
+        "latency_ms": latency_ms,
+    }
+    route_explain.update(rubric.to_route_explain(verdict, reason))
+    return {"ok": verdict, "value": value, "route_explain": route_explain}
+
+
+def run_scenario(
+    scn: Mapping[str, Any],
+    *,
+    adapters: Mapping[str, Any],
+    rubric: Rubric,
+) -> Dict[str, Any]:
+    """Execute all steps of a scenario."""
+    details: List[Dict[str, Any]] = []
+    for step in scn.get("steps", []):
+        res = run_step(step, adapters=adapters, rubric=rubric)
+        details.append({**step, **res})
+    passed_steps = sum(1 for d in details if d["ok"])
+    total_steps = len(details)
+    route_explain = {"steps": [d["route_explain"] for d in details]}
+    return {
+        "id": scn.get("id"),
+        "passed": passed_steps == total_steps,
+        "passed_steps": passed_steps,
+        "total_steps": total_steps,
+        "route_explain": route_explain,
+        "details": details,
+    }
+
+
+def run_all(
+    scenarios: Iterable[Mapping[str, Any]],
+    *,
+    adapters: Mapping[str, Any],
+    rubric: Rubric,
+) -> Dict[str, Any]:
+    """Run all scenarios in the iterable."""
+    results = [run_scenario(s, adapters=adapters, rubric=rubric) for s in scenarios]
+    total = len(results)
+    passed = sum(1 for r in results if r["passed"])
+    pass_rate = passed / total if total else 0.0
+    return {"summary": {"total": total, "passed": passed, "pass_rate": pass_rate}, "results": results}
+
+
+# ---------------------------------------------------------------------------
+# Replay
+# ---------------------------------------------------------------------------
+
+def replay(log_events: List[Mapping[str, Any]], *, rubric: Rubric) -> Dict[str, Any]:
+    """Re-judge previously recorded events.
+
+    Parameters
+    ----------
+    log_events:
+        Each event must contain at least ``expect`` and ``value`` fields.
+    """
+    events: List[Dict[str, Any]] = []
+    for ev in log_events:
+        verdict, reason = rubric.judge(ev.get("expect", {}), ev.get("value"))
+        event = {**ev, "ok": verdict}
+        event["route_explain"] = rubric.to_route_explain(verdict, reason)
+        events.append(event)
+    passed = sum(1 for e in events if e["ok"])
+    return {"summary": {"total": len(events), "passed": passed}, "events": events}
+

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -1,0 +1,67 @@
+from service.adapters.playwright_adapter import PlaywrightAdapter
+from service.adapters.gsheets_adapter import GSheetsAdapter
+from service.scenarios.runner import load_pack, run_step, run_scenario, run_all, replay
+from service.scenarios.rubric import Rubric
+
+
+def _adapters():
+    return {"playwright": PlaywrightAdapter(), "gsheets": GSheetsAdapter()}
+
+
+def test_pack_loads_30_plus_scenarios():
+    scenarios = load_pack()
+    assert len(scenarios) >= 30
+
+
+def test_run_single_scenario_pass_rate():
+    scenarios = load_pack()
+    res = run_scenario(scenarios[0], adapters=_adapters(), rubric=Rubric())
+    assert res["passed"]
+    assert res["passed_steps"] == res["total_steps"] == len(scenarios[0]["steps"])
+
+
+def test_runner_uses_adapters_and_returns_values():
+    step = load_pack()[0]["steps"][0]
+    res = run_step(step, adapters=_adapters(), rubric=Rubric())
+    assert res["ok"]
+    assert res["value"] == "Example Domain"
+    route = res["route_explain"]
+    assert route["adapter"] == "playwright"
+    assert "latency_ms" in route
+
+
+def test_rubric_equals_contains_regex_and_type():
+    r = Rubric()
+    assert r.judge({"equals": 5}, 5)[0]
+    assert r.judge({"contains": "ell"}, "hello")[0]
+    assert r.judge({"regex": "^he"}, "hello")[0]
+    assert r.judge({"type": "number"}, 3.14)[0]
+
+
+def test_record_then_replay_is_identical_10_of_10():
+    scenarios = load_pack()[:10]
+    run_res = run_all(scenarios, adapters=_adapters(), rubric=Rubric())
+    events = []
+    for sc in run_res["results"]:
+        for d in sc["details"]:
+            events.append({"expect": d["expect"], "value": d["value"], "ok": d["ok"]})
+    replay_res = replay(events, rubric=Rubric())
+    assert [e["ok"] for e in replay_res["events"]] == [e["ok"] for e in events]
+
+
+def test_summary_includes_pass_rate_and_counts():
+    scenarios = load_pack()[:3]
+    res = run_all(scenarios, adapters=_adapters(), rubric=Rubric())
+    summary = res["summary"]
+    assert summary["total"] == 3
+    assert summary["passed"] == 3
+    assert summary["pass_rate"] == 1.0
+
+
+def test_route_explain_fields_present():
+    scn = load_pack()[0]
+    res = run_scenario(scn, adapters=_adapters(), rubric=Rubric())
+    for d in res["details"]:
+        route = d["route_explain"]
+        for key in ["decision", "adapter", "latency_ms", "judged"]:
+            assert key in route


### PR DESCRIPTION
## Summary
- implement simple scenario runner with step execution, scenario aggregation, run-all summary, and replay
- add rubric supporting equals/contains/regex/type/approx to judge step results
- provide pack of 31 deterministic scenarios and tests exercising runner and replay

## Testing
- `pytest tests/test_scenarios.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c72c3c3d448329a4f15cb2df029afc