### PR TITLE
NEW-040: model-set registry and switcher

### DIFF
--- a/.specs/NEW-040.md
+++ b/.specs/NEW-040.md
@@ -1,0 +1,11 @@
+# NEW-040 · ModelSet Registry & Switcher
+
+Implementation adds a registry for model sets and a per-request switcher that
+honours request flags, tenant defaults and global defaults. Configuration lives
+in `service/config/model_sets.yaml` and must define at least two sets. Registry
+validates provider, model, limits and pricing hints. Resolver chooses the model
+set deterministically and records `route_explain.model_set` and
+`route_explain.model_set_reason`.
+
+Tests cover schema validation, deterministic ordering, selection priority,
+cost/latency changes when switching, and fallback behaviour.

--- a/docs/MODELSETS.md
+++ b/docs/MODELSETS.md
@@ -1,0 +1,55 @@
+# Model Sets
+
+Alpha Solver supports *model sets* – named bundles of model configuration that
+can be switched per request. Each set specifies the provider, model identifier,
+limits and cost hints used for routing and budget calculations.
+
+## Configuration
+
+Model sets are defined in `service/config/model_sets.yaml`:
+
+```yaml
+model_sets:
+  default:
+    provider: openai
+    model: gpt-5
+    max_tokens: 2048
+    timeout_ms: 60000
+    price_hint: { input_per_1k: 0.005, output_per_1k: 0.015 }
+  cost_saver:
+    provider: openai
+    model: gpt-5-mini
+    max_tokens: 1024
+    timeout_ms: 45000
+    price_hint: { input_per_1k: 0.0015, output_per_1k: 0.004 }
+```
+
+Rules:
+
+* at least two sets are required;
+* `provider` must be a known enum (`openai`, `anthropic`);
+* `model` is a non-empty string;
+* `max_tokens` and `timeout_ms` must be positive integers;
+* optional `price_hint` must include both `input_per_1k` and `output_per_1k`.
+
+Registry loading validates these constraints and raises a helpful error message
+if they are violated.
+
+## Per-request selection
+
+The `ModelSetResolver` chooses which set to use for a request. Priority order:
+
+1. explicit flag or `X-Model-Set` header
+2. tenant default (if configured)
+3. global default from configuration
+
+Unknown sets fall back to the global default and record the reason in
+`route_explain.model_set_reason`. The chosen set is always recorded in
+`route_explain.model_set` for observability.
+
+## Extending
+
+To add a new model set, edit `model_sets.yaml` and add another top‑level entry
+under `model_sets`. Commit the change with appropriate tests. Ensure secrets
+such as API keys are **never** placed in this file.
+

--- a/service/config/model_sets.yaml
+++ b/service/config/model_sets.yaml
@@ -1,0 +1,13 @@
+model_sets:
+  default:
+    provider: openai
+    model: gpt-5
+    max_tokens: 2048
+    timeout_ms: 60000
+    price_hint: { input_per_1k: 0.005, output_per_1k: 0.015 }
+  cost_saver:
+    provider: openai
+    model: gpt-5-mini
+    max_tokens: 1024
+    timeout_ms: 45000
+    price_hint: { input_per_1k: 0.0015, output_per_1k: 0.004 }

--- a/service/models/modelset_registry.py
+++ b/service/models/modelset_registry.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+"""Registry for configured model sets.
+
+Loads ``service/config/model_sets.yaml`` and exposes validated model
+information for routing and cost estimation.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Mapping, Optional
+import yaml
+
+__all__ = ["ModelSet", "ModelSetRegistry", "ModelSetError"]
+
+
+ALLOWED_PROVIDERS = {"openai", "anthropic"}
+
+
+class ModelSetError(ValueError):
+    """Raised for configuration problems with model sets."""
+
+
+@dataclass(frozen=True)
+class ModelSet:
+    name: str
+    provider: str
+    model: str
+    max_tokens: int
+    timeout_ms: int
+    price_hint: Optional[Mapping[str, float]] = None
+
+
+class ModelSetRegistry:
+    """Load and validate model set configuration."""
+
+    def __init__(self, path: str | Path | None = None):
+        cfg_path = (
+            Path(path)
+            if path is not None
+            else Path(__file__).resolve().parents[1] / "config" / "model_sets.yaml"
+        )
+        self._path = cfg_path
+        self._model_sets: Dict[str, ModelSet] = self._load(cfg_path)
+
+    # ------------------------------------------------------------------
+    def _load(self, path: Path) -> Dict[str, ModelSet]:
+        if not path.exists():
+            raise ModelSetError(f"model set config not found: {path}")
+        with open(path, "r", encoding="utf-8") as f:
+            raw = yaml.safe_load(f) or {}
+
+        if "model_sets" not in raw or not isinstance(raw["model_sets"], dict):
+            raise ModelSetError("model_sets.yaml missing 'model_sets' mapping")
+
+        sets = {}
+        for name in sorted(raw["model_sets"].keys()):
+            cfg = raw["model_sets"][name] or {}
+            self._validate_set(name, cfg)
+            sets[name] = ModelSet(
+                name=name,
+                provider=cfg["provider"],
+                model=cfg["model"],
+                max_tokens=cfg["max_tokens"],
+                timeout_ms=cfg["timeout_ms"],
+                price_hint=cfg.get("price_hint"),
+            )
+
+        if len(sets) < 2:
+            raise ModelSetError("model_sets.yaml must define at least two model sets")
+
+        return sets
+
+    # ------------------------------------------------------------------
+    def _validate_set(self, name: str, cfg: Mapping[str, object]) -> None:
+        provider = cfg.get("provider")
+        if provider not in ALLOWED_PROVIDERS:
+            raise ModelSetError(
+                f"Model set '{name}' has unknown provider '{provider}'"
+            )
+
+        model = cfg.get("model")
+        if not isinstance(model, str) or not model.strip():
+            raise ModelSetError(f"Model set '{name}' missing required field 'model'")
+
+        max_tokens = cfg.get("max_tokens")
+        if not isinstance(max_tokens, int) or max_tokens <= 0:
+            raise ModelSetError(
+                f"Model set '{name}' has invalid 'max_tokens': {max_tokens}"
+            )
+
+        timeout_ms = cfg.get("timeout_ms")
+        if not isinstance(timeout_ms, int) or timeout_ms <= 0:
+            raise ModelSetError(
+                f"Model set '{name}' has invalid 'timeout_ms': {timeout_ms}"
+            )
+
+        if "price_hint" in cfg:
+            ph = cfg["price_hint"]
+            if not isinstance(ph, Mapping):
+                raise ModelSetError(
+                    f"Model set '{name}' has invalid price_hint: {ph!r}"
+                )
+            for key in ("input_per_1k", "output_per_1k"):
+                if key not in ph:
+                    raise ModelSetError(
+                        f"Model set '{name}' price_hint missing '{key}'"
+                    )
+                val = ph[key]
+                if not isinstance(val, (int, float)) or val < 0:
+                    raise ModelSetError(
+                        f"Model set '{name}' price_hint.{key} invalid: {val}"
+                    )
+
+    # ------------------------------------------------------------------
+    def get(self, name: str) -> ModelSet:
+        try:
+            return self._model_sets[name]
+        except KeyError as exc:  # pragma: no cover - guard
+            raise ModelSetError(f"Unknown model set '{name}'") from exc
+
+    # ------------------------------------------------------------------
+    def names(self) -> list[str]:
+        return list(self._model_sets.keys())
+
+    # ------------------------------------------------------------------
+    def __iter__(self) -> Iterable[ModelSet]:
+        return iter(self._model_sets.values())
+

--- a/service/models/modelset_resolver.py
+++ b/service/models/modelset_resolver.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+"""Per-request model-set resolver.
+
+Selects a model set based on explicit request parameters, tenant defaults, or
+configured global default. The resolution is deterministic and records an
+explanation for observability.
+"""
+
+from typing import Dict, Mapping, Optional, Tuple
+
+from .modelset_registry import ModelSet, ModelSetRegistry, ModelSetError
+
+__all__ = ["ModelSetResolver"]
+
+
+class ModelSetResolver:
+    def __init__(self, registry: ModelSetRegistry, global_default: str = "default"):
+        self.registry = registry
+        self.global_default = (
+            global_default if global_default in registry.names() else registry.names()[0]
+        )
+
+    # --------------------------------------------------------------
+    def resolve(
+        self,
+        *,
+        requested: Optional[str] = None,
+        headers: Optional[Mapping[str, str]] = None,
+        tenant_default: Optional[str] = None,
+        route_explain: Optional[Dict[str, str]] = None,
+    ) -> Tuple[ModelSet, str]:
+        """Resolve the model set.
+
+        Args:
+            requested: explicit request flag.
+            headers: request headers (case-insensitive lookup for ``X-Model-Set``).
+            tenant_default: tenant configured default model set name.
+            route_explain: optional dict populated with ``model_set`` and
+                ``model_set_reason``.
+
+        Returns:
+            (ModelSet, reason) tuple where reason explains the selection.
+        """
+
+        reason = ""
+
+        header_choice = None
+        if headers:
+            for k, v in headers.items():
+                if k.lower() == "x-model-set":
+                    header_choice = v
+                    break
+
+        candidate = requested or header_choice
+        if candidate:
+            if candidate in self.registry.names():
+                selected_name = candidate
+                reason = "requested"
+            else:
+                selected_name = self.global_default
+                reason = f"unknown-requested:{candidate}"
+        elif tenant_default and tenant_default in self.registry.names():
+            selected_name = tenant_default
+            reason = "tenant-default"
+        else:
+            selected_name = self.global_default
+            if tenant_default and tenant_default not in self.registry.names():
+                reason = f"unknown-tenant-default:{tenant_default}"
+            else:
+                reason = "global-default"
+
+        if route_explain is not None:
+            route_explain["model_set"] = selected_name
+            route_explain["model_set_reason"] = reason
+
+        return self.registry.get(selected_name), reason
+

--- a/tests/test_modelset_registry.py
+++ b/tests/test_modelset_registry.py
@@ -1,0 +1,67 @@
+import pytest
+
+from service.models.modelset_registry import ModelSetRegistry, ModelSetError
+
+
+def test_registry_loads_sets():
+    reg = ModelSetRegistry()
+    names = reg.names()
+    assert "default" in names and "cost_saver" in names
+    # deterministic ordering
+    assert names == sorted(names)
+    # ensure data accessible
+    ms = reg.get("default")
+    assert ms.provider == "openai"
+    assert ms.max_tokens == 2048
+
+
+def test_invalid_schema_missing_model(tmp_path):
+    cfg = tmp_path / "model_sets.yaml"
+    cfg.write_text(
+        """model_sets:
+  bad:
+    provider: openai
+    max_tokens: 1
+    timeout_ms: 1
+"""
+    )
+    with pytest.raises(ModelSetError) as exc:
+        ModelSetRegistry(cfg)
+    assert "missing" in str(exc.value)
+
+
+def test_invalid_provider(tmp_path):
+    cfg = tmp_path / "model_sets.yaml"
+    cfg.write_text(
+        """model_sets:
+  bad:
+    provider: nope
+    model: m
+    max_tokens: 1
+    timeout_ms: 1
+"""
+    )
+    with pytest.raises(ModelSetError) as exc:
+        ModelSetRegistry(cfg)
+    assert "unknown provider" in str(exc.value)
+
+
+def test_deterministic_order(tmp_path):
+    cfg = tmp_path / "model_sets.yaml"
+    cfg.write_text(
+        """model_sets:
+  zed:
+    provider: openai
+    model: z
+    max_tokens: 1
+    timeout_ms: 1
+  alpha:
+    provider: openai
+    model: a
+    max_tokens: 1
+    timeout_ms: 1
+"""
+    )
+    reg = ModelSetRegistry(cfg)
+    assert reg.names() == ["alpha", "zed"]
+

--- a/tests/test_modelset_switcher.py
+++ b/tests/test_modelset_switcher.py
@@ -1,0 +1,67 @@
+import pytest
+
+from service.models.modelset_registry import ModelSetRegistry
+from service.models.modelset_resolver import ModelSetResolver
+
+
+def estimate_cost_latency(ms, tokens_in=100, tokens_out=0):
+    ph = ms.price_hint or {}
+    cost = tokens_in / 1000 * ph.get("input_per_1k", 0) + tokens_out / 1000 * ph.get(
+        "output_per_1k", 0
+    )
+    return cost, ms.timeout_ms
+
+
+def test_switch_changes_estimates():
+    reg = ModelSetRegistry()
+    resolver = ModelSetResolver(registry=reg)
+    default_ms, _ = resolver.resolve()
+    saver_ms, _ = resolver.resolve(requested="cost_saver")
+    default_cost, default_latency = estimate_cost_latency(default_ms, tokens_in=1000)
+    saver_cost, saver_latency = estimate_cost_latency(saver_ms, tokens_in=1000)
+    assert saver_cost < default_cost
+    assert saver_latency < default_latency
+
+
+def test_resolver_priority_and_fallback():
+    reg = ModelSetRegistry()
+    resolver = ModelSetResolver(registry=reg)
+
+    # header overrides tenant default
+    explain = {}
+    ms, reason = resolver.resolve(
+        headers={"X-Model-Set": "cost_saver"}, tenant_default="default", route_explain=explain
+    )
+    assert ms.name == "cost_saver"
+    assert reason == "requested"
+    assert explain["model_set"] == "cost_saver"
+    assert explain["model_set_reason"] == "requested"
+
+    # tenant default used when no header
+    explain = {}
+    ms, reason = resolver.resolve(tenant_default="cost_saver", route_explain=explain)
+    assert ms.name == "cost_saver"
+    assert reason == "tenant-default"
+    assert explain["model_set"] == "cost_saver"
+
+    # global default fallback
+    explain = {}
+    ms, reason = resolver.resolve(route_explain=explain)
+    assert ms.name == "default"
+    assert reason == "global-default"
+    assert explain["model_set_reason"] == "global-default"
+
+    # unknown requested falls back
+    explain = {}
+    ms, reason = resolver.resolve(requested="unknown", route_explain=explain)
+    assert ms.name == "default"
+    assert reason.startswith("unknown-requested")
+    assert explain["model_set_reason"].startswith("unknown-requested")
+
+    # unknown tenant default falls back deterministically
+    explain = {}
+    ms, reason = resolver.resolve(tenant_default="mystery", route_explain=explain)
+    assert ms.name == "default"
+    assert reason.startswith("unknown-tenant-default")
+    assert explain["model_set_reason"].startswith("unknown-tenant-default")
+


### PR DESCRIPTION
## Summary
- add model-set registry with validation and deterministic ordering
- enable per-request model-set selection with resolver and fallbacks
- document model set configuration and selection rules

## Testing
- `pytest -q -k "modelset_registry or modelset_switcher"`


------
https://chatgpt.com/codex/tasks/task_e_68c7adae27d083299963a459f66e5beb