### PR TITLE
obs(otel): add distributed tracing + alert rules (p95/budget) with tests

### DIFF
--- a/.specs/NEW-026.md
+++ b/.specs/NEW-026.md
@@ -1,0 +1,24 @@
+# NEW-026 · Distributed Tracing & Alerts
+
+Implements distributed tracing helpers and an in-process alert manager.
+
+### Tracing
+
+* `service.otel` wires an OpenTelemetry tracer with an in-memory exporter.
+* `span()` context manager redacts obvious PII and adds `latency_ms`.
+* Span hierarchy covers router → gates → adapter with attributes:
+  `request_id`, `tenant_id`, `decision`, `budget_verdict`, `cost_usd`, `tokens`.
+
+### Alerts
+
+* `AlertManager` tracks a rolling window of latencies.
+* Rules:
+  * p95 latency above target.
+  * budget_over events.
+* Alerts delivered via callback/log events.
+
+### Tests
+
+* Tracing coverage ≥95% of simulated requests, correct span tree and redaction.
+* Alert rules fire for p95 breaches and budget_over, silent under thresholds.
+

--- a/docs/TRACING_ALERTS.md
+++ b/docs/TRACING_ALERTS.md
@@ -1,0 +1,47 @@
+# Distributed Tracing & Alerts
+
+This project ships with light‑weight helpers for distributed tracing and
+in‑process alerting.
+
+## Tracing
+
+`service.otel` exposes `init_tracer()` and a `span()` context manager.  The
+tracer uses an in‑memory exporter so traces can be inspected locally without
+external infrastructure.
+
+Example:
+
+```python
+from service import otel
+
+tracer = otel.init_tracer()
+
+with otel.span("alpha.router", request_id="123", tenant_id="acme"):
+    with otel.span("alpha.gates"):
+        with otel.span("alpha.adapter"):
+            pass
+```
+
+Span attributes such as `decision`, `budget_verdict`, `cost_usd`, `tokens` and
+`latency_ms` are supported.  Obvious PII (`user_input`, `secret`, etc.) is
+redacted automatically.
+
+## Alerts
+
+`service.alerts.AlertManager` monitors request latencies and budget events.  Two
+rules are provided:
+
+* **p95 latency** – emits `{"type": "p95_latency"}` when the observed 95th
+  percentile latency over the rolling window exceeds `p95_target_ms`.
+* **budget overrun** – emits `{"type": "budget_over"}` when `record_budget_over`
+  is called.
+
+Alerts are delivered to a callback (defaults to storing events in memory) and
+can be consumed by logging or other systems.
+
+## Troubleshooting
+
+* Ensure `opentelemetry-sdk` is installed.  The helpers fall back to a no‑op
+  implementation if the package is missing.
+* Spans missing?  Confirm `init_tracer()` was called before emitting spans.
+

--- a/service/alerts.py
+++ b/service/alerts.py
@@ -1,0 +1,101 @@
+"""Simple in-process alert manager.
+
+The alert manager keeps a rolling window of request latencies and budget
+events.  It emits structured alert dictionaries through a callback when:
+
+* the observed p95 latency over the window exceeds ``p95_target_ms``
+* a ``budget_over`` event is recorded
+
+The implementation deliberately avoids external services; alerts are delivered
+via the provided callback, making it easy for tests to capture and assert on
+events.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from collections import deque
+from typing import Callable, Deque, Dict, Iterable, List, Tuple
+
+
+class AlertManager:
+    """Manage latency and budget alerts."""
+
+    def __init__(
+        self,
+        *,
+        p95_target_ms: float = 1000.0,
+        window_seconds: float = 60.0,
+        callback: Callable[[Dict[str, float]], None] | None = None,
+    ) -> None:
+        self.p95_target_ms = p95_target_ms
+        self.window_seconds = window_seconds
+        self.callback = callback or self._default_callback
+        self._latencies: Deque[Tuple[float, float]] = deque()
+        self._events: List[Dict[str, float]] = []
+
+    # -- internal utilities -------------------------------------------------
+
+    def _default_callback(self, event: Dict[str, float]) -> None:
+        self._events.append(event)
+
+    def _emit(self, event: Dict[str, float]) -> None:
+        self.callback(event)
+        # ensure events are always stored for inspection
+        if event not in self._events:
+            self._events.append(event)
+
+    def _trim(self, now: float) -> None:
+        while self._latencies and now - self._latencies[0][0] > self.window_seconds:
+            self._latencies.popleft()
+
+    # -- recording ----------------------------------------------------------
+
+    def record_latency(self, latency_ms: float, *, now: float | None = None) -> None:
+        """Record a latency measurement and evaluate alert rules."""
+
+        now = now if now is not None else time.time()
+        self._latencies.append((now, latency_ms))
+        self._trim(now)
+        self._check_latency(now)
+
+    def record_budget_over(self, *, now: float | None = None) -> None:
+        """Record that a budget has been exceeded."""
+
+        event = {
+            "type": "budget_over",
+            "timestamp": now if now is not None else time.time(),
+        }
+        self._emit(event)
+
+    # -- alert checks -------------------------------------------------------
+
+    def _check_latency(self, now: float) -> None:
+        if not self._latencies:
+            return
+        latencies = [lat for _, lat in self._latencies]
+        idx = max(int(math.ceil(0.95 * len(latencies))) - 1, 0)
+        p95 = sorted(latencies)[idx]
+        if p95 > self.p95_target_ms:
+            event = {
+                "type": "p95_latency",
+                "p95": p95,
+                "target": self.p95_target_ms,
+                "window": self.window_seconds,
+                "timestamp": now,
+            }
+            self._emit(event)
+
+    # -- public inspection helpers -----------------------------------------
+
+    def get_events(self) -> List[Dict[str, float]]:
+        return list(self._events)
+
+    def reset(self) -> None:
+        self._latencies.clear()
+        self._events.clear()
+
+
+__all__ = ["AlertManager"]
+

--- a/service/otel.py
+++ b/service/otel.py
@@ -1,58 +1,164 @@
-from contextlib import contextmanager
-from typing import Any
+"""Minimal OpenTelemetry helpers for Alpha Solver.
 
-try:
+This module wires a tracer with an in-memory exporter so tests can inspect
+spans.  When OpenTelemetry is not installed a small no-op tracer is used
+instead so importing this module never raises ImportError in constrained
+environments.
+
+The :func:`span` context manager performs attribute redaction to avoid
+accidentally recording user supplied text or secrets in telemetry data.  A
+latency attribute is automatically added if one is not supplied.
+"""
+
+from __future__ import annotations
+
+import time
+from contextlib import contextmanager
+from typing import Any, Dict
+
+try:  # Prefer the real OpenTelemetry SDK if available
     from opentelemetry import trace
     from opentelemetry.sdk.trace import TracerProvider
-    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    from opentelemetry.sdk.trace.export import (InMemorySpanExporter,
+                                                SimpleSpanProcessor)
+
     HAVE_OTEL = True
 except Exception:  # package missing or partial install
     trace = None  # type: ignore
-    TracerProvider = BatchSpanProcessor = None  # type: ignore
+    TracerProvider = InMemorySpanExporter = SimpleSpanProcessor = None  # type: ignore
     HAVE_OTEL = False
 
 
-class _NoopSpan:
-    def __enter__(self):
-        return self
+TRACER = None
+EXPORTER = None
+_STUB_SPANS = []  # used when OpenTelemetry SDK is unavailable
 
-    def __exit__(self, exc_type, exc, tb):
-        return False
+# --- redaction -----------------------------------------------------------
+
+_SENSITIVE_KEYS = {"user_input", "secret", "password", "pii", "raw"}
 
 
-class _NoopTracer:
-    def start_as_current_span(self, *_: Any, **__: Any):
+def _redact(attrs: Dict[str, Any]) -> Dict[str, Any]:
+    """Remove obviously sensitive information from span attributes."""
+
+    clean: Dict[str, Any] = {}
+    for key, val in attrs.items():
+        lowered = str(key).lower()
+        if any(s in lowered for s in _SENSITIVE_KEYS):
+            continue
+        if isinstance(val, str) and any(s in val.lower() for s in _SENSITIVE_KEYS):
+            continue
+        clean[key] = val
+    return clean
+
+
+# --- span helpers -------------------------------------------------------
+
+
+@contextmanager
+def span(name: str, **attrs: Any):
+    """Start a traced span with basic attribute redaction.
+
+    The active tracer is used if available; otherwise a no-op tracer.  The span
+    is automatically annotated with ``latency_ms`` if the caller did not supply
+    one.
+    """
+
+    tracer = TRACER or _StubTracer()
+    clean = _redact(attrs)
+    start = time.time()
+    with tracer.start_as_current_span(name) as sp:  # pragma: no cover - context
+        if hasattr(sp, "set_attribute"):
+            for k, v in clean.items():
+                sp.set_attribute(k, v)
+        yield sp
+        if hasattr(sp, "set_attribute") and "latency_ms" not in clean:
+            sp.set_attribute("latency_ms", (time.time() - start) * 1000.0)
+
+
+# --- tracer init/export helpers ----------------------------------------
+
+
+def init_tracer(app: Any | None = None):
+    """Initialise a tracer with an in-memory exporter.
+
+    The exporter allows tests to verify spans without external dependencies.
+    When OpenTelemetry is unavailable a no-op tracer is returned.
+    """
+
+    global TRACER, EXPORTER
+
+    if not HAVE_OTEL:
+        TRACER = _StubTracer()
+        if app is not None and hasattr(app, "state"):
+            app.state.tracer = TRACER
+        return TRACER
+
+    provider = TracerProvider()  # type: ignore[call-arg]
+    EXPORTER = InMemorySpanExporter()  # type: ignore[call-arg]
+    provider.add_span_processor(SimpleSpanProcessor(EXPORTER))  # type: ignore[arg-type]
+    trace.set_tracer_provider(provider)  # type: ignore[call-arg]
+    TRACER = trace.get_tracer("alpha_solver")  # type: ignore[attr-defined]
+    if app is not None and hasattr(app, "state"):
+        app.state.tracer = TRACER
+    return TRACER
+
+
+def get_exported_spans():
+    """Return spans recorded by the in-memory exporter."""
+
+    if HAVE_OTEL and EXPORTER is not None:
+        return list(EXPORTER.get_finished_spans())  # type: ignore[return-value]
+    return list(_STUB_SPANS)
+
+
+def reset_exported_spans() -> None:
+    """Clear all spans from the exporter."""
+
+    if HAVE_OTEL and EXPORTER is not None:
+        EXPORTER.clear()  # type: ignore[operator]
+    _STUB_SPANS.clear()
+
+
+# --- fallback tracer implementation ------------------------------------
+
+
+class _StubSpan:
+    def __init__(self, name: str, parent_ctx: Any | None = None) -> None:
+        self.name = name
+        self.parent = parent_ctx
+        self.attributes: Dict[str, Any] = {}
+        self.context = type("_Ctx", (), {"span_id": id(self)})()
+
+    def set_attribute(self, key: str, value: Any) -> None:
+        self.attributes[key] = value
+
+
+class _StubTracer:
+    def __init__(self) -> None:
+        self._stack: list[_StubSpan] = []
+
+    def start_as_current_span(self, name: str):
+        parent_ctx = self._stack[-1].context if self._stack else None
+        span = _StubSpan(name, parent_ctx)
+
         @contextmanager
         def _cm():
-            yield _NoopSpan()
+            self._stack.append(span)
+            try:
+                yield span
+            finally:
+                self._stack.pop()
+                _STUB_SPANS.append(span)
 
         return _cm()
 
 
-def init_tracer(app=None):
-    """
-    Initialize tracing if opentelemetry is available; otherwise install a no-op tracer.
-    Must NEVER raise ImportError on clean CI environments.
-    """
-    if not HAVE_OTEL:
-        tracer = _NoopTracer()
-        if app is not None and hasattr(app, "state"):
-            app.state.tracer = tracer
-        return tracer
-
-    # Real wiring (kept minimal; extend if needed)
-    provider = TracerProvider()  # type: ignore
-    # NOTE: exporter wiring can be added here when available; BatchSpanProcessor optional
-    # provider.add_span_processor(BatchSpanProcessor(exporter))
-    if trace is not None:
-        trace.set_tracer_provider(provider)  # type: ignore
-        tracer = trace.get_tracer("alpha_solver")  # type: ignore
-    else:
-        tracer = _NoopTracer()
-    if app is not None and hasattr(app, "state"):
-        app.state.tracer = tracer
-    return tracer
-
-
-__all__ = ["init_tracer", "HAVE_OTEL", "_NoopTracer"]
+__all__ = [
+    "init_tracer",
+    "span",
+    "get_exported_spans",
+    "reset_exported_spans",
+    "HAVE_OTEL",
+]
 

--- a/tests/test_alert_rules.py
+++ b/tests/test_alert_rules.py
@@ -1,0 +1,36 @@
+"""Tests for the alert manager."""
+
+from __future__ import annotations
+
+from service.alerts import AlertManager
+
+
+def test_p95_latency_alert_and_budget_over():
+    events = []
+    mgr = AlertManager(p95_target_ms=100, window_seconds=60, callback=events.append)
+
+    # First feed latencies below threshold
+    for i in range(95):
+        mgr.record_latency(50, now=float(i))
+
+    assert not events
+
+    # Now push p95 above threshold
+    for i in range(95, 100):
+        mgr.record_latency(500, now=float(i))
+
+    assert any(e["type"] == "p95_latency" for e in events)
+
+    mgr.record_budget_over(now=101.0)
+    assert any(e["type"] == "budget_over" for e in events)
+
+
+def test_no_alert_under_thresholds():
+    events = []
+    mgr = AlertManager(p95_target_ms=100, window_seconds=60, callback=events.append)
+
+    for i in range(100):
+        mgr.record_latency(50, now=float(i))
+
+    assert events == []
+

--- a/tests/test_tracing_coverage.py
+++ b/tests/test_tracing_coverage.py
@@ -1,0 +1,78 @@
+"""Tests for distributed tracing helpers."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+from service import otel
+
+
+def _simulate_request(i: int) -> None:
+    req_id = f"req-{i}"
+    with otel.span(
+        "alpha.router",
+        request_id=req_id,
+        tenant_id="tenant",
+        decision="allow",
+        budget_verdict="under",
+        cost_usd=0.01,
+        tokens=10,
+        user_input="hello world",
+        secret="token",
+    ):
+        with otel.span("alpha.gates"):
+            with otel.span("alpha.adapter"):
+                pass
+
+
+def test_trace_coverage_and_structure():
+    tracer = otel.init_tracer()
+    otel.reset_exported_spans()
+
+    for i in range(100):
+        _simulate_request(i)
+
+    spans = otel.get_exported_spans()
+    names = [s.name for s in spans]
+    router_spans = [s for s in spans if s.name == "alpha.router"]
+
+    # ≥95% of requests traced (we trace all so allow some leeway)
+    assert len(router_spans) >= 95
+
+    # ensure attributes present and sensitive attrs redacted
+    sample = router_spans[0]
+    attrs = sample.attributes
+    for key in [
+        "request_id",
+        "tenant_id",
+        "decision",
+        "budget_verdict",
+        "cost_usd",
+        "tokens",
+        "latency_ms",
+    ]:
+        assert key in attrs
+    assert "user_input" not in attrs
+    assert "secret" not in attrs
+
+    # verify span hierarchy router->gates->adapter
+    span_by_id = {s.context.span_id: s for s in spans}
+    children = defaultdict(list)
+    for s in spans:
+        if s.parent is not None:
+            children[s.parent.span_id].append(s)
+
+    for r in router_spans:
+        gate_spans = [s for s in children.get(r.context.span_id, []) if s.name == "alpha.gates"]
+        assert gate_spans, "router span missing gates child"
+        for g in gate_spans:
+            adapter_spans = [
+                s
+                for s in children.get(g.context.span_id, [])
+                if s.name == "alpha.adapter"
+            ]
+            assert adapter_spans, "gates span missing adapter child"
+
+    # trace export succeeded locally
+    assert spans, "no spans exported"
+


### PR DESCRIPTION
## Summary
- add minimal OpenTelemetry tracer with in-memory exporter and span helper
- add alert manager for p95 latency and budget_over rules
- document tracing and alerts usage

## Testing
- `pytest -q -k "tracing_coverage or alert_rules"`

## Sample
```
alpha.router
└─alpha.gates
  └─alpha.adapter
```

Alert payload example:
```json
{"type": "p95_latency", "p95": 500, "target": 100, "window": 60}
```

------
https://chatgpt.com/codex/tasks/task_e_68c7a0d620148329bfd20eb07ce6b9e6