### PR TITLE
Add budget guard and CLI with RES-08 integration

### DIFF
--- a/service/budget/cli.py
+++ b/service/budget/cli.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+from .guard import BudgetGuard
+from .simulator import load_cost_models, simulate
+
+
+def _read_items(path: Path) -> List[Dict[str, Any]]:
+    suffix = path.suffix.lower()
+    if suffix == ".jsonl":
+        items: List[Dict[str, Any]] = []
+        with path.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                items.append(json.loads(line))
+        return items
+    if suffix == ".json":
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, list):
+            raise ValueError("JSON must be a list of items")
+        return data
+    raise ValueError(f"Unsupported file extension: {suffix}")
+
+
+def _scrub(obj: Any) -> Any:
+    if isinstance(obj, dict):
+        result = {}
+        for k, v in obj.items():
+            if k == "pii_raw" or k.endswith("_token") or k.endswith("_secret"):
+                continue
+            result[k] = _scrub(v)
+        return result
+    if isinstance(obj, list):
+        return [_scrub(v) for v in obj]
+    return obj
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Budget simulation and guard")
+    parser.add_argument("--provider", required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--items", required=True)
+    parser.add_argument("--max-cost", type=float, required=True)
+    parser.add_argument("--max-tokens", type=int)
+    parser.add_argument("--jsonl-out")
+
+    args = parser.parse_args(argv)
+
+    try:
+        items = _read_items(Path(args.items))
+        cost_models = load_cost_models()
+        sim_result = simulate(items, cost_models, provider=args.provider, model=args.model)
+        guard = BudgetGuard(max_cost_usd=args.max_cost, max_tokens=args.max_tokens)
+        verdict = guard.check(sim_result)
+    except Exception as exc:  # invalid input
+        print(f"error: {exc}", file=sys.stderr)
+        final = {
+            "provider": args.provider,
+            "model": args.model,
+            "budget_verdict": "error",
+            "totals": {},
+        }
+        print(json.dumps(final, sort_keys=True))
+        return 1
+
+    if args.jsonl_out:
+        out_path = Path(args.jsonl_out)
+        with out_path.open("w", encoding="utf-8") as f:
+            for item in sim_result["items"]:
+                f.write(json.dumps(_scrub(item), sort_keys=True) + "\n")
+
+    totals = sim_result["totals"]
+    summary = (
+        f"cost_usd={totals['cost_usd']:.4f} "
+        f"tokens={totals['tokens']} "
+        f"verdict={verdict['budget_verdict']}"
+    )
+    print(summary)
+    final = {
+        "provider": sim_result["provider"],
+        "model": sim_result["model"],
+        "budget_verdict": verdict["budget_verdict"],
+        "totals": totals,
+    }
+    print(json.dumps(final, sort_keys=True))
+    return 0 if verdict["ok"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/service/budget/guard.py
+++ b/service/budget/guard.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class BudgetGuard:
+    """Simple budget guard for enforcing cost and token budgets."""
+
+    max_cost_usd: float
+    max_tokens: Optional[int] | None = None
+
+    def check(self, sim_result: Dict[str, Any]) -> Dict[str, Any]:
+        """Check simulation totals against thresholds.
+
+        Parameters
+        ----------
+        sim_result:
+            The result from :func:`service.budget.simulator.simulate`.
+
+        Returns
+        -------
+        dict
+            A dictionary with keys ``ok``, ``budget_verdict``, ``totals`` and
+            ``route_explain``.
+        """
+
+        totals = sim_result.get("totals", {})
+        cost = float(totals.get("cost_usd", 0.0))
+        tokens = int(totals.get("tokens", 0))
+
+        over_cost = cost > self.max_cost_usd
+        over_tokens = self.max_tokens is not None and tokens > self.max_tokens
+
+        if over_cost:
+            verdict = "over_cost"
+        elif over_tokens:
+            verdict = "over_tokens"
+        else:
+            verdict = "ok"
+
+        ok = verdict == "ok"
+        decision = "allow" if ok else "block"
+
+        return {
+            "ok": ok,
+            "budget_verdict": verdict,
+            "totals": totals,
+            "route_explain": {"decision": decision, "budget_verdict": verdict},
+        }

--- a/tests/test_budget_cli_guard.py
+++ b/tests/test_budget_cli_guard.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from service.budget.simulator import load_cost_models, simulate
+from service.budget.guard import BudgetGuard
+
+ROOT = Path(__file__).resolve().parents[0]  # tests directory
+REPO_ROOT = ROOT.parent
+
+
+def run_cli(args: list[str]) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    return subprocess.run(
+        [sys.executable, "-m", "service.budget.cli", *args],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+
+def test_guard_ok_under_thresholds():
+    models = load_cost_models()
+    items = [
+        {"prompt_tokens": 100, "completion_tokens": 0, "latency_ms": 0.0}
+    ]
+    sim = simulate(items, models, provider="openai", model="gpt-4o")
+    guard = BudgetGuard(max_cost_usd=10.0, max_tokens=500)
+    res = guard.check(sim)
+    assert res["ok"]
+    assert res["budget_verdict"] == "ok"
+    assert res["route_explain"] == {"decision": "allow", "budget_verdict": "ok"}
+
+
+def test_guard_blocks_when_over_cost():
+    models = load_cost_models()
+    items = [
+        {"prompt_tokens": 1000, "completion_tokens": 0, "latency_ms": 0.0}
+    ]
+    sim = simulate(items, models, provider="openai", model="gpt-4o")
+    guard = BudgetGuard(max_cost_usd=1.0)
+    res = guard.check(sim)
+    assert not res["ok"]
+    assert res["budget_verdict"] == "over_cost"
+    assert res["route_explain"]["decision"] == "block"
+
+
+def test_guard_blocks_when_over_tokens():
+    models = load_cost_models()
+    items = [
+        {"prompt_tokens": 1000, "completion_tokens": 0, "latency_ms": 0.0}
+    ]
+    sim = simulate(items, models, provider="openai", model="gpt-4o")
+    guard = BudgetGuard(max_cost_usd=100.0, max_tokens=500)
+    res = guard.check(sim)
+    assert not res["ok"]
+    assert res["budget_verdict"] == "over_tokens"
+    assert res["route_explain"]["decision"] == "block"
+
+
+def test_cli_reads_json_and_jsonl_and_sets_exit_codes(tmp_path: Path):
+    items = [
+        {"prompt_tokens": 1000, "completion_tokens": 0, "latency_ms": 0.0}
+    ]
+    json_path = tmp_path / "items.json"
+    json_path.write_text(json.dumps(items))
+    jsonl_path = tmp_path / "items.jsonl"
+    with jsonl_path.open("w") as f:
+        for it in items:
+            f.write(json.dumps(it) + "\n")
+
+    ok_proc = run_cli([
+        "--provider", "openai",
+        "--model", "gpt-4o",
+        "--items", str(json_path),
+        "--max-cost", "10",
+    ])
+    assert ok_proc.returncode == 0, ok_proc.stderr
+    verdict_ok = json.loads(ok_proc.stdout.strip().splitlines()[-1])["budget_verdict"]
+    assert verdict_ok == "ok"
+
+    bad_proc = run_cli([
+        "--provider", "openai",
+        "--model", "gpt-4o",
+        "--items", str(jsonl_path),
+        "--max-cost", "1",
+    ])
+    assert bad_proc.returncode == 2, bad_proc.stderr
+    verdict_bad = json.loads(bad_proc.stdout.strip().splitlines()[-1])["budget_verdict"]
+    assert verdict_bad == "over_cost"
+
+
+def test_cli_writes_jsonl_output_and_contains_route_explain(tmp_path: Path):
+    items = [
+        {
+            "prompt_tokens": 10,
+            "completion_tokens": 0,
+            "latency_ms": 0.0,
+            "pii_raw": "secret",
+            "api_token": "123",
+        }
+    ]
+    jsonl_path = tmp_path / "items.jsonl"
+    with jsonl_path.open("w") as f:
+        for it in items:
+            f.write(json.dumps(it) + "\n")
+    out_path = tmp_path / "out.jsonl"
+    proc = run_cli([
+        "--provider", "openai",
+        "--model", "gpt-4o",
+        "--items", str(jsonl_path),
+        "--max-cost", "10",
+        "--jsonl-out", str(out_path),
+    ])
+    assert proc.returncode == 0, proc.stderr
+    assert out_path.exists()
+    first = json.loads(out_path.read_text().splitlines()[0])
+    assert "route_explain" in first
+    assert first["route_explain"]["decision"] == "simulate"
+    assert "pii_raw" not in first
+    assert "api_token" not in first
+
+
+def test_performance_p95_under_2s_for_200_items():
+    models = load_cost_models()
+    items = [
+        {"prompt_tokens": 100, "completion_tokens": 100, "latency_ms": 1.0}
+        for _ in range(200)
+    ]
+    guard = BudgetGuard(max_cost_usd=1000.0, max_tokens=1000000)
+    times: list[float] = []
+    for _ in range(20):
+        start = time.monotonic()
+        sim = simulate(items, models, provider="openai", model="gpt-4o")
+        guard.check(sim)
+        times.append(time.monotonic() - start)
+    times.sort()
+    idx = max(0, int(len(times) * 0.95) - 1)
+    p95 = times[idx]
+    assert p95 < 2.0
+
+
+def test_deterministic_outputs_plus_minus_point1pct():
+    models = load_cost_models()
+    items = [
+        {"prompt_tokens": 50, "completion_tokens": 25, "latency_ms": 0.0}
+        for _ in range(5)
+    ]
+    sim1 = simulate(items, models, provider="openai", model="gpt-4o")
+    sim2 = simulate(items, models, provider="openai", model="gpt-4o")
+    guard = BudgetGuard(max_cost_usd=100.0, max_tokens=100000)
+    res1 = guard.check(sim1)
+    res2 = guard.check(sim2)
+    c1 = res1["totals"]["cost_usd"]
+    c2 = res2["totals"]["cost_usd"]
+    assert c1 == pytest.approx(c2, rel=0.001)
+    assert res1["totals"]["tokens"] == res2["totals"]["tokens"]


### PR DESCRIPTION
## Summary
- add `BudgetGuard` for cost and token budget checks with route explanations
- build `service.budget.cli` to run simulator and enforce budgets, scrub secrets, and optional JSONL output
- introduce tests for guard, CLI behavior, performance and determinism

## Testing
- `pytest tests/test_budget_cli_guard.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7433e9a488329b14f87904c380a9f