### PR TITLE
feat: add metrics exporter and dashboards

### DIFF
--- a/dashboards/alpha_observability.json
+++ b/dashboards/alpha_observability.json
@@ -1,0 +1,36 @@
+{
+  "annotations": {"list": []},
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "schemaVersion": 39,
+  "templating": {"list": []},
+  "title": "Alpha Observability",
+  "panels": [
+    {
+      "type": "graph",
+      "title": "Route Decision Allow Rate",
+      "datasource": "${DS_PROMETHEUS}",
+      "targets": [
+        {"expr": "rate(alpha_solver_route_decision_total{decision=\"allow\"}[5m])"}
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Budget Verdict Totals",
+      "datasource": "${DS_PROMETHEUS}",
+      "targets": [
+        {"expr": "sum by (budget_verdict)(alpha_solver_budget_verdict_total)"}
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Latency p95 ms",
+      "datasource": "${DS_PROMETHEUS}",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(alpha_solver_latency_ms_bucket[5m])) by (le))"
+        }
+      ]
+    }
+  ]
+}

--- a/dashboards/cost_budget.json
+++ b/dashboards/cost_budget.json
@@ -1,0 +1,33 @@
+{
+  "annotations": {"list": []},
+  "editable": false,
+  "schemaVersion": 39,
+  "templating": {"list": []},
+  "title": "Cost and Budget",
+  "panels": [
+    {
+      "type": "graph",
+      "title": "Tokens Per Second",
+      "datasource": "${DS_PROMETHEUS}",
+      "targets": [
+        {"expr": "sum(rate(alpha_solver_tokens_total[5m]))"}
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Cost USD Per Second",
+      "datasource": "${DS_PROMETHEUS}",
+      "targets": [
+        {"expr": "sum(rate(alpha_solver_cost_usd_total[5m]))"}
+      ]
+    },
+    {
+      "type": "table",
+      "title": "Confidence Avg",
+      "datasource": "${DS_PROMETHEUS}",
+      "targets": [
+        {"expr": "avg(alpha_solver_confidence)"}
+      ]
+    }
+  ]
+}

--- a/service/metrics/exporter.py
+++ b/service/metrics/exporter.py
@@ -1,0 +1,233 @@
+"""Prometheus metrics exporter for Alpha Solver.
+
+This module exposes the :class:`MetricsExporter` which provides a tiny
+wrapper around ``prometheus_client`` registry objects.  The exporter exposes
+an ASGI application serving ``/metrics`` compatible with the Prometheus text
+format.  Only the standard library and ``prometheus_client`` are used to keep
+runtime light-weight.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+import importlib.util
+import sys
+from pathlib import Path
+
+if "prometheus_client" in sys.modules:
+    del sys.modules["prometheus_client"]
+
+def _load_prometheus_client():
+    for path in sys.path:
+        if "site-packages" not in path:
+            continue
+        candidate = Path(path) / "prometheus_client" / "__init__.py"
+        if candidate.exists():
+            spec = importlib.util.spec_from_file_location(
+                "prometheus_client", candidate
+            )
+            module = importlib.util.module_from_spec(spec)
+            assert spec.loader is not None
+            sys.modules["prometheus_client"] = module
+            spec.loader.exec_module(module)  # type: ignore[assignment]
+            return module
+    raise ImportError("prometheus_client package not found")
+
+prom = _load_prometheus_client()
+CollectorRegistry = prom.CollectorRegistry
+Counter = prom.Counter
+Gauge = prom.Gauge
+Histogram = prom.Histogram
+generate_latest = prom.generate_latest
+
+from starlette.applications import Starlette
+from starlette.responses import Response
+from starlette.routing import Route
+
+__all__ = ["MetricsExporter"]
+
+
+def _is_redacted(name: str) -> bool:
+    """Return ``True`` if a metric label should be redacted.
+
+    Labels named ``pii_raw`` or ending with ``_secret``/``_token`` are
+    considered sensitive and are never exported.
+    """
+
+    return name == "pii_raw" or name.endswith("_secret") or name.endswith("_token")
+
+
+def _sanitize_labels(labels: Dict[str, str]) -> Dict[str, str]:
+    """Filter out sensitive labels and normalise their values.
+
+    Any label names matching :func:`_is_redacted` are dropped.  Values that
+    themselves look sensitive are replaced with ``"redacted"``.
+    """
+
+    clean: Dict[str, str] = {}
+    for key, value in labels.items():
+        if _is_redacted(key):
+            continue
+        if isinstance(value, str) and _is_redacted(value):
+            clean[key] = "redacted"
+        else:
+            clean[key] = value
+    return clean
+
+
+@dataclass
+class _Metrics:
+    decision: Counter
+    budget: Counter
+    policy: Counter
+    confidence: Gauge
+    latency: Histogram
+    tokens: Counter
+    cost: Counter
+
+
+class MetricsExporter:
+    """Small helper used by tests and services to expose Prometheus metrics."""
+
+    def __init__(self, namespace: str = "alpha_solver") -> None:
+        self.namespace = namespace
+        self.registry = CollectorRegistry()
+        self._metrics: Optional[_Metrics] = None
+
+    # ------------------------------------------------------------------
+    # Metric registration
+    def register_route_explain(self) -> None:
+        """Register counters and gauges for route explanations.
+
+        Metrics registered:
+        ``*_route_decision_total`` – counter labelled by ``decision``.
+        ``*_budget_verdict_total`` – counter labelled by ``budget_verdict``.
+        ``*_policy_verdict_total`` – counter labelled by ``policy_verdict``.
+        ``*_confidence`` – gauge storing the latest confidence score.
+        """
+
+        if self._metrics is not None:
+            return
+
+        decision = Counter(
+            f"{self.namespace}_route_decision_total",
+            "Route decision count",
+            ["decision"],
+            registry=self.registry,
+        )
+        budget = Counter(
+            f"{self.namespace}_budget_verdict_total",
+            "Budget verdict count",
+            ["budget_verdict"],
+            registry=self.registry,
+        )
+        policy = Counter(
+            f"{self.namespace}_policy_verdict_total",
+            "Policy verdict count",
+            ["policy_verdict"],
+            registry=self.registry,
+        )
+        confidence = Gauge(
+            f"{self.namespace}_confidence",
+            "Latest confidence score",
+            registry=self.registry,
+        )
+        # Placeholder metrics for latency, tokens and cost. These may be
+        # redefined later if :meth:`register_cost_latency` is invoked.
+        latency = Histogram(
+            f"{self.namespace}_latency_ms",
+            "Request latency in milliseconds",
+            buckets=(1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000),
+            registry=self.registry,
+        )
+        tokens = Counter(
+            f"{self.namespace}_tokens_total",
+            "Total tokens consumed",
+            registry=self.registry,
+        )
+        cost = Counter(
+            f"{self.namespace}_cost_usd_total",
+            "Total cost in USD",
+            registry=self.registry,
+        )
+
+        self._metrics = _Metrics(
+            decision=decision,
+            budget=budget,
+            policy=policy,
+            confidence=confidence,
+            latency=latency,
+            tokens=tokens,
+            cost=cost,
+        )
+
+    def register_cost_latency(self) -> None:
+        """No-op for backwards compatibility.
+
+        The latency, token and cost metrics are initialised in
+        :meth:`register_route_explain`, so this method simply ensures metrics
+        are registered and is kept for API parity with the specification.
+        """
+
+        if self._metrics is None:
+            self.register_route_explain()
+        # Metrics already created; nothing further required.
+
+    # ------------------------------------------------------------------
+    # Recording
+    def record_event(
+        self,
+        *,
+        decision: str,
+        confidence: float,
+        budget_verdict: Optional[str],
+        latency_ms: Optional[float],
+        tokens: Optional[int],
+        cost_usd: Optional[float],
+        policy_verdict: Optional[str] | None = None,
+    ) -> None:
+        """Record a single routing event.
+
+        Parameters mirror those described in the specification.  Any label
+        values that look sensitive are redacted prior to export.
+        """
+
+        if self._metrics is None:
+            raise RuntimeError("metrics not registered; call register_route_explain")
+
+        m = self._metrics
+
+        # Counters / gauge for routing decisions and verdicts
+        labels = _sanitize_labels({"decision": decision})
+        m.decision.labels(**labels).inc()
+        if budget_verdict:
+            bv = _sanitize_labels({"budget_verdict": budget_verdict})
+            m.budget.labels(**bv).inc()
+        if policy_verdict:
+            pv = _sanitize_labels({"policy_verdict": policy_verdict})
+            m.policy.labels(**pv).inc()
+
+        m.confidence.set(confidence)
+
+        # Cost / latency metrics
+        if latency_ms is not None:
+            m.latency.observe(latency_ms)
+        if tokens is not None:
+            m.tokens.inc(tokens)
+        if cost_usd is not None:
+            m.cost.inc(cost_usd)
+
+    # ------------------------------------------------------------------
+    # Application
+    def app(self) -> Starlette:
+        """Return an ASGI application exposing ``/metrics``."""
+
+        async def metrics_endpoint(_request) -> Response:
+            data = generate_latest(self.registry)
+            return Response(
+                data,
+                media_type="text/plain; version=0.0.4; charset=utf-8",
+            )
+
+        return Starlette(routes=[Route("/metrics", metrics_endpoint)])

--- a/tests/test_metrics_dashboards.py
+++ b/tests/test_metrics_dashboards.py
@@ -1,0 +1,125 @@
+import json
+import time
+from pathlib import Path
+
+from starlette.testclient import TestClient
+
+from service.metrics.exporter import MetricsExporter
+
+
+# ---------------------------------------------------------------------------
+# Metrics exporter tests
+
+def _scrape(exporter: MetricsExporter) -> str:
+    client = TestClient(exporter.app())
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+    return resp.text
+
+
+def test_metrics_exporter_registers_and_scrapes():
+    exp = MetricsExporter()
+    exp.register_route_explain()
+    exp.register_cost_latency()
+    exp.record_event(
+        decision="allow",
+        confidence=0.9,
+        budget_verdict="under",
+        latency_ms=12.0,
+        tokens=3,
+        cost_usd=0.01,
+        policy_verdict="clean",
+    )
+    metrics_text = _scrape(exp)
+    assert "alpha_solver_route_decision_total" in metrics_text
+    assert "alpha_solver_budget_verdict_total" in metrics_text
+    assert "alpha_solver_latency_ms_bucket" in metrics_text
+
+
+def test_record_event_updates_counters_histograms():
+    exp = MetricsExporter()
+    exp.register_route_explain()
+    exp.register_cost_latency()
+    for _ in range(3):
+        exp.record_event(
+            decision="allow",
+            confidence=0.5,
+            budget_verdict="under",
+            latency_ms=100,
+            tokens=10,
+            cost_usd=0.01,
+            policy_verdict="clean",
+        )
+    text = _scrape(exp)
+    assert 'alpha_solver_route_decision_total{decision="allow"} 3.0' in text
+    assert 'alpha_solver_budget_verdict_total{budget_verdict="under"} 3.0' in text
+    assert 'alpha_solver_tokens_total 30.0' in text
+    assert 'alpha_solver_cost_usd_total 0.03' in text
+
+
+def test_performance_scrape_p95_under_200ms():
+    exp = MetricsExporter()
+    exp.register_route_explain()
+    exp.register_cost_latency()
+    start = time.monotonic()
+    for _ in range(100):
+        exp.record_event(
+            decision="allow",
+            confidence=0.5,
+            budget_verdict="under",
+            latency_ms=10,
+            tokens=1,
+            cost_usd=0.001,
+            policy_verdict="clean",
+        )
+    _scrape(exp)
+    duration_ms = (time.monotonic() - start) * 1000
+    assert duration_ms < 200
+
+
+# ---------------------------------------------------------------------------
+# Dashboard tests
+
+def _load_dash(path: str) -> dict:
+    with open(Path("dashboards") / path, "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def test_dashboards_are_json_and_have_min_panels():
+    obs = _load_dash("alpha_observability.json")
+    cost = _load_dash("cost_budget.json")
+
+    assert len(obs["panels"]) >= 3
+    assert len(cost["panels"]) >= 3
+
+    obs_exprs = [t["expr"] for p in obs["panels"] for t in p.get("targets", [])]
+    assert 'rate(alpha_solver_route_decision_total{decision="allow"}[5m])' in obs_exprs
+    assert 'sum by (budget_verdict)(alpha_solver_budget_verdict_total)' in obs_exprs
+    assert (
+        'histogram_quantile(0.95, sum(rate(alpha_solver_latency_ms_bucket[5m])) by (le))'
+        in obs_exprs
+    )
+
+    cost_exprs = [t["expr"] for p in cost["panels"] for t in p.get("targets", [])]
+    assert 'sum(rate(alpha_solver_tokens_total[5m]))' in cost_exprs
+    assert 'sum(rate(alpha_solver_cost_usd_total[5m]))' in cost_exprs
+    assert 'avg(alpha_solver_confidence)' in cost_exprs
+
+
+def test_no_pii_in_metrics_labels_or_values():
+    exp = MetricsExporter()
+    exp.register_route_explain()
+    exp.register_cost_latency()
+    exp.record_event(
+        decision="pii_raw",
+        confidence=0.1,
+        budget_verdict="under_secret",
+        latency_ms=1,
+        tokens=1,
+        cost_usd=0.001,
+        policy_verdict="over_token",
+    )
+    text = _scrape(exp)
+    assert "pii_raw" not in text
+    assert "under_secret" not in text
+    assert "over_token" not in text


### PR DESCRIPTION
## Summary
- add Prometheus-based `MetricsExporter` with routing, cost, and latency metrics
- provide sample Grafana dashboards for observability and cost tracking
- test exporter behaviour, dashboards, performance, and PII redaction

## Testing
- `pytest tests/test_metrics_dashboards.py tests/test_mcp_errors.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c74f42ae38832999e882efd784cf07