### PR TITLE
feat: add evidence pack store

### DIFF
--- a/service/evidence/api.py
+++ b/service/evidence/api.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from . import store
+
+router = APIRouter()
+
+
+@router.post("/evidence")
+def post_evidence(body: dict):
+    manifest = body.get("manifest", {})
+    simulation_lines = body.get("simulation_lines", [])
+    metrics = body.get("metrics", {})
+    tags = body.get("tags")
+    return store.put_pack(manifest, simulation_lines, metrics, tags=tags)
+
+
+@router.get("/evidence")
+def get_evidence_list(start: str | None = None, end: str | None = None, tag: str | None = None, limit: int = 100):
+    return store.list_packs(start=start, end=end, tag=tag, limit=limit)
+
+
+@router.get("/evidence/{evidence_id}")
+def get_evidence(evidence_id: str):
+    return store.get_pack(evidence_id)
+

--- a/service/evidence/store.py
+++ b/service/evidence/store.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+import zipfile
+
+# Base paths (can be monkeypatched in tests)
+BASE_DIR = Path(__file__).resolve().parent
+INDEX_PATH = BASE_DIR / "index.jsonl"
+PACKS_DIR = BASE_DIR / "packs"
+
+
+def _utcnow() -> datetime:
+    """Return current UTC time with tzinfo."""
+    return datetime.utcnow().replace(tzinfo=timezone.utc)
+
+
+def _sanitize(obj: Any) -> Any:
+    """Recursively drop PII/secret keys."""
+    if isinstance(obj, dict):
+        clean = {}
+        for k, v in obj.items():
+            if k == "pii_raw" or k.endswith("_token") or k.endswith("_secret"):
+                continue
+            clean[k] = _sanitize(v)
+        return clean
+    if isinstance(obj, list):
+        return [_sanitize(v) for v in obj]
+    return obj
+
+
+def _atomic_write(path: Path, data: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + ".tmp")
+    with open(tmp, "wb") as f:
+        f.write(data)
+    os.replace(tmp, path)
+
+
+def put_pack(
+    manifest: Dict[str, Any],
+    simulation_lines: List[str],
+    metrics: Dict[str, Any],
+    *,
+    tags: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    now = _utcnow()
+    ts = now.isoformat().replace("+00:00", "Z")
+    date_str = now.strftime("%Y%m%d")
+    pack_id = uuid.uuid4().hex
+
+    pack_dir = PACKS_DIR / date_str / pack_id
+    pack_dir.mkdir(parents=True, exist_ok=False)
+
+    manifest_clean = _sanitize(manifest)
+    metrics_clean = _sanitize(metrics)
+
+    manifest_path = pack_dir / "manifest.json"
+    metrics_path = pack_dir / "metrics.json"
+    sim_path = pack_dir / "simulation.jsonl"
+    zip_path = pack_dir / "evidence.zip"
+
+    _atomic_write(
+        manifest_path, json.dumps(manifest_clean, separators=(",", ":")).encode("utf-8")
+    )
+    sim_content = "\n".join(simulation_lines)
+    if simulation_lines:
+        sim_content += "\n"
+    _atomic_write(sim_path, sim_content.encode("utf-8"))
+    _atomic_write(
+        metrics_path, json.dumps(metrics_clean, separators=(",", ":")).encode("utf-8")
+    )
+
+    tmp_zip = zip_path.with_name(zip_path.name + ".tmp")
+    with zipfile.ZipFile(tmp_zip, "w", compression=zipfile.ZIP_DEFLATED) as z:
+        z.writestr(
+            "manifest.json", json.dumps(manifest_clean, separators=(",", ":"))
+        )
+        z.writestr("simulation.jsonl", sim_content)
+        z.writestr(
+            "metrics.json", json.dumps(metrics_clean, separators=(",", ":"))
+        )
+    os.replace(tmp_zip, zip_path)
+
+    h = hashlib.sha256()
+    with open(zip_path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    sha256_zip = h.hexdigest()
+    size_zip = zip_path.stat().st_size
+
+    entry = {
+        "id": pack_id,
+        "ts": ts,
+        "tags": tags or [],
+        "sha256_zip": sha256_zip,
+        "size_zip": size_zip,
+        "paths": {"zip": str(zip_path)},
+    }
+
+    lock_path = INDEX_PATH.with_suffix(".lock")
+    lock_fd = None
+    while True:
+        try:
+            lock_fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_RDWR)
+            break
+        except FileExistsError:
+            time.sleep(0.01)
+    try:
+        INDEX_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with open(INDEX_PATH, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry, separators=(",", ":")) + "\n")
+    finally:
+        if lock_fd is not None:
+            os.close(lock_fd)
+            os.unlink(lock_path)
+
+    return entry
+
+
+def list_packs(
+    *,
+    start: Optional[str] = None,
+    end: Optional[str] = None,
+    tag: Optional[str] = None,
+    limit: int = 100,
+) -> List[Dict[str, Any]]:
+    if not INDEX_PATH.exists():
+        return []
+    results: List[Dict[str, Any]] = []
+    with open(INDEX_PATH, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            obj = json.loads(line)
+            if start and obj["ts"] < start:
+                continue
+            if end and obj["ts"] > end:
+                continue
+            if tag and tag not in obj.get("tags", []):
+                continue
+            results.append(obj)
+    results.sort(key=lambda x: x["ts"], reverse=True)
+    return results[:limit]
+
+
+def get_pack(pack_id: str) -> Dict[str, Any]:
+    if not INDEX_PATH.exists():
+        raise KeyError(pack_id)
+    entry: Optional[Dict[str, Any]] = None
+    with open(INDEX_PATH, "r", encoding="utf-8") as f:
+        for line in f:
+            obj = json.loads(line)
+            if obj.get("id") == pack_id:
+                entry = obj
+    if entry is None:
+        raise KeyError(pack_id)
+
+    zip_path = Path(entry["paths"]["zip"])
+    h = hashlib.sha256()
+    with open(zip_path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    size = zip_path.stat().st_size
+    if h.hexdigest() != entry["sha256_zip"] or size != entry["size_zip"]:
+        raise ValueError("evidence.zip integrity check failed")
+
+    pack_dir = zip_path.parent
+    manifest_path = pack_dir / "manifest.json"
+    metrics_path = pack_dir / "metrics.json"
+    sim_path = pack_dir / "simulation.jsonl"
+    manifest = json.loads(manifest_path.read_text("utf-8"))
+    metrics = json.loads(metrics_path.read_text("utf-8"))
+
+    result = dict(entry)
+    result.update(
+        {
+            "manifest": manifest,
+            "metrics": metrics,
+            "paths": {
+                "zip": str(zip_path),
+                "manifest": str(manifest_path),
+                "metrics": str(metrics_path),
+                "simulation": str(sim_path),
+            },
+        }
+    )
+    return result
+
+
+def to_route_explain(entry: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "evidence_id": entry["id"],
+        "sha256": entry["sha256_zip"],
+        "size_zip": entry["size_zip"],
+        "tags": entry.get("tags", []),
+    }
+

--- a/tests/test_evidence_store.py
+++ b/tests/test_evidence_store.py
@@ -1,0 +1,112 @@
+import json
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from service.evidence import store
+
+
+@pytest.fixture(autouse=True)
+def temp_store(tmp_path, monkeypatch):
+    base = tmp_path / "evidence"
+    monkeypatch.setattr(store, "BASE_DIR", base)
+    monkeypatch.setattr(store, "INDEX_PATH", base / "index.jsonl")
+    monkeypatch.setattr(store, "PACKS_DIR", base / "packs")
+    store.INDEX_PATH.parent.mkdir(parents=True, exist_ok=True)
+    store.INDEX_PATH.touch()
+    yield
+
+
+def test_put_pack_writes_files_and_catalog(monkeypatch):
+    now = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    monkeypatch.setattr(store, "_utcnow", lambda: now)
+    entry = store.put_pack({"foo": "bar"}, ["line1", "line2"], {"m": 1}, tags=["tag1"])
+    pack_dir = store.PACKS_DIR / now.strftime("%Y%m%d") / entry["id"]
+    assert (pack_dir / "manifest.json").exists()
+    assert (pack_dir / "simulation.jsonl").exists()
+    assert (pack_dir / "metrics.json").exists()
+    assert (pack_dir / "evidence.zip").exists()
+    lines = store.INDEX_PATH.read_text().strip().splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0])["id"] == entry["id"]
+
+
+def test_list_packs_filter_by_date_and_tag(monkeypatch):
+    t1 = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    t2 = datetime(2024, 1, 2, tzinfo=timezone.utc)
+    monkeypatch.setattr(store, "_utcnow", lambda: t1)
+    e1 = store.put_pack({"a": 1}, [], {}, tags=["a"])
+    monkeypatch.setattr(store, "_utcnow", lambda: t2)
+    e2 = store.put_pack({"b": 1}, [], {}, tags=["b"])
+    res_tag = store.list_packs(tag="a")
+    assert [r["id"] for r in res_tag] == [e1["id"]]
+    start_iso = t2.isoformat().replace("+00:00", "Z")
+    res_start = store.list_packs(start=start_iso)
+    assert [r["id"] for r in res_start] == [e2["id"]]
+
+
+def test_get_pack_verifies_sha_and_size(monkeypatch):
+    now = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    monkeypatch.setattr(store, "_utcnow", lambda: now)
+    entry = store.put_pack({"x": 1}, ["l"], {"y": 2})
+    got = store.get_pack(entry["id"])
+    assert got["manifest"]["x"] == 1
+    zip_path = Path(got["paths"]["zip"])
+    zip_path.write_bytes(b"tamper")
+    with pytest.raises(ValueError):
+        store.get_pack(entry["id"])
+
+
+def test_route_explain_shape(monkeypatch):
+    now = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    monkeypatch.setattr(store, "_utcnow", lambda: now)
+    entry = store.put_pack({"x": 1}, [], {}, tags=["t"])
+    explain = store.to_route_explain(entry)
+    assert explain == {
+        "evidence_id": entry["id"],
+        "sha256": entry["sha256_zip"],
+        "size_zip": entry["size_zip"],
+        "tags": ["t"],
+    }
+
+
+def test_no_pii_or_secrets_in_catalog_or_files(monkeypatch):
+    now = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    monkeypatch.setattr(store, "_utcnow", lambda: now)
+    manifest = {"pii_raw": "secret", "ok": {"inner_token": "s", "keep": 1}}
+    metrics = {"val": 1, "api_secret": "x", "nested": {"child_token": "y"}}
+    entry = store.put_pack(manifest, [], metrics)
+    pack_dir = store.PACKS_DIR / now.strftime("%Y%m%d") / entry["id"]
+    manifest_data = json.loads((pack_dir / "manifest.json").read_text())
+    metrics_data = json.loads((pack_dir / "metrics.json").read_text())
+    assert "pii_raw" not in manifest_data
+    assert "inner_token" not in manifest_data["ok"]
+    assert "api_secret" not in metrics_data
+    assert "child_token" not in metrics_data["nested"]
+    line = store.INDEX_PATH.read_text().strip()
+    assert "pii_raw" not in line and "api_secret" not in line
+
+
+def test_list_packs_p95_under_500ms_with_1k_items():
+    now = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    lines = []
+    for i in range(1000):
+        ts = (now + timedelta(seconds=i)).isoformat().replace("+00:00", "Z")
+        entry = {
+            "id": f"id{i}",
+            "ts": ts,
+            "tags": [],
+            "sha256_zip": "0" * 64,
+            "size_zip": 1,
+            "paths": {"zip": "dummy"},
+        }
+        lines.append(json.dumps(entry, separators=(",", ":")))
+    store.INDEX_PATH.write_text("\n".join(lines) + "\n")
+    start = time.perf_counter()
+    res = store.list_packs(limit=100)
+    elapsed_ms = (time.perf_counter() - start) * 1000
+    assert elapsed_ms < 500
+    assert len(res) == 100
+    assert res[0]["id"] == "id999"


### PR DESCRIPTION
## Summary
- implement evidence pack store with secure redaction and integrity checks
- add FastAPI endpoints for storing and retrieving evidence packs
- include comprehensive tests for catalog, filtering, and performance

## Testing
- `pytest tests/test_evidence_store.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c741c8d6308329996523900f94b965