### PR TITLE
Implement MCP registry loader with defaults and wiring helpers

### DIFF
--- a/registries/mcp/loader.py
+++ b/registries/mcp/loader.py
@@ -49,6 +49,7 @@ TOOL_SCHEMA: Dict[str, Any] = {
         "type": {"type": "string", "enum": ["http", "script", "remote"]},
         "entry": {"type": "string"},
         "timeout_ms": {"type": "integer", "minimum": 0, "default": 15000},
+        "estimated_latency_ms": {"type": "integer", "minimum": 0, "default": 200},
         "enabled": {"type": "boolean", "default": True},
         "retry": {
             "type": "object",
@@ -94,6 +95,7 @@ Registry = Dict[str, Any]
 def _apply_defaults(registry: Registry) -> None:
     for tool in registry.get("tool", []):
         tool.setdefault("timeout_ms", 15000)
+        tool.setdefault("estimated_latency_ms", 200)
         tool.setdefault("enabled", True)
 
 

--- a/tests/test_mcp_loader.py
+++ b/tests/test_mcp_loader.py
@@ -24,6 +24,7 @@ def test_valid_registry_loads_and_lists():
     assert list_tools(registry) == ["alpha-tool", "beta-tool"]
     tool = get_tool(registry, "alpha-tool")
     assert tool["timeout_ms"] == 15000
+    assert tool["estimated_latency_ms"] == 200
     assert tool["enabled"] is True
 
 


### PR DESCRIPTION
## Summary
- implement MCP registry loader with schema validation and default fields
- provide wiring helpers for summarising tool counts and registry metadata
- add comprehensive tests covering registry loading, secrets, and wiring summaries

## Testing
- `pytest tests/test_mcp_loader.py tests/test_mcp_errors.py`


------
https://chatgpt.com/codex/tasks/task_e_68c730eb7fe88329823a1adedd20ca9a