### PR TITLE
audit(immutable): hash-chained append-only audit log + export + tests

### DIFF
--- a/.specs/NEW-025.md
+++ b/.specs/NEW-025.md
@@ -1,0 +1,15 @@
+# NEW-025 · Audit Logging (Immutable)
+
+Implements an append-only, hash-chained audit log with JSONL export.
+Key aspects:
+
+* **Immutability:** each entry includes `prev_hash` and `hash` forming a chain.
+* **Redaction:** simple regex based redaction for emails, phone numbers and
+  token/password like substrings.
+* **Retention:** entries older than `retention_days` are compacted on write and
+  hash chain recomputed.
+* **Export:** filtered export to JSON Lines with manifest containing head/tail
+  hashes and entry count.
+* **Verification:** walking the chain detects the first corrupt entry.
+
+Tests cover integrity, redaction, performance, retention and export.

--- a/docs/AUDIT_LOGGING.md
+++ b/docs/AUDIT_LOGGING.md
@@ -1,0 +1,53 @@
+# Audit Logging (Immutable)
+
+The audit log records security‐relevant events in an append‐only, hash‐chained
+sequence.  Each entry contains:
+
+```json
+{
+  "ts": <float seconds>,
+  "id": <sequential int>,
+  "tenant_id": "<tenant>",
+  "type": "<event type>",
+  "payload": {"…"},
+  "prev_hash": "<sha256>",
+  "hash": "<sha256>"
+}
+```
+
+The hash is computed as `SHA256(canonical_json(entry_without_hash) + prev_hash)`
+providing tamper–evidence.  Retention is enforced on write based on
+`retention_days` from `service/config/audit.yaml`.
+
+## Usage
+
+```python
+from service.audit import audit_log, exporter
+
+ctx = {"principal": {"tenant_id": "t1", "sub": "user"}}
+audit_log.record("auth.login", {"ip": "1.2.3.4"}, ctx)
+
+# verify existing log
+assert audit_log.verify(audit_log._audit_log.iter_entries()) is None
+```
+
+## Export
+
+```python
+from io import StringIO
+from service.audit import exporter
+
+buf = StringIO()
+manifest = exporter.export(audit_log._audit_log.iter_entries(), buf)
+print(manifest)
+print(buf.getvalue())  # JSONL
+```
+
+## Troubleshooting
+
+* **Verification fails** – `verify()` returns the index of the first corrupt
+  entry.  Inspect or rebuild the log from backups.
+* **Secrets in payloads** – ensure all sensitive fields match the basic
+  redaction rules (emails, phone numbers, token/password like substrings).
+* **Performance** – writes should complete in <50ms p95; if exceeded, check
+  disk or locking contention.

--- a/service/audit/audit_log.py
+++ b/service/audit/audit_log.py
@@ -1,0 +1,89 @@
+import re
+import threading
+import time
+from typing import Any, Dict, Iterable, List, Optional
+
+from .hash_chain import ZERO_HASH, compute_hash, verify_chain
+
+
+_EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+_PHONE_RE = re.compile(r"\b\d{3}[-.\s]?\d{3}[-.\s]?\d{4}\b")
+_TOKEN_RE = re.compile(r"\b(?:token|secret|password)[A-Za-z0-9_-]*\b", re.I)
+
+
+class AuditLog:
+    def __init__(
+        self,
+        retention_days: int = 30,
+        enabled_event_types: Optional[List[str]] = None,
+    ) -> None:
+        self.retention_seconds = retention_days * 24 * 3600
+        self.enabled_event_types = enabled_event_types
+        self._entries: List[Dict[str, Any]] = []
+        self._lock = threading.Lock()
+
+    # --- redaction -----------------------------------------------------
+    def _redact(self, value: Any) -> Any:
+        if isinstance(value, str):
+            value = _EMAIL_RE.sub("[REDACTED]", value)
+            value = _PHONE_RE.sub("[REDACTED]", value)
+            value = _TOKEN_RE.sub("[REDACTED]", value)
+            return value
+        if isinstance(value, dict):
+            return {k: self._redact(v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [self._redact(v) for v in value]
+        return value
+
+    # --- retention -----------------------------------------------------
+    def _enforce_retention(self) -> None:
+        cutoff = time.time() - self.retention_seconds
+        removed = False
+        while self._entries and self._entries[0]["ts"] < cutoff:
+            self._entries.pop(0)
+            removed = True
+        if removed:
+            prev = ZERO_HASH
+            for entry in self._entries:
+                entry["prev_hash"] = prev
+                body = {k: v for k, v in entry.items() if k != "hash"}
+                entry["hash"] = compute_hash(body, prev)
+                prev = entry["hash"]
+
+    # --- public API ----------------------------------------------------
+    def record(self, event_type: str, payload: Dict[str, Any], ctx: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        if self.enabled_event_types and event_type not in self.enabled_event_types:
+            return None
+        ts = time.time()
+        with self._lock:
+            entry_id = len(self._entries) + 1
+            tenant_id = ctx.get("principal", {}).get("tenant_id")
+            prev_hash = self._entries[-1]["hash"] if self._entries else ZERO_HASH
+            body = {
+                "ts": ts,
+                "id": entry_id,
+                "tenant_id": tenant_id,
+                "type": event_type,
+                "payload": self._redact(payload),
+                "prev_hash": prev_hash,
+            }
+            entry_hash = compute_hash(body, prev_hash)
+            entry = {**body, "hash": entry_hash}
+            self._entries.append(entry)
+            self._enforce_retention()
+            return entry
+
+    def iter_entries(self) -> List[Dict[str, Any]]:
+        with self._lock:
+            return list(self._entries)
+
+
+_audit_log = AuditLog()
+
+
+def record(event_type: str, payload: Dict[str, Any], ctx: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    return _audit_log.record(event_type, payload, ctx)
+
+
+def verify(stream: Iterable[Dict[str, Any]]) -> Optional[int]:
+    return verify_chain(stream)

--- a/service/audit/exporter.py
+++ b/service/audit/exporter.py
@@ -1,0 +1,45 @@
+import json
+from typing import Iterable, List, Optional, Sequence, TextIO
+
+
+def export(
+    entries: Iterable[dict],
+    fp: TextIO,
+    *,
+    start_ts: Optional[float] = None,
+    end_ts: Optional[float] = None,
+    event_types: Optional[Sequence[str]] = None,
+    tenant_id: Optional[str] = None,
+) -> dict:
+    """Export audit log entries to JSONL with optional filtering.
+
+    Args:
+        entries: iterable of entries.
+        fp: file-like object to write JSON lines to.
+        start_ts, end_ts: inclusive time window.
+        event_types: sequence of event types to include.
+        tenant_id: only include entries matching this tenant.
+    Returns:
+        Manifest dict containing ``count`` and ``head``/``tail`` hashes.
+    """
+    filtered: List[dict] = []
+    for e in entries:
+        if start_ts is not None and e["ts"] < start_ts:
+            continue
+        if end_ts is not None and e["ts"] > end_ts:
+            continue
+        if event_types is not None and e["type"] not in event_types:
+            continue
+        if tenant_id is not None and e.get("tenant_id") != tenant_id:
+            continue
+        filtered.append(e)
+
+    filtered.sort(key=lambda x: (x["ts"], x["id"]))
+    for e in filtered:
+        fp.write(json.dumps(e, sort_keys=True) + "\n")
+
+    manifest = {"count": len(filtered), "head": None, "tail": None}
+    if filtered:
+        manifest["head"] = filtered[0]["hash"]
+        manifest["tail"] = filtered[-1]["hash"]
+    return manifest

--- a/service/audit/hash_chain.py
+++ b/service/audit/hash_chain.py
@@ -1,0 +1,36 @@
+import hashlib
+import json
+from typing import Dict, Iterable, Optional
+
+ZERO_HASH = "0" * 64
+
+
+def _canonical_json(data: Dict) -> str:
+    """Return a deterministic JSON string for hashing."""
+    return json.dumps(data, sort_keys=True, separators=(",", ":"))
+
+
+def compute_hash(entry: Dict, prev_hash: str) -> str:
+    """Compute the SHA256 hash of the entry chained with ``prev_hash``."""
+    to_hash = _canonical_json(entry) + prev_hash
+    return hashlib.sha256(to_hash.encode("utf-8")).hexdigest()
+
+
+def verify_chain(entries: Iterable[Dict]) -> Optional[int]:
+    """Verify integrity of a hash chain.
+
+    Args:
+        entries: iterable of audit log entries ordered by ``id``.
+    Returns:
+        ``None`` if the chain is valid, otherwise the index of the first corrupt
+        entry.
+    """
+    prev_hash = ZERO_HASH
+    for idx, entry in enumerate(entries):
+        # reconstruct entry without the ``hash`` field for recomputation
+        body = {k: v for k, v in entry.items() if k != "hash"}
+        expected = compute_hash(body, prev_hash)
+        if entry.get("prev_hash") != prev_hash or entry.get("hash") != expected:
+            return idx
+        prev_hash = entry["hash"]
+    return None

--- a/service/config/audit.yaml
+++ b/service/config/audit.yaml
@@ -1,0 +1,19 @@
+retention_days: 30
+redact_rules:
+  emails: true
+  phones: true
+  tokens: true
+enabled_event_types:
+  - auth.login
+  - auth.deny
+  - auth.jwt_expired
+  - policy.allow
+  - policy.deny
+  - policy.redacted
+  - budget.block
+  - budget.warn
+  - route.chosen
+  - route.fallback
+  - system.start
+  - system.ready
+  - system.shutdown

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -1,0 +1,76 @@
+import json
+import time
+from io import StringIO
+
+from service.audit import audit_log, exporter
+from service.audit.hash_chain import ZERO_HASH
+
+
+CTX = {"principal": {"tenant_id": "t1", "sub": "user"}}
+
+
+def test_integrity_and_corruption_detection():
+    log = audit_log.AuditLog()
+    for i in range(5):
+        log.record("system.start", {"i": i}, CTX)
+    assert audit_log.verify(log.iter_entries()) is None
+
+    entries = log.iter_entries()
+    entries[2]["payload"]["i"] = 999  # mutate
+    assert audit_log.verify(entries) == 2
+
+
+def test_redaction_rules():
+    payload = {
+        "email": "user@example.com",
+        "phone": "555-123-4567",
+        "token": "secret-token-abc",
+    }
+    log = audit_log.AuditLog()
+    entry = log.record("auth.login", payload, CTX)
+    stored = entry["payload"]
+    assert "example.com" not in json.dumps(stored)
+    assert "555" not in json.dumps(stored)
+    assert "secret" not in json.dumps(stored)
+
+
+def test_perf_p95_under_budget():
+    log = audit_log.AuditLog()
+    times = []
+    for i in range(1000):
+        start = time.monotonic()
+        log.record("auth.login", {"n": i}, CTX)
+        times.append(time.monotonic() - start)
+    times.sort()
+    p95 = times[int(0.95 * len(times))]
+    assert p95 <= 0.05
+
+
+def test_retention_compaction():
+    log = audit_log.AuditLog(retention_days=1)
+    first = log.record("system.start", {}, CTX)
+    # simulate old entry
+    log._entries[0]["ts"] = time.time() - 2 * 24 * 3600
+    second = log.record("system.ready", {}, CTX)
+    entries = log.iter_entries()
+    assert len(entries) == 1
+    assert entries[0]["id"] == second["id"]
+    assert entries[0]["prev_hash"] == ZERO_HASH
+
+
+def test_export_jsonl_manifest():
+    log = audit_log.AuditLog()
+    log.record("auth.login", {}, CTX)
+    time.sleep(0.01)
+    log.record("policy.deny", {}, {"principal": {"tenant_id": "t2"}})
+
+    start = 0
+    end = time.time() + 1
+    buf = StringIO()
+    manifest = exporter.export(
+        log.iter_entries(), buf, start_ts=start, end_ts=end, tenant_id="t1"
+    )
+    lines = [json.loads(l) for l in buf.getvalue().strip().splitlines()]
+    assert manifest["count"] == len(lines) == 1
+    assert lines[0]["tenant_id"] == "t1"
+    assert manifest["head"] == manifest["tail"] == lines[0]["hash"]


### PR DESCRIPTION
## Summary
- implement in-memory hash-chained audit log with redaction and retention
- add exporter to JSONL with manifest of head/tail hashes
- document immutable audit logging and include NEW-025 spec

## Testing
- `pytest -q -k audit_log`


------
https://chatgpt.com/codex/tasks/task_e_68c7a06226ec8329a78c795b38343d81