### PR TITLE
docs(evidence): add runnable examples + API reference; enforce ≥90% docstrings

### DIFF
--- a/.specs/NEW-032.md
+++ b/.specs/NEW-032.md
@@ -1,0 +1,5 @@
+# NEW-032 · Evidence Pack & Docstrings Coverage
+
+Implements documentation, evidence examples, and docstring coverage tooling.
+Includes runnable examples, API reference, how-to guides, and tests to ensure
+examples and documentation build cleanly.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,0 +1,13 @@
+# API Reference
+
+This document lists the public API surface for the Alpha Solver service layer.
+
+- `alpha.executors.math_exec` – local math evaluation helper `evaluate`.
+- `service.security` – utilities like `sanitize_query`.
+- `service.alerts` – `AlertManager` for latency/budget alerts.
+- `service.otel` – tracing helpers `init_tracer`, `span`, `get_exported_spans`.
+- `service.logging.redactor` – `redact` strings and mappings with PII removal.
+- `service.gating.gates` – routing gate evaluation via `GateConfig` and `evaluate_gates`.
+- `service.tenancy.context` – tenant resolution helpers `extract_tenant_id`, `require_tenant_id`.
+- `service.mcp.policy_auth` – token providers such as `OAuthClientCredentials`.
+- `service.auth.api_keys` – minimal API key management helpers.

--- a/docs/EVIDENCE_PACK.md
+++ b/docs/EVIDENCE_PACK.md
@@ -1,0 +1,97 @@
+# Evidence Pack
+
+## CLI Help
+
+```bash
+python alpha_solver_cli.py --help
+```
+
+```text
+--multi-branch
+```
+
+## Basic Solve (LLM-only)
+
+```python
+from alpha.executors.math_exec import evaluate
+print(evaluate("2+2")["result"])
+```
+
+```text
+4.0
+```
+
+## Route with Budget Gate Verdict
+
+```python
+from service.gating.gates import evaluate_gates
+decision, info = evaluate_gates(confidence=0.2, budget_tokens=100, policy_flags={})
+print(decision, info["budget_verdict"])
+```
+
+```text
+clarify low
+```
+
+## Policy/PII Redaction Before Log
+
+```python
+from service.logging.redactor import redact
+print(redact("Contact me at a@b.com"))
+```
+
+```text
+Contact me at a***@b***.com
+```
+
+## Replay 10/10
+
+```python
+from alpha.core.replay import ReplayHarness
+h = ReplayHarness(base_dir="artifacts/replay_tmp")
+for i in range(10):
+    h.record({"i": i})
+sid = h.save("demo")
+session = h.load("demo")
+h.load_for_replay("demo")
+for ev in session.events:
+    h.verify(ev)
+print(len(session.events))
+```
+
+```text
+10
+```
+
+## Tracing/Metrics Quick Check
+
+```python
+import logging
+from service.otel import init_tracer, span, get_exported_spans, reset_exported_spans
+logging.getLogger().setLevel(logging.ERROR)
+reset_exported_spans(); init_tracer()
+with span("demo", user_input="secret", answer=42):
+    pass
+spans = get_exported_spans()
+print(len(spans), "answer" in spans[0].attributes, "user_input" in spans[0].attributes)
+```
+
+```text
+1 True False
+```
+
+## MCP Adapter Call
+
+```python
+import os
+from service.mcp.policy_auth import OAuthClientCredentials, attach_auth_headers
+os.environ["CLIENT_ID"] = "id"
+os.environ["CLIENT_SECRET"] = "secret"
+provider = OAuthClientCredentials("https://auth", "CLIENT_ID", "CLIENT_SECRET")
+req = attach_auth_headers({}, provider)
+print(req["Authorization"])
+```
+
+```text
+Bearer oauth-token-1
+```

--- a/docs/howto/QUICK_INTEGRATION.md
+++ b/docs/howto/QUICK_INTEGRATION.md
@@ -1,0 +1,20 @@
+# Quick Integration
+
+Use the Alpha Solver components in your application:
+
+1. Install package and set up environment.
+2. Fetch a token or API key if required.
+3. Call the solver utilities.
+
+Example using the local math evaluator:
+
+```python
+from alpha.executors.math_exec import evaluate
+print(evaluate("1+2")["result"])
+```
+
+Run the CLI for help on available flags:
+
+```bash
+python alpha_solver_cli.py --help
+```

--- a/docs/howto/REPLAY_AND_DEBUG.md
+++ b/docs/howto/REPLAY_AND_DEBUG.md
@@ -1,0 +1,20 @@
+# Replay and Debug
+
+The replay harness captures and verifies event sequences.
+
+```python
+from alpha.core.replay import ReplayHarness
+h = ReplayHarness(base_dir="artifacts/replay_tmp")
+# ... record events ...
+h.save("session")
+```
+
+For debugging spans and metrics:
+
+```python
+from service.otel import init_tracer, span, get_exported_spans
+init_tracer()
+with span("debug"):
+    pass
+print(get_exported_spans())
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,3 +91,16 @@ include = [
     "service/metrics/*",
 ]
 fail_under = 95
+
+[tool.docs]
+modules = [
+    "service.security",
+    "service.alerts",
+    "service.otel",
+    "service.logging.redactor",
+    "service.gating.gates",
+    "service.tenancy.context",
+    "service.mcp.policy_auth",
+    "service.auth.api_keys",
+    "alpha.executors.math_exec",
+]

--- a/scripts/check_docstrings.py
+++ b/scripts/check_docstrings.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Check docstring coverage for public API modules.
+
+Modules are taken from ``[tool.docs]`` in ``pyproject.toml``. Only symbols
+exported via ``__all__`` are considered public. Modules without ``__all__`` are
+ignored.  The script reports the overall coverage and fails if below the
+specified threshold.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from pathlib import Path
+
+try:  # Python 3.11+
+    import tomllib
+except Exception:  # pragma: no cover
+    import tomli as tomllib  # type: ignore
+
+
+def load_modules(pyproject: Path) -> list[str]:
+    data = tomllib.loads(pyproject.read_text())
+    return data.get("tool", {}).get("docs", {}).get("modules", [])
+
+
+def iter_public_defs(path: Path):
+    tree = ast.parse(path.read_text())
+    module_all = None
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for tgt in node.targets:
+                if isinstance(tgt, ast.Name) and tgt.id == "__all__":
+                    try:
+                        module_all = {elt.s for elt in node.value.elts}
+                    except Exception:  # pragma: no cover - malformed __all__
+                        module_all = None
+    if module_all is None:
+        return
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            name = node.name
+            if name.startswith("_"):
+                continue
+            if module_all is not None and name not in module_all:
+                continue
+            yield name, ast.get_docstring(node)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--fail-under", type=float, default=90.0)
+    args = ap.parse_args(argv)
+
+    modules = load_modules(Path("pyproject.toml"))
+    total = covered = 0
+    for mod in modules:
+        path = Path(mod.replace(".", "/") + ".py")
+        if not path.exists():
+            continue
+        for name, doc in iter_public_defs(path) or []:
+            total += 1
+            if doc:
+                covered += 1
+    percent = (covered / total * 100.0) if total else 100.0
+    print(f"docstring coverage: {percent:.1f}% ({covered}/{total})")
+    if percent < args.fail_under:
+        print(f"coverage below threshold {args.fail_under}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_evidence_examples.py
+++ b/tests/test_evidence_examples.py
@@ -1,0 +1,41 @@
+import io
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+try:  # Python 3.11+
+    import tomllib
+except Exception:  # pragma: no cover
+    import tomli as tomllib  # type: ignore
+
+EXAMPLE_RE = re.compile(
+    r"```(python|bash)\n(.*?)```\n```text\n(.*?)```",
+    re.DOTALL,
+)
+
+def iter_examples():
+    text = Path('docs/EVIDENCE_PACK.md').read_text()
+    for match in EXAMPLE_RE.finditer(text):
+        lang, code, expected = match.groups()
+        yield lang, code.strip(), expected.strip()
+
+def test_examples_run():
+    for lang, code, expected in iter_examples():
+        if lang == 'python':
+            proc = subprocess.run([sys.executable, '-c', code], capture_output=True, text=True)
+            output = proc.stdout.strip()
+            assert proc.returncode == 0
+        else:
+            proc = subprocess.run(code, shell=True, capture_output=True, text=True)
+            output = proc.stdout.strip()
+            assert proc.returncode == 0
+        assert expected in output
+
+def test_docs_build_clean():
+    cfg = tomllib.loads(Path('pyproject.toml').read_text())
+    modules = cfg.get('tool', {}).get('docs', {}).get('modules', [])
+    for mod in modules:
+        proc = subprocess.run([sys.executable, '-m', 'pydoc', mod], capture_output=True, text=True)
+        output = proc.stdout + proc.stderr
+        assert 'WARNING' not in output


### PR DESCRIPTION
## Summary
- add runnable evidence pack and how-to docs
- generate API reference and doc build config
- enforce docstring coverage with script and tests

## Testing
- `python scripts/check_docstrings.py --fail-under 90`
- `pytest -q -k evidence_examples`


------
https://chatgpt.com/codex/tasks/task_e_68c7bdf75d2483299f96ccbb9b437bee