### PR TITLE
NEW-027: implement tenant isolation and rate limiting

### DIFF
--- a/.specs/NEW-027.md
+++ b/.specs/NEW-027.md
@@ -1,0 +1,6 @@
+# NEW-027 · Multi-Tenant Isolation & Rate Limiting
+
+Implements per-tenant context extraction, token-bucket rate limiting and daily
+quotas. Configuration is supplied via `service/config/tenants.yaml` and can be
+hot reloaded.  Tests validate isolation across three tenants, correct rate limit
+and quota behaviour and ≥99% rejection of over-limit requests.

--- a/docs/TENANCY_LIMITS.md
+++ b/docs/TENANCY_LIMITS.md
@@ -1,0 +1,43 @@
+# Tenant Rate Limits
+
+The service enforces per-tenant rate limits and optional daily quotas using a
+simple in-memory token bucket.  Limits are configured via YAML.
+
+## Configuration
+
+`service/config/tenants.yaml`
+
+```yaml
+default:
+  rate_per_sec: 5  # tokens refilled each second
+  burst: 10        # bucket capacity
+  quota_per_day: 100
+
+tenants:
+  tenant_a:
+    rate_per_sec: 2
+    burst: 3
+    quota_per_day: 5
+```
+
+Each tenant inherits the `default` values with the ability to override any of
+them.  `quota_per_day` is optional; omit it to disable quota enforcement.
+
+## Hot Reload
+
+Configuration can be reloaded at runtime without restarting the server:
+
+```python
+from service.tenancy.limiter import TenantLimiter
+limiter = TenantLimiter("service/config/tenants.yaml")
+limiter.reload_config()  # re-read the YAML file
+```
+
+Tests trigger reloads by mutating the YAML file and calling `reload_config`.
+
+## Observability
+
+The limiter keeps simple in-memory counters of allowed/denied requests per
+tenant (`limiter.metrics`) and a chronological event log (`limiter.events`).
+These structures contain no secrets and make it easy to assert tenant isolation
+in tests.

--- a/service/config/tenants.yaml
+++ b/service/config/tenants.yaml
@@ -1,0 +1,21 @@
+default:
+  rate_per_sec: 5
+  burst: 10
+  quota_per_day: 100
+
+# Example per-tenant overrides used by tests
+# Each tenant can specify rate_per_sec (tokens added per second),
+# burst (bucket capacity) and quota_per_day (optional daily maximum).
+tenants:
+  tenant_a:
+    rate_per_sec: 2
+    burst: 3
+    quota_per_day: 5
+  tenant_b:
+    rate_per_sec: 1
+    burst: 2
+    quota_per_day: 3
+  tenant_c:
+    rate_per_sec: 1
+    burst: 1
+    quota_per_day: 2

--- a/service/middleware/tenant_middleware.py
+++ b/service/middleware/tenant_middleware.py
@@ -1,0 +1,36 @@
+"""Middleware wiring tenant context and rate limiting."""
+from __future__ import annotations
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from service.tenancy.context import extract_tenant_id
+from service.tenancy.limiter import TenantLimiter
+
+
+class TenantMiddleware(BaseHTTPMiddleware):
+    """Attach tenant information to the request and enforce limits."""
+
+    def __init__(self, app, limiter: TenantLimiter) -> None:
+        super().__init__(app)
+        self.limiter = limiter
+
+    async def dispatch(self, request: Request, call_next):
+        tenant_id = extract_tenant_id(request)
+        if not tenant_id:
+            return JSONResponse(
+                status_code=400,
+                content={"code": "missing_tenant", "detail": "tenant id required"},
+            )
+        request.state.tenant_id = tenant_id
+        allowed, reason = self.limiter.allow_request(tenant_id)
+        if not allowed:
+            return JSONResponse(
+                status_code=429,
+                content={"code": reason, "detail": "rate limit exceeded"},
+            )
+        return await call_next(request)
+
+
+__all__ = ["TenantMiddleware"]

--- a/service/tenancy/context.py
+++ b/service/tenancy/context.py
@@ -1,0 +1,45 @@
+"""Tenant context utilities.
+
+Derives the tenant identifier for a request. The tenant id is primarily
+sourced from the authenticated principal inserted by :class:`JWTAuthMiddleware`.
+If no authenticated principal is present, the ``X-Tenant-ID`` header is used as
+fallback.  The functions here are intentionally lightweight to keep request
+processing fast.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from starlette.requests import Request
+
+
+def extract_tenant_id(request: Request) -> Optional[str]:
+    """Return the tenant id associated with *request*.
+
+    The lookup order is:
+    1. ``request.state.principal['tenant_id']`` if available.
+    2. ``X-Tenant-ID`` header.
+    Returns ``None`` if no tenant identifier can be found.
+    """
+
+    principal = getattr(request.state, "principal", None)
+    if principal:
+        tid = principal.get("tenant_id")
+        if tid:
+            return str(tid)
+    header_tid = request.headers.get("X-Tenant-ID")
+    if header_tid:
+        return header_tid
+    return None
+
+
+def require_tenant_id(request: Request) -> str:
+    """Like :func:`extract_tenant_id` but raise ``ValueError`` if missing."""
+
+    tenant_id = extract_tenant_id(request)
+    if not tenant_id:
+        raise ValueError("tenant id not found")
+    return tenant_id
+
+
+__all__ = ["extract_tenant_id", "require_tenant_id"]

--- a/service/tenancy/limiter.py
+++ b/service/tenancy/limiter.py
@@ -1,0 +1,132 @@
+"""Per-tenant rate limiting utilities.
+
+This module implements a very small in-memory token bucket limiter with an
+optional daily quota.  It is intentionally lightweight and aimed at unit tests
+and small deployments.  Configuration is sourced from a YAML file mapping tenant
+ids to rate/quotas.  The configuration can be reloaded at runtime via
+:meth:`TenantLimiter.reload_config`.
+"""
+from __future__ import annotations
+
+import time
+import datetime as _dt
+from pathlib import Path
+from typing import Dict, Tuple, Optional
+
+import yaml
+
+
+class TenantLimiter:
+    """Token bucket limiter keyed by tenant id."""
+
+    def __init__(self, config_path: Path | str):
+        self.config_path = Path(config_path)
+        self._config_mtime = 0.0
+        self.default: Dict[str, float] = {
+            "rate_per_sec": 1.0,
+            "burst": 1.0,
+            "quota_per_day": None,
+        }
+        self.tenants: Dict[str, Dict[str, float]] = {}
+        # bucket state: tenant -> {tokens, last, quota_used, quota_day}
+        self._buckets: Dict[str, Dict[str, float]] = {}
+        # metrics and event log for observability and tests
+        self.metrics: Dict[str, Dict[str, int]] = {}
+        self.events: Dict[str, list] = {}
+        self.load_config()
+
+    # ------------------------------------------------------------------ config
+    def load_config(self) -> None:
+        """Load configuration from ``self.config_path``."""
+        if not self.config_path.exists():
+            self.tenants = {}
+            return
+        stat = self.config_path.stat()
+        if stat.st_mtime <= self._config_mtime:
+            return
+        data = yaml.safe_load(self.config_path.read_text()) or {}
+        self.default.update(data.get("default", {}))
+        self.tenants = data.get("tenants", {})
+        self._config_mtime = stat.st_mtime
+        # reset existing buckets to new burst levels
+        now = time.monotonic()
+        for tenant, limits in self.tenants.items():
+            bucket = self._buckets.get(tenant)
+            if bucket:
+                bucket["tokens"] = float(limits.get("burst", self.default["burst"]))
+                bucket["last"] = now
+
+    reload_config = load_config
+
+    # ----------------------------------------------------------------- helpers
+    def _limits_for(self, tenant_id: str) -> Dict[str, float]:
+        cfg = {**self.default, **self.tenants.get(tenant_id, {})}
+        return cfg
+
+    def reset_quota(self, tenant_id: str) -> None:
+        bucket = self._buckets.get(tenant_id)
+        if bucket:
+            bucket["quota_used"] = 0
+            bucket["quota_day"] = _dt.date.today()
+
+    # --------------------------------------------------------------- main API
+    def allow_request(self, tenant_id: str) -> Tuple[bool, Optional[str]]:
+        """Return ``(True, None)`` if request may proceed.
+
+        When rejected a tuple ``(False, reason)`` is returned where ``reason`` is
+        ``"rate_limited"`` or ``"quota_exceeded"``.
+        """
+
+        limits = self._limits_for(tenant_id)
+        now = time.monotonic()
+        bucket = self._buckets.setdefault(
+            tenant_id,
+            {
+                "tokens": float(limits.get("burst", 1.0)),
+                "last": now,
+                "quota_used": 0,
+                "quota_day": _dt.date.today(),
+            },
+        )
+        elapsed = now - bucket["last"]
+        bucket["last"] = now
+        bucket["tokens"] = min(
+            float(limits.get("burst", 1.0)),
+            bucket["tokens"] + elapsed * float(limits.get("rate_per_sec", 0.0)),
+        )
+
+        # daily quota reset
+        today = _dt.date.today()
+        if bucket["quota_day"] != today:
+            bucket["quota_day"] = today
+            bucket["quota_used"] = 0
+
+        # enforce quota
+        qpd = limits.get("quota_per_day")
+        if qpd is not None and bucket["quota_used"] >= float(qpd):
+            self._record(tenant_id, False, "quota_exceeded")
+            return False, "quota_exceeded"
+
+        if bucket["tokens"] >= 1.0:
+            bucket["tokens"] -= 1.0
+            bucket["quota_used"] += 1
+            self._record(tenant_id, True, None)
+            return True, None
+
+        self._record(tenant_id, False, "rate_limited")
+        return False, "rate_limited"
+
+    # ------------------------------------------------------------- observability
+    def _record(self, tenant_id: str, allowed: bool, reason: Optional[str]) -> None:
+        m = self.metrics.setdefault(tenant_id, {"allowed": 0, "denied": 0})
+        if allowed:
+            m["allowed"] += 1
+            action = "allow"
+        else:
+            m["denied"] += 1
+            action = "deny"
+        e = self.events.setdefault(tenant_id, [])
+        e.append({"tenant": tenant_id, "action": action, "reason": reason})
+
+
+__all__ = ["TenantLimiter"]

--- a/tests/test_rate_limits.py
+++ b/tests/test_rate_limits.py
@@ -1,0 +1,97 @@
+import time
+from pathlib import Path
+
+import yaml
+from starlette.applications import Starlette
+from starlette.responses import JSONResponse
+from starlette.testclient import TestClient
+
+from service.middleware.tenant_middleware import TenantMiddleware
+from service.tenancy.limiter import TenantLimiter
+
+
+def build_app(cfg_path: Path) -> tuple[Starlette, TenantLimiter, TestClient]:
+    limiter = TenantLimiter(cfg_path)
+    app = Starlette()
+
+    @app.route("/ping")
+    async def ping(request):
+        return JSONResponse({"tenant": request.state.tenant_id})
+
+    app.add_middleware(TenantMiddleware, limiter=limiter)
+    client = TestClient(app)
+    return app, limiter, client
+
+
+def test_rate_limiting_and_quota(tmp_path: Path):
+    cfg = {
+        "default": {"rate_per_sec": 0, "burst": 1},
+        "tenants": {
+            "tenant_a": {"rate_per_sec": 0, "burst": 2},
+            "tenant_b": {"rate_per_sec": 1, "burst": 1},
+            "tenant_c": {"rate_per_sec": 5, "burst": 5, "quota_per_day": 3},
+        },
+    }
+    cfg_path = tmp_path / "tenants.yaml"
+    cfg_path.write_text(yaml.safe_dump(cfg))
+
+    _, limiter, client = build_app(cfg_path)
+
+    # tenant_a: burst=2, no refill -> over-limit rejection
+    h = {"X-Tenant-ID": "tenant_a"}
+    assert client.get("/ping", headers=h).status_code == 200
+    assert client.get("/ping", headers=h).status_code == 200
+    assert client.get("/ping", headers=h).status_code == 429
+    over = sum(1 for _ in range(100) if client.get("/ping", headers=h).status_code == 429)
+    assert over >= 99
+
+    # tenant_b: rate=1/sec, burst=1 -> allow after refill
+    h = {"X-Tenant-ID": "tenant_b"}
+    assert client.get("/ping", headers=h).status_code == 200
+    assert client.get("/ping", headers=h).status_code == 429
+    time.sleep(1.1)
+    assert client.get("/ping", headers=h).status_code == 200
+
+    # tenant_c: quota 3/day
+    h = {"X-Tenant-ID": "tenant_c"}
+    for _ in range(3):
+        assert client.get("/ping", headers=h).status_code == 200
+    r = client.get("/ping", headers=h)
+    assert r.status_code == 429
+    assert r.json()["code"] == "quota_exceeded"
+    limiter.reset_quota("tenant_c")
+    assert client.get("/ping", headers=h).status_code == 200
+
+
+def test_reload_and_performance(tmp_path: Path):
+    cfg = {
+        "default": {"rate_per_sec": 0, "burst": 1},
+        "tenants": {"r": {"rate_per_sec": 0, "burst": 1}},
+    }
+    cfg_path = tmp_path / "tenants.yaml"
+    cfg_path.write_text(yaml.safe_dump(cfg))
+
+    _, limiter, client = build_app(cfg_path)
+    h = {"X-Tenant-ID": "r"}
+    assert client.get("/ping", headers=h).status_code == 200
+    assert client.get("/ping", headers=h).status_code == 429
+
+    # change burst and reload
+    cfg["tenants"]["r"]["burst"] = 2
+    cfg_path.write_text(yaml.safe_dump(cfg))
+    limiter.reload_config()
+    assert client.get("/ping", headers=h).status_code == 200
+    assert client.get("/ping", headers=h).status_code == 200
+
+    # performance check
+    times = []
+    for _ in range(200):
+        t0 = time.perf_counter()
+        limiter.allow_request("perf")
+        times.append(time.perf_counter() - t0)
+    p95 = sorted(times)[int(len(times) * 0.95)]
+    if p95 > 0.005:  # environment too slow
+        import pytest
+
+        pytest.skip("environment slow")
+    assert p95 < 0.001

--- a/tests/test_tenant_isolation.py
+++ b/tests/test_tenant_isolation.py
@@ -1,0 +1,43 @@
+import yaml
+from pathlib import Path
+from starlette.applications import Starlette
+from starlette.responses import JSONResponse
+from starlette.testclient import TestClient
+
+from service.middleware.tenant_middleware import TenantMiddleware
+from service.tenancy.limiter import TenantLimiter
+
+
+def build_app(cfg_path: Path) -> tuple[Starlette, TenantLimiter]:
+    limiter = TenantLimiter(cfg_path)
+    app = Starlette()
+
+    @app.route("/ping")
+    async def ping(request):
+        return JSONResponse({"tenant": request.state.tenant_id})
+
+    app.add_middleware(TenantMiddleware, limiter=limiter)
+    return app, limiter
+
+
+def test_tenant_isolation(tmp_path: Path):
+    cfg = {
+        "default": {"rate_per_sec": 10, "burst": 10},
+        "tenants": {"A": {}, "B": {}, "C": {}},
+    }
+    cfg_path = tmp_path / "tenants.yaml"
+    cfg_path.write_text(yaml.safe_dump(cfg))
+
+    app, limiter = build_app(cfg_path)
+    client = TestClient(app)
+    tenants = ["A", "B", "C"]
+    for t in tenants:
+        r = client.get("/ping", headers={"X-Tenant-ID": t})
+        assert r.status_code == 200
+        assert r.json()["tenant"] == t
+
+    # ensure metrics/logs are segregated per tenant
+    for t in tenants:
+        assert limiter.metrics[t]["allowed"] == 1
+        assert limiter.metrics[t]["denied"] == 0
+        assert all(ev["tenant"] == t for ev in limiter.events[t])


### PR DESCRIPTION
## Summary
- add per-tenant context extractor and middleware enforcing token-bucket limits
- introduce in-memory limiter with quotas + hot reload from YAML
- document tenant limit config and add tests for isolation and rate limits

## Testing
- `pytest -q -k "tenant_isolation or rate_limits"`


------
https://chatgpt.com/codex/tasks/task_e_68c7a31d9ddc8329a619a2cc89620837