### PR TITLE
Add Grafana dashboards and validation tests

### DIFF
--- a/.specs/EPIC_DASH_001.md
+++ b/.specs/EPIC_DASH_001.md
@@ -1,0 +1,22 @@
+---
+id: EPIC_DASH_001
+title: Dashboards & Admin
+owner: alpha-solver
+phase: Next
+priority: P2A
+track: RES_Dash
+spec_version: 1.0
+---
+## Goal
+Ship production-ready dashboards for gates, replay, budget, adapters, reliability SLOs.
+
+## Acceptance Criteria
+- All panels render from live metrics; dashboard loads < 2s locally
+- Prometheus queries pass validation; 10/10 CI checks
+- Obs-card snippet prints per run; README section updated
+
+## Code Targets
+- alpha/dashboard/panels.json (proposed)
+- alpha/dashboard/alerts.json (proposed)
+- tests/dashboard/test_dash_config.py
+- docs/DASHBOARDS.md

--- a/alpha/dashboard/alerts.json
+++ b/alpha/dashboard/alerts.json
@@ -1,0 +1,43 @@
+{
+  "alerts": [
+    {
+      "name": "Gate Decision Denial Spike",
+      "expr": "(sum(rate(gate_decisions_total{environment=\"prod\",decision=\"denied\"}[5m])) / sum(rate(gate_decisions_total{environment=\"prod\"}[5m]))) > 0.20",
+      "for": "5m",
+      "labels": {
+        "severity": "warning",
+        "team": "release"
+      },
+      "annotations": {
+        "summary": "Gate denials exceeded 20% over the last 5 minutes.",
+        "runbook": "https://runbooks.alpha/observability/gates"
+      }
+    },
+    {
+      "name": "Adapter Latency Regression",
+      "expr": "quantile_over_time(0.95, adapter_latency_ms{environment=\"prod\"}[5m]) > 750",
+      "for": "10m",
+      "labels": {
+        "severity": "critical",
+        "team": "adapters"
+      },
+      "annotations": {
+        "summary": "Adapter latency P95 breached 750ms threshold.",
+        "runbook": "https://runbooks.alpha/observability/adapters"
+      }
+    },
+    {
+      "name": "Reliability SLO Burn",
+      "expr": "(1 - ((sum(rate(retries_total{environment=\"prod\"}[30m])) + sum(rate(breaker_open_total{environment=\"prod\"}[30m]))) / sum(rate(requests_total{environment=\"prod\"}[30m])))) < 0.995",
+      "for": "30m",
+      "labels": {
+        "severity": "critical",
+        "team": "reliability"
+      },
+      "annotations": {
+        "summary": "Composite reliability SLO dipped below 99.5% over the last 30 minutes.",
+        "runbook": "https://runbooks.alpha/observability/reliability"
+      }
+    }
+  ]
+}

--- a/alpha/dashboard/panels.json
+++ b/alpha/dashboard/panels.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://grafana.com/schemas/v11/dashboard.schema.json",
+  "title": "Alpha Production Observability",
+  "refresh": "30s",
+  "timezone": "browser",
+  "panels": [
+    {
+      "id": "gate-decisions-rate",
+      "title": "Gate Decisions (5m rate)",
+      "type": "timeseries",
+      "datasource": "Prometheus",
+      "unit": "ops",
+      "description": "Track the rolling decision rate coming from automated gating.",
+      "targets": [
+        {
+          "expr": "sum by (decision) (rate(gate_decisions_total{environment=\"prod\"}[5m]))",
+          "legend": "{{decision}}",
+          "format": "time_series"
+        }
+      ],
+      "interval": "30s"
+    },
+    {
+      "id": "replay-pass-ratio",
+      "title": "Replay Pass Throughput",
+      "type": "timeseries",
+      "datasource": "Prometheus",
+      "unit": "ops",
+      "description": "How many replay runs succeed per minute across prod environments.",
+      "targets": [
+        {
+          "expr": "sum(rate(replay_pass_total{environment=\"prod\"}[5m]))",
+          "legend": "passes",
+          "format": "time_series"
+        }
+      ],
+      "interval": "30s"
+    },
+    {
+      "id": "budget-spend-cents",
+      "title": "Budget Spend (¢ per hour)",
+      "type": "stat",
+      "datasource": "Prometheus",
+      "unit": "cents",
+      "description": "Hourly budget spend derived from the cents counter.",
+      "targets": [
+        {
+          "expr": "sum(increase(budget_spend_cents{environment=\"prod\"}[1h]))",
+          "legend": "hourly spend",
+          "format": "time_series"
+        }
+      ],
+      "interval": "1m"
+    },
+    {
+      "id": "adapter-latency",
+      "title": "Adapter Latency P95",
+      "type": "timeseries",
+      "datasource": "Prometheus",
+      "unit": "milliseconds",
+      "description": "P95 latency for adapter calls aggregated across adapters.",
+      "targets": [
+        {
+          "expr": "quantile_over_time(0.95, adapter_latency_ms{environment=\"prod\"}[5m])",
+          "legend": "p95",
+          "format": "time_series"
+        }
+      ],
+      "interval": "30s"
+    },
+    {
+      "id": "reliability-slo",
+      "title": "Reliability SLO",
+      "type": "stat",
+      "datasource": "Prometheus",
+      "unit": "percent",
+      "description": "Rolling 30m SLO derived from retries and breaker open events.",
+      "targets": [
+        {
+          "expr": "(1 - ((sum(rate(retries_total{environment=\"prod\"}[30m])) + sum(rate(breaker_open_total{environment=\"prod\"}[30m]))) / sum(rate(requests_total{environment=\"prod\"}[30m])))) * 100",
+          "legend": "SLO",
+          "format": "time_series"
+        }
+      ],
+      "interval": "30s"
+    }
+  ]
+}

--- a/docs/DASHBOARDS.md
+++ b/docs/DASHBOARDS.md
@@ -1,0 +1,41 @@
+# Dashboards & Admin (EPIC_DASH_001)
+
+The Alpha Production Observability dashboard ships a curated slice of the core runtime metrics: gate decisions, replay outcomes, budget burn, adapter performance, and a composite reliability SLO. Use this document as the handoff for ops and release partners when rolling the dashboard into shared Grafana instances.
+
+## Importing the JSON into Grafana
+
+1. Download `alpha/dashboard/panels.json` and `alpha/dashboard/alerts.json` from the repository.
+2. In Grafana, open **Dashboards → New → Import** and upload `panels.json`. Grafana will create a new dashboard using the saved layout and queries.
+3. Navigate to **Alerting → Alert rules → New alert rule → Import** (Grafana 9+) and paste the contents of `alerts.json` to register the alert definitions.
+4. Point both the dashboard panels and the alert rules at your Prometheus data source. The JSON expects a Prometheus data source named `Prometheus`; adjust the datasource if your environment uses a different name.
+5. Save the imported resources and share the links with the on-call rotation. First load should complete in under two seconds with a warm Prometheus cache.
+
+## Panel Catalog
+
+| Panel | PromQL | Screenshot Placeholder |
+| --- | --- | --- |
+| Gate Decisions (5m rate) | `sum by (decision) (rate(gate_decisions_total{environment="prod"}[5m]))` | ![Gate Decisions Panel Placeholder](images/gate_decisions_panel.png) |
+| Replay Pass Throughput | `sum(rate(replay_pass_total{environment="prod"}[5m]))` | ![Replay Pass Panel Placeholder](images/replay_pass_panel.png) |
+| Budget Spend (¢ per hour) | `sum(increase(budget_spend_cents{environment="prod"}[1h]))` | ![Budget Spend Panel Placeholder](images/budget_spend_panel.png) |
+| Adapter Latency P95 | `quantile_over_time(0.95, adapter_latency_ms{environment="prod"}[5m])` | ![Adapter Latency Panel Placeholder](images/adapter_latency_panel.png) |
+| Reliability SLO | `(1 - ((sum(rate(retries_total{environment="prod"}[30m])) + sum(rate(breaker_open_total{environment="prod"}[30m]))) / sum(rate(requests_total{environment="prod"}[30m])))) * 100` | ![Reliability SLO Panel Placeholder](images/reliability_slo_panel.png) |
+
+> _Replace the placeholder images above after the first dashboard render in your environment._
+
+## Alert Coverage
+
+The companion alert rules mirror the dashboard metrics:
+
+- **Gate Decision Denial Spike** – Watches the ratio of `gate_decisions_total` with `decision="denied"` exceeding 20% for five minutes.
+- **Adapter Latency Regression** – Triggers when `quantile_over_time(0.95, adapter_latency_ms[5m])` rises above 750 ms for ten minutes.
+- **Reliability SLO Burn** – Guards the SLO using retry and breaker counters to ensure the 99.5% target is met across a 30-minute window.
+
+## Obs-card Snippet
+
+Copy/paste the following one-liner into PRs, incidents, or release notes to provide quick context:
+
+```
+> obs-card alpha-dashboards gate=ok replay=ok budget=steady adapter_p95=<-ms slo=99.9%
+```
+
+Update the tokens (`ok`, `steady`, `99.9%`, etc.) with the latest readings before posting.

--- a/tests/dashboard/test_dash_config.py
+++ b/tests/dashboard/test_dash_config.py
@@ -1,0 +1,120 @@
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PANELS_PATH = REPO_ROOT / "alpha" / "dashboard" / "panels.json"
+ALERTS_PATH = REPO_ROOT / "alpha" / "dashboard" / "alerts.json"
+
+
+@pytest.fixture(scope="module")
+def panels_config():
+    raw = PANELS_PATH.read_text()
+    data = json.loads(raw)
+    assert isinstance(data, dict), "panels.json must be a JSON object"
+    assert "panels" in data and isinstance(data["panels"], list), "panels.json needs a panels list"
+    return data
+
+
+@pytest.fixture(scope="module")
+def alerts_config():
+    raw = ALERTS_PATH.read_text()
+    data = json.loads(raw)
+    assert isinstance(data, dict), "alerts.json must be a JSON object"
+    assert "alerts" in data and isinstance(data["alerts"], list), "alerts.json needs an alerts list"
+    return data
+
+
+def validate_promql(expr: str) -> None:
+    assert isinstance(expr, str), "PromQL expression must be a string"
+    stripped = expr.strip()
+    assert stripped, "PromQL expression should not be empty"
+    assert stripped == expr, "PromQL expression should not contain leading/trailing whitespace"
+
+    pairs = {")": "(",
+        "]": "[",
+        "}": "{",
+    }
+    openers = set(pairs.values())
+    stack = []
+    for char in expr:
+        if char in openers:
+            stack.append(char)
+        elif char in pairs:
+            assert stack, f"Unbalanced bracket near {char}"
+            opener = stack.pop()
+            assert opener == pairs[char], f"Mismatched {opener} and {char}"
+    assert not stack, "PromQL expression has unclosed brackets"
+
+    # Ensure expressions look like PromQL by requiring at least one metric token and a function/operator.
+    has_metric = any(part.isidentifier() and part[0].isalpha() for part in stripped.replace("{", " ").replace("}", " ").replace("(", " ").replace(")", " ").split())
+    assert has_metric, "PromQL expression should reference at least one metric identifier"
+    assert any(op in expr for op in ("sum", "rate", "increase", "quantile", "histogram_quantile", "+", "-", "/", "*")), "PromQL expression missing expected functions"
+
+
+def test_panels_config_structure(panels_config):
+    panels = panels_config["panels"]
+    assert len(panels) >= 5, "Expected at least five panels"
+
+    required_metrics = {
+        "gate_decisions_total": False,
+        "replay_pass_total": False,
+        "budget_spend_cents": False,
+        "adapter_latency_ms": False,
+        "retries_total": False,
+        "breaker_open_total": False,
+    }
+
+    seen_ids = set()
+    for panel in panels:
+        assert set(panel.keys()) >= {"id", "title", "type", "datasource", "targets"}
+        assert panel["id"], "Panel id must not be empty"
+        assert panel["id"] not in seen_ids, "Panel ids should be unique"
+        seen_ids.add(panel["id"])
+
+        assert isinstance(panel["targets"], list) and panel["targets"], "Each panel needs at least one target"
+        for target in panel["targets"]:
+            assert set(target.keys()) >= {"expr", "legend"}
+            validate_promql(target["expr"])
+            for metric in required_metrics:
+                if metric in target["expr"]:
+                    required_metrics[metric] = True
+
+    assert all(required_metrics.values()), "Not all required metrics are represented in panels"
+
+
+def test_alerts_config_structure(alerts_config):
+    alerts = alerts_config["alerts"]
+    assert alerts, "Expected at least one alert"
+
+    metric_presence = {
+        "gate_decisions_total": False,
+        "adapter_latency_ms": False,
+        "retries_total": False,
+        "breaker_open_total": False,
+    }
+
+    for alert in alerts:
+        assert set(alert.keys()) >= {"name", "expr", "for", "labels", "annotations"}
+        assert alert["name"].strip(), "Alert must have a name"
+        validate_promql(alert["expr"])
+        assert isinstance(alert["labels"], dict), "Alert labels must be a dict"
+        assert isinstance(alert["annotations"], dict), "Alert annotations must be a dict"
+
+        for metric in metric_presence:
+            if metric in alert["expr"]:
+                metric_presence[metric] = True
+
+    for key, present in metric_presence.items():
+        assert present, f"Alert coverage missing required metric: {key}"
+
+
+def test_promql_parses_for_panels_and_alerts(panels_config, alerts_config):
+    """Smoke test to ensure every expression is PromQL-ish by checking token balance."""
+
+    panel_exprs = [target["expr"] for panel in panels_config["panels"] for target in panel["targets"]]
+    alert_exprs = [alert["expr"] for alert in alerts_config["alerts"]]
+
+    for expr in panel_exprs + alert_exprs:
+        validate_promql(expr)


### PR DESCRIPTION
## Summary
- add Grafana dashboard definition for gate, replay, budget, latency, and reliability metrics
- add alert rules aligned with the dashboard SLO coverage
- document import steps and add tests to validate PromQL structure

## Testing
- pytest tests/dashboard/test_dash_config.py

------
https://chatgpt.com/codex/tasks/task_e_68c857221908832994d057ced7ec46fc