### PR TITLE
feat: add token providers and auth helpers

### DIFF
--- a/service/mcp/policy_auth.py
+++ b/service/mcp/policy_auth.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+"""Minimal auth helpers for MCP policies.
+
+This module provides a small token provider abstraction with several strategies
+used in tests.  All providers expose a :class:`TokenProvider` interface with a
+``get_token`` method, ``expires_at`` timestamp and ``valid`` method.  The
+implementation deliberately avoids any real network calls; the OAuth client
+credentials strategy simulates token fetching with deterministic values.
+"""
+
+import os
+import time
+from typing import Any, Callable, Dict, List, Optional
+
+
+class AuthError(Exception):
+    """Raised when authentication prerequisites are not met."""
+
+
+# ---------------------------------------------------------------------------
+# Policy guards
+# ---------------------------------------------------------------------------
+
+def deny_if_missing_env(vars: List[str]) -> None:
+    """Ensure all environment variables exist or raise :class:`AuthError`."""
+
+    missing = [v for v in vars if v not in os.environ]
+    if missing:
+        raise AuthError(f"missing env vars: {', '.join(missing)}")
+
+
+def validate_allowlist(name: str, allow: List[str]) -> bool:
+    """Return ``True`` if *name* is present in the allowlist."""
+
+    return name in allow
+
+
+def _redact_key(key: str) -> bool:
+    k = key.lower()
+    return "token" in k or "secret" in k or "authorization" in k
+
+
+def redact_dict(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a copy of ``data`` with token-like fields redacted."""
+
+    redacted: Dict[str, Any] = {}
+    for k, v in data.items():
+        if isinstance(v, dict):
+            redacted[k] = redact_dict(v)
+        else:
+            redacted[k] = "***" if _redact_key(k) else v
+    return redacted
+
+
+# ---------------------------------------------------------------------------
+# Token providers
+# ---------------------------------------------------------------------------
+
+
+class TokenProvider:
+    """Base token provider interface."""
+
+    auth_method: str = ""
+
+    _token: Optional[str] = None
+    _expires_at: Optional[float] = None
+
+    def get_token(self) -> str:  # pragma: no cover - interface method
+        raise NotImplementedError
+
+    # expiry ---------------------------------------------------------------
+    @property
+    def expires_at(self) -> Optional[float]:
+        return self._expires_at
+
+    def valid(self) -> bool:
+        if self._expires_at is None:
+            return True
+        return time.time() < self._expires_at
+
+    # ------------------------------------------------------------------
+    def to_route_explain(self) -> Dict[str, Any]:
+        """Return minimal, redacted metadata for routing/explanation."""
+
+        return {"auth_method": self.auth_method, "redacted": True}
+
+
+class StaticToken(TokenProvider):
+    """Token provider that reads a static token from an environment variable."""
+
+    def __init__(self, name: str, env: str):
+        self.name = name
+        self.env = env
+        self.auth_method = "static"
+        deny_if_missing_env([env])
+        self._token = os.environ[env]
+        self._expires_at = None
+
+    def get_token(self) -> str:
+        return self._token
+
+
+class BearerToken(TokenProvider):
+    """Token provider using an arbitrary callable to supply a bearer token."""
+
+    def __init__(self, getter: Callable[[], str]):
+        self.getter = getter
+        self.auth_method = "bearer"
+        self._expires_at = None
+
+    def get_token(self) -> str:
+        if self._token is None:
+            self._token = self.getter()
+        return self._token
+
+
+class OAuthClientCredentials(TokenProvider):
+    """Simulated OAuth2 client-credentials flow.
+
+    No network requests are made.  Instead, a deterministic token is generated
+    whenever a refresh is required.  Each refresh increments an internal
+    counter to produce a new token value and sets the expiry one minute ahead.
+    """
+
+    def __init__(
+        self,
+        token_url: str,
+        client_id_env: str,
+        client_secret_env: str,
+        scope: Optional[str] = None,
+    ):
+        self.token_url = token_url
+        self.client_id_env = client_id_env
+        self.client_secret_env = client_secret_env
+        self.scope = scope
+        self.auth_method = "oauth_cc"
+
+        deny_if_missing_env([client_id_env, client_secret_env])
+        self.client_id = os.environ[client_id_env]
+        self.client_secret = os.environ[client_secret_env]
+
+        self._counter = 0
+        self._token = None
+        self._expires_at = None
+
+    def _refresh(self) -> None:
+        self._counter += 1
+        # deterministic token and expiry
+        self._token = f"oauth-token-{self._counter}"
+        self._expires_at = time.time() + 60  # 1 minute from now
+
+    def get_token(self) -> str:
+        if not self.valid() or self._token is None:
+            self._refresh()
+        return self._token
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def attach_auth_headers(req: Dict[str, Any], provider: TokenProvider) -> Dict[str, Any]:
+    """Return a new request dictionary with the auth header attached."""
+
+    token = provider.get_token()
+    header = f"Bearer {token}"
+    if provider.auth_method == "static":
+        header = f"Token {token}"
+    new_req = dict(req)
+    new_req["Authorization"] = header
+    return new_req
+
+
+__all__ = [
+    "AuthError",
+    "deny_if_missing_env",
+    "validate_allowlist",
+    "TokenProvider",
+    "StaticToken",
+    "BearerToken",
+    "OAuthClientCredentials",
+    "attach_auth_headers",
+    "redact_dict",
+]

--- a/tests/test_mcp_auth.py
+++ b/tests/test_mcp_auth.py
@@ -1,0 +1,77 @@
+import os
+import time
+
+import pytest
+
+from service.mcp.policy_auth import (
+    AuthError,
+    StaticToken,
+    BearerToken,
+    OAuthClientCredentials,
+    attach_auth_headers,
+    deny_if_missing_env,
+    validate_allowlist,
+)
+
+
+def test_static_bearer_headers(monkeypatch):
+    monkeypatch.setenv("STATIC_TOKEN", "static-secret")
+    static = StaticToken("svc", "STATIC_TOKEN")
+    req = attach_auth_headers({}, static)
+    assert req["Authorization"] == "Token static-secret"
+    assert static.valid()
+    assert static.expires_at is None
+
+    bearer = BearerToken(lambda: "bear")
+    req2 = attach_auth_headers({}, bearer)
+    assert req2["Authorization"] == "Bearer bear"
+
+
+def test_oauth_cc_refresh_and_headers(monkeypatch):
+    monkeypatch.setenv("CLIENT_ID", "id")
+    monkeypatch.setenv("CLIENT_SECRET", "sec")
+    provider = OAuthClientCredentials("https://example/token", "CLIENT_ID", "CLIENT_SECRET")
+
+    req = attach_auth_headers({}, provider)
+    assert req["Authorization"] == "Bearer oauth-token-1"
+
+    # force expiry
+    provider._expires_at = time.time() - 1
+    req2 = attach_auth_headers({}, provider)
+    assert req2["Authorization"] == "Bearer oauth-token-2"
+    assert provider.valid()
+
+
+def test_missing_env_raises_autherror(monkeypatch):
+    if "MISSING" in os.environ:
+        del os.environ["MISSING"]
+    with pytest.raises(AuthError):
+        deny_if_missing_env(["MISSING"])
+
+
+def test_redaction_in_route_explain(monkeypatch):
+    monkeypatch.setenv("STATIC_TOKEN", "s3cr3t")
+    static = StaticToken("svc", "STATIC_TOKEN")
+    expl = static.to_route_explain()
+    assert expl == {"auth_method": "static", "redacted": True}
+
+
+def test_allowlist_policy():
+    allow = ["a", "b"]
+    assert validate_allowlist("a", allow)
+    assert not validate_allowlist("c", allow)
+
+
+def test_no_secret_values_in_logs(monkeypatch, capsys):
+    monkeypatch.setenv("STATIC_TOKEN", "shh")
+    static = StaticToken("svc", "STATIC_TOKEN")
+
+    captured = []
+
+    def fake_print(*args, **kwargs):
+        captured.append(" ".join(str(a) for a in args))
+
+    monkeypatch.setattr("builtins.print", fake_print)
+    attach_auth_headers({}, static)
+    # our code never prints, so captured should be empty
+    assert not captured


### PR DESCRIPTION
## Summary
- add policy auth token providers (static, bearer, oauth client credentials)
- support env guard/allowlist helpers and header attachment with redaction
- cover auth helpers with tests

## Testing
- `pytest tests/test_mcp_auth.py tests/test_mcp_errors.py`

------
https://chatgpt.com/codex/tasks/task_e_68c73002897883298b7577655160aae8