### PR TITLE
clarify: add ambiguity detector + template deck + router hooks + tests

### DIFF
--- a/.specs/NEW-031.md
+++ b/.specs/NEW-031.md
@@ -1,0 +1,7 @@
+# NEW-031 Prompt/Template Clarifier & Decks
+
+Implements clarifier_v1 with a template deck covering eight common intents and
+router hooks. Clarifier asks a question when confidence is below
+`clarify_conf_threshold` and merges the user's response into the request.
+Tests cover effectiveness, determinism, template sanity and threshold/failure
+behaviour.

--- a/docs/CLARIFIER_TEMPLATES.md
+++ b/docs/CLARIFIER_TEMPLATES.md
@@ -27,6 +27,11 @@ The deck currently covers:
 - classify
 - cite
 - web_extract
+- ask_missing_fields
+- disambiguate_intent
+- reduce_scope_low_budget
+- pick_tool_first
+- generic_clarify
 
 ## Examples
 ```

--- a/docs/CLARIFIER_TEMPLATES.md
+++ b/docs/CLARIFIER_TEMPLATES.md
@@ -1,0 +1,42 @@
+# Clarifier Templates
+
+This document describes the `clarifier_v1` template deck. The clarifier triggers
+when model confidence falls below `clarify_conf_threshold` or when required fields
+are missing. A single concise question (<=120 chars) is asked and the user's
+answer is merged back into the request payload.
+
+## How it works
+1. Detect ambiguity via confidence, missing fields or intent flags.
+2. Render a clarifying question using `templates.yaml`.
+3. Merge the answer into the payload and re-run routing.
+
+```python
+from service.clarify import router_hooks
+from service.clarify import clarifier
+```
+
+## Templates
+Templates are stored in `service/clarify/templates.yaml`. Each entry defines
+`id`, `intent`, `system`, `user` and optional `variables` with defaults.
+The deck currently covers:
+- summarize
+- extract
+- rewrite
+- plan
+- codegen
+- classify
+- cite
+- web_extract
+
+## Examples
+```
+You're missing: intent. Please provide them briefly.
+```
+```
+I can do summarize or extract. Which do you want?
+```
+
+## Failure modes
+If no answer is provided or the clarifier cannot generate a question, routing
+continues without modification. The `route_explain` payload records whether the
+clarifier triggered and if the answer was used.

--- a/service/clarify/clarifier.py
+++ b/service/clarify/clarifier.py
@@ -1,0 +1,62 @@
+"""Prompt/Template clarifier core."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple
+
+from . import render, trigger
+
+MAX_QUESTION_CHARS = 120
+MAX_USER_ECHO = 256
+
+
+@dataclass
+class Clarifier:
+    """Generate and merge clarification questions."""
+
+    templates: Dict[str, Any]
+
+    def __post_init__(self) -> None:
+        # Build a mapping of clarifier templates for quick rendering.
+        mapping: Dict[str, str] = {}
+        for tpl in self.templates.get("templates", []):
+            if tpl.get("intent") == "clarify":
+                mapping[tpl["id"]] = tpl.get("user", "")
+        self._templates = mapping
+        self.deck_sha = render.deck_sha(mapping)
+        self.last_template: Optional[str] = None
+
+    # ------------------------------------------------------------------
+    def detect(self, payload: Dict[str, Any]) -> Tuple[bool, str]:
+        """Detect if clarification is required and return (flag, reason)."""
+        reasons = []
+        confidence = float(payload.get("confidence", 1.0))
+        if confidence < trigger.CLARIFY_CONF_THRESHOLD:
+            reasons.append("low_confidence")
+        if payload.get("missing_fields"):
+            reasons.append("missing_fields")
+        if payload.get("ambiguous"):
+            reasons.append("ambiguous")
+        if payload.get("contradictory"):
+            reasons.append("contradictory_intent")
+        triggered = bool(reasons)
+        return triggered, reasons[0] if triggered else "pass"
+
+    # ------------------------------------------------------------------
+    def generate_question(self, payload: Dict[str, Any]) -> str:
+        """Generate a concise clarification question."""
+        template_key = trigger.choose_template(payload)
+        question = render.render(template_key, payload, self._templates).strip()
+        if len(question) > MAX_QUESTION_CHARS:
+            question = question[:MAX_QUESTION_CHARS]
+        self.last_template = template_key
+        return question
+
+    # ------------------------------------------------------------------
+    def merge_answer(self, payload: Dict[str, Any], answer: Optional[str]) -> Dict[str, Any]:
+        """Merge the user clarification answer into the payload."""
+        merged = dict(payload)
+        if answer:
+            merged["intent"] = answer.strip()[:MAX_USER_ECHO]
+            merged["clarify_answer"] = merged["intent"]
+        return merged

--- a/service/clarify/router_hooks.py
+++ b/service/clarify/router_hooks.py
@@ -1,0 +1,49 @@
+"""Router integration hooks for clarifier."""
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from .clarifier import Clarifier
+from . import trigger
+
+
+def maybe_clarify(payload: Dict[str, Any], config: Any, templates: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """Apply clarifier if confidence below threshold.
+
+    Returns updated payload and route_explain metadata.
+    """
+    clarifier = Clarifier(templates)
+    confidence = float(payload.get("confidence", 1.0))
+    # consult trigger helper for decision
+    clarify_flag, reason = trigger.should_clarify(
+        decision=payload.get("decision", ""),
+        confidence=confidence,
+        budget_tokens=payload.get("budget_tokens", 0),
+        policy_flags={},
+    )
+    # honour runtime config threshold
+    threshold = getattr(config, "clarify_conf_threshold", trigger.CLARIFY_CONF_THRESHOLD)
+    if confidence >= threshold:
+        clarify_flag = False
+        reason = "high_confidence"
+
+    explain = {
+        "clarify": {
+            "triggered": clarify_flag,
+            "reason": reason,
+            "question": None,
+            "answer_used": False,
+            "deck_sha": clarifier.deck_sha,
+        }
+    }
+    if not clarify_flag:
+        return payload, explain
+
+    question = clarifier.generate_question(payload)
+    if not question:
+        return payload, explain
+
+    answer = payload.get("clarify_answer")
+    new_payload = clarifier.merge_answer(payload, answer)
+    explain["clarify"].update({"question": question, "answer_used": bool(answer)})
+    return new_payload, explain

--- a/service/clarify/templates.yaml
+++ b/service/clarify/templates.yaml
@@ -14,6 +14,20 @@ templates:
     variables:
       options:
         default: []
+  - id: reduce_scope_low_budget
+    intent: clarify
+    system: "You help narrow scope when tokens are limited."
+    user: "Token budget is low; please narrow to {{ suggested_scope }}."
+    variables:
+      suggested_scope:
+        default: ""
+  - id: pick_tool_first
+    intent: clarify
+    system: "You help pick tools when useful."
+    user: "Which tool fits best: {{ tools|join(', ') }}?"
+    variables:
+      tools:
+        default: []
   - id: generic_clarify
     intent: clarify
     system: "You clarify requests."
@@ -77,8 +91,8 @@ templates:
     intent: web_extract
     system: "You use web tools to extract data."
     user: "Use the web to extract: {{ info }}"
+    tool_hints:
+      - web
     variables:
       info:
         default: ""
-      tool_hints:
-        default: web

--- a/service/clarify/templates.yaml
+++ b/service/clarify/templates.yaml
@@ -1,9 +1,84 @@
-{
-  "templates": {
-    "ask_missing_fields": "You're missing: {{ missing_fields|join(', ') }}. Please provide them briefly.",
-    "disambiguate_intent": "I can do A or B. Which one do you want? Reply with just A or B.",
-    "reduce_scope_low_budget": "We have limited budget. Can you narrow to {{ suggested_scope }}?",
-    "pick_tool_first": "I can use a tool to fetch {{ target }}. Should I proceed? (yes/no)",
-    "generic_clarify": "Please clarify your request in one sentence."
-  }
-}
+deck: clarifier_v1
+templates:
+  - id: ask_missing_fields
+    intent: clarify
+    system: "You help gather missing information."
+    user: "You're missing: {{ missing_fields|join(', ') }}. Please provide them briefly."
+    variables:
+      missing_fields:
+        default: []
+  - id: disambiguate_intent
+    intent: clarify
+    system: "You resolve ambiguous intents."
+    user: "I can do {{ options|join(' or ') }}. Which do you want?"
+    variables:
+      options:
+        default: []
+  - id: generic_clarify
+    intent: clarify
+    system: "You clarify requests."
+    user: "Please clarify your request in one sentence."
+  - id: summarize
+    intent: summarize
+    system: "You are a helpful summarizer."
+    user: "Summarize the following text: {{ text }}"
+    variables:
+      text:
+        default: ""
+  - id: extract
+    intent: extract
+    system: "You extract structured data."
+    user: "Extract {{ fields|join(', ') }} from: {{ text }}"
+    variables:
+      text:
+        default: ""
+      fields:
+        default: []
+  - id: rewrite
+    intent: rewrite
+    system: "You rewrite text in different styles."
+    user: "Rewrite the text to be {{ style }}: {{ text }}"
+    variables:
+      text:
+        default: ""
+      style:
+        default: concise
+  - id: plan
+    intent: plan
+    system: "You break down tasks into plans."
+    user: "Plan the following task: {{ task }}"
+    variables:
+      task:
+        default: ""
+  - id: codegen
+    intent: codegen
+    system: "You generate code snippets."
+    user: "Write {{ language }} code to {{ task }}"
+    variables:
+      language:
+        default: python
+      task:
+        default: ""
+  - id: classify
+    intent: classify
+    system: "You classify text."
+    user: "Classify the sentiment of: {{ text }}"
+    variables:
+      text:
+        default: ""
+  - id: cite
+    intent: cite
+    system: "You provide citations for claims."
+    user: "Provide a citation for: {{ claim }}"
+    variables:
+      claim:
+        default: ""
+  - id: web_extract
+    intent: web_extract
+    system: "You use web tools to extract data."
+    user: "Use the web to extract: {{ info }}"
+    variables:
+      info:
+        default: ""
+      tool_hints:
+        default: web

--- a/tests/test_clarifier_effectiveness.py
+++ b/tests/test_clarifier_effectiveness.py
@@ -1,0 +1,81 @@
+import random
+import yaml
+
+from service.clarify.router_hooks import maybe_clarify
+
+INTENTS = [
+    "summarize",
+    "extract",
+    "rewrite",
+    "plan",
+    "codegen",
+    "classify",
+    "cite",
+    "web_extract",
+]
+
+
+class Cfg:
+    clarify_conf_threshold = 0.55
+
+
+def route(payload):
+    return payload.get("intent", "unknown")
+
+
+def test_clarifier_improves_accuracy():
+    random.seed(0)
+    with open("service/clarify/templates.yaml", "r", encoding="utf-8") as f:
+        templates = yaml.safe_load(f)
+    cfg = Cfg()
+    scenarios = []
+    for i in range(30):
+        correct = random.choice(INTENTS)
+        if i < 15:
+            base_payload = {"confidence": 0.4, "missing_fields": ["intent"], "clarify_answer": correct}
+            payload = dict(base_payload)
+        else:
+            base_payload = {"confidence": 0.9, "intent": correct}
+            payload = dict(base_payload)
+        scenarios.append((base_payload, payload, correct))
+
+    baseline = 0
+    after = 0
+    for base_payload, payload, correct in scenarios:
+        if route(base_payload) == correct:
+            baseline += 1
+        clarified, explain = maybe_clarify(payload, cfg, templates)
+        if route(clarified) == correct:
+            after += 1
+    baseline_acc = baseline / len(scenarios)
+    after_acc = after / len(scenarios)
+    assert after_acc >= baseline_acc + 0.05
+
+
+def test_deterministic_run():
+    with open("service/clarify/templates.yaml", "r", encoding="utf-8") as f:
+        templates = yaml.safe_load(f)
+    cfg = Cfg()
+    payload = {"confidence": 0.4, "missing_fields": ["intent"], "clarify_answer": "summarize"}
+    res1, expl1 = maybe_clarify(payload, cfg, templates)
+    res2, expl2 = maybe_clarify(payload, cfg, templates)
+    assert res1 == res2
+    assert expl1 == expl2
+
+
+def test_threshold_behavior_and_failure_mode():
+    with open("service/clarify/templates.yaml", "r", encoding="utf-8") as f:
+        templates = yaml.safe_load(f)
+    cfg = Cfg()
+    low = {"confidence": 0.4, "missing_fields": ["intent"], "clarify_answer": "summarize"}
+    high = {"confidence": 0.9, "missing_fields": ["intent"], "clarify_answer": "summarize"}
+    no_answer = {"confidence": 0.4, "missing_fields": ["intent"], "clarify_answer": ""}
+
+    clarified_low, explain_low = maybe_clarify(low, cfg, templates)
+    clarified_high, explain_high = maybe_clarify(high, cfg, templates)
+    clarified_none, explain_none = maybe_clarify(no_answer, cfg, templates)
+
+    assert explain_low["clarify"]["triggered"]
+    assert not explain_high["clarify"]["triggered"]
+    assert "intent" not in clarified_none
+    assert explain_none["clarify"]["triggered"]

--- a/tests/test_clarify.py
+++ b/tests/test_clarify.py
@@ -1,6 +1,7 @@
-import json
 import math
 from pathlib import Path
+
+import yaml
 
 from service.clarify.trigger import (
     should_clarify,
@@ -10,7 +11,8 @@ from service.clarify.trigger import (
 from service.clarify.render import render, deck_sha
 
 
-TEMPLATES = json.loads(Path("service/clarify/templates.yaml").read_text())["templates"]
+_TEMPLATES = yaml.safe_load(Path("service/clarify/templates.yaml").read_text())["templates"]
+TEMPLATES = {t["id"]: t["user"] for t in _TEMPLATES}
 
 
 def test_should_clarify_by_decision_flag():

--- a/tests/test_templates_sanity.py
+++ b/tests/test_templates_sanity.py
@@ -1,0 +1,38 @@
+import yaml
+from service.clarify import render
+
+EXPECTED_INTENTS = {"summarize", "extract", "rewrite", "plan", "codegen", "classify", "cite", "web_extract"}
+
+
+def _sample_context(variables):
+    ctx = {}
+    for name, meta in variables.items():
+        default = meta.get("default", "sample")
+        if isinstance(default, list):
+            ctx[name] = default or ["x"]
+        else:
+            ctx[name] = default or "sample"
+    return ctx
+
+
+def test_template_deck_sanity():
+    with open("service/clarify/templates.yaml", "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    templates = data["templates"]
+    intents = {t["intent"] for t in templates if t["intent"] != "clarify"}
+    assert EXPECTED_INTENTS.issubset(intents)
+    for tpl in templates:
+        user = tpl.get("user", "")
+        system = tpl.get("system", "")
+        vars_meta = tpl.get("variables", {})
+        ctx = _sample_context(vars_meta)
+        rendered = render.render(tpl["id"], ctx, {tpl["id"]: user})
+        assert "{{" not in rendered
+        assert rendered.count("\n") < 25
+        for line in rendered.splitlines():
+            assert not line.strip().isupper()
+        assert "SECRET" not in rendered
+        assert rendered == render.render(tpl["id"], ctx, {tpl["id"]: user})
+        assert system.count("\n") < 25
+        for line in system.splitlines():
+            assert not line.strip().isupper()


### PR DESCRIPTION
## Summary
- add clarifier core to detect ambiguity and merge answers
- introduce clarifier_v1 template deck covering 8 intents and clarify prompts
- hook clarifier into routing flow with observability
- document templates and add effectiveness & sanity tests

## Testing
- `pytest tests/test_clarifier_effectiveness.py tests/test_templates_sanity.py -q -k "clarifier_effectiveness or templates_sanity"`


------
https://chatgpt.com/codex/tasks/task_e_68c7a66d903c8329a2652c7c2cb65ab9