### PR TITLE
auth: implement API key authentication

### DIFF
--- a/.specs/NEW-019.md
+++ b/.specs/NEW-019.md
@@ -1,0 +1,8 @@
+# NEW-019 · API Authentication & Key Management
+
+Implements API key authentication with JWT fallback. Features:
+
+- YAML-backed API key store with salted hashes, scopes, and tenant binding.
+- Middleware requiring JWT or `X-API-Key` header on protected routes.
+- Scope enforcement, per-tenant rate limiting, and audit log events.
+- Unit tests covering allow/deny, revocation, rate limiting, and logging.

--- a/docs/API_KEYS.md
+++ b/docs/API_KEYS.md
@@ -1,0 +1,33 @@
+# API Key Management
+
+The service supports API keys for authenticating requests. Keys are stored as
+salted SHA256 hashes in `service/config/api_keys.yaml`:
+
+```yaml
+keys:
+  - id: example
+    hash: abc123$<sha256>
+    tenant_id: tenant1
+    scopes: [read, write]
+    status: active
+    created_at: 1700000000
+```
+
+Use `service.auth.api_keys.hash_key()` to generate the `salt$hash` value when
+creating new keys. Raw keys are never stored on disk.
+
+Each key is bound to a tenant and a list of scopes. The middleware attaches the
+resolved principal to `request.state.principal` and enforces required scopes for
+protected routes.
+
+To rotate or revoke keys update the YAML file and reload the service. Changing a
+key's `status` to `revoked` or `disabled` immediately prevents further use.
+
+Example request:
+
+```bash
+curl -H "X-API-Key: <key>" https://example/api/protected
+```
+
+JWTs are also supported via the `Authorization: Bearer` header. If both headers
+are present the JWT is preferred.

--- a/service/auth/api_keys.py
+++ b/service/auth/api_keys.py
@@ -1,0 +1,103 @@
+"""API key management utilities."""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Set
+
+import yaml
+
+
+@dataclass
+class APIKey:
+    """Represents a single API key entry loaded from config."""
+
+    id: str
+    hash: str  # stored as "<salt>$<digest>"
+    tenant_id: str
+    scopes: Set[str]
+    status: str
+    created_at: float
+
+    def verify(self, raw: str) -> bool:
+        """Verify a raw key against this entry's salted hash."""
+        try:
+            salt, digest = self.hash.split("$", 1)
+        except ValueError:  # pragma: no cover - config error
+            return False
+        check = hashlib.sha256((salt + raw).encode()).hexdigest()
+        return secrets.compare_digest(check, digest)
+
+
+def hash_key(key: str, salt: str | None = None) -> str:
+    """Return a salt$digest string for the given key."""
+    salt = salt or secrets.token_hex(8)
+    digest = hashlib.sha256((salt + key).encode()).hexdigest()
+    return f"{salt}${digest}"
+
+
+class APIKeyStore:
+    """Simple YAML-backed API key store."""
+
+    def __init__(self, path: Path | str) -> None:
+        self.path = Path(path)
+        self._mtime: float = 0.0
+        self._keys: List[APIKey] = []
+        self.reload(force=True)
+
+    def reload(self, force: bool = False) -> None:
+        try:
+            mtime = self.path.stat().st_mtime
+        except FileNotFoundError:
+            self._keys = []
+            self._mtime = 0.0
+            return
+        if not force and mtime == self._mtime:
+            return
+        data = yaml.safe_load(self.path.read_text()) or {}
+        items = []
+        for item in data.get("keys", []):
+            if not item:
+                continue
+            scopes = set(item.get("scopes") or [])
+            items.append(
+                APIKey(
+                    id=str(item.get("id")),
+                    hash=str(item.get("hash")),
+                    tenant_id=str(item.get("tenant_id") or ""),
+                    scopes=scopes,
+                    status=str(item.get("status") or "active"),
+                    created_at=float(item.get("created_at") or 0),
+                )
+            )
+        self._keys = items
+        self._mtime = mtime
+
+    def match_key(self, raw_key: str) -> Optional[APIKey]:
+        """Return the key matching the raw value regardless of status."""
+        self.reload()
+        for entry in self._keys:
+            if entry.verify(raw_key):
+                return entry
+        return None
+
+    def find_key(self, raw_key: str) -> Optional[APIKey]:
+        """Return the APIKey if it matches and is active."""
+        entry = self.match_key(raw_key)
+        if entry and entry.status == "active":
+            return entry
+        return None
+
+    def get(self, key_id: str) -> Optional[APIKey]:
+        """Return the key by id regardless of status."""
+        self.reload()
+        for entry in self._keys:
+            if entry.id == key_id:
+                return entry
+        return None
+
+
+__all__ = ["APIKey", "APIKeyStore", "hash_key"]

--- a/service/config/api_keys.yaml
+++ b/service/config/api_keys.yaml
@@ -1,0 +1,7 @@
+keys:
+  - id: demo
+    hash: abc123$f874a6c9a43c5bb47cb45592a7e9eaec507e3e725206b1d1352a8e9e0720d40e
+    tenant_id: tenant1
+    scopes: [read, write]
+    status: active
+    created_at: 1700000000

--- a/service/middleware/auth_middleware.py
+++ b/service/middleware/auth_middleware.py
@@ -1,0 +1,141 @@
+"""Authentication middleware supporting JWTs and API keys."""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Dict, Iterable, Optional
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from service.auth.api_keys import APIKeyStore
+from service.auth.jwt_utils import AuthKeyStore as JWTKeyStore, JWTError, verify_jwt
+from service.audit import audit_log
+
+logger = logging.getLogger("service.middleware.auth")
+
+
+class AuthMiddleware(BaseHTTPMiddleware):
+    """Middleware enforcing JWT or API key authentication."""
+
+    def __init__(
+        self,
+        app,
+        api_key_store: APIKeyStore,
+        jwt_key_store: JWTKeyStore | None = None,
+        audience: str | None = None,
+        issuer: str | None = None,
+        exempt_paths: Optional[Iterable[str]] = None,
+        scope_map: Optional[Dict[str, Iterable[str]]] = None,
+        rate_limit: Optional[tuple[int, int]] = None,
+        time_func=time.time,
+    ) -> None:
+        super().__init__(app)
+        self.api_key_store = api_key_store
+        self.jwt_key_store = jwt_key_store
+        self.audience = audience
+        self.issuer = issuer
+        self.exempt_paths = set(exempt_paths or [])
+        self.scope_map = {p: set(s) for p, s in (scope_map or {}).items()}
+        self.rate_limit = rate_limit
+        self._time = time_func
+        self._counters: Dict[str, tuple[float, int]] = {}
+
+    async def dispatch(self, request: Request, call_next):
+        path = request.url.path
+        if path in self.exempt_paths:
+            return await call_next(request)
+
+        auth = request.headers.get("authorization")
+        api_key = request.headers.get("x-api-key")
+        principal: Dict[str, object] | None = None
+
+        if auth and auth.lower().startswith("bearer ") and self.jwt_key_store:
+            token = auth.split(" ", 1)[1]
+            try:
+                payload = verify_jwt(
+                    token, self.jwt_key_store, audience=self.audience, issuer=self.issuer
+                )
+            except JWTError as e:
+                logger.warning("jwt validation failed: %s", e.code)
+                audit_log.record(
+                    "auth.deny", {"code": e.code, "auth_type": "jwt"}, {"principal": {}}
+                )
+                return JSONResponse(status_code=401, content={"code": e.code, "detail": e.detail})
+            principal = {
+                "sub": payload.get("sub"),
+                "tenant_id": payload.get("tenant") or payload.get("tenant_id"),
+                "scopes": payload.get("scopes", []),
+                "auth": "jwt",
+            }
+        elif api_key:
+            entry = self.api_key_store.find_key(api_key)
+            if not entry:
+                matched = self.api_key_store.match_key(api_key)
+                code = "key_revoked" if matched else "invalid_api_key"
+                logger.warning("api key rejected")
+                audit_log.record(
+                    "auth.deny", {"code": code, "auth_type": "api_key"}, {"principal": {}}
+                )
+                return JSONResponse(
+                    status_code=401,
+                    content={"code": code, "detail": "invalid API key"},
+                )
+            principal = {
+                "key_id": entry.id,
+                "tenant_id": entry.tenant_id,
+                "scopes": list(entry.scopes),
+                "auth": "api_key",
+            }
+        else:
+            audit_log.record("auth.deny", {"code": "missing_api_key"}, {"principal": {}})
+            return JSONResponse(
+                status_code=401,
+                content={"code": "missing_api_key", "detail": "missing credentials"},
+            )
+
+        # scope enforcement
+        required = self.scope_map.get(path, set())
+        if required and not set(principal.get("scopes", [])).issuperset(required):
+            audit_log.record(
+                "auth.deny",
+                {"code": "insufficient_scope", "required": list(required)},
+                {"principal": principal},
+            )
+            return JSONResponse(
+                status_code=403,
+                content={"code": "insufficient_scope", "detail": "insufficient scope"},
+            )
+
+        # rate limiting per tenant
+        if self.rate_limit:
+            window, max_requests = self.rate_limit
+            tenant = str(principal.get("tenant_id") or principal.get("key_id") or "global")
+            now = self._time()
+            start, count = self._counters.get(tenant, (now, 0))
+            if now - start >= window:
+                start, count = now, 0
+            if count >= max_requests:
+                audit_log.record(
+                    "auth.deny", {"code": "rate_limited"}, {"principal": principal}
+                )
+                return JSONResponse(
+                    status_code=429,
+                    content={"code": "rate_limited", "detail": "rate limit exceeded"},
+                )
+            self._counters[tenant] = (start, count + 1)
+
+        request.state.principal = {
+            k: v for k, v in principal.items() if k != "auth" and v is not None
+        }
+        audit_log.record(
+            "auth.login",
+            {"auth_type": principal.get("auth"), "key_id": principal.get("key_id")},
+            {"principal": request.state.principal},
+        )
+        return await call_next(request)
+
+
+__all__ = ["AuthMiddleware"]

--- a/tests/test_api_keys.py
+++ b/tests/test_api_keys.py
@@ -1,0 +1,149 @@
+import logging
+import random
+import time
+from pathlib import Path
+
+import yaml
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from service.auth.api_keys import APIKeyStore, hash_key
+from service.middleware.auth_middleware import AuthMiddleware
+
+
+def build_app(tmp_path: Path, scope_map=None, rate_limit=None, time_func=None):
+    k1 = "key-full"
+    k2 = "key-disabled"
+    k3 = "key-read"
+    data = {
+        "keys": [
+            {
+                "id": "k1",
+                "hash": hash_key(k1),
+                "tenant_id": "t1",
+                "scopes": ["read", "write"],
+                "status": "active",
+                "created_at": 0,
+            },
+            {
+                "id": "k2",
+                "hash": hash_key(k2),
+                "tenant_id": "t1",
+                "scopes": ["read"],
+                "status": "disabled",
+                "created_at": 0,
+            },
+            {
+                "id": "k3",
+                "hash": hash_key(k3),
+                "tenant_id": "t1",
+                "scopes": ["read"],
+                "status": "active",
+                "created_at": 0,
+            },
+        ]
+    }
+    path = tmp_path / "api_keys.yaml"
+    path.write_text(yaml.safe_dump(data))
+    store = APIKeyStore(path)
+    app = FastAPI()
+    app.add_middleware(
+        AuthMiddleware,
+        api_key_store=store,
+        scope_map=scope_map or {},
+        rate_limit=rate_limit,
+        time_func=time_func or time.time,
+    )
+
+    @app.get("/protected")
+    async def protected(request: Request):
+        return request.state.principal
+
+    return app, store, path, {"full": k1, "disabled": k2, "read": k3}
+
+
+def test_valid_api_key(tmp_path):
+    app, _store, _path, keys = build_app(tmp_path)
+    client = TestClient(app)
+    r = client.get("/protected", headers={"X-API-Key": keys["full"]})
+    assert r.status_code == 200
+    assert r.json()["tenant_id"] == "t1"
+    assert r.json()["key_id"] == "k1"
+
+
+def test_invalid_and_disabled_key(tmp_path):
+    app, _store, _path, keys = build_app(tmp_path)
+    client = TestClient(app)
+    r = client.get("/protected", headers={"X-API-Key": "bad"})
+    assert r.status_code == 401
+    assert r.json()["code"] == "invalid_api_key"
+    r = client.get("/protected", headers={"X-API-Key": keys["disabled"]})
+    assert r.status_code == 401
+    assert r.json()["code"] == "key_revoked"
+
+
+def test_scope_enforcement(tmp_path):
+    app, _store, _path, keys = build_app(tmp_path, scope_map={"/protected": ["write"]})
+    client = TestClient(app)
+    r = client.get("/protected", headers={"X-API-Key": keys["read"]})
+    assert r.status_code == 403
+    assert r.json()["code"] == "insufficient_scope"
+
+
+def test_revocation(tmp_path):
+    app, store, path, keys = build_app(tmp_path)
+    client = TestClient(app)
+    r = client.get("/protected", headers={"X-API-Key": keys["full"]})
+    assert r.status_code == 200
+    data = yaml.safe_load(path.read_text())
+    for item in data["keys"]:
+        if item["id"] == "k1":
+            item["status"] = "revoked"
+    path.write_text(yaml.safe_dump(data))
+    r = client.get("/protected", headers={"X-API-Key": keys["full"]})
+    assert r.status_code == 401
+    assert r.json()["code"] == "key_revoked"
+
+
+def test_rate_limit(tmp_path):
+    now = [0.0]
+
+    def _time():
+        return now[0]
+
+    app, _store, _path, keys = build_app(
+        tmp_path, rate_limit=(60, 2), time_func=_time
+    )
+    client = TestClient(app)
+    headers = {"X-API-Key": keys["full"]}
+    for _ in range(2):
+        assert client.get("/protected", headers=headers).status_code == 200
+        now[0] += 1
+    r = client.get("/protected", headers=headers)
+    assert r.status_code == 429
+    now[0] += 61
+    assert client.get("/protected", headers=headers).status_code == 200
+
+
+def test_rejection_rate(tmp_path):
+    app, _store, _path, _keys = build_app(tmp_path)
+    client = TestClient(app)
+    bad = ["bad1", "bad2", None]
+    rejected = 0
+    for _ in range(100):
+        val = random.choice(bad)
+        headers = {"X-API-Key": val} if val else {}
+        r = client.get("/protected", headers=headers)
+        if r.status_code == 401:
+            rejected += 1
+    assert rejected >= 95
+
+
+def test_no_secret_in_logs(tmp_path, caplog):
+    app, _store, _path, keys = build_app(tmp_path)
+    client = TestClient(app)
+    bad = "bad-secret"
+    with caplog.at_level(logging.WARNING, logger="service.middleware.auth"):
+        client.get("/protected", headers={"X-API-Key": bad})
+    assert bad not in caplog.text
+    assert "api key rejected" in caplog.text


### PR DESCRIPTION
## Summary
- add YAML-backed API key store with salted hashes and tenant scopes
- enforce API key/JWT authentication with middleware including scope checks and per-tenant rate limiting
- document API key management and add tests

## Testing
- `pytest -q -k api_keys`

Example:
```bash
curl -H "X-API-Key: <key>" https://example/api/protected
```

Scope matrix:
| scope | description |
|-------|-------------|
| read  | read-only access |
| write | modify resources |
| admin | full control |


------
https://chatgpt.com/codex/tasks/task_e_68c7a4d0ccc08329a3511d01f42548c9