### PR TITLE
NEW-042: retry with exponential backoff & jitter

### DIFF
--- a/.specs/NEW-042.md
+++ b/.specs/NEW-042.md
@@ -1,0 +1,7 @@
+# NEW-042: Retry with Exponential Backoff & Jitter
+
+Implements capped exponential backoff with full jitter for adapter calls.  The
+policy retries only transient errors and honours idempotency flags.  Metrics and
+logs expose retry attempts and sleep time while redacting payload data.
+Tests cover success lift, fatal short circuit, latency bounds, idempotency
+behaviour, metrics and log redaction.

--- a/docs/RETRY_BACKOFF.md
+++ b/docs/RETRY_BACKOFF.md
@@ -1,0 +1,35 @@
+# Retry Backoff
+
+Alpha Solver adapters use an exponential backoff policy with full jitter for
+transient failures.  The defaults are:
+
+- `max_retries=3`
+- `base_ms=100`
+- `max_sleep_ms=1000`
+- `timeout_ceiling_ms=2000`
+
+Sleep time for attempt *n* is drawn from `rand(0, base_ms * 2**(n-1))` and
+clamped by `max_sleep_ms`.  Total backoff time will never exceed the ceiling.
+
+Only transient errors are retried.  Examples:
+
+- HTTP 429/5xx, timeouts or connection resets are **transient**
+- validation errors or most 4xx codes are **fatal**
+
+Retries are executed only when the operation is known to be idempotent.  For
+state‑changing operations an explicit idempotency key must be supplied.
+
+Metrics emitted:
+
+- `alpha_adapter_retry_total{adapter, outcome="success|giveup", attempts="N"}`
+- `alpha_adapter_retry_sleep_ms_sum{adapter}`
+
+Logs record each failed attempt in a redacted one‑line format:
+`adapter=<name> attempt=<n> err_class=<cls> transient=<bool>`.
+
+## Troubleshooting
+
+- Ensure the adapter was invoked with an idempotency key before expecting
+  retries for write operations.
+- Increase `max_retries` or `base_ms` if transient errors persist but latency
+  budget allows.

--- a/service/adapters/base_adapter.py
+++ b/service/adapters/base_adapter.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+"""Adapter retry wrapper with metrics and logging."""
+
+from typing import Callable, Dict, Any
+
+from .retry import retry_call
+from service.metrics.exporter import Counter, _REGISTRY
+
+_RETRY_TOTAL = Counter(
+    "alpha_adapter_retry_total",
+    "adapter retries",
+    ["adapter", "outcome", "attempts"],
+    registry=_REGISTRY,
+)
+_RETRY_SLEEP = Counter(
+    "alpha_adapter_retry_sleep_ms_sum",
+    "total retry sleep ms",
+    ["adapter"],
+    registry=_REGISTRY,
+)
+
+
+def with_retry(
+    fn: Callable[[], Dict[str, Any]],
+    *,
+    adapter: str,
+    idempotent: bool,
+    budget_guard=None,
+) -> Dict[str, Any]:
+    """Execute ``fn`` with retry semantics and record metrics."""
+
+    try:
+        res, attempts, sleep_ms = retry_call(
+            fn,
+            adapter=adapter,
+            idempotent=idempotent,
+            budget_guard=budget_guard,
+        )
+    except Exception as err:  # pragma: no cover - error path
+        attempts = getattr(err, "_alpha_retry_attempts", 1)
+        sleep_ms = getattr(err, "_alpha_retry_sleep_ms", 0.0)
+        _RETRY_TOTAL.labels(adapter=adapter, outcome="giveup", attempts=str(attempts)).inc()
+        if sleep_ms:
+            _RETRY_SLEEP.labels(adapter=adapter).inc(sleep_ms)
+        raise
+    _RETRY_TOTAL.labels(adapter=adapter, outcome="success", attempts=str(attempts)).inc()
+    if sleep_ms:
+        _RETRY_SLEEP.labels(adapter=adapter).inc(sleep_ms)
+    if isinstance(res, dict) and isinstance(res.get("meta"), dict):
+        res["meta"]["attempts"] = attempts
+    return res

--- a/service/adapters/gsheets_adapter.py
+++ b/service/adapters/gsheets_adapter.py
@@ -12,7 +12,6 @@ class GSheetsAdapter:
     """In-memory sheet store with idempotent appends and retries."""
 
     _LATENCY_S = 0.002
-    _MAX_ATTEMPTS = 2
 
     def __init__(self) -> None:
         self._sheets: Dict[str, List[List[Any]]] = {}
@@ -21,14 +20,12 @@ class GSheetsAdapter:
             Tuple[str, str, str | None, Tuple[Tuple[Any, ...], ...]],
             Dict[str, Any],
         ] = {}
-        # track keys for which we've already simulated a transient failure
-        self._transient_once: set[Tuple[str, str, Tuple[Tuple[Any, ...], ...]]] = set()
 
     # Protocol methods -------------------------------------------------------
     def name(self) -> str:  # pragma: no cover - trivial
         return "gsheets"
 
-    def run(
+    def _run_once(
         self,
         payload: Dict[str, Any],
         *,
@@ -70,33 +67,14 @@ class GSheetsAdapter:
             if idempotency_key and idem_key in self._idem:
                 return self._idem[idem_key]
 
-            attempts = 0
+            rows = self._sheets.setdefault(sheet, [])
+            rows.extend([list(r) for r in sanitized_values])
+            value = len(sanitized_values)
             start = perf_counter()
-            value: Any = None
-            while True:
-                attempts += 1
-                try:
-                    if (
-                        (sheet, cell_range, tuple(tuple(r) for r in sanitized_values))
-                        not in self._transient_once
-                    ):
-                        self._transient_once.add(
-                            (sheet, cell_range, tuple(tuple(r) for r in sanitized_values))
-                        )
-                        raise AdapterError(code="TRANSIENT", retryable=True)
-
-                    rows = self._sheets.setdefault(sheet, [])
-                    rows.extend([list(r) for r in sanitized_values])
-                    value = len(sanitized_values)
-                    break
-                except AdapterError as err:
-                    if err.code == "TRANSIENT" and err.retryable and attempts < self._MAX_ATTEMPTS:
-                        continue
-                    raise
             end = perf_counter()
             meta = {
                 "latency_ms": (end - start) * 1000,
-                "attempts": attempts,
+                "attempts": 1,
                 "idempotent": False,
                 "sanitized_cells": sanitized_cells,
                 "retryable": False,
@@ -120,6 +98,23 @@ class GSheetsAdapter:
                 "retryable": False,
             }
             return {"ok": True, "value": value, "meta": meta}
+
+    def run(
+        self,
+        payload: Dict[str, Any],
+        *,
+        idempotency_key: str | None = None,
+        timeout_s: float = 5.0,
+    ) -> Dict[str, Any]:
+        from .base_adapter import with_retry
+
+        op = payload.get("op")
+        idem = op != "append" or bool(idempotency_key or payload.get("idempotency_key"))
+        return with_retry(
+            lambda: self._run_once(payload, idempotency_key=idempotency_key, timeout_s=timeout_s),
+            adapter=self.name(),
+            idempotent=idem,
+        )
 
     def _sanitize_values(self, values: List[List[Any]]) -> Tuple[List[List[Any]], int]:
         sanitized: List[List[Any]] = []

--- a/service/adapters/retry.py
+++ b/service/adapters/retry.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+"""Generic retry helpers with exponential backoff and jitter."""
+
+from typing import Callable, Tuple, TypeVar
+import random
+import time
+import logging
+
+from .base import AdapterError
+
+T = TypeVar("T")
+
+log = logging.getLogger("alpha.adapters.retry")
+
+# default knobs
+DEFAULT_MAX_RETRIES = 3
+DEFAULT_BASE_MS = 100
+DEFAULT_MAX_SLEEP_MS = 1000
+DEFAULT_TIMEOUT_CEILING_MS = 2000
+
+_TRANSIENT_HTTP = {408, 409, 425, 429}
+
+
+def classify_error(err: Exception) -> bool:
+    """Return True if the error is considered transient."""
+    if isinstance(err, AdapterError):
+        return bool(err.retryable)
+    status = getattr(err, "status", None) or getattr(err, "status_code", None)
+    if isinstance(status, int):
+        if status >= 500 or status in _TRANSIENT_HTTP:
+            return True
+        if 400 <= status < 500:
+            return False
+    if isinstance(err, (TimeoutError, ConnectionError, OSError)):
+        return True
+    return False
+
+
+def retry_call(
+    fn: Callable[[], T],
+    *,
+    adapter: str,
+    idempotent: bool = True,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+    base_ms: int = DEFAULT_BASE_MS,
+    max_sleep_ms: int = DEFAULT_MAX_SLEEP_MS,
+    timeout_ceiling_ms: int = DEFAULT_TIMEOUT_CEILING_MS,
+    budget_guard=None,
+) -> Tuple[T, int, float]:
+    """Call ``fn`` retrying transient failures.
+
+    Returns a tuple ``(result, attempts, sleep_ms)``.
+    On final failure the original exception is raised with ``_alpha_retry_attempts``
+    and ``_alpha_retry_sleep_ms`` attributes populated for metrics.
+    """
+
+    attempts = 0
+    total_sleep_ms = 0.0
+    while True:
+        try:
+            attempts += 1
+            return fn(), attempts, total_sleep_ms
+        except Exception as err:  # pragma: no cover - transient path
+            transient = classify_error(err)
+            log.info(
+                "adapter=%s attempt=%d err_class=%s transient=%s",
+                adapter,
+                attempts,
+                err.__class__.__name__,
+                str(transient).lower(),
+            )
+            if (not idempotent) or (not transient) or attempts > max_retries:
+                setattr(err, "_alpha_retry_attempts", attempts)
+                setattr(err, "_alpha_retry_sleep_ms", total_sleep_ms)
+                raise
+            sleep_ms = min(base_ms * (2 ** (attempts - 1)), max_sleep_ms)
+            sleep_ms = random.uniform(0, sleep_ms)
+            if total_sleep_ms + sleep_ms > timeout_ceiling_ms:
+                setattr(err, "_alpha_retry_attempts", attempts)
+                setattr(err, "_alpha_retry_sleep_ms", total_sleep_ms)
+                raise
+            if budget_guard and not budget_guard(sleep_ms):
+                setattr(err, "_alpha_retry_attempts", attempts)
+                setattr(err, "_alpha_retry_sleep_ms", total_sleep_ms)
+                raise
+            time.sleep(sleep_ms / 1000.0)
+            total_sleep_ms += sleep_ms

--- a/tests/test_retry_backoff.py
+++ b/tests/test_retry_backoff.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import logging
+import random
+import re
+import time
+
+import pytest
+
+from service.adapters.base import AdapterError
+from service.adapters.base_adapter import with_retry
+from service.metrics.exporter import _REGISTRY
+
+
+class FlakyAdapter:
+    def __init__(self, p_fail: float = 0.5) -> None:
+        self.p_fail = p_fail
+
+    def run(self, payload):
+        if random.random() < self.p_fail:
+            raise AdapterError(code="TRANSIENT", retryable=True)
+        return {"ok": True, "value": 1, "meta": {"attempts": 1}}
+
+
+def test_success_lift_and_metrics():
+    random.seed(0)
+    n = 200
+    baseline = 0
+    for _ in range(n):
+        ad = FlakyAdapter()
+        try:
+            ad.run({})
+            baseline += 1
+        except AdapterError:
+            pass
+    baseline_rate = baseline / n
+
+    random.seed(0)
+    success = 0
+    for _ in range(n):
+        ad = FlakyAdapter()
+        try:
+            with_retry(lambda: ad.run({}), adapter="flaky", idempotent=True)
+            success += 1
+        except AdapterError:
+            pass
+    retry_rate = success / n
+    assert retry_rate >= baseline_rate + 0.10
+
+    # force giveup case for metrics
+    def always_fail():
+        raise AdapterError(code="TRANSIENT", retryable=True)
+
+    with pytest.raises(AdapterError):
+        with_retry(always_fail, adapter="flaky", idempotent=True)
+
+    metrics = {
+        (s.labels.get("adapter"), s.labels.get("outcome")): s.value
+        for m in _REGISTRY.collect()
+        if m.name == "alpha_adapter_retry"
+        for s in m.samples
+        if s.name == "alpha_adapter_retry_total"
+    }
+    assert ("flaky", "success") in metrics
+    assert ("flaky", "giveup") in metrics
+
+    sleep_metric = {
+        s.labels.get("adapter"): s.value
+        for m in _REGISTRY.collect()
+        if m.name == "alpha_adapter_retry_sleep_ms_sum"
+        for s in m.samples
+        if s.name == "alpha_adapter_retry_sleep_ms_sum_total"
+    }
+    assert "flaky" in sleep_metric
+
+
+def test_fatal_short_circuit():
+    calls = 0
+
+    def fatal():
+        nonlocal calls
+        calls += 1
+        raise AdapterError(code="SCHEMA", retryable=False)
+
+    with pytest.raises(AdapterError):
+        with_retry(fatal, adapter="fatal", idempotent=True)
+    assert calls == 1
+
+
+def test_latency_bounds():
+    def always_transient():
+        raise AdapterError(code="TRANSIENT", retryable=True)
+
+    start = time.perf_counter()
+    with pytest.raises(AdapterError):
+        with_retry(always_transient, adapter="slow", idempotent=True)
+    elapsed_ms = (time.perf_counter() - start) * 1000
+    assert elapsed_ms <= 2000
+
+
+def test_idempotency_guard():
+    calls = 0
+
+    def transient():
+        nonlocal calls
+        calls += 1
+        raise AdapterError(code="TRANSIENT", retryable=True)
+
+    with pytest.raises(AdapterError):
+        with_retry(transient, adapter="guard", idempotent=False)
+    assert calls == 1
+
+
+def test_no_secrets_in_logs(caplog):
+    caplog.set_level(logging.INFO)
+
+    def transient():
+        raise AdapterError(code="TRANSIENT", retryable=True)
+
+    with pytest.raises(AdapterError):
+        with_retry(transient, adapter="log", idempotent=True)
+
+    assert not re.search("token|secret", caplog.text)


### PR DESCRIPTION
## Summary
- add reusable adapter retry policy with capped exponential backoff and jitter
- wrap adapter calls with idempotency-aware retry, logging and Prometheus metrics
- document retry configuration and transient vs fatal taxonomy

## Testing
- `pytest -q -k retry_backoff`


------
https://chatgpt.com/codex/tasks/task_e_68c7ae925e80832993db3c09ec65d643