### PR TITLE
feat: expose metrics exporter and grafana dashboards

### DIFF
--- a/alpha_solver_entry.py
+++ b/alpha_solver_entry.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
+from alpha.core.observability import ObservabilityManager
 from service.gating.gates import GateConfig, evaluate_gates
 
 ENTRY = Path(__file__).with_name("alpha-solver-v91-python.py")
@@ -26,6 +27,7 @@ def _tree_of_thought(
     clarify_conf_threshold: float = 0.55,
     min_budget_tokens: int = 256,
     enable_cot_fallback: bool = True,
+    observability: ObservabilityManager | None = None,
     **kwargs,
 ) -> dict:
     """Execute reasoning pipeline and run deterministic gating.
@@ -34,12 +36,20 @@ def _tree_of_thought(
     are forwarded to :func:`evaluate_gates`.
     """
 
-    result = _module._tree_of_thought(
-        query,
-        low_conf_threshold=low_conf_threshold,
-        enable_cot_fallback=enable_cot_fallback,
-        **kwargs,
-    )
+    obs = observability
+    if obs:
+        obs.log_event({"event": "query_start", "query": query})
+    try:
+        result = _module._tree_of_thought(
+            query,
+            low_conf_threshold=low_conf_threshold,
+            enable_cot_fallback=enable_cot_fallback,
+            **kwargs,
+        )
+    except Exception as exc:
+        if obs:
+            obs.log_event({"event": "query_error", "error": str(exc), "query": query})
+        raise
     confidence = float(result.get("confidence", 0.0))
     usage = result.get("usage") or {}
     budget_tokens = int(usage.get("total_tokens", 0))
@@ -53,6 +63,14 @@ def _tree_of_thought(
     decision, explain = evaluate_gates(confidence, budget_tokens, policy_flags, cfg)
     result["route_explain"] = explain
     result["decision"] = decision
+    if obs:
+        obs.log_event(
+            {
+                "event": "query_success",
+                "route_explain": explain,
+                "decision": decision,
+            }
+        )
     return result
 
 

--- a/dashboards/alpha_observability.json
+++ b/dashboards/alpha_observability.json
@@ -1,0 +1,37 @@
+{
+  "annotations": {"list": []},
+  "editable": false,
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Allow Decision Rate",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "targets": [
+        {"expr": "rate(alpha_solver_route_decision_total{decision=\"allow\"}[5m])"}
+      ]
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Budget Verdict Totals",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "targets": [
+        {"expr": "sum by (budget_verdict)(alpha_solver_budget_verdict_total)"}
+      ]
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "P95 Latency",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "targets": [
+        {"expr": "histogram_quantile(0.95, sum(rate(alpha_solver_latency_ms_bucket[5m])) by (le))"}
+      ]
+    }
+  ],
+  "schemaVersion": 39,
+  "templating": {"list": []},
+  "title": "Alpha Observability",
+  "version": 1
+}

--- a/dashboards/cost_budget.json
+++ b/dashboards/cost_budget.json
@@ -1,0 +1,37 @@
+{
+  "annotations": {"list": []},
+  "editable": false,
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Tokens Rate",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "targets": [
+        {"expr": "sum(rate(alpha_solver_tokens_total[5m]))"}
+      ]
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Cost USD Rate",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "targets": [
+        {"expr": "sum(rate(alpha_solver_cost_usd_total[5m]))"}
+      ]
+    },
+    {
+      "id": 3,
+      "type": "table",
+      "title": "Confidence Avg",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "targets": [
+        {"expr": "avg(alpha_solver_confidence)"}
+      ]
+    }
+  ],
+  "schemaVersion": 39,
+  "templating": {"list": []},
+  "title": "Cost & Budget",
+  "version": 1
+}

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -1,0 +1,29 @@
+# Observability
+
+The Alpha Solver CLI can record and replay reasoning sessions using the built-in
+P3 observability components.
+
+## Record a run
+
+```bash
+python alpha_solver_cli.py "2+2" --record --obs-stats
+```
+
+The solver writes events to a replay file and prints a JSON summary on the
+second line, including the `session_id`.
+
+## Replay a session
+
+```bash
+python alpha_solver_cli.py "2+2" --replay SESSION_ID
+```
+
+Replay verifies that the events and results match the recorded session.
+
+## View stats without recording
+
+```bash
+python alpha_solver_cli.py "2+2" --obs-stats
+```
+
+Stats report the number of events logged and sessions recorded for the run.

--- a/service/metrics/exporter.py
+++ b/service/metrics/exporter.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+"""Prometheus metrics exporter for Alpha Solver.
+
+This module exposes :class:`MetricsExporter` which registers a small set of
+counters, gauges and histograms and serves them via a Starlette application.
+The exporter is intentionally lightweight and avoids exporting values that may
+contain secrets or PII.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+import sys
+
+# Ensure the real ``prometheus_client`` package from site-packages is used even
+# if a lightweight stub exists in the repository (its path would otherwise take
+# precedence in ``sys.path``).
+_site_packages = [p for p in sys.path if "site-packages" in p]
+sys.path = _site_packages + [p for p in sys.path if p not in _site_packages]
+
+from prometheus_client import (
+    CONTENT_TYPE_LATEST,
+    CollectorRegistry,
+    Counter,
+    Gauge,
+    Histogram,
+    generate_latest,
+)
+from starlette.applications import Starlette
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+
+
+_REDACTION_VALUES = {"pii_raw"}
+_REDACTION_SUFFIXES = ("_secret", "_token")
+
+
+def _sanitize(value: Optional[str]) -> Optional[str]:
+    """Redact values that may contain secrets.
+
+    Any value equal to ``pii_raw`` or ending with ``_secret`` or ``_token`` is
+    replaced with the string ``redacted``.
+    """
+
+    if value is None:
+        return None
+    if value in _REDACTION_VALUES or value.endswith(_REDACTION_SUFFIXES):
+        return "redacted"
+    return value
+
+
+@dataclass
+class MetricsExporter:
+    """Minimal Prometheus metrics exporter."""
+
+    namespace: str = "alpha_solver"
+
+    def __post_init__(self) -> None:  # noqa: D401 - dataclass post init
+        self.registry = CollectorRegistry()
+
+    # -- registration -----------------------------------------------------
+    def register_route_explain(self) -> None:
+        """Register counters and gauges related to routing decisions."""
+
+        self.decision_counter = Counter(
+            "route_decision_total",
+            "Total number of routing decisions",
+            ["decision"],
+            namespace=self.namespace,
+            registry=self.registry,
+        )
+        self.budget_verdict_counter = Counter(
+            "budget_verdict_total",
+            "Total number of budget verdicts",
+            ["budget_verdict"],
+            namespace=self.namespace,
+            registry=self.registry,
+        )
+        self.policy_verdict_counter = Counter(
+            "policy_verdict_total",
+            "Total number of policy verdicts",
+            ["policy_verdict"],
+            namespace=self.namespace,
+            registry=self.registry,
+        )
+        self.confidence_gauge = Gauge(
+            "confidence",
+            "Latest decision confidence",
+            namespace=self.namespace,
+            registry=self.registry,
+        )
+
+    def register_cost_latency(self) -> None:
+        """Register latency histogram and resource cost counters."""
+
+        self.latency_histogram = Histogram(
+            "latency_ms",
+            "Latency in milliseconds",
+            namespace=self.namespace,
+            registry=self.registry,
+            buckets=(10, 50, 100, 250, 500, 1000, 2500, 5000, 10000),
+        )
+        self.tokens_counter = Counter(
+            "tokens_total",
+            "Total tokens consumed",
+            namespace=self.namespace,
+            registry=self.registry,
+        )
+        self.cost_counter = Counter(
+            "cost_usd_total",
+            "Total cost in USD",
+            namespace=self.namespace,
+            registry=self.registry,
+        )
+
+    # -- recording --------------------------------------------------------
+    def record_event(
+        self,
+        *,
+        decision: str,
+        confidence: float,
+        budget_verdict: Optional[str],
+        latency_ms: Optional[float],
+        tokens: Optional[int],
+        cost_usd: Optional[float],
+        policy_verdict: Optional[str] = None,
+    ) -> None:
+        """Record a single routing event.
+
+        Parameters mirror the metrics that are exported. Any sensitive values are
+        sanitized before being emitted.
+        """
+
+        if hasattr(self, "decision_counter"):
+            self.decision_counter.labels(decision=_sanitize(decision)).inc()
+            self.confidence_gauge.set(confidence)
+        if hasattr(self, "budget_verdict_counter") and budget_verdict is not None:
+            self.budget_verdict_counter.labels(
+                budget_verdict=_sanitize(budget_verdict)
+            ).inc()
+        if hasattr(self, "policy_verdict_counter") and policy_verdict is not None:
+            self.policy_verdict_counter.labels(
+                policy_verdict=_sanitize(policy_verdict)
+            ).inc()
+        if hasattr(self, "latency_histogram") and latency_ms is not None:
+            self.latency_histogram.observe(latency_ms)
+        if hasattr(self, "tokens_counter") and tokens is not None:
+            self.tokens_counter.inc(tokens)
+        if hasattr(self, "cost_counter") and cost_usd is not None:
+            self.cost_counter.inc(cost_usd)
+
+    # -- app --------------------------------------------------------------
+    def app(self) -> Starlette:
+        """Return a Starlette application exposing ``/metrics``."""
+
+        async def metrics_endpoint(request):  # pragma: no cover - simple wrapper
+            data = generate_latest(self.registry)
+            return PlainTextResponse(data, media_type=CONTENT_TYPE_LATEST)
+
+        return Starlette(routes=[Route("/metrics", metrics_endpoint)])

--- a/service/observability/diff.py
+++ b/service/observability/diff.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
-"""Lightweight helpers to diff observability log files."""
+"""Helpers to produce unified diffs between observability logs."""
 
-import json
 import difflib
-from typing import Iterable, List, Dict, Any, Optional
+import json
+from typing import Any, Dict, Iterable, List, Optional
 
 from .replay import ReplayHarness
+
+__all__ = ["diff_events", "diff_logs"]
 
 
 # ---------------------------------------------------------------------------

--- a/service/observability/diff.py
+++ b/service/observability/diff.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+"""Lightweight helpers to diff observability log files."""
+
+import json
+import difflib
+from typing import Iterable, List, Dict, Any, Optional
+
+from .replay import ReplayHarness
+
+
+# ---------------------------------------------------------------------------
+def _events_to_lines(events: Iterable[Dict[str, Any]]) -> List[str]:
+    """Normalise event dictionaries into stable JSON lines."""
+    lines: List[str] = []
+    for event in events:
+        lines.append(json.dumps(event, sort_keys=True, separators=(",", ":")))
+    return lines
+
+
+# ---------------------------------------------------------------------------
+def diff_events(
+    events_a: Iterable[Dict[str, Any]],
+    events_b: Iterable[Dict[str, Any]],
+) -> str:
+    """Return a unified diff between two event collections."""
+
+    a_lines = _events_to_lines(events_a)
+    b_lines = _events_to_lines(events_b)
+    diff = difflib.unified_diff(a_lines, b_lines, fromfile="a", tofile="b", lineterm="")
+    return "\n".join(diff)
+
+
+# ---------------------------------------------------------------------------
+def diff_logs(path_a: str, path_b: str, name: Optional[str] = None) -> str:
+    """Diff two JSONL log files on disk."""
+
+    harness_a = ReplayHarness(path_a)
+    harness_b = ReplayHarness(path_b)
+    return diff_events(harness_a.iter_events(name), harness_b.iter_events(name))

--- a/service/observability/replay_cli.py
+++ b/service/observability/replay_cli.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
-"""Simple command line interface for replaying observability logs."""
+"""Command line interface for replaying and diffing observability logs."""
 
 import argparse
 import json
 from typing import List, Optional
 
-from .replay import ReplayHarness
 from . import diff as diff_mod
+from .replay import ReplayHarness
+
+__all__ = ["main"]
 
 
 # ---------------------------------------------------------------------------

--- a/service/observability/replay_cli.py
+++ b/service/observability/replay_cli.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""Simple command line interface for replaying observability logs."""
+
+import argparse
+import json
+from typing import List, Optional
+
+from .replay import ReplayHarness
+from . import diff as diff_mod
+
+
+# ---------------------------------------------------------------------------
+def main(argv: Optional[List[str]] = None) -> int:
+    """Entry point for the replay CLI.
+
+    Parameters
+    ----------
+    argv:
+        Optional list of arguments. When ``None`` the arguments are taken from
+        ``sys.argv``.
+    """
+
+    parser = argparse.ArgumentParser(description="Replay observability JSONL logs")
+    parser.add_argument("log", help="path to primary log file")
+    parser.add_argument("--diff", dest="diff", help="optional secondary log to diff")
+    parser.add_argument("--name", dest="name", help="filter by event name", default=None)
+    args = parser.parse_args(argv)
+
+    harness = ReplayHarness(args.log)
+
+    if args.diff:
+        output = diff_mod.diff_logs(args.log, args.diff, args.name)
+        if output:
+            print(output)
+    else:
+        for event in harness.iter_events(args.name):
+            print(json.dumps(event, sort_keys=True))
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_alpha_solver_smoke.py
+++ b/tests/test_alpha_solver_smoke.py
@@ -1,0 +1,38 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+CLI = Path(__file__).resolve().parents[1] / "alpha_solver_cli.py"
+
+
+def _run(tmp_path: Path, *args: str) -> list[str]:
+    cmd = [sys.executable, str(CLI), *args]
+    proc = subprocess.run(cmd, cwd=tmp_path, capture_output=True, text=True, check=True)
+    return [line for line in proc.stdout.splitlines() if line.strip()]
+
+
+def test_record_then_replay_identical(tmp_path: Path) -> None:
+    lines = _run(tmp_path, "2+2", "--record", "--obs-stats")
+    first = json.loads(lines[0])
+    expected = {
+        "solution": first["solution"],
+        "decision": first["decision"],
+        "route_explain": first["route_explain"],
+    }
+    stats = json.loads(lines[1])
+    session_id = stats["sessions"][0]
+    for _ in range(10):
+        replay_lines = _run(tmp_path, "2+2", "--replay", session_id)
+        replay_data = json.loads(replay_lines[0])
+        assert {
+            "solution": replay_data["solution"],
+            "decision": replay_data["decision"],
+            "route_explain": replay_data["route_explain"],
+        } == expected
+
+
+def test_obs_stats_fields(tmp_path: Path) -> None:
+    lines = _run(tmp_path, "1+1", "--record", "--obs-stats")
+    stats = json.loads(lines[1])
+    assert "events_logged" in stats and "sessions" in stats

--- a/tests/test_metrics_dashboards.py
+++ b/tests/test_metrics_dashboards.py
@@ -1,0 +1,154 @@
+import json
+import time
+from pathlib import Path
+
+from starlette.testclient import TestClient
+
+from service.metrics.exporter import MetricsExporter
+
+
+def _scrape(client: TestClient) -> str:
+    return client.get("/metrics").text
+
+
+def test_metrics_exporter_registers_and_scrapes():
+    exporter = MetricsExporter()
+    exporter.register_route_explain()
+    exporter.register_cost_latency()
+    exporter.record_event(
+        decision="allow",
+        confidence=0.9,
+        budget_verdict="within",
+        latency_ms=5.0,
+        tokens=3,
+        cost_usd=0.02,
+        policy_verdict="ok",
+    )
+    client = TestClient(exporter.app())
+    body = _scrape(client)
+    assert "alpha_solver_route_decision_total" in body
+    assert "alpha_solver_budget_verdict_total" in body
+    assert "alpha_solver_policy_verdict_total" in body
+    assert "alpha_solver_latency_ms_bucket" in body
+    assert "alpha_solver_tokens_total" in body
+    assert "alpha_solver_cost_usd_total" in body
+    assert "alpha_solver_confidence" in body
+
+
+def test_record_event_updates_counters_histograms():
+    exporter = MetricsExporter()
+    exporter.register_route_explain()
+    exporter.register_cost_latency()
+    exporter.record_event(
+        decision="allow",
+        confidence=0.5,
+        budget_verdict="within",
+        latency_ms=123.0,
+        tokens=7,
+        cost_usd=0.03,
+        policy_verdict="pass",
+    )
+    client = TestClient(exporter.app())
+    metrics_text = _scrape(client)
+    metrics = {}
+    for line in metrics_text.splitlines():
+        if not line or line.startswith("#"):
+            continue
+        name_and_labels, value = line.split()
+        if "{" in name_and_labels:
+            name, labels_str = name_and_labels.split("{", 1)
+            labels_str = labels_str.rstrip("}")
+            labels = tuple(
+                sorted(
+                    (part.split("=", 1)[0], part.split("=", 1)[1].strip('"'))
+                    for part in labels_str.split(",")
+                    if part
+                )
+            )
+        else:
+            name = name_and_labels
+            labels = tuple()
+        metrics[(name, labels)] = float(value)
+    assert metrics[("alpha_solver_route_decision_total", (("decision", "allow"),))] == 1.0
+    assert metrics[("alpha_solver_budget_verdict_total", (("budget_verdict", "within"),))] == 1.0
+    assert metrics[("alpha_solver_policy_verdict_total", (("policy_verdict", "pass"),))] == 1.0
+    assert metrics[("alpha_solver_tokens_total", tuple())] == 7.0
+    assert metrics[("alpha_solver_cost_usd_total", tuple())] == 0.03
+    assert metrics[("alpha_solver_latency_ms_count", tuple())] == 1.0
+    assert metrics[("alpha_solver_latency_ms_sum", tuple())] == 123.0
+    assert metrics[("alpha_solver_confidence", tuple())] == 0.5
+
+
+def test_performance_scrape_p95_under_200ms():
+    exporter = MetricsExporter()
+    exporter.register_route_explain()
+    exporter.register_cost_latency()
+    client = TestClient(exporter.app())
+    durations = []
+    for _ in range(5):
+        start = time.monotonic()
+        for _ in range(100):
+            exporter.record_event(
+                decision="allow",
+                confidence=0.1,
+                budget_verdict="ok",
+                latency_ms=1.0,
+                tokens=1,
+                cost_usd=0.001,
+                policy_verdict="ok",
+            )
+        _scrape(client)
+        durations.append(time.monotonic() - start)
+    durations.sort()
+    p95 = durations[int(len(durations) * 0.95)]
+    assert p95 < 0.2
+
+
+def test_dashboards_are_json_and_have_min_panels():
+    base = Path("dashboards")
+
+    with open(base / "alpha_observability.json", "r", encoding="utf-8") as fh:
+        obs = json.load(fh)
+    assert len(obs["panels"]) >= 3
+    obs_exprs = [p["targets"][0]["expr"] for p in obs["panels"]]
+    assert any(
+        "rate(alpha_solver_route_decision_total{decision=\"allow\"}[5m])" in e
+        for e in obs_exprs
+    )
+    assert any(
+        "sum by (budget_verdict)(alpha_solver_budget_verdict_total)" in e
+        for e in obs_exprs
+    )
+    assert any(
+        "histogram_quantile(0.95, sum(rate(alpha_solver_latency_ms_bucket[5m])) by (le))"
+        in e
+        for e in obs_exprs
+    )
+
+    with open(base / "cost_budget.json", "r", encoding="utf-8") as fh:
+        cost = json.load(fh)
+    assert len(cost["panels"]) >= 3
+    cost_exprs = [p["targets"][0]["expr"] for p in cost["panels"]]
+    assert any("sum(rate(alpha_solver_tokens_total[5m]))" in e for e in cost_exprs)
+    assert any("sum(rate(alpha_solver_cost_usd_total[5m]))" in e for e in cost_exprs)
+    assert any("avg(alpha_solver_confidence)" in e for e in cost_exprs)
+
+
+def test_no_pii_in_metrics_labels_or_values():
+    exporter = MetricsExporter()
+    exporter.register_route_explain()
+    exporter.record_event(
+        decision="pii_raw",
+        confidence=1.0,
+        budget_verdict="foo_secret",
+        latency_ms=None,
+        tokens=None,
+        cost_usd=None,
+        policy_verdict="bar_token",
+    )
+    client = TestClient(exporter.app())
+    text = _scrape(client)
+    assert "pii_raw" not in text
+    assert "foo_secret" not in text
+    assert "bar_token" not in text
+    assert "redacted" in text

--- a/tests/test_replay_cli_diff.py
+++ b/tests/test_replay_cli_diff.py
@@ -1,9 +1,11 @@
+"""Tests for the observability replay CLI and diff helpers."""
+
 import json
 from pathlib import Path
 from typing import List
 
-from service.observability import replay_cli
 from service.observability import diff as diff_mod
+from service.observability import replay_cli
 
 
 def _write_log(path: Path, events: List[dict]) -> None:

--- a/tests/test_replay_cli_diff.py
+++ b/tests/test_replay_cli_diff.py
@@ -1,0 +1,38 @@
+import json
+from pathlib import Path
+from typing import List
+
+from service.observability import replay_cli
+from service.observability import diff as diff_mod
+
+
+def _write_log(path: Path, events: List[dict]) -> None:
+    with open(path, "w", encoding="utf-8") as fp:
+        for event in events:
+            fp.write(json.dumps(event) + "\n")
+
+
+def test_replay_cli_prints_events(tmp_path, capsys):
+    log_path = tmp_path / "log.jsonl"
+    events = [{"name": "a", "route_explain": {"decision": "allow", "confidence": 1.0, "budget_verdict": "ok"}}]
+    _write_log(log_path, events)
+
+    replay_cli.main([str(log_path)])
+    out = capsys.readouterr().out.strip()
+    assert "allow" in out
+
+
+def test_replay_cli_diff(tmp_path, capsys):
+    log_a = tmp_path / "a.jsonl"
+    log_b = tmp_path / "b.jsonl"
+    events_a = [{"name": "a", "route_explain": {"decision": "allow", "confidence": 1.0, "budget_verdict": "ok"}}]
+    events_b = [{"name": "a", "route_explain": {"decision": "deny", "confidence": 0.2, "budget_verdict": "fail"}}]
+    _write_log(log_a, events_a)
+    _write_log(log_b, events_b)
+
+    replay_cli.main([str(log_a), "--diff", str(log_b)])
+    out = capsys.readouterr().out
+    assert "-" in out and "+" in out
+
+    diff_text = diff_mod.diff_logs(str(log_a), str(log_b))
+    assert "deny" in diff_text


### PR DESCRIPTION
## Summary
- add MetricsExporter to expose Prometheus metrics with latency, cost, and routing decision data
- include sample Grafana dashboards for observability and cost tracking
- test exporter registration, metric updates, redaction, performance, and dashboard structure

## Testing
- `pytest tests/test_metrics_dashboards.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7422f78a88329bb28ca788f28c23a