### PR TITLE
Implement RES-07 observability logger and replay features

### DIFF
--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -47,6 +47,7 @@ def test_policy_fields_passthrough_when_present(tmp_path):
         **BASE_ROUTE,
         "policy_verdict": "allow",
         "redaction_stats": {"foo": 1},
+        "extra": "drop-me",
     }
     log_path = tmp_path / "p.log"
     logger = JsonlLogger(str(log_path))
@@ -60,6 +61,8 @@ def test_policy_fields_passthrough_when_present(tmp_path):
     event = read_events(log_path)[0]
     assert "policy_verdict" in event["route_explain"]
     assert "redaction_stats" in event["route_explain"]
+    # ensure unexpected fields are removed from route_explain
+    assert "extra" not in event["route_explain"]
     assert "pii_raw" not in event["payload"]
     assert event["payload"]["keep"] == 1
 


### PR DESCRIPTION
## Summary
- sanitize route_explain data in JSONL logger, always include required keys and optional policy fields
- drop any `pii_raw` payload data and emit UTC timestamps
- expand observability tests covering replay, policy field pass-through, and performance

## Testing
- `pytest tests/test_observability.py tests/test_mcp_errors.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c72cc30a0483299cbe22b6b6105317