### PR TITLE
feat: add prompt deck system

### DIFF
--- a/service/prompts/decks.yaml
+++ b/service/prompts/decks.yaml
@@ -1,0 +1,25 @@
+decks:
+  generic:
+    system: |
+      You are Alpha Solver. Be concise. Show the final answer only.
+    user_template: |
+      {{ task }}
+  web_extract:
+    system: |
+      Extract only the essentials from the provided page context.
+    user_template: |
+      URL: {{ url }}
+      Goal: {{ goal }}
+      Return: {{ fields|join(", ") }}
+  sheets_ops:
+    system: |
+      Operate on tabular data safely and idempotently.
+    user_template: |
+      Op: {{ op }}
+      Sheet: {{ sheet }}
+      Values: {{ values }}
+  policy_clarify:
+    system: |
+      Ask only what is necessary to proceed while respecting policy.
+    user_template: |
+      Missing: {{ missing_fields|join(", ") }}

--- a/service/prompts/renderer.py
+++ b/service/prompts/renderer.py
@@ -1,0 +1,100 @@
+"""Prompt deck renderer and helpers."""
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Any, Dict, List
+
+
+def deck_sha(decks_yaml_text: str) -> str:
+    """Return stable SHA256 hex digest for the given decks YAML text."""
+    h = hashlib.sha256()
+    h.update(decks_yaml_text.encode("utf-8"))
+    return h.hexdigest()
+
+
+def load_decks(path: str = "service/prompts/decks.yaml") -> Dict[str, Any]:
+    """Load decks from a YAML file without external dependencies."""
+    with open(path, "r", encoding="utf-8") as f:
+        text = f.read()
+    sha = deck_sha(text)
+    decks: Dict[str, Dict[str, str]] = {}
+    current_deck: str | None = None
+    current_key: str | None = None
+    block_lines: List[str] = []
+    collecting = False
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        if line.startswith("decks:"):
+            continue
+        if line.startswith("  ") and not line.startswith("    "):
+            # New deck
+            if collecting and current_deck and current_key:
+                decks[current_deck][current_key] = "\n".join(block_lines).rstrip()
+                collecting = False
+                block_lines = []
+            current_deck = line.strip().rstrip(":")
+            decks[current_deck] = {}
+        elif line.startswith("    ") and not line.startswith("      "):
+            # key within deck
+            if collecting and current_deck and current_key:
+                decks[current_deck][current_key] = "\n".join(block_lines).rstrip()
+                collecting = False
+                block_lines = []
+            key, rest = line.strip().split(":", 1)
+            rest = rest.strip()
+            if rest == "|":
+                collecting = True
+                current_key = key
+                block_lines = []
+            else:
+                decks[current_deck][key] = rest
+        else:
+            if collecting and current_deck and current_key:
+                block_lines.append(line[6:])
+    if collecting and current_deck and current_key:
+        decks[current_deck][current_key] = "\n".join(block_lines).rstrip()
+    decks["_deck_sha"] = sha
+    return decks
+
+
+_TEMPLATE_RE = re.compile(r"{{\s*([a-zA-Z0-9_]+)(?:\|join\(\s*['\"]([^'\"]*)['\"]\s*\))?\s*}}");
+
+
+def _render_template(template: str, ctx: Dict[str, Any]) -> str:
+    def repl(match: re.Match) -> str:
+        var = match.group(1)
+        joiner = match.group(2)
+        value = ctx.get(var, "")
+        if joiner is not None:
+            if isinstance(value, (list, tuple)):
+                return joiner.join(str(x) for x in value)
+            return str(value)
+        return str(value)
+
+    return _TEMPLATE_RE.sub(repl, template).strip()
+
+
+def render(deck_name: str, ctx: Dict[str, Any], decks: Dict[str, Any]) -> Dict[str, str]:
+    deck = decks[deck_name]
+    system = _render_template(deck.get("system", ""), ctx)
+    user = _render_template(deck.get("user_template", ""), ctx)
+    return {"system": system, "user": user, "deck_sha": decks.get("_deck_sha", "")}
+
+
+def to_route_explain(deck_name: str, deck_sha_str: str) -> Dict[str, str]:
+    return {"prompt_deck": deck_name, "deck_sha": deck_sha_str}
+
+
+def estimate_tokens(text: str) -> int:
+    return len(text.split())
+
+
+def compare_token_savings(baseline_prompts: List[str], new_prompts: List[str]) -> float:
+    base = sum(estimate_tokens(p) for p in baseline_prompts)
+    new = sum(estimate_tokens(p) for p in new_prompts)
+    if base == 0:
+        return 0.0
+    return (base - new) / base * 100.0
+

--- a/service/prompts/selector.py
+++ b/service/prompts/selector.py
@@ -1,0 +1,56 @@
+"""Prompt deck selector."""
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+
+# Mapping from deck names to required context keys
+_DECK_KEYS = {
+    "generic": ["task"],
+    "web_extract": ["url", "goal", "fields"],
+    "sheets_ops": ["op", "sheet", "values"],
+    "policy_clarify": ["missing_fields"],
+}
+
+
+def _normalize_value(value: Any) -> Any:
+    """Strip whitespace from strings and items inside lists."""
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, list):
+        return [_normalize_value(v) for v in value]
+    return value
+
+
+def choose_deck(context: Dict[str, Any]) -> Tuple[str, Dict[str, Any]]:
+    """Choose a prompt deck and minimal render context.
+
+    Deterministic rules:
+      - if context.get("intent") == "browse" -> "web_extract"
+      - elif context.get("intent") == "sheet" -> "sheets_ops"
+      - elif context.get("clarify", False) -> "policy_clarify"
+      - else -> "generic"
+    """
+
+    intent = (context.get("intent") or "").strip()
+    deck = "generic"
+    if intent == "browse":
+        deck = "web_extract"
+    elif intent == "sheet":
+        deck = "sheets_ops"
+    elif bool(context.get("clarify", False)):
+        deck = "policy_clarify"
+
+    keys = _DECK_KEYS[deck]
+    render_ctx: Dict[str, Any] = {}
+    for k in keys:
+        if k in context:
+            render_ctx[k] = _normalize_value(context[k])
+        else:
+            # ensure key exists for template substitution
+            if k in ("fields", "values", "missing_fields"):
+                render_ctx[k] = []
+            else:
+                render_ctx[k] = ""
+    return deck, render_ctx
+

--- a/tests/test_prompt_decks.py
+++ b/tests/test_prompt_decks.py
@@ -1,0 +1,89 @@
+import time
+
+from service.prompts.selector import choose_deck
+from service.prompts.renderer import (
+    compare_token_savings,
+    load_decks,
+    render,
+    deck_sha,
+    to_route_explain,
+)
+
+
+def test_choose_deck_intents_are_deterministic():
+    deck, ctx = choose_deck({"task": "do"})
+    assert deck == "generic"
+    assert ctx == {"task": "do"}
+
+    deck, ctx = choose_deck({"intent": "browse", "url": "u", "goal": "g", "fields": ["a"]})
+    assert deck == "web_extract"
+    assert ctx == {"url": "u", "goal": "g", "fields": ["a"]}
+
+    deck, ctx = choose_deck({"intent": "sheet", "op": "append", "sheet": "s", "values": [1, 2]})
+    assert deck == "sheets_ops"
+    assert ctx == {"op": "append", "sheet": "s", "values": [1, 2]}
+
+    deck, ctx = choose_deck({"clarify": True, "missing_fields": ["x", "y"]})
+    assert deck == "policy_clarify"
+    assert ctx == {"missing_fields": ["x", "y"]}
+
+
+def test_render_substitutes_vars_and_joins():
+    decks = load_decks()
+    ctx = {"url": "http://a", "goal": "info", "fields": ["title", "body"]}
+    rendered = render("web_extract", ctx, decks)
+    assert "Extract only the essentials" in rendered["system"]
+    assert "URL: http://a" in rendered["user"]
+    assert "Return: title, body" in rendered["user"]
+
+
+def test_deck_sha_is_stable():
+    with open("service/prompts/decks.yaml", "r", encoding="utf-8") as f:
+        text = f.read()
+    sha1 = deck_sha(text)
+    sha2 = deck_sha(text)
+    assert sha1 == sha2
+
+
+def test_route_explain_contains_deck_and_sha():
+    decks = load_decks()
+    rendered = render("generic", {"task": "t"}, decks)
+    info = to_route_explain("generic", rendered["deck_sha"])
+    assert info["prompt_deck"] == "generic"
+    assert info["deck_sha"] == rendered["deck_sha"]
+
+
+def test_token_savings_ge_20_percent_on_sample_set():
+    baseline = [
+        (
+            "System: You are a highly verbose assistant that must respond with long, detailed explanations for every request. "
+            "User: please complete task one with all reasoning shown."
+        ),
+        (
+            "System: You are a highly verbose assistant that must respond with long, detailed explanations for every request. "
+            "User: please complete task two with all reasoning shown."
+        ),
+    ]
+    decks = load_decks()
+    contexts = [{"task": "task one"}, {"task": "task two"}]
+    new_prompts = []
+    for ctx in contexts:
+        deck, rctx = choose_deck(ctx)
+        rendered = render(deck, rctx, decks)
+        new_prompts.append(rendered["system"] + " " + rendered["user"])
+    reduction = compare_token_savings(baseline, new_prompts)
+    assert reduction >= 20.0
+
+
+def test_p95_render_under_200ms():
+    decks = load_decks()
+    durations = []
+    for i in range(100):
+        ctx = {"task": f"do {i}"}
+        deck, rctx = choose_deck(ctx)
+        start = time.monotonic()
+        render(deck, rctx, decks)
+        durations.append(time.monotonic() - start)
+    durations.sort()
+    p95 = durations[int(len(durations) * 0.95)]
+    assert p95 < 0.2


### PR DESCRIPTION
## Summary
- add prompt decks for generic, web extraction, sheets ops, and policy clarification
- implement deterministic deck selection and rendering helpers with SHA tracking
- cover new deck flow with token-savings and performance tests

## Testing
- `pytest tests/test_prompt_decks.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c73f1b37f083298d999ffea5407450