### PR TITLE
auth(oauth): token provider and secret rotation scaffold

### DIFF
--- a/.specs/NEW-044.md
+++ b/.specs/NEW-044.md
@@ -1,0 +1,11 @@
+# NEW-044 · OAuth/Secrets Scaffold
+
+Implements a simulated OAuth token provider, secret store and middleware.
+Tokens are cached with expiry awareness and jittered prefetch.  Secrets are
+versioned and support rotation and rollback.  Middleware attaches bearer
+tokens without leaking secrets.
+
+This spec is fulfilled by tests in:
+- `tests/test_oauth_token_provider.py`
+- `tests/test_secret_store.py`
+- `tests/test_oauth_integration.py`

--- a/docs/OAUTH_SECRETS.md
+++ b/docs/OAUTH_SECRETS.md
@@ -1,0 +1,24 @@
+# OAuth & Secrets Scaffold
+
+This document describes how the simulated OAuth token system and secret
+store are configured for tests.  It is **not** a real authentication system.
+
+## Configuration
+
+Providers are declared in `service/config/oauth_providers.yaml` and include
+allowed scopes, cache settings and prefetch jitter used for background
+refresh.  Secrets for tenants live in `service/config/secrets.example.yaml`.
+Each entry is versioned so rotation can occur without downtime.
+
+## Rotation
+
+To rotate a secret create a new version with `SecretStore.set` and deploy the
+updated file.  The previous version is retained and can be restored with
+`SecretStore.rollback` if needed.
+
+## Safety
+
+No secrets are logged by the token provider, OAuth client or middleware.
+Tests scan logs to ensure that client secrets and refresh tokens are absent.
+
+This scaffold is intentionally simple and intended for unit tests only.

--- a/service/auth/oauth_client.py
+++ b/service/auth/oauth_client.py
@@ -1,0 +1,71 @@
+import hashlib
+import time
+from typing import Callable, Iterable, Tuple
+
+
+class OAuthError(Exception):
+    """Represents an OAuth related error."""
+
+    def __init__(self, code: str, detail: str | None = None) -> None:
+        super().__init__(code)
+        self.code = code
+        self.detail = detail or ""
+
+
+class OAuthClient:
+    """Simulated OAuth client supporting two flows.
+
+    The client does not perform any network operations. Instead it
+    deterministically generates tokens based on the input parameters. This
+    allows tests to run quickly and without external dependencies.
+    """
+
+    def __init__(self, clock: Callable[[], float] | None = None) -> None:
+        self._clock = clock or time.time
+
+    # ------------------------------------------------------------------
+    # internal helpers
+    def _scope_hash(self, scopes: Iterable[str]) -> str:
+        joined = " ".join(sorted(scopes))
+        return hashlib.sha1(joined.encode()).hexdigest()[:8]
+
+    def _expiry(self, provider: str, tenant: str, scope_hash: str) -> int:
+        base = hashlib.sha256(f"{provider}:{tenant}:{scope_hash}".encode()).hexdigest()
+        rnd = int(base, 16) % 180  # 0-179
+        return int(self._clock() + 120 + rnd)  # 120-299s
+
+    # ------------------------------------------------------------------
+    def fetch_token(
+        self,
+        flow: str,
+        provider: str,
+        tenant_id: str,
+        scopes: Iterable[str],
+        secret: dict,
+    ) -> Tuple[str, int]:
+        """Return (access_token, expires_at) or raise :class:`OAuthError`.
+
+        ``flow`` must be either ``client_credentials`` or ``refresh_token``.
+        ``secret`` is a mapping containing ``client_secret`` and optionally
+        ``refresh_token``. To simulate invalid credentials any secret value
+        starting with ``"invalid"`` triggers an error.
+        """
+
+        if flow not in {"client_credentials", "refresh_token"}:
+            raise OAuthError("unsupported_flow")
+
+        if flow == "client_credentials":
+            if secret.get("client_secret", "").startswith("invalid"):
+                raise OAuthError("invalid_client", "bad client secret")
+        elif flow == "refresh_token":
+            rt = secret.get("refresh_token")
+            if not rt or rt.startswith("invalid"):
+                raise OAuthError("invalid_grant", "bad refresh token")
+
+        scope_hash = self._scope_hash(scopes)
+        exp = self._expiry(provider, tenant_id, scope_hash)
+        token = f"tok_{provider}_{tenant_id}_{scope_hash}_{exp}"
+        return token, exp
+
+
+__all__ = ["OAuthClient", "OAuthError"]

--- a/service/auth/secret_store.py
+++ b/service/auth/secret_store.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+from typing import Dict, Tuple
+
+import yaml
+
+
+class SecretStore:
+    """Simple versioned secret store backed by YAML data."""
+
+    def __init__(self, path: Path | str | None = None, data: dict | None = None) -> None:
+        if data is None:
+            if path is None:
+                raise ValueError("path or data required")
+            data = yaml.safe_load(Path(path).read_text()) or {}
+        self._store: Dict[Tuple[str, str], Dict[str, object]] = {}
+        for item in data.get("secrets", []):
+            provider = item.get("provider")
+            tenant = item.get("tenant_id")
+            if not provider or not tenant:
+                # allow "id" as "provider-tenant"
+                pid = item.get("id", "-")
+                provider, tenant = pid.split("-", 1)
+            version = item["version"]
+            key = (provider, tenant)
+            entry = self._store.setdefault(key, {"current": version, "versions": {}, "previous": None})
+            entry["versions"][version] = {k: v for k, v in item.items() if k not in {"provider", "tenant_id", "id"}}
+            entry["current"] = version
+
+    # ------------------------------------------------------------------
+    def get(self, provider: str, tenant_id: str, version: str | None = None) -> dict:
+        """Return a copy of the secret for provider/tenant/version."""
+        entry = self._store[(provider, tenant_id)]
+        ver = version or entry["current"]
+        return deepcopy(entry["versions"][ver])
+
+    def set(self, provider: str, tenant_id: str, secret: dict) -> None:
+        """Rotate to a new secret version."""
+        version = secret["version"]
+        key = (provider, tenant_id)
+        entry = self._store.setdefault(key, {"current": version, "versions": {}, "previous": None})
+        entry["previous"] = entry.get("current")
+        entry["versions"][version] = {k: v for k, v in secret.items() if k not in {"provider", "tenant_id"}}
+        entry["current"] = version
+
+    def rollback(self, provider: str, tenant_id: str) -> None:
+        key = (provider, tenant_id)
+        entry = self._store[key]
+        prev = entry.get("previous")
+        if prev:
+            entry["current"], entry["previous"] = prev, entry["current"]
+
+    # ------------------------------------------------------------------
+    def __repr__(self) -> str:  # pragma: no cover - repr only for debugging
+        keys = [f"{p}:{t}" for (p, t) in self._store.keys()]
+        return f"<SecretStore keys={keys}>"
+
+
+__all__ = ["SecretStore"]

--- a/service/auth/token_provider.py
+++ b/service/auth/token_provider.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import threading
+import time
+from typing import Callable, Iterable, Tuple
+
+from .oauth_client import OAuthClient, OAuthError
+from .secret_store import SecretStore
+
+
+class TokenError(Exception):
+    def __init__(self, code: str, detail: str | None = None) -> None:
+        super().__init__(code)
+        self.code = code
+        self.detail = detail or ""
+
+
+class TokenProvider:
+    """High level token provider with caching and refresh logic."""
+
+    def __init__(
+        self,
+        oauth_client: OAuthClient,
+        secret_store: SecretStore,
+        config: dict,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        self._client = oauth_client
+        self._secrets = secret_store
+        self._config = config
+        self._clock = clock or time.time
+        self._cache: dict[Tuple[str, str, Tuple[str, ...]], dict] = {}
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    def get_token(self, provider: str, tenant_id: str, scopes: Iterable[str]) -> str:
+        cfg = self._config.get("providers", {}).get(provider)
+        if not cfg:
+            raise TokenError("invalid_provider", f"unknown provider {provider}")
+        for s in scopes:
+            if s not in cfg.get("scopes", []):
+                raise TokenError("invalid_scope", s)
+        scopes_key = tuple(sorted(scopes))
+        key = (provider, tenant_id, scopes_key)
+        now = self._clock()
+        with self._lock:
+            entry = self._cache.get(key)
+            if entry and now + cfg.get("prefetch_jitter_s", 0) < entry["expires_at"]:
+                return entry["access_token"]
+        # Need to fetch/refresh
+        secret = self._secrets.get(provider, tenant_id)
+        flow = "client_credentials"
+        if entry:
+            # token exists but is expiring/expired
+            if secret.get("refresh_token"):
+                flow = "refresh_token"
+            else:
+                raise TokenError("invalid_grant", "missing refresh token")
+        token, exp = self._client.fetch_token(flow, provider, tenant_id, scopes_key, secret)
+        with self._lock:
+            self._cache[key] = {"access_token": token, "expires_at": exp}
+        return token
+
+
+__all__ = ["TokenProvider", "TokenError"]

--- a/service/config/oauth_providers.yaml
+++ b/service/config/oauth_providers.yaml
@@ -1,0 +1,10 @@
+providers:
+  default:
+    token_url: "https://example.com/token"
+    flows: ["client_credentials", "refresh_token"]
+    cache_ttl_s: 300
+    prefetch_jitter_s: 30
+    scopes:
+      - "sheets.read"
+      - "sheets.write"
+      - "web.read"

--- a/service/config/secrets.example.yaml
+++ b/service/config/secrets.example.yaml
@@ -1,0 +1,8 @@
+secrets:
+  - provider: default
+    tenant_id: tenantA
+    version: v1
+    client_id: clientA
+    client_secret: secretA
+    refresh_token: refreshA
+    kid: kid-001

--- a/service/middleware/secret_middleware.py
+++ b/service/middleware/secret_middleware.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+
+from service.auth.token_provider import TokenProvider
+
+
+class SecretMiddleware(BaseHTTPMiddleware):
+    """Attach OAuth bearer tokens for protected routes.
+
+    The middleware is intentionally small; it only injects an Authorization
+    header for paths matching ``path_prefix``. No secrets are logged.
+    """
+
+    def __init__(
+        self,
+        app,
+        token_provider: TokenProvider,
+        provider: str,
+        tenant_id: str,
+        scopes: Iterable[str],
+        path_prefix: str = "/",
+    ) -> None:
+        super().__init__(app)
+        self._tp = token_provider
+        self._provider = provider
+        self._tenant = tenant_id
+        self._scopes = tuple(scopes)
+        self._prefix = path_prefix
+
+    async def dispatch(self, request: Request, call_next):
+        if request.url.path.startswith(self._prefix):
+            token = self._tp.get_token(self._provider, self._tenant, self._scopes)
+            headers = list(request.scope.get("headers", []))
+            headers.append((b"authorization", f"Bearer {token}".encode()))
+            request.scope["headers"] = headers
+        response = await call_next(request)
+        return response
+
+
+__all__ = ["SecretMiddleware"]

--- a/tests/test_oauth_integration.py
+++ b/tests/test_oauth_integration.py
@@ -1,0 +1,66 @@
+import logging
+
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from service.auth.oauth_client import OAuthClient
+from service.auth.secret_store import SecretStore
+from service.auth.token_provider import TokenProvider
+from service.middleware.secret_middleware import SecretMiddleware
+
+
+def build_app():
+    provider_cfg = {
+        "providers": {
+            "default": {
+                "prefetch_jitter_s": 30,
+                "scopes": ["web.read"],
+            }
+        }
+    }
+    secrets = {
+        "secrets": [
+            {
+                "provider": "default",
+                "tenant_id": "tenantA",
+                "version": "v1",
+                "client_id": "id1",
+                "client_secret": "secretA",
+                "refresh_token": "refreshA",
+                "kid": "kid-001",
+            }
+        ]
+    }
+    store = SecretStore(data=secrets)
+    client = OAuthClient()
+    tp = TokenProvider(client, store, provider_cfg)
+
+    app = FastAPI()
+    app.add_middleware(
+        SecretMiddleware,
+        token_provider=tp,
+        provider="default",
+        tenant_id="tenantA",
+        scopes=["web.read"],
+        path_prefix="/needs-token",
+    )
+
+    @app.get("/needs-token")
+    async def needs_token(request: Request):
+        return {"auth": request.headers.get("authorization")}
+
+    return app
+
+
+def test_middleware_attaches_bearer_and_no_secret_logs(caplog):
+    caplog.set_level(logging.INFO)
+    app = build_app()
+    client = TestClient(app)
+    resp = client.get("/needs-token")
+    assert resp.status_code == 200
+    assert resp.json()["auth"].startswith("Bearer tok_")
+    # ensure no secrets in logs
+    for rec in caplog.records:
+        msg = rec.getMessage()
+        assert "secretA" not in msg
+        assert "refreshA" not in msg

--- a/tests/test_oauth_token_provider.py
+++ b/tests/test_oauth_token_provider.py
@@ -1,0 +1,121 @@
+import time
+import pytest
+
+from service.auth.oauth_client import OAuthClient, OAuthError
+from service.auth.secret_store import SecretStore
+from service.auth.token_provider import TokenProvider, TokenError
+
+
+def build_provider(clock):
+    provider_cfg = {
+        "providers": {
+            "default": {
+                "flows": ["client_credentials", "refresh_token"],
+                "cache_ttl_s": 300,
+                "prefetch_jitter_s": 30,
+                "scopes": ["web.read"],
+            }
+        }
+    }
+    secrets_data = {
+        "secrets": [
+            {
+                "provider": "default",
+                "tenant_id": "tenantA",
+                "version": "v1",
+                "client_id": "id1",
+                "client_secret": "secretA",
+                "refresh_token": "refreshA",
+                "kid": "kid-001",
+            }
+        ]
+    }
+    store = SecretStore(data=secrets_data)
+    client = OAuthClient(clock=clock)
+    return TokenProvider(client, store, provider_cfg, clock=clock)
+
+
+def test_cache_and_prefetch():
+    now = [1000.0]
+    clock = lambda: now[0]
+    tp = build_provider(clock)
+    start = time.perf_counter()
+    tok1 = tp.get_token("default", "tenantA", ["web.read"])
+    miss = time.perf_counter() - start
+    assert miss < 0.6
+    start = time.perf_counter()
+    tok2 = tp.get_token("default", "tenantA", ["web.read"])
+    hit = time.perf_counter() - start
+    assert hit < 0.1
+    assert tok1 == tok2
+    exp = int(tok1.split("_")[-1])
+    now[0] = exp - 29  # jitter =30 -> trigger refresh
+    tok3 = tp.get_token("default", "tenantA", ["web.read"])
+    assert tok3 != tok1
+
+
+def test_invalid_scope_and_creds():
+    now = [1000.0]
+    clock = lambda: now[0]
+    tp = build_provider(clock)
+    with pytest.raises(TokenError) as exc:
+        tp.get_token("default", "tenantA", ["bad.scope"])
+    assert exc.value.code == "invalid_scope"
+
+    secrets_bad = {
+        "secrets": [
+            {
+                "provider": "default",
+                "tenant_id": "bad",
+                "version": "v1",
+                "client_id": "id",
+                "client_secret": "invalid-secret",
+                "refresh_token": "refreshA",
+                "kid": "kid-001",
+            }
+        ]
+    }
+    store_bad = SecretStore(data=secrets_bad)
+    client = OAuthClient(clock=clock)
+    tp_bad = TokenProvider(client, store_bad, {"providers": {"default": {"scopes": ["web.read"], "prefetch_jitter_s": 30}}}, clock=clock)
+    failures = 0
+    for _ in range(50):
+        try:
+            tp_bad.get_token("default", "bad", ["web.read"])
+        except OAuthError:
+            failures += 1
+    assert failures >= 49
+
+
+def test_refresh_flow():
+    now = [1000.0]
+    clock = lambda: now[0]
+    tp = build_provider(clock)
+    tok1 = tp.get_token("default", "tenantA", ["web.read"])
+    exp = int(tok1.split("_")[-1])
+    now[0] = exp + 1
+    tok2 = tp.get_token("default", "tenantA", ["web.read"])
+    assert tok2 != tok1
+
+    # missing refresh token
+    secrets_no = {
+        "secrets": [
+            {
+                "provider": "default",
+                "tenant_id": "t2",
+                "version": "v1",
+                "client_id": "id",
+                "client_secret": "secretA",
+                "kid": "kid-003",
+            }
+        ]
+    }
+    store_no = SecretStore(data=secrets_no)
+    client = OAuthClient(clock=clock)
+    tp_no = TokenProvider(client, store_no, {"providers": {"default": {"scopes": ["web.read"], "prefetch_jitter_s": 30}}}, clock=clock)
+    tok = tp_no.get_token("default", "t2", ["web.read"])
+    exp2 = int(tok.split("_")[-1])
+    now[0] = exp2 + 1
+    with pytest.raises(TokenError) as exc:
+        tp_no.get_token("default", "t2", ["web.read"])
+    assert exc.value.code == "invalid_grant"

--- a/tests/test_secret_store.py
+++ b/tests/test_secret_store.py
@@ -1,0 +1,51 @@
+import logging
+
+from service.auth.secret_store import SecretStore
+
+
+def make_store():
+    data = {
+        "secrets": [
+            {
+                "provider": "default",
+                "tenant_id": "tenantA",
+                "version": "v1",
+                "client_id": "id1",
+                "client_secret": "secretA",
+                "refresh_token": "refreshA",
+                "kid": "kid-001",
+            }
+        ]
+    }
+    return SecretStore(data=data)
+
+
+def test_rotation_and_rollback():
+    store = make_store()
+    s1 = store.get("default", "tenantA")
+    assert s1["client_secret"] == "secretA"
+    store.set(
+        "default",
+        "tenantA",
+        {
+            "version": "v2",
+            "client_id": "id2",
+            "client_secret": "secretB",
+            "refresh_token": "refreshB",
+            "kid": "kid-002",
+        },
+    )
+    s2 = store.get("default", "tenantA")
+    assert s2["client_secret"] == "secretB"
+    old = store.get("default", "tenantA", version="v1")
+    assert old["client_secret"] == "secretA"
+    store.rollback("default", "tenantA")
+    again = store.get("default", "tenantA")
+    assert again["client_secret"] == "secretA"
+
+
+def test_repr_redacts_secrets():
+    store = make_store()
+    rep = repr(store)
+    assert "secretA" not in rep
+    assert "refreshA" not in rep


### PR DESCRIPTION
## Summary
- add simulated OAuth client and token provider with expiry-aware caching
- introduce versioned secret store with rotation and rollback utilities
- middleware attaches bearer tokens while keeping secrets out of logs

```
TokenProvider --> OAuthClient
      ^              |
      |              v
  SecretStore (versioned)
```

## Testing
- `pytest -k "oauth_token_provider or secret_store or oauth_integration"`


------
https://chatgpt.com/codex/tasks/task_e_68c7afe9a52083298d6014c9ea2589f9