### PR TITLE
security(validation): add input schema validation and sanitization middleware

### DIFF
--- a/.specs/NEW-028.md
+++ b/.specs/NEW-028.md
@@ -1,0 +1,12 @@
+# NEW-028 · Input Schema Validation & Sanitization
+
+Adds JSON schema validation and request sanitization middleware.
+
+* `service.validation.validator` enforces a canonical request schema and returns
+  structured errors.
+* `service.validation.sanitizer` strips scripts, SQL/JS injection markers and
+  redacts secrets/PII.
+* `ValidationMiddleware` sanitizes then validates all incoming JSON payloads
+  before handlers.
+* Comprehensive tests cover valid/invalid requests, XSS/SQL attempts, PII
+  redaction and fuzzed malformed inputs.

--- a/docs/INPUT_VALIDATION.md
+++ b/docs/INPUT_VALIDATION.md
@@ -1,0 +1,39 @@
+# Input Validation & Sanitization
+
+Incoming requests are first sanitized then validated against a strict JSON schema.
+
+## Schema
+
+Required fields:
+
+- `prompt` – string, 1-1000 characters.
+- `task` – string enum: `solve` or `plan`.
+- `opts` – optional object. Known keys:
+  - `strategy` – enum: `react`, `cot`, `tot`.
+  - `timeout` – number 0-60 seconds.
+
+No additional top-level properties are allowed.
+
+## Sanitizer
+
+The sanitizer removes or redacts dangerous input before validation:
+
+- Strips `<script>` tags, event handlers like `onload=`, and `javascript:` URLs.
+- Removes SQL injection markers such as `;`, `--`, `DROP TABLE`.
+- Collapses control characters and excessive whitespace.
+- Redacts obvious secrets (`api`, `token`, `key` patterns) and masks emails/phones.
+
+Sanitization happens before schema validation. Sanitized values are passed to
+downstream handlers and stored in place of the original payload.
+
+### Examples
+
+Input:
+```json
+{"prompt": "<script>alert(1)</script> contact me test@example.com", "task": "solve"}
+```
+
+Output:
+```json
+{"prompt": "contact me t***@e***.com", "task": "solve"}
+```

--- a/service/middleware/validation_middleware.py
+++ b/service/middleware/validation_middleware.py
@@ -1,0 +1,37 @@
+import json
+import logging
+from typing import Callable
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from service.validation.sanitizer import sanitize
+from service.validation.validator import ValidationError, validate_request
+
+logger = logging.getLogger("service.middleware.validation")
+
+
+class ValidationMiddleware(BaseHTTPMiddleware):
+    """Sanitize and validate incoming JSON requests before handlers."""
+
+    async def dispatch(self, request: Request, call_next: Callable):  # type: ignore[override]
+        try:
+            payload = await request.json()
+        except Exception:
+            return JSONResponse(
+                status_code=400,
+                content={"code": "invalid_json", "errors": [{"field": "<body>", "reason": "invalid json", "code": "invalid_json"}]},
+            )
+
+        sanitized = sanitize(payload)
+        try:
+            validate_request(sanitized)
+        except ValidationError as exc:
+            return JSONResponse(status_code=400, content={"code": "invalid_request", "errors": exc.errors})
+
+        request._body = json.dumps(sanitized).encode("utf-8")
+        return await call_next(request)
+
+
+__all__ = ["ValidationMiddleware"]

--- a/service/validation/sanitizer.py
+++ b/service/validation/sanitizer.py
@@ -1,0 +1,37 @@
+import re
+from typing import Any, Dict, List
+
+from service.policy.redaction import redact
+
+SCRIPT_RE = re.compile(r"<script.*?>.*?</script>", re.IGNORECASE | re.DOTALL)
+EVENT_HANDLER_RE = re.compile(r'on\w+\s*=\s*"?[^"]*"?', re.IGNORECASE)
+JS_PROTO_RE = re.compile(r'javascript:', re.IGNORECASE)
+SQL_INJECTION_RE = re.compile(r"(?i)(--|;|/\*|\*/|drop table|union select|insert into|delete from|update)")
+SECRET_RE = re.compile(r"(?i)(api|secret|token|key)[\s:=]+[A-Za-z0-9\-]{16,}")
+CONTROL_RE = re.compile(r"[\x00-\x1f\x7f]")
+WHITESPACE_RE = re.compile(r"\s+")
+
+
+def _clean_str(s: str) -> str:
+    s = SCRIPT_RE.sub("", s)
+    s = EVENT_HANDLER_RE.sub("", s)
+    s = JS_PROTO_RE.sub("", s)
+    s = SQL_INJECTION_RE.sub("", s)
+    s = SECRET_RE.sub("<redacted>", s)
+    s, _ = redact(s, {"email": True, "phone": True})
+    s = CONTROL_RE.sub("", s)
+    s = WHITESPACE_RE.sub(" ", s).strip()
+    return s
+
+
+def sanitize(data: Any) -> Any:
+    if isinstance(data, str):
+        return _clean_str(data)
+    if isinstance(data, list):
+        return [sanitize(i) for i in data]
+    if isinstance(data, dict):
+        return {k: sanitize(v) for k, v in data.items()}
+    return data
+
+
+__all__ = ["sanitize"]

--- a/service/validation/schemas/request_schema.json
+++ b/service/validation/schemas/request_schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "prompt": {"type": "string", "minLength": 1, "maxLength": 1000},
+    "task": {"type": "string", "enum": ["solve", "plan"]},
+    "opts": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "strategy": {"type": "string", "enum": ["react", "cot", "tot"]},
+        "timeout": {"type": "number", "minimum": 0, "maximum": 60}
+      }
+    }
+  },
+  "required": ["prompt", "task"]
+}

--- a/service/validation/validator.py
+++ b/service/validation/validator.py
@@ -1,0 +1,88 @@
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List
+
+SCHEMA_PATH = Path(__file__).parent / "schemas" / "request_schema.json"
+
+
+@dataclass
+class FieldError:
+    code: str
+    field: str
+    reason: str
+
+
+class ValidationError(Exception):
+    def __init__(self, errors: List[FieldError]):
+        super().__init__("invalid request")
+        self.errors = [e.__dict__ for e in errors]
+
+
+def _load_schema() -> Dict[str, Any]:
+    with open(SCHEMA_PATH, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+SCHEMA = _load_schema()
+
+
+def _validate(schema: Dict[str, Any], data: Any, path: str = "") -> List[FieldError]:
+    errors: List[FieldError] = []
+    t = schema.get("type")
+    field = path.rstrip(".") or "<root>"
+    if t == "object":
+        if not isinstance(data, dict):
+            return [FieldError("invalid_type", field, "expected object")]
+        props = schema.get("properties", {})
+        if not schema.get("additionalProperties", True):
+            for key in data:
+                if key not in props:
+                    errors.append(FieldError("unknown_field", f"{field}.{key}" if field != "<root>" else key, "additional property not allowed"))
+        for req in schema.get("required", []):
+            if req not in data:
+                errors.append(FieldError("missing_field", f"{field}.{req}" if field != "<root>" else req, "field required"))
+        for key, subschema in props.items():
+            if key in data:
+                errors.extend(_validate(subschema, data[key], f"{field}.{key}" if field != "<root>" else f"{key}"))
+    elif t == "string":
+        if not isinstance(data, str):
+            errors.append(FieldError("invalid_type", field, "expected string"))
+        else:
+            min_len = schema.get("minLength")
+            if min_len is not None and len(data) < min_len:
+                errors.append(FieldError("too_short", field, f"min length {min_len}"))
+            max_len = schema.get("maxLength")
+            if max_len is not None and len(data) > max_len:
+                errors.append(FieldError("too_long", field, f"max length {max_len}"))
+            enum = schema.get("enum")
+            if enum is not None and data not in enum:
+                errors.append(FieldError("invalid_value", field, f"expected one of {enum}"))
+    elif t == "number":
+        if not isinstance(data, (int, float)):
+            errors.append(FieldError("invalid_type", field, "expected number"))
+        else:
+            minimum = schema.get("minimum")
+            if minimum is not None and data < minimum:
+                errors.append(FieldError("too_small", field, f"minimum {minimum}"))
+            maximum = schema.get("maximum")
+                
+            if maximum is not None and data > maximum:
+                errors.append(FieldError("too_large", field, f"maximum {maximum}"))
+    elif t == "array":
+        if not isinstance(data, list):
+            errors.append(FieldError("invalid_type", field, "expected array"))
+        else:
+            item_schema = schema.get("items", {})
+            for idx, item in enumerate(data):
+                errors.extend(_validate(item_schema, item, f"{field}[{idx}]"))
+    return errors
+
+
+def validate_request(payload: Dict[str, Any]) -> None:
+    errors = _validate(SCHEMA, payload)
+    if errors:
+        raise ValidationError(errors)
+
+
+__all__ = ["validate_request", "ValidationError"]

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -1,0 +1,87 @@
+import random
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from service.middleware.validation_middleware import ValidationMiddleware
+
+
+app = FastAPI()
+app.add_middleware(ValidationMiddleware)
+
+
+@app.post("/echo")
+async def echo(request: Request):
+    return await request.json()
+
+
+client = TestClient(app)
+
+
+def test_valid_payload():
+    payload = {"prompt": "hello", "task": "solve", "opts": {"strategy": "react"}}
+    r = client.post("/echo", json=payload)
+    assert r.status_code == 200
+    assert r.json() == payload
+
+
+def test_missing_fields_and_types():
+    r = client.post("/echo", json={"task": "solve"})
+    assert r.status_code == 400
+    data = r.json()
+    assert any(e["field"] == "prompt" for e in data["errors"])
+
+    r = client.post("/echo", json={"prompt": 5, "task": "solve"})
+    assert r.status_code == 400
+    data = r.json()
+    assert any(e["field"] == "prompt" and e["code"] == "invalid_type" for e in data["errors"])
+
+
+def test_xss_and_sql_sanitization():
+    payload = {"prompt": "<script>alert(1)</script>hello", "task": "solve"}
+    r = client.post("/echo", json=payload)
+    assert r.status_code == 200
+    assert "script" not in r.json()["prompt"].lower()
+
+    payload = {"prompt": "1; DROP TABLE users", "task": "solve"}
+    r = client.post("/echo", json=payload)
+    assert r.status_code == 200
+    assert "drop table" not in r.json()["prompt"].lower()
+
+    payload = {"prompt": "<img src=x onerror=alert(1)>hi", "task": "solve"}
+    r = client.post("/echo", json=payload)
+    assert "onerror" not in r.json()["prompt"].lower()
+
+    payload = {"prompt": "javascript:alert(1)", "task": "solve"}
+    r = client.post("/echo", json=payload)
+    assert "javascript:" not in r.json()["prompt"].lower()
+
+
+def test_pii_and_secret_redaction():
+    payload = {
+        "prompt": "Email test@example.com phone +12345678901 token=APIKEYSECRET1234567890",
+        "task": "solve",
+    }
+    r = client.post("/echo", json=payload)
+    assert r.status_code == 200
+    text = r.json()["prompt"]
+    assert "test@example.com" not in text
+    assert "+12345678901" not in text
+    assert "APIKEYSECRET1234567890" not in text
+    assert "<redacted>" in text or "***" in text
+
+
+def test_fuzz_invalid_inputs():
+    bad_payloads = [
+        {},
+        {"prompt": 123, "task": "solve"},
+        {"prompt": "", "task": "solve"},
+        {"prompt": "hi", "task": "unknown"},
+        {"prompt": "hi"},
+        {"task": "solve"},
+        {"prompt": "hi", "task": "solve", "extra": 1},
+    ]
+    for _ in range(100):
+        payload = random.choice(bad_payloads)
+        r = client.post("/echo", json=payload)
+        assert r.status_code == 400
+        assert r.json()["code"] == "invalid_request"


### PR DESCRIPTION
## Summary
- enforce canonical request schema and field constraints
- sanitize inputs (strip scripts/SQL markers, redact secrets & PII)
- middleware validates every request before hitting handlers

## Testing
- `pytest -q -k input_validation`


------
https://chatgpt.com/codex/tasks/task_e_68c7a396d71c8329b2c6ce0290839100