### PR TITLE
feat: add prompt quality evaluator

### DIFF
--- a/service/prompts/quality/evaluator.py
+++ b/service/prompts/quality/evaluator.py
@@ -1,0 +1,107 @@
+import hashlib
+import re
+from typing import Dict, List, Optional
+
+import yaml
+
+
+def rubrics_sha(yaml_text: str) -> str:
+    """Return SHA256 hex digest of rubrics YAML."""
+    return hashlib.sha256(yaml_text.encode("utf-8")).hexdigest()
+
+
+def estimate_tokens(text: str) -> int:
+    """Very rough token estimate using whitespace splitting."""
+    return len(text.strip().split()) if text.strip() else 0
+
+
+class QualityEvaluator:
+    """Heuristic evaluator for prompt responses."""
+
+    def __init__(self, rubrics: Dict, yaml_text: Optional[str] = None):
+        self.rubrics = rubrics
+        if yaml_text is None:
+            yaml_text = yaml.safe_dump(rubrics, sort_keys=True)
+        self.rubrics_sha = rubrics_sha(yaml_text)
+
+    # --- helpers -----------------------------------------------------------------
+    def _score_correctness(self, response: str, context: Dict) -> int:
+        required: List[str] = context.get("must_include", [])
+        if not required:
+            return 2
+        present = sum(1 for k in required if re.search(re.escape(k), response, re.IGNORECASE))
+        if present == len(required):
+            return 2
+        if present > 0:
+            return 1
+        return 0
+
+    def _score_brevity(self, response: str, context: Dict) -> int:
+        threshold = context.get("max_tokens", 120)
+        tokens = estimate_tokens(response)
+        if tokens <= threshold:
+            return 2
+        if tokens <= threshold * 1.5:
+            return 1
+        return 0
+
+    def _score_structure(self, response: str, context: Dict) -> int:
+        checks = []
+        if context.get("require_headings"):
+            checks.append(bool(re.search(r"^#.+", response, re.MULTILINE)))
+        if context.get("require_bullets"):
+            checks.append(bool(re.search(r"^[\-\*] ", response, re.MULTILINE)))
+        fields: List[str] = context.get("required_fields", [])
+        for f in fields:
+            pattern = rf"{re.escape(f)}:"  # field followed by colon
+            checks.append(bool(re.search(pattern, response)))
+        if not checks:
+            return 2
+        passed = sum(checks)
+        if passed == len(checks):
+            return 2
+        if passed > 0:
+            return 1
+        return 0
+
+    def _score_safety(self, response: str, context: Dict) -> int:
+        if context.get("pii_raw"):
+            return 0
+        email_re = r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}"
+        phone_re = r"\b\d{3}[- ]?\d{3}[- ]?\d{4}\b"
+        if re.search(email_re, response) or re.search(phone_re, response):
+            return 0
+        return 2
+
+    # --- public API ---------------------------------------------------------------
+    def score(self, response: str, *, context: Optional[Dict] = None) -> Dict:
+        ctx = context or {}
+        scores = {
+            "correctness": self._score_correctness(response, ctx),
+            "brevity": self._score_brevity(response, ctx),
+            "structure": self._score_structure(response, ctx),
+            "safety": self._score_safety(response, ctx),
+        }
+        total = sum(scores.values())
+        return {"scores": scores, "total": total, "max": 8}
+
+    def compare(self, baseline: str, variant: str, *, context: Optional[Dict] = None) -> Dict:
+        ctx = context or {}
+        baseline_score = self.score(baseline, context=ctx)
+        variant_score = self.score(variant, context=ctx)
+        if baseline_score["total"] > variant_score["total"]:
+            winner = "baseline"
+        elif baseline_score["total"] < variant_score["total"]:
+            winner = "variant"
+        else:
+            winner = "tie"
+        route_explain = {
+            "prompt_deck_sha": ctx.get("prompt_deck_sha"),
+            "rubrics_sha": self.rubrics_sha,
+        }
+        return {
+            "baseline": baseline_score,
+            "variant": variant_score,
+            "winner": winner,
+            "route_explain": route_explain,
+        }

--- a/service/prompts/quality/report.py
+++ b/service/prompts/quality/report.py
@@ -1,0 +1,28 @@
+from typing import List, Dict
+
+
+def batch_compare(pairs: List[Dict], evaluator, *, deck_sha: str, rubrics_sha_str: str) -> Dict:
+    items = []
+    wins = 0
+    total = len(pairs)
+    for pair in pairs:
+        ctx = pair.get("context", {})
+        # ensure deck sha propagated for per-item route_explain
+        ctx = {**ctx, "prompt_deck_sha": deck_sha}
+        result = evaluator.compare(pair["baseline"], pair["variant"], context=ctx)
+        if result["winner"] == "variant":
+            wins += 1
+        items.append({"id": pair["id"], **result})
+    win_rate = wins / total if total else 0.0
+    summary = {
+        "total": total,
+        "wins": wins,
+        "win_rate": win_rate,
+        "items": items,
+        "route_explain": {
+            "prompt_deck_sha": deck_sha,
+            "rubrics_sha": rubrics_sha_str,
+            "win_rate": win_rate,
+        },
+    }
+    return summary

--- a/service/prompts/quality/rubrics.yaml
+++ b/service/prompts/quality/rubrics.yaml
@@ -1,0 +1,17 @@
+rubrics:
+  correctness:
+    desc: "Answers are factually correct for stated task."
+    scale: [0,1,2]   # 0=fail,1=partial,2=pass
+    hints: ["must address task directly","no hallucinated facts"]
+  brevity:
+    desc: "Unnecessary verbosity is avoided."
+    scale: [0,1,2]
+    hints: ["no filler","< 120 tokens when possible"]
+  structure:
+    desc: "Response follows requested format."
+    scale: [0,1,2]
+    hints: ["headings/bullets as required","fields present"]
+  safety:
+    desc: "No policy or PII issues in output."
+    scale: [0,1,2]
+    hints: ["no PII echo","no unsafe content"]

--- a/tests/test_prompt_quality.py
+++ b/tests/test_prompt_quality.py
@@ -1,0 +1,103 @@
+import time
+import yaml
+from service.prompts.quality.evaluator import QualityEvaluator, rubrics_sha
+from service.prompts.quality.report import batch_compare
+
+
+RUBRICS_PATH = "service/prompts/quality/rubrics.yaml"
+with open(RUBRICS_PATH, "r", encoding="utf-8") as f:
+    RUBRICS_TEXT = f.read()
+RUBRICS = yaml.safe_load(RUBRICS_TEXT)
+RUBRICS_SHA = rubrics_sha(RUBRICS_TEXT)
+
+
+def make_evaluator():
+    return QualityEvaluator(RUBRICS, RUBRICS_TEXT)
+
+
+def test_rubrics_sha_stable():
+    assert RUBRICS_SHA == "fd2e588b1725e4df7d5aca764caf89ac8cc5366ea18949a4182fd316c51e7daf"
+
+
+def test_evaluator_scores_keywords_brevity_structure_safety():
+    evaluator = make_evaluator()
+    context = {
+        "must_include": ["alpha", "beta"],
+        "require_headings": True,
+        "require_bullets": True,
+        "required_fields": ["Name"],
+    }
+    good_response = "# Heading\nName: Foo\n- alpha\n- beta"
+    res = evaluator.score(good_response, context=context)
+    assert res["scores"] == {
+        "correctness": 2,
+        "brevity": 2,
+        "structure": 2,
+        "safety": 2,
+    }
+    unsafe_response = good_response + "\njohn@example.com"
+    res2 = evaluator.score(unsafe_response, context=context)
+    assert res2["scores"]["safety"] == 0
+
+
+def test_compare_selects_winner_and_route_explain_has_shas():
+    evaluator = make_evaluator()
+    context = {"must_include": ["alpha"], "prompt_deck_sha": "deck123"}
+    baseline = "This lacks keyword."
+    variant = "# H\n- alpha"
+    out = evaluator.compare(baseline, variant, context=context)
+    assert out["winner"] == "variant"
+    assert out["route_explain"]["prompt_deck_sha"] == "deck123"
+    assert out["route_explain"]["rubrics_sha"] == RUBRICS_SHA
+
+
+def test_batch_compare_reports_win_rate_ge_10pct_on_sample():
+    evaluator = make_evaluator()
+    pairs = []
+    for i in range(10):
+        ctx = {"must_include": ["alpha"]}
+        if i < 2:
+            baseline = ""
+            variant = "alpha"
+        else:
+            baseline = "alpha"
+            variant = ""
+        pairs.append({"id": str(i), "baseline": baseline, "variant": variant, "context": ctx})
+    result = batch_compare(pairs, evaluator, deck_sha="deckX", rubrics_sha_str=RUBRICS_SHA)
+    assert result["total"] == 10
+    assert result["wins"] >= 1
+    assert result["win_rate"] >= 0.1
+    assert result["route_explain"]["prompt_deck_sha"] == "deckX"
+    assert result["route_explain"]["rubrics_sha"] == RUBRICS_SHA
+
+
+def test_performance_p95_under_2s_for_100():
+    evaluator = make_evaluator()
+    pairs = []
+    for i in range(100):
+        ctx = {"must_include": ["alpha"]}
+        baseline = "alpha" if i % 2 == 0 else ""
+        variant = "alpha"
+        pairs.append({"id": str(i), "baseline": baseline, "variant": variant, "context": ctx})
+    start = time.monotonic()
+    batch_compare(pairs, evaluator, deck_sha="deckY", rubrics_sha_str=RUBRICS_SHA)
+    duration = time.monotonic() - start
+    assert duration < 2
+
+
+def test_no_pii_in_outputs():
+    evaluator = make_evaluator()
+    pairs = [
+        {
+            "id": "1",
+            "baseline": "safe",
+            "variant": "alpha",
+            "context": {"pii_raw": "secret", "api_token": "tok", "must_include": []},
+        }
+    ]
+    result = batch_compare(pairs, evaluator, deck_sha="deckZ", rubrics_sha_str=RUBRICS_SHA)
+    text = str(result)
+    assert "pii_raw" not in text
+    assert "secret" not in text
+    assert "api_token" not in text
+    assert "tok" not in text


### PR DESCRIPTION
## Summary
- add YAML rubrics for prompt quality and compute SHA
- implement heuristic QualityEvaluator with scoring and comparison
- batch evaluation reporting with deck and rubrics SHAs
- add tests for rubrics hash, evaluator scoring, comparisons, performance, and PII hygiene

## Testing
- `pytest tests/test_prompt_quality.py -q`
- `pytest tests/test_mcp_errors.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7447fcc588329997eb3dac514ff00