### PR TITLE
docs(baseline): MVP quickstart, architecture, observability, determinism, budgeting, roadmap & contributing

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,14 @@
+---
+name: Bug report
+about: Report a bug in Alpha Solver
+labels: bug
+---
+
+**Describe the bug**
+
+**To Reproduce**
+
+**Expected behavior**
+
+**Environment**
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,12 @@
+---
+name: Feature request
+about: Suggest an idea for Alpha Solver
+labels: enhancement
+---
+
+**Problem**
+
+**Proposal**
+
+**Additional context**
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,32 @@
 # Contributing
 
-- Use feature branches and squash merge PRs.
-- Keep `make test` green.
-- Run `ruff check alpha`.
-- Add or adjust tests for new code.
-- Follow the PR template (summary, tests, docs).
+## Workflow
 
-## Observability workflows
+1. Spec Kit → 2. Codex → 3. PR → 4. CI → 5. Squash & Merge
 
-- Use `alpha-solver-v91-python.py --record <session>` to capture replay sessions.
-- Validate deterministic output with `--replay <session>`.
-- Benchmarks write JSON/Markdown to `artifacts/benchmarks/`.
+## Branch naming
+
+- `mvp/*` for baseline work
+- `next/*` for future iterations
+
+## Local development
+
+```bash
+pip install -r requirements.txt
+pytest -q
+```
+
+## Style
+
+- Type hints and docstrings
+- Deterministic tests
+
+## Pull requests
+
+- Keep branches up to date
+- Squash merge after CI passes
+
+## Issue templates
+
+Templates live under `.github/ISSUE_TEMPLATE/`.
+

--- a/README.md
+++ b/README.md
@@ -1,468 +1,78 @@
+<!--
+Repo: Reasoning & routing layer for LLM+tools (MCP). Ships gates, scoring, observability, replay, determinism, and budget guard.
+Topics: reasoning, router, mcp, observability, replay, determinism, budget, prometheus, grafana, prompt-engineering
+-->
+
 # Alpha Solver
 
-Alpha Solver is a lightweight planning and execution engine for tool‑augmented
-reasoning. It currently provides a Tree‑of‑Thought solver, a SAFE‑OUT policy
-engine for governed execution, and an experimental FastAPI service with
-observability. Users can interact through the CLI, Python SDK, or HTTP API, and
-built‑in executors handle math, CSV, and sandboxed subprocesses.
+[![CI](https://github.com/alpha-solver/alpha-solver/actions/workflows/ci.yml/badge.svg)](https://github.com/alpha-solver/alpha-solver/actions/workflows/ci.yml)
+[![Tests](https://github.com/alpha-solver/alpha-solver/actions/workflows/tests.yml/badge.svg)](https://github.com/alpha-solver/alpha-solver/actions/workflows/tests.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
+## What is Alpha Solver?
 
-## MVP Quickstart (5 minutes)
+A reasoning/routing layer with optional MCP tool calls. Ships gates, scoring, observability, replay, determinism & budget guard.
 
-### 1) CLI (local)
-```bash
-python -m alpha.cli.main solve --strategy react --seed 1337 --prompt "Explain 21*3 with brief rationale and answer."
-```
+## Status
 
-### 2) Python SDK (local)
-```bash
-pip install -e clients/python
-python - <<'PY'
-from alpha_client import AlphaClient
-client = AlphaClient("http://localhost:8000")
-print(client.solve(prompt="Explain 21*3 with brief rationale and answer.", strategy="react"))
-PY
-```
+MVP ready; P0 & P1 merged:
 
-### 3) API (HTTP)
-```bash
-curl -X POST http://localhost:8000/v1/solve \
-  -H "Content-Type: application/json" \
-  -d '{"prompt": "Explain 21*3 with brief rationale and answer.", "strategy": "react"}'
-```
+- Scoring & routing
+- Gates & policy
+- Observability & replay
+- Determinism harness
+- Budget guard
 
-### 4) Quality gates
-```bash
-make gates
-```
-
-See [docs/api.md](docs/api.md) for API details, [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md) for telemetry, and the production stack in [infrastructure/docker-compose.prod.yml](infrastructure/docker-compose.prod.yml).
-
-## Local executors
-
-See [docs/EXECUTORS.md](docs/EXECUTORS.md) for built-in math and CSV executors.
-
-The sandbox executor can run tiny subprocesses with resource limits:
+## Quickstart
 
 ```bash
-python - <<'PY'
-from alpha.executors.sandbox import run_subprocess
-print(run_subprocess(["echo", "hi"], timeout_s=1))
-PY
+# clone + deps
+python -m pip install -U pip
+pip install -r requirements.txt
+
+# run example
+python Alpha\ Solver.py
+
+# run tests (fast)
+pytest -q
+
+# targeted suites
+pytest -q -k "policy or gates or mcp or determinism or budget or observability"
 ```
 
-## API Service
-
-An experimental FastAPI wrapper is available for running the solver as a web
-service. Start the stack (API + telemetry + monitoring) with:
+## Using ChatGPT-5 via API (env-first)
 
 ```bash
-docker compose -f infrastructure/docker-compose.yml up --build
+export OPENAI_API_KEY=...
+export ALPHA_MODEL="gpt-5"           # or your provider/model key
+python Alpha\ Solver.py
 ```
 
-See [docs/api.md](docs/api.md) for usage details.
+### Config
 
-```bash
-python -m alpha.executors.math_exec "2+2"
-```
+Models and providers read from environment (`ALPHA_MODEL`, `ALPHA_PROVIDER`) or CLI flags. See `alpha.config.loader.load_config` for overrides.
 
-### Production Quickstart
+### Record / Replay / Metrics
 
-```bash
-docker compose -f infrastructure/docker-compose.prod.yml up -d
-```
+See [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md).
 
-Set `API_KEY` before launching. Prometheus runs on `http://localhost:9090` and Grafana on `http://localhost:3000` (read-only dashboards).
+### Determinism & Budget guard
 
-Example request:
+See [docs/DETERMINISM.md](docs/DETERMINISM.md) and [docs/BUDGETING.md](docs/BUDGETING.md).
 
-```bash
-curl -H "X-API-Key: $API_KEY" -H "Content-Type: application/json" \
-     -d '{"query":"hi","strategy":"react"}' \
-     http://localhost:8000/v1/solve
-```
+### Architecture overview
 
-Python client:
+See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
-```python
-from alpha_solver_sdk import AlphaClient
+### Roadmap
 
-client = AlphaClient("http://localhost:8000", "changeme")
-print(client.solve("2+2?", strategy="react", context={"seed": 42}))
-```
+See [docs/ROADMAP.md](docs/ROADMAP.md).
 
-## Using Tree-of-Thought
-
-### Observability & Replay
-
-`alpha-solver-v91-python.py` exposes optional observability flags:
-
-```bash
-python alpha-solver-v91-python.py "demo" --record mysession
-python alpha-solver-v91-python.py "demo" --replay mysession --strict-accessibility
-```
-
-Logs can be redirected with `--log-path` and telemetry sent via `--telemetry-endpoint`.
-
-```python
-from alpha_solver_entry import _tree_of_thought
-result = _tree_of_thought("solve x")
-print(result["final_answer"], result["confidence"])
-```
-
-Note: `_tree_of_thought` is imported from `alpha_solver_entry` (a small shim)
-because the canonical file name is hyphenated for historical reasons.
-
-`_tree_of_thought` is the stable public API. Advanced users may import
-`AlphaSolver` from `alpha_solver_entry`, which wraps the P3 observability
-implementation in `alpha.solver.observability`.
-
-```python
-_tree_of_thought(
-    query: str,
-    *,
-    seed: int = 42,
-    branching_factor: int = 3,
-    score_threshold: float = 0.70,
-    max_depth: int = 5,
-    timeout_s: int = 10,
-    dynamic_prune_margin: float = 0.15,
-    low_conf_threshold: float = 0.60,        # SAFE-OUT policy
-    enable_cot_fallback: bool = True,        # SAFE-OUT policy
-    multi_branch: bool = False,
-    max_width: int = 3,
-    max_nodes: int = 100,
-    enable_progressive_router: bool = False,
-    router_min_progress: float = 0.3,
-    enable_agents_v12: bool = False,
-    agents_v12_order: tuple[str, ...] = ("decomposer", "checker", "calculator"),
-    scorer: str = "composite",
-    scorer_weights: dict[str, float] | None = None,
-    enable_cache: bool = True,
-    cache_path: str | None = None,
-) -> dict
-```
-
-Configuration highlights:
-
-| key | default | description |
-|---|---|---|
-| `scorer` | `"composite"` | Path scoring strategy (`lexical`, `constraint`, `composite`). |
-| `scorer_weights` | `{\"lexical\": 0.6, \"constraint\": 0.4}` | Weights for composite scorer. |
-| `enable_cache` | `True` | Enable persistent ToT cache. |
-| `cache_path` | `artifacts/cache/tot_cache.json` | Location for cache file. |
-
-### Safety: Low-Confidence Fallback (SAFE-OUT)
-
-Tree-of-Thought exposes two thresholds:
-
-- `score_threshold` – accept a path inside the solver (default `0.70`); if no path ≥ threshold, ToT returns best-so-far with reason `"below_threshold"`.
-- `low_conf_threshold` – trigger SAFE-OUT policy (default `0.60`); if final confidence < this, the policy routes to `cot_fallback` (when enabled) or `best_effort`.
-
-Returned policy output schema:
-
-```python
-{
-  "final_answer": "...",
-  "route": "tot" | "cot_fallback" | "best_effort",
-  "confidence": 0.0,
-  "reason": "ok" | "low_confidence" | "timeout" | "below_threshold",
-  "notes": "...",
-  "tot": { "answer": "...", "confidence": 0.0, "path": [], "explored_nodes": 0, "config": {...}, "reason": "ok|timeout|below_threshold" },
-  "cot": { "answer": "...", "confidence": 0.0, "steps": [] }  # present only if fallback executed
-}
-```
-
-Usage:
-
-```python
-from alpha_solver_entry import _tree_of_thought
-
-result = _tree_of_thought(
-    "vague query",
-    score_threshold=0.70,
-    low_conf_threshold=0.60,
-)
-print(result["route"], result["final_answer"])
-```
-
-### `alpha_solver_cli.py`
-
-A thin wrapper around `_tree_of_thought` exposes router and SAFE-OUT flags:
-
-```bash
-python alpha_solver_cli.py "demo" --multi-branch --max-width 2 --max-nodes 4 \
-    --enable-progressive-router --router-escalation basic,structured,constrained \
-    --low-conf-threshold 0.5 --no-cot-fallback
-```
-
-### Multi-Branch ToT & Progressive Router
-
-```python
-from alpha_solver_entry import _tree_of_thought
-
-
-def demo_router() -> None:
-    """Run a deterministic progressive-router example."""
-    env = _tree_of_thought(
-        "color puzzle",
-        seed=42,
-        multi_branch=True,
-        max_width=2,
-        max_nodes=4,
-        enable_progressive_router=True,
-        router_escalation=("basic", "structured", "constrained"),
-        router_min_progress=0.8,
-    )
-    print(env["final_answer"])
-    print(env["diagnostics"]["router"]["stage"])
-    print(env["diagnostics"]["tot"]["explored_nodes"])
-
-
-if __name__ == "__main__":
-    demo_router()
-```
-
-Sample output:
-
-```text
-To proceed, clarify: color puzzle
-structured
-2
-```
-
-Determinism: beam expansion sorts candidates by score (rounded to 3 decimals) and lexical path.
-
-| option | default | description |
-| --- | --- | --- |
-| `max_width` | `3` | Beam width for multi-branch search |
-| `max_nodes` | `100` | Node expansion limit |
-| `router_escalation` | `basic→structured→constrained` | Progressive stages |
-
-### SAFE-OUT v1.1 (State Machine & Structured Recovery)
-
-```python
-from alpha_solver_entry import _tree_of_thought
-
-result = _tree_of_thought("unclear query")
-print(result["route"])
-print(result["phases"])
-print(result["notes"])
-```
-
-Example output:
-
-```json
-{
-  "final_answer": "To proceed, clarify: unclear query …",
-  "route": "cot_fallback",
-  "confidence": 0.5,
-  "reason": "low_confidence",
-  "notes": "Confidence below 0.60; used chain-of-thought fallback. | phases: init->assess->fallback->finalize",
-  "tot": {"confidence": 0.55, "reason": "ok", ...},
-  "cot": {"confidence": 0.5, "steps": []},
-  "phases": ["init", "assess", "fallback", "finalize"]
-}
-```
-
-_tree_of_thought maintains backward compatibility: existing keys are unchanged; phases and enriched notes are additive.
-
-## Telemetry Leaderboard (offline, stdlib-only)
-
-Generate a Markdown leaderboard from telemetry JSONL files:
-
-```bash
-python scripts/telemetry_leaderboard.py --paths telemetry/*.jsonl --topk 5 --format md --out artifacts/leaderboard.md
-```
-
-To produce CSV output instead:
-
-```bash
-python scripts/telemetry_leaderboard.py --paths telemetry/*.jsonl --topk 5 --format csv --out artifacts/leaderboard.csv
-```
-
-## Observability & Nightly
-
-- `make telemetry` – generate leaderboards and overview
-- `make replay` – replay the last plan deterministically
-- `make bench` – benchmark sample queries
-
-See [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md) for details.
-
-## Artifacts & Repro
-
-See [docs/ARTIFACTS.md](docs/ARTIFACTS.md) for details on artifact schema
-versioning and run snapshots.
-
-```bash
-python scripts/env_snapshot.py
-python scripts/bundle_artifacts.py
-```
-
-## Plan Spine & Transparency
-
-The runner can emit a minimal *plan spine* showing how a query will be solved.
-
-```bash
-python -m alpha.core.runner --plan-only --query "Test"
-python -m alpha.core.runner --explain --query "Test"
-```
-
-`--plan-only` writes `artifacts/last_plan.json` without executing any steps.
-`--explain` adds human readable summaries; omit both flags (or use `--execute`)
-to run the plan and emit the same artifact with results.
-
-## Recency priors (optional)
-
-```markdown
-optional recency signal via dated priors
-export ALPHA_RECENCY_PRIORS_PATH=registries/priors/dated_priors.sample.json
-export ALPHA_RECENCY_WEIGHT=0.15
-export ALPHA_RECENCY_HALFLIFE_DAYS=90
-python scripts/preflight.py # validates priors & registry IDs
-```
-
-## Shortlist snapshots
-
-```vbnet
-produced by runner / overnight sweep
-artifacts/shortlists/<region>/<query_hash>.json
-
-contains rank, tool_id, score, prior; useful for audits and diffs
-```
-
-## Reasons & Confidence
-
-Each shortlist item now includes:
-
-- `confidence`: normalized 0-1 score relative to other items in the shortlist.
-- `explain`: component scores (lexical, semantic, priors, recency, total).
-- `reason`: plain text summary of the score parts.
-
-## Optional region weights
-
-Provide a JSON file mapping region codes to multipliers:
-
-```bash
-export ALPHA_REGION_WEIGHTS_PATH=registries/region_weights.sample.json
-python scripts/preflight.py  # validates file if set
-```
-
-Weights (if any) are applied to scores before tie-breaks.
-
-## Preflight
-
-Validate the registry and basic settings:
-
-```bash
-make preflight
-# or
-python scripts/preflight.py --fix-ids
-```
-
-## Determinism switch
-
-Set `ALPHA_DETERMINISM=1` to lock a global seed and a single UTC
-timestamp in session traces for reproducible runs.
-
-## Governance (MVP)
-
-The lightweight policy engine enforces step/time budgets and a simple
-circuit breaker, with optional data classification.  Decisions are logged to
-`artifacts/policy_audit.jsonl`.
-
-CLI flags:
-
-```bash
---policy-dry-run
---budget-max-steps INT
---budget-max-seconds FLOAT
---breaker-max-fails INT
---data-policy PATH
-```
-
-See [docs/POLICY.md](docs/POLICY.md) for details.
-
-## Governance v1
-
-```bash
-export ALPHA_BUDGET_STEPS=100
-export ALPHA_MAX_ERRORS=5
-# optional dry-run mode
-export ALPHA_POLICY_DRYRUN=1
-```
-
-See [docs/GOVERNANCE.md](docs/GOVERNANCE.md) for full details.
-
-## Audit reminder
-
-Keep shortlist snapshots under `artifacts/shortlists/` and run `make telemetry`
-to collect usage logs for later review.
-
-## Further Reading
-
-- [Leaderboard Guide](docs/LEADERBOARD_GUIDE.md)
-- [Adding Tools](docs/ADDING_TOOLS.md)
-
-## Telemetry Scrubbing
-
-```bash
-export ALPHA_TELEMETRY_SCRUB=1
-# optional override
-export ALPHA_TELEMETRY_SCRUB_FIELDS="query_text,raw_prompt"
-```
-
-## Formatting & Linting
-
-We lint the **core library** with `ruff` (scoped to `alpha/`) in CI and pre-commit:
-`ruff check alpha` (CI) and `ruff check --fix alpha` locally.
-We lint the core library with Ruff. Black is temporarily **not** enforced in CI to avoid a noisy repo-wide rewrite; a one-time format PR will re-enable `black --check`. You can still run Black locally.
-
-The `scripts/` and `tests/` trees are covered by `black` only to keep CI fast and noise-free.
-
-CLI: `quick-audit` now invokes the audit script via `python -m scripts.quick_audit`, so it works both from the repo and when installed.
-Use the make targets below to keep style consistent.
-
-```bash
-make fmt       # format with black
-make fmt-check # check formatting
-make lint      # run ruff check
-```
-
-Optional: install pre-commit hooks locally:
-
-```bash
-pip install pre-commit && pre-commit install
-```
-
-## Agents v12: what’s enabled by the flag
-
-Setting `enable_agents_v12=True` wires deterministic helper agents
-(`decomposer`, `checker`, `calculator`) used for simple arithmetic reasoning.
-The flag is off by default and enabling it only affects branch ordering and scoring.
-
-## SAFE-OUT v1.2: richer reasons & evidence
-
-SAFE-OUT now emits additional reason codes and an `evidence` list summarising
-why a result was considered low confidence. Fallback routes include
-`recovery_notes` describing any escalations.
-
-## Config layering (defaults/env/CLI)
-
-Configuration is now loaded via `alpha.config.loader.load_config`. Defaults are
-stored centrally and can be overridden by environment variables (`ALPHA_*`) or
-explicit keyword arguments.
-
-## Telemetry schema v1 + Tiny Web Viz
-
-Telemetry events carry a `schema_version` (`1.0.0`) and can be validated with
-`alpha.reasoning.logging.validate_event`. The `viz/index.html` viewer renders
-JSONL telemetry logs without external dependencies.
-
-## Contributing
+### Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).
 
-## Release process
+## License / Support
 
-See [RELEASE.md](RELEASE.md). Release notes are generated with `make release-notes`.
+Licensed under the [MIT License](LICENSE). Issues and feature requests welcome via GitHub.
+

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,36 @@
+# Architecture
+
+Alpha Solver routes user requests through scoring, gates, and optional MCP tools before reaching an LLM. Key steps:
+
+- Input → router selects a path.
+- **RES-03 scoring** evaluates candidates.
+- **RES-04 gates** enforce allow/deny.
+- Low confidence triggers **Clarify (NEW-009/010)**.
+- `use_mcp` (**MCP-002**) calls tools via adapters (**RES-05/AS-145**).
+- LLM invocation.
+- **RES-07 observability** logs events for replay.
+- **Budget guard (NEW-012)** checks cost before output.
+
+```
+user input
+    │
+    ▼
+[RES-03 scoring] → [RES-04 gates] ── low conf? ──► [Clarify (NEW-009/010)]
+    │                                  │
+    ├─ use_mcp (MCP-002) ─► [MCP tools via adapters (RES-05/AS-145)]
+    │
+    ▼
+[LLM call] ─► [RES-07 observability + replay] ─► [Budget guard (NEW-012)] ─► output
+```
+
+## Module map
+
+- **RES-03**: scoring heuristics.
+- **RES-04**: gates/policy enforcement.
+- **RES-05/AS-145**: MCP adapters for external tools.
+- **RES-07**: observability and replay hooks.
+- **MCP-002**: toggle for MCP usage.
+- **NEW-009/010**: clarify step on low confidence.
+- **NEW-012**: cost budget guard.
+- **NEW-015**: determinism harness ensuring stable outputs.
+

--- a/docs/BUDGETING.md
+++ b/docs/BUDGETING.md
@@ -1,0 +1,27 @@
+# Budgeting
+
+## Simulator (RES-08)
+
+Estimate costs before running:
+
+```bash
+python -m service.budget.simulator --items eval/sample.jsonl
+```
+
+## CLI Guard (NEW-012)
+
+```bash
+python -m service.budget.cli --provider OPENAI --model gpt-5 \
+  --items eval/sample.jsonl --max-cost 2.50 --max-tokens 200000 \
+  --jsonl-out out/budget.jsonl
+echo $?  # 0=ok, 2=over thresholds
+```
+
+Example `out/budget.jsonl`:
+
+```json
+{"item_id": "q1", "tokens": 400, "cost_usd": 0.02, "budget_verdict": "under"}
+```
+
+`budget_verdict` reports `under` or `over` against the thresholds.
+

--- a/docs/DETERMINISM.md
+++ b/docs/DETERMINISM.md
@@ -1,0 +1,17 @@
+# Determinism
+
+The determinism harness (**NEW-015**) ensures runs are repeatable.
+
+## Harness usage
+
+```bash
+pytest -q -k determinism
+# or in code
+from service.determinism.harness import DeterminismHarness
+DeterminismHarness(...).run_replay(["out/events.jsonl"])
+```
+
+## CI gate
+
+CI fails on any flap: outputs, events, or metrics must match between runs. Noise injection is disabled; differing keys trigger a gate failure.
+

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -1,0 +1,52 @@
+# Observability
+
+## Record
+
+```bash
+alpha_solver_cli --record --events out/events.jsonl
+```
+
+## Replay
+
+```bash
+python -m service.observability.replay_cli --events out/events.jsonl
+```
+
+## Diff
+
+```bash
+python -m service.observability.replay_cli --compare out/a.jsonl --events out/b.jsonl
+```
+
+## Metrics
+
+Expose Prometheus metrics at `/metrics`.
+
+Metrics referenced by tests:
+
+- `alpha_solver_route_decision_total{...}`
+- `alpha_solver_budget_verdict_total{...}`
+- `alpha_solver_latency_ms_bucket{...}`
+- `alpha_solver_tokens_total`
+- `alpha_solver_cost_usd_total`
+- `alpha_solver_confidence`
+
+## Dashboards
+
+- `dashboards/alpha_observability.json`
+- `dashboards/cost_budget.json`
+
+Datasource placeholder: `${DS_PROMETHEUS}`.
+
+## Sample `route_explain`
+
+```json
+{
+  "route": "default",
+  "decision": "allow",
+  "confidence": 0.82,
+  "scorers": {"tot": 0.82},
+  "gates": ["budget_ok"]
+}
+```
+

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,20 @@
+# Roadmap
+
+## Done (MVP: P0 & P1)
+
+- Metrics exporter and dashboards ([#99](https://github.com/alpha-solver/alpha-solver/pull/99))
+- Prompt quality evaluator ([#98](https://github.com/alpha-solver/alpha-solver/pull/98))
+- Replay CLI and diff utilities ([#97](https://github.com/alpha-solver/alpha-solver/pull/97))
+- Budget guard and CLI ([#96](https://github.com/alpha-solver/alpha-solver/pull/96))
+- Deterministic weight tuning harness ([#95](https://github.com/alpha-solver/alpha-solver/pull/95))
+- Evidence pack store ([#93](https://github.com/alpha-solver/alpha-solver/pull/93))
+- Clarify templates and trigger ([#92](https://github.com/alpha-solver/alpha-solver/pull/92))
+- Determinism harness ([#91](https://github.com/alpha-solver/alpha-solver/pull/91))
+
+## Next (P1/P2)
+
+- Rich MCP adapter library – expand tool coverage with tests.
+- Advanced budget modeling – per-route and per-token projections.
+- Policy engine v2 – granular gates with audit trail.
+- Scenario runner – compose multi-step evaluation flows.
+


### PR DESCRIPTION
## Summary
- streamline README with quickstart, ChatGPT-5 API usage, and doc links
- document architecture, observability, determinism harness, budgeting guard, and roadmap
- add contributing guide and issue templates

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'opentelemetry'; OSError: [Errno 98] Address already in use)*
- `pip install opentelemetry-sdk` *(fails: Could not find a version that satisfies the requirement opentelemetry-sdk)*
- `pytest -q -k "policy or gates or mcp or determinism or budget or observability"` *(fails: OSError: [Errno 98] Address already in use)*

------
https://chatgpt.com/codex/tasks/task_e_68c76858cdfc83298286720a7b60f1d1