### PR TITLE
Implement NEW-013 Replay CLI and diff utilities

### DIFF
--- a/service/observability/diff.py
+++ b/service/observability/diff.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+DEFAULT_FIELDS = [
+    "decision",
+    "confidence",
+    "budget_verdict",
+    "tool",
+    "score",
+    "sandbox_decision",
+]
+
+
+# ---------------------------------------------------------------------------
+def _is_secret(key: str) -> bool:
+    key_lower = key.lower()
+    if key_lower == "pii_raw":
+        return True
+    return key_lower.endswith("_token") or key_lower.endswith("_secret")
+
+
+def normalize(event: Dict, *, keep_keys: List[str]) -> Dict:
+    """Return a normalized view of *event*.
+
+    Only keys from ``keep_keys`` plus the default fields are kept. Any float
+    values are rounded to four decimal places. Keys containing potential PII
+    such as ``pii_raw`` or those ending in ``_token`` or ``_secret`` are
+    removed.
+    """
+
+    allowed = set(DEFAULT_FIELDS) | set(keep_keys)
+    out: Dict = {}
+    for key in allowed:
+        if key not in event:
+            continue
+        if _is_secret(key):
+            continue
+        value = event[key]
+        if isinstance(value, float):
+            value = round(value, 4)
+        out[key] = value
+    return out
+
+
+# ---------------------------------------------------------------------------
+def diff_lists(
+    a: List[Dict],
+    b: List[Dict],
+    *,
+    id_key: str = "id",
+    keys: List[str],
+) -> List[str]:
+    """Return deterministic textual diffs between two lists of events.
+
+    ``a`` and ``b`` are lists of dicts. Events are paired by ``id_key`` and the
+    specified ``keys`` are compared. The output is sorted by id ascending and is
+    limited to 200 lines. When more mismatches are present, a final line
+    ``"... (truncated)"`` is appended.
+    """
+
+    keep = list(set(keys) | {id_key})
+    a_map = {e[id_key]: normalize(e, keep_keys=keep) for e in a if id_key in e}
+    b_map = {e[id_key]: normalize(e, keep_keys=keep) for e in b if id_key in e}
+
+    ids = sorted(set(a_map) | set(b_map))
+    lines: List[str] = []
+    mismatch_count = 0
+    limit = 200
+
+    for eid in ids:
+        ea = a_map.get(eid)
+        eb = b_map.get(eid)
+        if ea is None or eb is None:
+            mismatch_count += 1
+            if len(lines) < limit:
+                side = "a" if ea is None else "b"
+                lines.append(f"id={eid} missing in {side}")
+            continue
+        for key in keys:
+            va = ea.get(key)
+            vb = eb.get(key)
+            if va != vb:
+                mismatch_count += 1
+                if len(lines) < limit:
+                    lines.append(f"id={eid} {key}: {va} != {vb}")
+
+    if mismatch_count > len(lines):
+        if len(lines) > limit:
+            lines = lines[:limit]
+        lines.append("... (truncated)")
+    return lines

--- a/service/observability/replay_cli.py
+++ b/service/observability/replay_cli.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+from .diff import DEFAULT_FIELDS, diff_lists, normalize
+
+
+def _parse_filter(expr: Optional[str]) -> Optional[Tuple[str, str]]:
+    if not expr:
+        return None
+    if "=" not in expr:
+        raise ValueError("filter must be of form key=value")
+    k, v = expr.split("=", 1)
+    return k, v
+
+
+def _load_events(
+    path: Path, *, flt: Optional[Tuple[str, str]] = None, limit: Optional[int] = None
+) -> List[Dict]:
+    events: List[Dict] = []
+    with open(path, encoding="utf-8") as fp:
+        for line in fp:
+            line = line.strip()
+            if not line:
+                continue
+            event = json.loads(line)
+            if flt is not None:
+                key, value = flt
+                if str(event.get(key)) != value:
+                    continue
+            events.append(event)
+            if limit is not None and len(events) >= limit:
+                break
+    return events
+
+
+def _percentile(values: List[float], pct: float) -> float:
+    if not values:
+        return 0.0
+    values_sorted = sorted(values)
+    k = int((len(values_sorted) - 1) * (pct / 100.0))
+    return values_sorted[k]
+
+
+# ---------------------------------------------------------------------------
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--events", required=True, help="JSONL event log")
+    parser.add_argument("--compare", help="Second JSONL log to diff against")
+    parser.add_argument("--filter", dest="filter_expr")
+    parser.add_argument("--limit", type=int, default=200)
+    parser.add_argument("--out")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    try:
+        filt = _parse_filter(args.filter_expr)
+        events_a = _load_events(Path(args.events), flt=filt, limit=args.limit)
+    except Exception:
+        return 1
+
+    durations: List[float] = []
+    for e in events_a:
+        start = time.monotonic()
+        normalize(e, keep_keys=DEFAULT_FIELDS)
+        durations.append((time.monotonic() - start) * 1000)
+
+    diff_lines: List[str] = []
+    mismatches = 0
+    if args.compare:
+        try:
+            events_b = _load_events(Path(args.compare), flt=filt, limit=args.limit)
+        except Exception:
+            return 1
+        diff_lines = diff_lists(events_a, events_b, id_key="id", keys=DEFAULT_FIELDS)
+        mismatches = len([l for l in diff_lines if l != "... (truncated)"])
+
+    summary = {
+        "total": len(events_a),
+        "mismatches": mismatches,
+        "p95_ms": round(_percentile(durations, 95), 3),
+    }
+    print(json.dumps(summary))
+
+    if args.out:
+        Path(args.out).write_text("\n".join(diff_lines), encoding="utf-8")
+
+    return 2 if mismatches > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_replay_cli_diff.py
+++ b/tests/test_replay_cli_diff.py
@@ -1,0 +1,224 @@
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from service.observability.diff import diff_lists
+
+# Path to the project root so ``service`` is importable when running the CLI
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _write_events(path: Path, events: list[dict]) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        for e in events:
+            f.write(json.dumps(e) + "\n")
+
+
+# ---------------------------------------------------------------------------
+def test_replay_10_of_10_identical_no_mismatches_exit0(tmp_path: Path) -> None:
+    events = [
+        {
+            "id": f"evt-{i:03}",
+            "name": "mcp.call",
+            "decision": "allow",
+            "confidence": 0.91,
+            "budget_verdict": "ok",
+            "tool": "t",
+            "score": 0.1,
+            "sandbox_decision": "allow",
+        }
+        for i in range(10)
+    ]
+    path = tmp_path / "events.jsonl"
+    _write_events(path, events)
+
+    cmd = [sys.executable, "-m", "service.observability.replay_cli", "--events", str(path)]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(PROJECT_ROOT)
+    res = subprocess.run(cmd, capture_output=True, text=True, cwd=PROJECT_ROOT, env=env)
+    assert res.returncode == 0
+    summary = json.loads(res.stdout.strip())
+    assert summary["total"] == 10
+    assert summary["mismatches"] == 0
+
+
+# ---------------------------------------------------------------------------
+def test_compare_detects_mismatches_and_exit2(tmp_path: Path) -> None:
+    a = {
+        "id": "evt-001",
+        "name": "mcp.call",
+        "decision": "allow",
+        "confidence": 0.9,
+        "budget_verdict": "ok",
+        "tool": "t",
+        "score": 0.1,
+        "sandbox_decision": "allow",
+    }
+    b = dict(a)
+    b["decision"] = "deny"
+    path_a = tmp_path / "a.jsonl"
+    path_b = tmp_path / "b.jsonl"
+    _write_events(path_a, [a])
+    _write_events(path_b, [b])
+    out_path = tmp_path / "out.txt"
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "service.observability.replay_cli",
+        "--events",
+        str(path_a),
+        "--compare",
+        str(path_b),
+        "--out",
+        str(out_path),
+    ]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(PROJECT_ROOT)
+    res = subprocess.run(cmd, capture_output=True, text=True, cwd=PROJECT_ROOT, env=env)
+    assert res.returncode == 2
+    summary = json.loads(res.stdout.strip())
+    assert summary["mismatches"] >= 1
+    assert "decision" in out_path.read_text()
+
+
+# ---------------------------------------------------------------------------
+def test_diff_is_deterministic_and_limited_lines() -> None:
+    a = [
+        {"id": f"evt-{i:03}", "decision": "allow"}
+        for i in range(205)
+    ]
+    b = [
+        {"id": f"evt-{i:03}", "decision": "deny"}
+        for i in range(205)
+    ]
+    lines1 = diff_lists(list(reversed(a)), list(reversed(b)), keys=["decision"])
+    lines2 = diff_lists(list(reversed(a)), list(reversed(b)), keys=["decision"])
+    assert lines1 == lines2
+    assert lines1[0] == "id=evt-000 decision: allow != deny"
+    assert lines1[-1] == "... (truncated)"
+    assert len(lines1) == 201
+
+
+# ---------------------------------------------------------------------------
+def test_filters_by_event_name_and_limit(tmp_path: Path) -> None:
+    events = []
+    for i in range(5):
+        events.append({
+            "id": f"evt-a-{i}",
+            "name": "mcp.call",
+            "decision": "allow",
+            "confidence": 0.9,
+        })
+    for i in range(5):
+        events.append({
+            "id": f"evt-b-{i}",
+            "name": "other",
+            "decision": "allow",
+            "confidence": 0.9,
+        })
+    path = tmp_path / "events.jsonl"
+    _write_events(path, events)
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "service.observability.replay_cli",
+        "--events",
+        str(path),
+        "--compare",
+        str(path),
+        "--filter",
+        "name=mcp.call",
+        "--limit",
+        "3",
+    ]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(PROJECT_ROOT)
+    res = subprocess.run(cmd, capture_output=True, text=True, cwd=PROJECT_ROOT, env=env)
+    summary = json.loads(res.stdout.strip())
+    assert summary["total"] == 3
+    assert summary["mismatches"] == 0
+
+
+# ---------------------------------------------------------------------------
+def test_performance_p95_under_2s_for_200_events(tmp_path: Path) -> None:
+    events = [
+        {
+            "id": f"evt-{i:03}",
+            "name": "mcp.call",
+            "decision": "allow",
+            "confidence": 0.8,
+        }
+        for i in range(200)
+    ]
+    path = tmp_path / "events.jsonl"
+    _write_events(path, events)
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "service.observability.replay_cli",
+        "--events",
+        str(path),
+        "--compare",
+        str(path),
+    ]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(PROJECT_ROOT)
+    start = time.monotonic()
+    res = subprocess.run(cmd, capture_output=True, text=True, cwd=PROJECT_ROOT, env=env)
+    duration = time.monotonic() - start
+    summary = json.loads(res.stdout.strip())
+    assert summary["total"] == 200
+    assert summary["mismatches"] == 0
+    assert summary["p95_ms"] < 2000
+    assert duration < 10
+
+
+# ---------------------------------------------------------------------------
+def test_no_pii_in_outputs_or_logs(tmp_path: Path) -> None:
+    a = {
+        "id": "evt-001",
+        "name": "mcp.call",
+        "decision": "allow",
+        "confidence": 0.9,
+        "pii_raw": "secret stuff",
+        "api_token": "token123",
+        "user_secret": "very secret",
+    }
+    b = dict(a)
+    b["decision"] = "deny"
+    path_a = tmp_path / "a.jsonl"
+    path_b = tmp_path / "b.jsonl"
+    _write_events(path_a, [a])
+    _write_events(path_b, [b])
+    out_path = tmp_path / "out.txt"
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "service.observability.replay_cli",
+        "--events",
+        str(path_a),
+        "--compare",
+        str(path_b),
+        "--out",
+        str(out_path),
+    ]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(PROJECT_ROOT)
+    res = subprocess.run(cmd, capture_output=True, text=True, cwd=PROJECT_ROOT, env=env)
+    output = res.stdout.lower()
+    report = out_path.read_text().lower()
+    assert "pii" not in output
+    assert "token" not in output
+    assert "secret" not in output
+    assert "pii" not in report
+    assert "token" not in report
+    assert "secret" not in report


### PR DESCRIPTION
## Summary
- add deterministic diff utilities and normalization for RES-07 events
- implement replay CLI to filter, replay, and compare event logs
- add tests for diffing, CLI filtering, performance, and PII scrubbing

## Testing
- `pytest tests/test_replay_cli_diff.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c743c370a88329acc7d7d4bae4551f