### PR TITLE
adapters(cb): per-adapter circuit breakers + metrics + fallback + tests

### DIFF
--- a/.specs/NEW-041.md
+++ b/.specs/NEW-041.md
@@ -1,0 +1,14 @@
+# NEW-041 · Circuit Breakers for Adapters
+
+Implements per-adapter circuit breakers with metrics, jittered backoff and
+fallback handling. Breakers transition through `closed`, `open` and
+`half_open` states and expose metrics:
+- `alpha_adapter_breaker_state{adapter,state}`
+- `alpha_adapter_calls_total{adapter,result}`
+- `alpha_adapter_open_total{adapter}`
+
+Adapters automatically skip calls when open, returning a structured fallback so
+the router can fall back to LLM-only behavior.
+
+Tests cover failure storms, half-open recovery, metrics, latency and log
+redaction.

--- a/docs/CIRCUIT_BREAKERS.md
+++ b/docs/CIRCUIT_BREAKERS.md
@@ -1,0 +1,38 @@
+# Circuit Breakers
+
+Per-adapter circuit breakers guard flaky adapters and expose metrics.
+
+## States
+- **closed**: normal operation. Failures increment a counter.
+- **open**: adapter is skipped and a fallback result is returned.
+- **half_open**: limited trial after recovery timeout.
+
+### Transitions
+1. `closed` → `open` when consecutive failures reach the threshold.
+2. `open` → `half_open` after `recovery_timeout_ms`.
+3. `half_open` → `closed` on success.
+4. `half_open` → `open` on failure (jittered backoff applied).
+
+Defaults:
+```
+failure_threshold: 5
+recovery_timeout_ms: 10000
+half_open_max_calls: 1
+backoff_base_ms: 200 (±30% jitter)
+```
+
+## Metrics
+```
+alpha_adapter_breaker_state{adapter, state}
+alpha_adapter_calls_total{adapter, result="success|failure|fallback"}
+alpha_adapter_open_total{adapter}
+```
+
+## Fallback
+When a breaker is open the adapter is skipped and the router may fall back to
+LLM-only responses. The wrapper returns:
+`{"adapter_skipped": true, "reason": "circuit_open"}`.
+
+## Troubleshooting
+- Check `/metrics` for breaker state and open counters.
+- Reduce thresholds for noisy environments via adapter config.

--- a/service/adapters/base_adapter.py
+++ b/service/adapters/base_adapter.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
-"""Adapter retry wrapper with metrics and logging."""
+"""Adapter retry wrapper with circuit breaker and metrics."""
 
 from typing import Callable, Dict, Any
+import logging
 
 from .retry import retry_call
-from service.metrics.exporter import Counter, _REGISTRY
+from .circuit_breaker import CircuitBreaker
+from service.metrics.exporter import Counter, _REGISTRY, prom
 
+log = logging.getLogger(__name__)
+
+# Retry metrics ---------------------------------------------------------------
 _RETRY_TOTAL = Counter(
     "alpha_adapter_retry_total",
     "adapter retries",
@@ -19,6 +24,33 @@ _RETRY_SLEEP = Counter(
     ["adapter"],
     registry=_REGISTRY,
 )
+
+# Circuit breaker metrics ----------------------------------------------------
+_CALLS = Counter(
+    "alpha_adapter_calls_total",
+    "adapter calls",
+    ["adapter", "result"],
+    registry=_REGISTRY,
+)
+_OPEN_TOTAL = Counter(
+    "alpha_adapter_open_total",
+    "breaker opened",
+    ["adapter"],
+    registry=_REGISTRY,
+)
+_BREAKER_STATE = prom.Gauge(
+    "alpha_adapter_breaker_state",
+    "breaker state",
+    ["adapter", "state"],
+    registry=_REGISTRY,
+)
+
+_BREAKERS: dict[str, CircuitBreaker] = {}
+
+
+def _state_metrics(adapter: str, state: str) -> None:
+    for s in ("closed", "open", "half_open"):
+        _BREAKER_STATE.labels(adapter=adapter, state=s).set(1 if s == state else 0)
 
 
 def with_retry(
@@ -50,3 +82,40 @@ def with_retry(
     if isinstance(res, dict) and isinstance(res.get("meta"), dict):
         res["meta"]["attempts"] = attempts
     return res
+
+
+def call_adapter(
+    fn: Callable[[], Dict[str, Any]],
+    *,
+    adapter: str,
+    idempotent: bool,
+    budget_guard=None,
+) -> Dict[str, Any]:
+    """Execute ``fn`` guarded by a per-adapter circuit breaker."""
+
+    breaker = _BREAKERS.setdefault(adapter, CircuitBreaker(adapter))
+    if not breaker.allow_call():
+        _CALLS.labels(adapter=adapter, result="fallback").inc()
+        _state_metrics(adapter, breaker.state)
+        return {"adapter_skipped": True, "reason": "circuit_open"}
+
+    try:
+        res = with_retry(
+            fn,
+            adapter=adapter,
+            idempotent=idempotent,
+            budget_guard=budget_guard,
+        )
+    except Exception:
+        opened = breaker.record_failure()
+        _CALLS.labels(adapter=adapter, result="failure").inc()
+        _state_metrics(adapter, breaker.state)
+        if opened:
+            _OPEN_TOTAL.labels(adapter=adapter).inc()
+        raise
+
+    breaker.record_success()
+    _CALLS.labels(adapter=adapter, result="success").inc()
+    _state_metrics(adapter, breaker.state)
+    return res
+

--- a/service/adapters/circuit_breaker.py
+++ b/service/adapters/circuit_breaker.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+"""Simple per-adapter circuit breaker with jittered backoff."""
+
+from dataclasses import dataclass, field
+import random
+import time
+from typing import Literal
+
+State = Literal["closed", "open", "half_open"]
+
+
+@dataclass
+class CircuitBreaker:
+    adapter: str
+    failure_threshold: int = 5
+    recovery_timeout_ms: int = 10_000
+    half_open_max_calls: int = 1
+    backoff_base_ms: int = 200
+    backoff_jitter: float = 0.30
+
+    state: State = field(default="closed", init=False)
+    _failure_count: int = field(default=0, init=False)
+    _open_until: float = field(default=0.0, init=False)  # epoch seconds
+    _half_open_calls: int = field(default=0, init=False)
+
+    def allow_call(self) -> bool:
+        """Return True if call is allowed under breaker state."""
+        now = time.time()
+        if self.state == "open":
+            if now >= self._open_until:
+                self.state = "half_open"
+                self._half_open_calls = 0
+            else:
+                return False
+        if self.state == "half_open":
+            if self._half_open_calls >= self.half_open_max_calls:
+                return False
+            self._half_open_calls += 1
+        return True
+
+    def record_success(self) -> None:
+        self._failure_count = 0
+        if self.state in {"half_open", "open"}:
+            self.state = "closed"
+            self._open_until = 0.0
+
+    def record_failure(self) -> bool:
+        """Record a failure and return True if breaker moved to open."""
+        if self.state == "half_open":
+            self._trip(open_with_backoff=True)
+            return True
+        self._failure_count += 1
+        if self._failure_count >= self.failure_threshold:
+            self._trip(open_with_backoff=False)
+            return True
+        return False
+
+    # Internal ---------------------------------------------------------------
+    def _trip(self, *, open_with_backoff: bool) -> None:
+        self.state = "open"
+        self._failure_count = 0
+        base = self.recovery_timeout_ms
+        if open_with_backoff:
+            jitter = 1 + random.uniform(-self.backoff_jitter, self.backoff_jitter)
+            base += self.backoff_base_ms * jitter
+        self._open_until = time.time() + base / 1000.0
+
+    @property
+    def opened_until(self) -> float:
+        return self._open_until

--- a/service/adapters/gsheets_adapter.py
+++ b/service/adapters/gsheets_adapter.py
@@ -119,11 +119,11 @@ class GSheetsAdapter:
         idempotency_key: str | None = None,
         timeout_s: float = 5.0,
     ) -> Dict[str, Any]:
-        from .base_adapter import with_retry
+        from .base_adapter import call_adapter
 
         # treat operations as safe to retry since _run_once raises before mutation
         idem = True
-        return with_retry(
+        return call_adapter(
             lambda: self._run_once(payload, idempotency_key=idempotency_key, timeout_s=timeout_s),
             adapter=self.name(),
             idempotent=idem,

--- a/service/adapters/playwright_adapter.py
+++ b/service/adapters/playwright_adapter.py
@@ -82,10 +82,10 @@ class PlaywrightAdapter:
         idempotency_key: str | None = None,
         timeout_s: float = 5.0,
     ) -> Dict[str, Any]:
-        from .base_adapter import with_retry
+        from .base_adapter import call_adapter
 
         idempotent = payload.get("action") != "click"
-        return with_retry(
+        return call_adapter(
             lambda: self._run_once(payload, idempotency_key=idempotency_key, timeout_s=timeout_s),
             adapter=self.name(),
             idempotent=idempotent,

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -1,0 +1,100 @@
+import time
+import logging
+
+import pytest
+
+from service.adapters.circuit_breaker import CircuitBreaker
+from service.adapters.base_adapter import call_adapter, _BREAKERS
+from service.metrics.exporter import MetricsExporter
+
+
+def _metrics_text() -> str:
+    client = MetricsExporter().test_client()
+    return client.get("/metrics").text
+
+
+def test_open_and_fallback_metrics():
+    _BREAKERS["dummy"] = CircuitBreaker("dummy", failure_threshold=2, recovery_timeout_ms=50, backoff_base_ms=10)
+
+    def fail():
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError):
+        call_adapter(fail, adapter="dummy", idempotent=False)
+    with pytest.raises(RuntimeError):
+        call_adapter(fail, adapter="dummy", idempotent=False)
+    res = call_adapter(fail, adapter="dummy", idempotent=False)
+    assert res == {"adapter_skipped": True, "reason": "circuit_open"}
+
+    metrics = _metrics_text()
+    assert 'alpha_adapter_calls_total{adapter="dummy",result="failure"} 2.0' in metrics
+    assert 'alpha_adapter_calls_total{adapter="dummy",result="fallback"} 1.0' in metrics
+    assert 'alpha_adapter_breaker_state{adapter="dummy",state="open"} 1.0' in metrics
+    assert 'alpha_adapter_open_total{adapter="dummy"} 1.0' in metrics
+
+
+def test_half_open_recovery_and_failure_backoff():
+    breaker = CircuitBreaker("dummy2", failure_threshold=1, recovery_timeout_ms=20, backoff_base_ms=10)
+    _BREAKERS["dummy2"] = breaker
+
+    def fail():
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError):
+        call_adapter(fail, adapter="dummy2", idempotent=False)
+    assert call_adapter(fail, adapter="dummy2", idempotent=False) == {"adapter_skipped": True, "reason": "circuit_open"}
+    first_open = breaker.opened_until
+    time.sleep(0.03)  # allow transition to half-open
+
+    def succeed():
+        return {"ok": True}
+
+    res = call_adapter(succeed, adapter="dummy2", idempotent=False)
+    assert res["ok"] is True
+    metrics = _metrics_text()
+    assert 'alpha_adapter_breaker_state{adapter="dummy2",state="closed"} 1.0' in metrics
+
+    # trip again and fail during half-open
+    with pytest.raises(RuntimeError):
+        call_adapter(fail, adapter="dummy2", idempotent=False)
+    assert call_adapter(fail, adapter="dummy2", idempotent=False) == {"adapter_skipped": True, "reason": "circuit_open"}
+    time.sleep(0.03)
+    with pytest.raises(RuntimeError):
+        call_adapter(fail, adapter="dummy2", idempotent=False)
+    assert call_adapter(fail, adapter="dummy2", idempotent=False) == {"adapter_skipped": True, "reason": "circuit_open"}
+    second_open = breaker.opened_until
+    assert second_open - time.time() > (breaker.recovery_timeout_ms + breaker.backoff_base_ms * 0.5) / 1000.0
+    assert second_open > first_open
+
+
+def test_failure_storm_latency_p95():
+    _BREAKERS["storm"] = CircuitBreaker("storm", failure_threshold=1, recovery_timeout_ms=1000)
+
+    def fail():
+        raise RuntimeError("boom")
+
+    lat = []
+    for _ in range(20):
+        start = time.time()
+        try:
+            call_adapter(fail, adapter="storm", idempotent=False)
+        except RuntimeError:
+            pass
+        lat.append(time.time() - start)
+    lat.sort()
+    p95 = lat[int(len(lat) * 0.95) - 1]
+    assert p95 < 5.0
+
+
+def test_no_secrets_in_logs(caplog):
+    _BREAKERS["log"] = CircuitBreaker("log", failure_threshold=1, recovery_timeout_ms=50)
+    secret = "super_secret_token"
+
+    def fail():
+        raise RuntimeError(secret)
+
+    with caplog.at_level(logging.INFO):
+        with pytest.raises(RuntimeError):
+            call_adapter(fail, adapter="log", idempotent=False)
+    for rec in caplog.records:
+        assert secret not in rec.getMessage()


### PR DESCRIPTION
## Summary
- add reusable CircuitBreaker with jittered backoff and states
- wrap adapters with call_adapter that exports metrics and fallback when open
- document breaker behavior and enforce with tests

## Testing
- `pytest -q -k circuit_breaker`

## State Machine
```
closed --(failures)--> open --(timeout)--> half_open
half_open --(success)--> closed
half_open --(failure)--> open (jittered backoff)
```

## Metrics
```
alpha_adapter_breaker_state{adapter="dummy",state="open"} 1
alpha_adapter_calls_total{adapter="dummy",result="fallback"} 1
alpha_adapter_open_total{adapter="dummy"} 1
```

------
https://chatgpt.com/codex/tasks/task_e_68c7bb3b79d48329b4cc6b24a0a647a1