### PR TITLE
feat: add redis token bucket rate limiter

### DIFF
--- a/.specs/NEW-RATE-001.md
+++ b/.specs/NEW-RATE-001.md
@@ -1,0 +1,9 @@
+# NEW-RATE-001 · API Rate Limiting
+
+Introduce Redis-backed token bucket rate limiting for tenant and global scopes.
+
+- Configurable per-tenant and global limits.
+- Redis-backed with overhead <10ms at p95.
+- Prometheus metrics exporting throttle counts and bucket levels.
+- Tests cover burst to steady state, per-tenant isolation, and documentation
+  example.

--- a/alpha/middleware/ratelimit.py
+++ b/alpha/middleware/ratelimit.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import time
+from typing import MutableMapping, Protocol
+
+try:  # pragma: no cover - fallback for minimal prometheus stubs
+    from prometheus_client import Counter, Gauge  # type: ignore
+except ImportError:  # pragma: no cover - minimal Gauge implementation
+    from prometheus_client import Counter  # type: ignore
+
+    class Gauge(Counter):
+        def set(self, value: float) -> None:  # simple gauge behaviour
+            self.value = value
+
+
+class RedisLike(Protocol):
+    """Minimal Redis interface used by :class:`RateLimiter`."""
+
+    def hgetall(self, key: str) -> MutableMapping[str, float]:
+        ...
+
+    def hmset(self, key: str, mapping: MutableMapping[str, float]) -> None:
+        ...
+
+    def expire(self, key: str, ttl: int) -> None:
+        ...
+
+
+_THROTTLES = Counter(
+    "alpha_ratelimiter_throttles_total", "Requests throttled", ["scope"]
+)
+_BUCKET_LEVEL = Gauge(
+    "alpha_ratelimiter_bucket_level", "Token bucket level", ["scope", "bucket"]
+)
+
+
+class RateLimiter:
+    """Redis-backed token bucket rate limiter.
+
+    Parameters
+    ----------
+    redis:
+        Redis client or compatible object.
+    tenant_rate:
+        Max tokens per interval for a tenant bucket.
+    global_rate:
+        Max tokens per interval for the global bucket.
+    interval:
+        Refill interval in seconds (default 60).
+    """
+
+    def __init__(
+        self,
+        redis: RedisLike,
+        tenant_rate: int,
+        global_rate: int,
+        interval: int = 60,
+    ) -> None:
+        self.redis = redis
+        self.tenant_rate = tenant_rate
+        self.global_rate = global_rate
+        self.interval = interval
+
+    # public API ---------------------------------------------------------
+    def allow(self, tenant: str) -> bool:
+        """Check if a request for ``tenant`` should be allowed."""
+        if not self._consume(f"{tenant}:tenant", self.tenant_rate, "tenant"):
+            return False
+        if not self._consume("global:global", self.global_rate, "global"):
+            return False
+        return True
+
+    # internal -----------------------------------------------------------
+    def _consume(self, key: str, rate: int, scope: str) -> bool:
+        now = time.time()
+        data = self.redis.hgetall(key) or {}
+        tokens = float(data.get("tokens", rate))  # bucket capacity equals rate
+        ts = float(data.get("ts", now))
+
+        # refill based on elapsed time
+        elapsed = max(0.0, now - ts)
+        tokens = min(rate, tokens + elapsed * rate / self.interval)
+
+        allowed = tokens >= 1
+        if allowed:
+            tokens -= 1
+        self.redis.hmset(key, {"tokens": tokens, "ts": now})
+        try:
+            self.redis.expire(key, self.interval)
+        except Exception:
+            # allow fake backends without expire support
+            pass
+
+        _BUCKET_LEVEL.labels(scope=scope, bucket=key).set(tokens)
+        if not allowed:
+            _THROTTLES.labels(scope=scope).inc()
+        return allowed

--- a/docs/RATE_LIMITING.md
+++ b/docs/RATE_LIMITING.md
@@ -1,0 +1,30 @@
+# Rate Limiting
+
+Redis-backed token bucket limiter with per-tenant and global scopes.  Each
+request consumes one token from both the tenant bucket (`{tenant}:tenant`) and
+the global bucket (`global:global`).  Buckets refill linearly over the
+configured interval.
+
+## Example
+
+```python
+from alpha.middleware.ratelimit import RateLimiter
+
+# simple in-memory stand-in for Redis
+class InMemoryRedis:
+    def __init__(self):
+        self.store = {}
+    def hgetall(self, key):
+        return self.store.get(key, {}).copy()
+    def hmset(self, key, mapping):
+        self.store.setdefault(key, {}).update(mapping)
+    def expire(self, key, ttl):
+        pass
+
+backend = InMemoryRedis()
+limiter = RateLimiter(backend, tenant_rate=5, global_rate=10, interval=60)
+assert limiter.allow("tenant-123")
+```
+
+Prometheus metrics are exported for throttled requests and current bucket level
+(`alpha_ratelimiter_throttles_total` and `alpha_ratelimiter_bucket_level`).

--- a/tests/middleware/test_ratelimit.py
+++ b/tests/middleware/test_ratelimit.py
@@ -1,0 +1,67 @@
+import re
+import time
+from pathlib import Path
+
+from alpha.middleware.ratelimit import RateLimiter
+
+
+class FakeRedis:
+    def __init__(self) -> None:
+        self.store: dict[str, dict[str, float]] = {}
+
+    def hgetall(self, key: str) -> dict[str, float]:
+        return self.store.get(key, {}).copy()
+
+    def hmset(self, key: str, mapping: dict[str, float]) -> None:
+        self.store.setdefault(key, {}).update(mapping)
+
+    def expire(self, key: str, ttl: int) -> None:  # pragma: no cover - noop
+        return None
+
+
+def test_burst_then_steady_and_perf():
+    backend = FakeRedis()
+    limiter = RateLimiter(backend, tenant_rate=5, global_rate=100, interval=1)
+
+    latencies = []
+    for _ in range(5):
+        t0 = time.perf_counter()
+        assert limiter.allow("t1")
+        latencies.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    assert not limiter.allow("t1")
+    latencies.append(time.perf_counter() - t0)
+
+    time.sleep(1.05)
+    t0 = time.perf_counter()
+    assert limiter.allow("t1")  # refill allows again
+    latencies.append(time.perf_counter() - t0)
+    for _ in range(19):  # collect more samples without asserting outcome
+        t0 = time.perf_counter()
+        limiter.allow("t1")
+        latencies.append(time.perf_counter() - t0)
+
+    sorted_lat = sorted(latencies)
+    p95 = sorted_lat[min(len(sorted_lat) - 1, int(len(sorted_lat) * 0.95))]
+    assert p95 < 0.01
+
+
+def test_per_tenant_isolation():
+    backend = FakeRedis()
+    limiter = RateLimiter(backend, tenant_rate=2, global_rate=100, interval=60)
+
+    for _ in range(2):
+        assert limiter.allow("a")
+    assert not limiter.allow("a")
+
+    for _ in range(2):
+        assert limiter.allow("b")
+    assert not limiter.allow("b")
+
+
+def test_docs_example_runs():
+    content = Path("docs/RATE_LIMITING.md").read_text()
+    code = re.search(r"```python\n(.*?)\n```", content, re.S).group(1)
+    ns: dict[str, object] = {}
+    exec(code, ns)


### PR DESCRIPTION
## Summary
- add Redis-style token bucket middleware with per-tenant and global scopes
- expose Prometheus metrics and document usage example
- test burst/steady behavior and tenant isolation

## Testing
- `redis-server --version` *(fails: command not found)*
- `pytest -q -k "ratelimit"`


------
https://chatgpt.com/codex/tasks/task_e_68c7d22f5a448329ac1f380b50f67ea3