### PR TITLE
feat: add lightweight MCP observability hooks

### DIFF
--- a/service/mcp/observability.py
+++ b/service/mcp/observability.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, Optional
+
+from .error_taxonomy import MCPError, map_exception, is_retryable, to_route_explain
+
+
+__all__ = [
+    "start_call",
+    "record_success",
+    "record_error",
+    "to_jsonl",
+    "from_jsonl",
+]
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _iso_utc() -> str:
+    """Return an ISO formatted UTC timestamp."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+_SECRET_SUFFIXES: Iterable[str] = ("_secret", "_token")
+
+
+def _redact(extra: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a new dict dropping obvious secret keys."""
+    if not extra:
+        return {}
+    return {
+        k: v
+        for k, v in extra.items()
+        if k != "pii_raw" and not any(k.endswith(suf) for suf in _SECRET_SUFFIXES)
+    }
+
+
+# ---------------------------------------------------------------------------
+# context manager
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class _CallCtx:
+    tool: str
+    request_id: str
+    idempotency_key: Optional[str]
+    attempt: int = 1
+    start: float | None = None
+    latency_ms: float | None = None
+
+
+class _CallTimer:
+    def __init__(self, ctx: _CallCtx):
+        self.ctx = ctx
+
+    def __enter__(self) -> _CallCtx:
+        self.ctx.start = time.monotonic()
+        return self.ctx
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        end = time.monotonic()
+        if self.ctx.start is not None:
+            self.ctx.latency_ms = (end - self.ctx.start) * 1000.0
+        return False
+
+
+# ---------------------------------------------------------------------------
+# public API
+# ---------------------------------------------------------------------------
+
+
+def start_call(tool: str, request_id: str, *, idempotency_key: str | None = None) -> _CallTimer:
+    """Create a context manager for an MCP tool call."""
+    ctx = _CallCtx(tool=tool, request_id=request_id, idempotency_key=idempotency_key)
+    return _CallTimer(ctx)
+
+
+def _base_event(ctx: _CallCtx, route_explain: Dict[str, Any]) -> Dict[str, Any]:
+    payload = {
+        "tool": ctx.tool,
+        "request_id": ctx.request_id,
+        "idempotency_key": ctx.idempotency_key,
+    }
+    meta = {
+        "attempt": ctx.attempt,
+        "latency_ms": ctx.latency_ms,
+    }
+    return {
+        "ts": _iso_utc(),
+        "name": "mcp.call",
+        "route_explain": route_explain,
+        "payload": payload,
+        "meta": meta,
+    }
+
+
+def record_success(
+    ctx: _CallCtx,
+    *,
+    confidence: float,
+    budget_verdict: str = "ok",
+    extra: Dict[str, Any] | None = None,
+) -> Dict[str, Any]:
+    """Return an event dict for a successful MCP call."""
+    route_explain: Dict[str, Any] = {
+        "decision": "success",
+        "confidence": confidence,
+        "budget_verdict": budget_verdict,
+    }
+    if extra:
+        route_explain.update(_redact(extra))
+
+    event = _base_event(ctx, route_explain)
+    event["meta"].update({"error_class": None, "retryable": False})
+    return event
+
+
+def record_error(
+    ctx: _CallCtx,
+    mcp_error: Exception | MCPError,
+    *,
+    confidence: float = 0.0,
+    budget_verdict: str = "ok",
+) -> Dict[str, Any]:
+    """Return an event dict for a failed MCP call."""
+    err = mcp_error if isinstance(mcp_error, MCPError) else map_exception(mcp_error)
+    route_explain: Dict[str, Any] = {
+        "decision": "error",
+        "confidence": confidence,
+        "budget_verdict": budget_verdict,
+    }
+    route_explain.update(to_route_explain(err))
+
+    event = _base_event(ctx, route_explain)
+    event["meta"].update(
+        {
+            "error_class": err.cls.value,
+            "retryable": is_retryable(err),
+        }
+    )
+    return event
+
+
+# ---------------------------------------------------------------------------
+# jsonl helpers
+# ---------------------------------------------------------------------------
+
+
+def to_jsonl(event: Dict[str, Any]) -> str:
+    """Serialize an event to a single JSON line."""
+    return json.dumps(event, separators=(",", ":"), sort_keys=True)
+
+
+def from_jsonl(line: str) -> Dict[str, Any]:
+    """Parse a JSON line back into an event dict."""
+    return json.loads(line)
+

--- a/tests/test_mcp_observability.py
+++ b/tests/test_mcp_observability.py
@@ -1,0 +1,91 @@
+import time
+
+import pytest
+
+from service.mcp import observability as obs
+from service.mcp.error_taxonomy import ErrorClass
+
+
+FIXED_TS = "2023-01-01T00:00:00+00:00"
+
+
+@pytest.fixture(autouse=True)
+def fixed_ts(monkeypatch):
+    monkeypatch.setattr(obs, "_iso_utc", lambda: FIXED_TS)
+
+
+def test_success_event_shape_and_redaction():
+    with obs.start_call("toolA", "req1", idempotency_key="idem") as ctx:
+        pass
+    event = obs.record_success(
+        ctx,
+        confidence=0.9,
+        extra={"pii_raw": "x", "api_token": "y", "foo": 1, "db_secret": "z"},
+    )
+
+    assert event["name"] == "mcp.call"
+    assert event["payload"] == {
+        "tool": "toolA",
+        "request_id": "req1",
+        "idempotency_key": "idem",
+    }
+    route = event["route_explain"]
+    assert route["decision"] == "success"
+    assert route["confidence"] == 0.9
+    assert route["budget_verdict"] == "ok"
+    assert "foo" in route
+    assert "pii_raw" not in route and "api_token" not in route and "db_secret" not in route
+    assert event["meta"]["error_class"] is None
+
+
+def test_error_event_includes_error_class_and_retryable_meta():
+    with obs.start_call("toolB", "req2") as ctx:
+        pass
+    event = obs.record_error(ctx, TimeoutError("boom"))
+
+    assert event["route_explain"]["decision"] == "error"
+    assert event["meta"]["error_class"] == ErrorClass.TIMEOUT.value
+    assert event["meta"]["retryable"] is True
+    assert event["route_explain"]["cls"] == ErrorClass.TIMEOUT.value
+
+
+def test_context_manager_measures_latency():
+    with obs.start_call("toolC", "req3") as ctx:
+        time.sleep(0.01)
+    event = obs.record_success(ctx, confidence=0.5)
+    assert event["meta"]["latency_ms"] >= 10
+
+
+def test_jsonl_roundtrip():
+    with obs.start_call("toolD", "req4") as ctx:
+        pass
+    event = obs.record_success(ctx, confidence=1.0)
+    line = obs.to_jsonl(event)
+    out = obs.from_jsonl(line)
+    assert out == event
+
+
+def test_overhead_p95_under_2ms():
+    times = []
+    for _ in range(100):
+        t0 = time.monotonic()
+        with obs.start_call("t", "r") as ctx:
+            pass
+        obs.record_success(ctx, confidence=0.1)
+        times.append((time.monotonic() - t0) * 1000)
+    times.sort()
+    p95 = times[int(len(times) * 0.95)]
+    assert p95 < 2.0
+
+
+def test_replay_10_of_10_identical(monkeypatch):
+    seq = iter(range(20))
+    monkeypatch.setattr(obs.time, "monotonic", lambda: next(seq))
+
+    lines = []
+    for _ in range(10):
+        with obs.start_call("tool", "req") as ctx:
+            pass
+        line = obs.to_jsonl(obs.record_success(ctx, confidence=1.0))
+        lines.append(line)
+    assert len(set(lines)) == 1


### PR DESCRIPTION
## Summary
- add context managed MCP call timing and JSONL helpers
- record success and error events with redaction and retryable metadata
- exercise observability hooks with dedicated tests

## Testing
- `pytest tests/test_mcp_observability.py tests/test_mcp_errors.py`

------
https://chatgpt.com/codex/tasks/task_e_68c7315fcd9c8329a75757c035acfdaa