### PR TITLE
Implement NEW-HEALTH-001 health check module

### DIFF
--- a/.specs/NEW-HEALTH-001.md
+++ b/.specs/NEW-HEALTH-001.md
@@ -1,0 +1,21 @@
+# NEW-HEALTH-001 — Health Check Endpoints
+
+## Goal
+Expose `/health` with dependency checks for Redis, the vector database and the
+model provider.
+
+## Acceptance Criteria
+- `/health` returns `{"app": "ok", "redis": "ok|down", "vectordb": "ok|down", "provider": "ok|down", "ts": ...}`.
+- Local p95 latency below 50 ms once the cache is warm.
+- CI includes 10/10 tests for the endpoint.
+
+## Implementation Notes
+- `alpha.api.health.HealthChecker` orchestrates dependency probes and memoises
+  the result for a short TTL to satisfy the latency budget.
+- The FastAPI router returned by `build_health_router` exposes the `/health`
+  route and can be mounted into the service application.
+- Probes may be synchronous or asynchronous callables; exceptions or falsey
+  return values mark the dependency as `"down"`.
+
+## Testing
+- `pytest tests/api/test_health.py`

--- a/alpha/api/health.py
+++ b/alpha/api/health.py
@@ -1,0 +1,151 @@
+"""Health check utilities for the Alpha Solver HTTP surface."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Awaitable, Callable, Dict, Mapping
+
+from typing_extensions import TypedDict
+
+from fastapi import APIRouter
+
+
+class HealthPayload(TypedDict):
+    """JSON payload returned by the ``/health`` endpoint."""
+
+    app: str
+    redis: str
+    vectordb: str
+    provider: str
+    ts: str
+
+
+Probe = Callable[[], Awaitable[object] | object]
+Clock = Callable[[], float]
+
+
+def _iso_timestamp() -> str:
+    """Return the current UTC timestamp formatted for JSON payloads."""
+
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+async def _run_probe(probe: Probe) -> str:
+    """Execute a dependency probe and normalise its status.
+
+    A probe is expected to return a truthy value on success. Any exception raised
+    by the probe is treated as a failure and results in a ``"down"`` status.
+    """
+
+    try:
+        result = probe()
+        if inspect.isawaitable(result):
+            result = await result
+    except Exception:
+        return "down"
+
+    if result is None:
+        return "ok"
+    try:
+        return "ok" if bool(result) else "down"
+    except Exception:
+        return "ok"
+
+
+@dataclass
+class HealthChecker:
+    """Aggregate dependency probes into the health payload.
+
+    The checker executes Redis, Vector DB and model provider probes and caches the
+    resulting status for ``cache_ttl`` seconds. Caching keeps subsequent endpoint
+    calls comfortably under the 50ms latency budget after the first (warm cache)
+    request.
+    """
+
+    redis_probe: Probe
+    vectordb_probe: Probe
+    provider_probe: Probe
+    cache_ttl: float = 5.0
+    clock: Clock = time.monotonic
+    _cache: Mapping[str, str] | None = field(default=None, init=False)
+    _cached_at: float | None = field(default=None, init=False)
+    _lock: asyncio.Lock | None = field(default=None, init=False, repr=False)
+
+    async def check(self) -> HealthPayload:
+        """Return the aggregated health payload, using the warm cache when valid."""
+
+        cached = self._cached_status()
+        if cached:
+            return self._compose_payload(cached)
+
+        lock = self._ensure_lock()
+        async with lock:
+            cached = self._cached_status()
+            if cached:
+                return self._compose_payload(cached)
+
+            statuses = await self._evaluate()
+            self._cache = statuses
+            self._cached_at = self.clock()
+
+        return self._compose_payload(statuses)
+
+    def invalidate(self) -> None:
+        """Clear the cached health status, forcing fresh probes on next call."""
+
+        self._cache = None
+        self._cached_at = None
+
+    def _cached_status(self) -> Mapping[str, str] | None:
+        if self._cache is None or self._cached_at is None:
+            return None
+        if self.clock() - self._cached_at >= self.cache_ttl:
+            return None
+        return self._cache
+
+    def _ensure_lock(self) -> asyncio.Lock:
+        lock = self._lock
+        if lock is None:
+            lock = asyncio.Lock()
+            self._lock = lock
+        return lock
+
+    async def _evaluate(self) -> Dict[str, str]:
+        redis_status, vectordb_status, provider_status = await asyncio.gather(
+            _run_probe(self.redis_probe),
+            _run_probe(self.vectordb_probe),
+            _run_probe(self.provider_probe),
+        )
+        return {
+            "redis": redis_status,
+            "vectordb": vectordb_status,
+            "provider": provider_status,
+        }
+
+    def _compose_payload(self, statuses: Mapping[str, str]) -> HealthPayload:
+        return {
+            "app": "ok" if all(status == "ok" for status in statuses.values()) else "down",
+            "redis": statuses.get("redis", "down"),
+            "vectordb": statuses.get("vectordb", "down"),
+            "provider": statuses.get("provider", "down"),
+            "ts": _iso_timestamp(),
+        }
+
+
+def build_health_router(checker: HealthChecker) -> APIRouter:
+    """Return a FastAPI router exposing ``/health`` backed by ``checker``."""
+
+    router = APIRouter()
+
+    @router.get("/health", name="health", tags=["health"])
+    async def health_endpoint() -> HealthPayload:  # pragma: no cover - exercised via router
+        return await checker.check()
+
+    return router
+
+
+__all__ = ["HealthChecker", "HealthPayload", "build_health_router"]

--- a/docs/HEALTH.md
+++ b/docs/HEALTH.md
@@ -1,0 +1,57 @@
+# Health Endpoint
+
+The Alpha Solver exposes a JSON health endpoint that reports the status of its
+critical dependencies. The endpoint is designed for infrastructure and
+observability systems that need to quickly decide whether the API is ready to
+serve traffic.
+
+## Route
+
+- `GET /health`
+
+## Response Schema
+
+```json
+{
+  "app": "ok",
+  "redis": "ok",
+  "vectordb": "ok",
+  "provider": "ok",
+  "ts": "2024-03-22T18:25:43.511Z"
+}
+```
+
+Key fields:
+
+- `app` – Aggregated service status. The value is `"ok"` when all dependency
+  probes succeed, otherwise `"down"`.
+- `redis` – Result of the Redis connectivity probe (`ping` style check).
+- `vectordb` – Result of the vector database probe.
+- `provider` – Result of the configured model provider probe.
+- `ts` – ISO-8601 UTC timestamp indicating when the health result was produced.
+
+## Implementation Notes
+
+The endpoint is backed by `alpha.api.health.HealthChecker`. Probes are provided
+as callables and may be synchronous or `async def`. Failures (exceptions or
+falsey return values) are mapped to the string `"down"`.
+
+To keep tail latencies low, the checker memoises the dependency results for a
+short window (default 5 seconds). With a warm cache, health responses complete
+well within the 50 ms latency target.
+
+### Example Integration
+
+```python
+from fastapi import FastAPI
+from alpha.api.health import HealthChecker, build_health_router
+
+app = FastAPI()
+checker = HealthChecker(redis_client.ping, vectordb.health, provider.ping)
+app.include_router(build_health_router(checker))
+```
+
+## Testing
+
+Unit tests for the health endpoint live in `tests/api/test_health.py`. They
+exercise the payload schema, failure handling and warm-cache latency budget.

--- a/tests/api/test_health.py
+++ b/tests/api/test_health.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from datetime import datetime, timezone
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from alpha.api.health import HealthChecker, build_health_router
+
+
+class SlowProbe:
+    def __init__(self, delay: float = 0.08) -> None:
+        self.delay = delay
+        self.calls = 0
+
+    async def __call__(self) -> bool:
+        self.calls += 1
+        await asyncio.sleep(self.delay)
+        return True
+
+
+def test_health_checker_success_payload() -> None:
+    async def scenario() -> None:
+        checker = HealthChecker(lambda: True, lambda: "pong", lambda: object())
+
+        payload = await checker.check()
+
+        assert payload["app"] == "ok"
+        assert payload["redis"] == "ok"
+        assert payload["vectordb"] == "ok"
+        assert payload["provider"] == "ok"
+
+        ts = payload["ts"]
+        parsed = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        assert parsed.tzinfo is not None
+        assert parsed <= datetime.now(timezone.utc)
+
+    asyncio.run(scenario())
+
+
+def test_health_checker_failure_marks_app_down() -> None:
+    async def scenario() -> None:
+        def failing_probe() -> bool:
+            raise RuntimeError("boom")
+
+        checker = HealthChecker(lambda: True, failing_probe, lambda: True)
+
+        payload = await checker.check()
+
+        assert payload["vectordb"] == "down"
+        assert payload["app"] == "down"
+
+    asyncio.run(scenario())
+
+
+def test_health_checker_warm_cache_under_latency_budget() -> None:
+    async def scenario() -> None:
+        slow = SlowProbe()
+        checker = HealthChecker(slow, lambda: True, lambda: True, cache_ttl=5.0)
+
+        await checker.check()  # warm cache
+
+        start = time.perf_counter()
+        payload = await checker.check()
+        duration_ms = (time.perf_counter() - start) * 1000
+
+        assert duration_ms < 50.0
+        assert payload["redis"] == "ok"
+        assert slow.calls == 1
+
+    asyncio.run(scenario())
+
+
+def test_health_router_smoke() -> None:
+    checker = HealthChecker(lambda: True, lambda: True, lambda: True)
+    app = FastAPI()
+    app.include_router(build_health_router(checker))
+    client = TestClient(app)
+
+    response = client.get("/health")
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["app"] == "ok"
+    assert payload["redis"] == "ok"
+    assert "ts" in payload


### PR DESCRIPTION
## Summary
- add a reusable `HealthChecker` and FastAPI router for `/health`, including dependency probes and caching
- document the health endpoint contract and capture the NEW-HEALTH-001 spec details
- cover the new functionality with unit tests for payload shape, failure handling, and latency budget

## Testing
- pytest tests/api/test_health.py

------
https://chatgpt.com/codex/tasks/task_e_68c8409254d0832983fd70f3b13cd871