### PR TITLE
Add budget simulator and evidence pack utilities

### DIFF
--- a/config/cost_models.yaml
+++ b/config/cost_models.yaml
@@ -1,0 +1,15 @@
+providers:
+  openai:
+    gpt-4o:
+      input_price_per_1k: 5.0
+      output_price_per_1k: 15.0
+      min_charge_usd: 0.0
+    gpt-4o-mini:
+      input_price_per_1k: 0.5
+      output_price_per_1k: 1.5
+      min_charge_usd: 0.0
+  anthropic:
+    claude-3-5-sonnet:
+      input_price_per_1k: 3.0
+      output_price_per_1k: 15.0
+      min_charge_usd: 0.0

--- a/service/budget/simulator.py
+++ b/service/budget/simulator.py
@@ -1,0 +1,101 @@
+"""Budget simulation utilities."""
+from __future__ import annotations
+
+from typing import Dict, List, Any
+import yaml
+
+
+# Type aliases
+CostModels = Dict[str, Any]
+Item = Dict[str, Any]
+
+
+def load_cost_models(path: str = "config/cost_models.yaml") -> CostModels:
+    """Load pricing models from a YAML file.
+
+    Parameters
+    ----------
+    path:
+        Path to the YAML file containing model pricing information.
+
+    Returns
+    -------
+    dict
+        Parsed cost model data.
+    """
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}
+
+
+def _compute_cost(item: Item, pricing: Dict[str, float]) -> float:
+    """Compute cost for a single item given pricing information."""
+    pt = item.get("prompt_tokens", 0)
+    ct = item.get("completion_tokens", 0)
+    cost = (
+        pt * pricing.get("input_price_per_1k", 0.0) / 1000.0
+        + ct * pricing.get("output_price_per_1k", 0.0) / 1000.0
+    )
+    min_charge = pricing.get("min_charge_usd", 0.0)
+    if cost < min_charge:
+        cost = min_charge
+    return cost
+
+
+def simulate(
+    items: List[Item],
+    cost_models: CostModels,
+    *,
+    provider: str,
+    model: str,
+) -> Dict[str, Any]:
+    """Simulate token usage costs.
+
+    Parameters
+    ----------
+    items:
+        List of items representing token usage.
+    cost_models:
+        Loaded cost model data.
+    provider:
+        Provider name.
+    model:
+        Model name.
+
+    Returns
+    -------
+    dict
+        Simulation result containing per-item details and totals.
+    """
+
+    pricing = cost_models["providers"][provider][model]
+
+    result_items: List[Item] = []
+    totals = {"cost_usd": 0.0, "tokens": 0, "latency_ms": 0.0}
+
+    for item in items:
+        tokens = int(item.get("prompt_tokens", 0) + item.get("completion_tokens", 0))
+        cost = _compute_cost(item, pricing)
+        latency = float(item.get("latency_ms", 0.0))
+        route_explain = {
+            "decision": "simulate",
+            "cost_usd": cost,
+            "tokens": tokens,
+            "latency_ms": latency,
+        }
+        enriched = {
+            **item,
+            "cost_usd": cost,
+            "tokens": tokens,
+            "route_explain": route_explain,
+        }
+        result_items.append(enriched)
+        totals["cost_usd"] += cost
+        totals["tokens"] += tokens
+        totals["latency_ms"] += latency
+
+    return {
+        "provider": provider,
+        "model": model,
+        "items": result_items,
+        "totals": totals,
+    }

--- a/service/evidence/collector.py
+++ b/service/evidence/collector.py
@@ -1,0 +1,131 @@
+"""Evidence pack generation utilities."""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import zipfile
+from datetime import datetime, timezone
+from typing import Dict, Any, List
+
+
+def sanitize_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a copy of ``payload`` with PII fields removed.
+
+    Keys named ``pii_raw`` or ending with ``"_pii"`` are dropped recursively.
+    """
+
+    def _sanitize(obj: Any) -> Any:
+        if isinstance(obj, dict):
+            clean = {}
+            for k, v in obj.items():
+                if k == "pii_raw" or k.endswith("_pii"):
+                    continue
+                clean[k] = _sanitize(v)
+            return clean
+        if isinstance(obj, list):
+            return [_sanitize(v) for v in obj]
+        return obj
+
+    return _sanitize(payload)
+
+
+def _sha256(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _p95(latencies: List[float]) -> float:
+    if not latencies:
+        return 0.0
+    latencies = sorted(latencies)
+    k = int(len(latencies) * 0.95)
+    if k >= len(latencies):
+        k = len(latencies) - 1
+    return float(latencies[k])
+
+
+def pack(sim_result: Dict[str, Any], *, meta: Dict[str, Any], out_dir: str) -> str:
+    """Write an evidence pack based on ``sim_result``.
+
+    Parameters
+    ----------
+    sim_result:
+        Simulation result as produced by :func:`simulate`.
+    meta:
+        Metadata with at least an ``id`` field.
+    out_dir:
+        Directory where the evidence folder and zip should be written.
+
+    Returns
+    -------
+    str
+        Path to the generated ``evidence.zip`` file.
+    """
+
+    evidence_dir = os.path.join(out_dir, "evidence")
+    os.makedirs(evidence_dir, exist_ok=True)
+
+    items = sorted(sim_result.get("items", []), key=lambda x: x["id"])
+    totals = sim_result.get("totals", {})
+
+    # Write simulation.jsonl
+    sim_path = os.path.join(evidence_dir, "simulation.jsonl")
+    with open(sim_path, "w", encoding="utf-8") as f:
+        for item in items:
+            payload = {
+                "id": item["id"],
+                "tokens": item.get("tokens", 0),
+                "cost_usd": item.get("cost_usd", 0.0),
+                "latency_ms": item.get("latency_ms", 0.0),
+                "route_explain": item.get("route_explain", {}),
+            }
+            json.dump(sanitize_payload(payload), f, sort_keys=True)
+            f.write("\n")
+
+    # Write metrics.json
+    metrics_path = os.path.join(evidence_dir, "metrics.json")
+    latencies = [item.get("latency_ms", 0.0) for item in items]
+    count = len(items)
+    averages = {
+        "cost_usd": totals.get("cost_usd", 0.0) / count if count else 0.0,
+        "tokens": totals.get("tokens", 0) / count if count else 0.0,
+        "latency_ms": totals.get("latency_ms", 0.0) / count if count else 0.0,
+    }
+    metrics = {
+        "totals": totals,
+        "averages": averages,
+        "p95_latency_ms": _p95(latencies),
+    }
+    with open(metrics_path, "w", encoding="utf-8") as f:
+        json.dump(sanitize_payload(metrics), f, sort_keys=True)
+
+    # Manifest with hashes
+    manifest = {
+        "id": meta.get("id"),
+        "created_at_utc": datetime.utcnow().replace(tzinfo=timezone.utc).isoformat(),
+        "provider": sim_result.get("provider"),
+        "model": sim_result.get("model"),
+        "counts": {
+            "items": count,
+            "tokens": totals.get("tokens", 0),
+        },
+        "sha256": {
+            "simulation.jsonl": _sha256(sim_path),
+            "metrics.json": _sha256(metrics_path),
+        },
+    }
+    manifest_path = os.path.join(evidence_dir, "manifest.json")
+    with open(manifest_path, "w", encoding="utf-8") as f:
+        json.dump(sanitize_payload(manifest), f, sort_keys=True)
+
+    # Zip the files
+    zip_path = os.path.join(out_dir, "evidence.zip")
+    with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for name in ("manifest.json", "simulation.jsonl", "metrics.json"):
+            zf.write(os.path.join(evidence_dir, name), arcname=name)
+
+    return zip_path

--- a/tests/test_budget_simulator.py
+++ b/tests/test_budget_simulator.py
@@ -1,0 +1,57 @@
+import time
+import pytest
+
+from service.budget.simulator import load_cost_models, simulate
+
+
+@pytest.fixture
+def sample_items():
+    return [
+        {"id": "a", "prompt_tokens": 100, "completion_tokens": 50, "latency_ms": 100.0},
+        {"id": "b", "prompt_tokens": 200, "completion_tokens": 100, "latency_ms": 200.0},
+    ]
+
+
+def test_load_cost_models():
+    models = load_cost_models()
+    assert models["providers"]["openai"]["gpt-4o"]["input_price_per_1k"] == 5.0
+
+
+def test_deterministic_costs_within_tolerance(sample_items):
+    models = load_cost_models()
+    sim1 = simulate(sample_items, models, provider="openai", model="gpt-4o-mini")
+    sim2 = simulate(sample_items, models, provider="openai", model="gpt-4o-mini")
+    assert sim1["totals"]["cost_usd"] == pytest.approx(sim2["totals"]["cost_usd"], rel=0.001)
+
+
+def test_totals_and_tokens(sample_items):
+    models = load_cost_models()
+    sim = simulate(sample_items, models, provider="openai", model="gpt-4o")
+    assert sim["totals"]["tokens"] == sum(
+        i["prompt_tokens"] + i["completion_tokens"] for i in sample_items
+    )
+    assert sim["totals"]["latency_ms"] == sum(i["latency_ms"] for i in sample_items)
+    assert len(sim["items"]) == len(sample_items)
+    for item, original in zip(sim["items"], sample_items):
+        assert item["tokens"] == original["prompt_tokens"] + original["completion_tokens"]
+
+
+def test_per_item_route_explain_shape(sample_items):
+    models = load_cost_models()
+    sim = simulate(sample_items, models, provider="openai", model="gpt-4o")
+    for item in sim["items"]:
+        rex = item["route_explain"]
+        assert rex["decision"] == "simulate"
+        assert set(rex) == {"decision", "cost_usd", "tokens", "latency_ms"}
+
+
+def test_p95_under_2s_for_200_items():
+    models = load_cost_models()
+    items = [
+        {"id": str(i), "prompt_tokens": 100, "completion_tokens": 100, "latency_ms": 50.0}
+        for i in range(200)
+    ]
+    start = time.perf_counter()
+    simulate(items, models, provider="openai", model="gpt-4o")
+    duration = time.perf_counter() - start
+    assert duration < 2.0

--- a/tests/test_evidence_pack.py
+++ b/tests/test_evidence_pack.py
@@ -1,0 +1,65 @@
+import json
+import os
+import zipfile
+
+from service.budget.simulator import load_cost_models, simulate
+from service.evidence.collector import pack
+
+
+def _run_sim():
+    models = load_cost_models()
+    items = [
+        {"id": "1", "prompt_tokens": 100, "completion_tokens": 50, "latency_ms": 100.0},
+        {"id": "2", "prompt_tokens": 200, "completion_tokens": 100, "latency_ms": 200.0},
+    ]
+    return simulate(items, models, provider="openai", model="gpt-4o-mini")
+
+
+def test_pack_writes_manifest_metrics_and_jsonl(tmp_path):
+    sim = _run_sim()
+    out = pack(sim, meta={"id": "run1"}, out_dir=str(tmp_path))
+    evidence_dir = tmp_path / "evidence"
+    assert (evidence_dir / "manifest.json").exists()
+    assert (evidence_dir / "metrics.json").exists()
+    assert (evidence_dir / "simulation.jsonl").exists()
+    assert os.path.exists(out)
+
+
+def test_manifest_has_hashes_and_counts(tmp_path):
+    sim = _run_sim()
+    pack(sim, meta={"id": "run1"}, out_dir=str(tmp_path))
+    evidence_dir = tmp_path / "evidence"
+    manifest = json.loads((evidence_dir / "manifest.json").read_text())
+    sim_hash = (evidence_dir / "simulation.jsonl").read_bytes()
+    metrics_hash = (evidence_dir / "metrics.json").read_bytes()
+    import hashlib
+
+    def sha(data):
+        h = hashlib.sha256(); h.update(data); return h.hexdigest()
+
+    assert manifest["counts"]["items"] == 2
+    assert manifest["counts"]["tokens"] == 450
+    assert manifest["sha256"]["simulation.jsonl"] == sha(sim_hash)
+    assert manifest["sha256"]["metrics.json"] == sha(metrics_hash)
+
+
+def test_jsonl_lines_are_sorted_and_sanitized(tmp_path):
+    sim = _run_sim()
+    for item in sim["items"]:
+        item["user_pii"] = "secret"
+        item["pii_raw"] = "secret"
+    pack(sim, meta={"id": "run1"}, out_dir=str(tmp_path))
+    lines = (tmp_path / "evidence" / "simulation.jsonl").read_text().strip().splitlines()
+    ids = [json.loads(line)["id"] for line in lines]
+    assert ids == sorted(ids)
+    for line in lines:
+        data = json.loads(line)
+        assert all("pii" not in key for key in data.keys())
+
+
+def test_zip_contains_expected_files(tmp_path):
+    sim = _run_sim()
+    zip_path = pack(sim, meta={"id": "run1"}, out_dir=str(tmp_path))
+    with zipfile.ZipFile(zip_path, "r") as zf:
+        names = set(zf.namelist())
+    assert {"manifest.json", "metrics.json", "simulation.jsonl"} <= names


### PR DESCRIPTION
## Summary
- implement cost model loader and budget simulation with per-item cost tracking
- add evidence collector that writes manifest, metrics, and simulation logs with hashing and sanitization
- provide default cost model configuration and tests

## Testing
- `pytest tests/test_budget_simulator.py tests/test_evidence_pack.py -q`
- `pytest tests/test_mcp_errors.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c72e4f93b48329a8d8a50f61b50083