### PR TITLE
Implement EPIC_RAG_001 RAG broker & semantic cache

### DIFF
--- a/.specs/EPIC_RAG_001.md
+++ b/.specs/EPIC_RAG_001.md
@@ -1,0 +1,32 @@
+---
+id: EPIC_RAG_001
+title: RAG & Semantic Cache Pack
+owner: alpha-solver
+phase: Next
+priority: P2A
+track: RES_RAG
+spec_version: 1.0
+---
+## Goal
+Deterministic RAG broker with semantic cache (TTL + LFU/LRU) and policy guardrails.
+
+## Acceptance Criteria
+- Citation accuracy ≥95% on seed; retrieval p95 < 100ms (local); cache hit rate ≥60% on replay
+- Strict tenant/role isolation with policy enforcement
+- Obs-card prints retrieval path + cache stats
+- 10/10 CI tests covering retrieval + cache behaviour
+
+## Workspace Recipe
+- `pytest tests/retrieval`
+
+## Code Targets
+- alpha/retrieval/broker.py
+- alpha/cache/semantic.py
+- tests/retrieval/test_broker.py
+- tests/retrieval/test_cache.py
+- docs/RAG.md
+
+## Notes
+- Provider shim must yield deterministic citations (stable ordering, source ids)
+- Cache exposes hit/miss counters and eviction metrics via hook
+- Replay metrics measured with `time.monotonic()` in tests

--- a/alpha/cache/semantic.py
+++ b/alpha/cache/semantic.py
@@ -1,0 +1,249 @@
+"""Semantic cache with TTL and LFU/LRU eviction policies."""
+from __future__ import annotations
+
+import hashlib
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterable, MutableMapping, Optional, Sequence, Tuple
+
+
+@dataclass
+class CacheEntry:
+    """Internal representation of cached values."""
+
+    value: Any
+    created_at: float
+    expiry: float
+    last_access: float
+    frequency: int = 1
+
+    def is_expired(self, now: float) -> bool:
+        return now >= self.expiry
+
+
+@dataclass(frozen=True)
+class CacheStats:
+    """Snapshot of cache counters."""
+
+    size: int
+    hits: int
+    misses: int
+    policy: str
+    ttl_seconds: float
+
+
+class SemanticCache:
+    """Semantic cache keyed by embeddings with TTL and eviction policies.
+
+    The cache hashes embedded representations of text queries and maintains
+    hit/miss counters as well as TTL-aware eviction. Entries are isolated by
+    tenant and role to prevent data bleed across security boundaries.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_size: int = 128,
+        ttl_seconds: float = 30.0,
+        policy: str = "lru",
+        embedder: Optional[Callable[[str], Sequence[float]]] = None,
+        metrics_hook: Optional[Callable[[Dict[str, Any]], None]] = None,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        if max_size <= 0:
+            raise ValueError("max_size must be positive")
+        if ttl_seconds <= 0:
+            raise ValueError("ttl_seconds must be positive")
+        normalised_policy = policy.lower()
+        if normalised_policy not in {"lru", "lfu"}:
+            raise ValueError("policy must be either 'lru' or 'lfu'")
+
+        self.max_size = max_size
+        self.ttl_seconds = ttl_seconds
+        self.policy = normalised_policy
+        self.embedder = embedder or self._default_embedder
+        self.metrics_hook = metrics_hook
+        self.clock = clock
+
+        self._entries: MutableMapping[Tuple[str, str, str], CacheEntry] = {}
+        self.hits = 0
+        self.misses = 0
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def get(self, text: str, *, tenant: str, role: str) -> Optional[Any]:
+        """Retrieve a cached value.
+
+        Args:
+            text: The query text used to derive the semantic key.
+            tenant: Tenant identifier for isolation.
+            role: Role identifier for isolation.
+
+        Returns:
+            The cached value if present and valid, otherwise ``None``.
+        """
+
+        now = self.clock()
+        self._purge_expired(now)
+
+        cache_key = self._make_key(text, tenant=tenant, role=role)
+        entry = self._entries.get(cache_key)
+        if entry is None:
+            self._register_miss(cache_key)
+            return None
+        if entry.is_expired(now):
+            del self._entries[cache_key]
+            self._register_miss(cache_key)
+            return None
+
+        entry.last_access = now
+        entry.frequency += 1
+        self._register_hit(cache_key)
+        return entry.value
+
+    def set(
+        self,
+        text: str,
+        value: Any,
+        *,
+        tenant: str,
+        role: str,
+        ttl_seconds: Optional[float] = None,
+    ) -> None:
+        """Insert or update a cached value."""
+
+        now = self.clock()
+        effective_ttl = float(ttl_seconds) if ttl_seconds is not None else self.ttl_seconds
+        if effective_ttl <= 0:
+            raise ValueError("ttl_seconds must be positive")
+
+        self._purge_expired(now)
+
+        cache_key = self._make_key(text, tenant=tenant, role=role)
+        replacing_existing = cache_key in self._entries
+        expiry = now + effective_ttl
+        entry = CacheEntry(value=value, created_at=now, expiry=expiry, last_access=now)
+        self._entries[cache_key] = entry
+        self._ensure_capacity(protected_key=None if replacing_existing else cache_key)
+        self._emit_metrics("store", cache_key)
+
+    def clear(self) -> None:
+        """Remove all cache entries and reset counters."""
+
+        self._entries.clear()
+        self.hits = 0
+        self.misses = 0
+        self._emit_metrics("clear", None)
+
+    def stats(self) -> CacheStats:
+        """Return cache statistics."""
+
+        return CacheStats(
+            size=len(self._entries),
+            hits=self.hits,
+            misses=self.misses,
+            policy=self.policy,
+            ttl_seconds=self.ttl_seconds,
+        )
+
+    def snapshot(self) -> Dict[str, Any]:
+        """Return a dictionary snapshot for observability hooks."""
+
+        stats = self.stats()
+        return {
+            "size": stats.size,
+            "hits": stats.hits,
+            "misses": stats.misses,
+            "policy": stats.policy,
+            "ttl_seconds": stats.ttl_seconds,
+        }
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _make_key(self, text: str, *, tenant: str, role: str) -> Tuple[str, str, str]:
+        embedding = self.embedder(text)
+        hashed = self._hash_embedding(embedding)
+        return tenant, role, hashed
+
+    def _hash_embedding(self, embedding: Sequence[float]) -> str:
+        if not isinstance(embedding, Iterable):  # type: ignore[arg-type]
+            raise TypeError("embedding must be iterable")
+        materialised = list(embedding)  # type: ignore[arg-type]
+        payload = ",".join(self._normalise_component(component) for component in materialised)
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _normalise_component(component: Any) -> str:
+        if isinstance(component, (float, int)):
+            return f"{float(component):.12f}"
+        return str(component)
+
+    def _purge_expired(self, now: Optional[float] = None) -> None:
+        reference = self.clock() if now is None else now
+        expired_keys = [key for key, entry in self._entries.items() if entry.is_expired(reference)]
+        for key in expired_keys:
+            del self._entries[key]
+
+    def _ensure_capacity(self, protected_key: Optional[Tuple[str, str, str]] = None) -> None:
+        if len(self._entries) <= self.max_size:
+            return
+
+        while len(self._entries) > self.max_size:
+            candidates = [
+                (key, entry)
+                for key, entry in self._entries.items()
+                if key != protected_key or len(self._entries) <= self.max_size
+            ]
+            if not candidates:
+                candidates = list(self._entries.items())
+
+            if self.policy == "lru":
+                eviction_key = min(
+                    candidates,
+                    key=lambda item: (item[1].last_access, item[0]),
+                )[0]
+            else:  # lfu
+                eviction_key = min(
+                    candidates,
+                    key=lambda item: (item[1].frequency, item[1].last_access, item[0]),
+                )[0]
+            del self._entries[eviction_key]
+            self._emit_metrics("evict", eviction_key)
+
+    def _register_hit(self, cache_key: Tuple[str, str, str]) -> None:
+        self.hits += 1
+        self._emit_metrics("hit", cache_key)
+
+    def _register_miss(self, cache_key: Tuple[str, str, str]) -> None:
+        self.misses += 1
+        self._emit_metrics("miss", cache_key)
+
+    def _emit_metrics(self, event: str, cache_key: Optional[Tuple[str, str, str]]) -> None:
+        if not self.metrics_hook:
+            return
+        payload = self.snapshot()
+        payload.update({
+            "event": event,
+            "namespace": None if cache_key is None else f"{cache_key[0]}:{cache_key[1]}",
+        })
+        try:
+            self.metrics_hook(payload)
+        except Exception:
+            # Metrics hooks must never destabilise cache operations.
+            pass
+
+    @staticmethod
+    def _default_embedder(text: str) -> Sequence[float]:
+        if not text:
+            return (0.0, 0.0, 0.0)
+        tokens = text.split()
+        char_sum = sum(ord(char) for char in text)
+        word_lengths = sum(len(token) ** 2 for token in tokens)
+        return (
+            float(len(tokens)),
+            float(len(text)),
+            float(char_sum % 10_000),
+            float(word_lengths % 10_000),
+        )

--- a/alpha/retrieval/broker.py
+++ b/alpha/retrieval/broker.py
@@ -1,0 +1,227 @@
+"""Deterministic retrieval broker backed by a semantic cache."""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, Iterable, List, Mapping, Optional, Protocol, Sequence
+
+from alpha.cache.semantic import SemanticCache
+
+
+class PolicyDeniedError(RuntimeError):
+    """Raised when the policy guard rejects a request."""
+
+
+class ProviderError(RuntimeError):
+    """Raised when the provider returns an invalid response."""
+
+
+@dataclass(frozen=True)
+class RetrievedDocument:
+    """Document returned from the retrieval provider."""
+
+    source_id: str
+    content: str
+    score: float
+    metadata: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class BrokerResponse:
+    """Response payload emitted by the broker."""
+
+    documents: Sequence[RetrievedDocument]
+    citations: Sequence[str]
+    latency_ms: float
+    cache_hit: bool
+    provider: str
+    obs_card: str
+
+
+class ProviderShim(Protocol):
+    """Protocol describing the provider interface expected by the broker."""
+
+    name: str
+
+    def retrieve(
+        self,
+        query: str,
+        *,
+        top_k: int,
+        tenant: str,
+        role: str,
+    ) -> Iterable[Any]:
+        ...
+
+
+class PolicyGuard(Protocol):
+    """Protocol describing the policy interface expected by the broker."""
+
+    def ensure_permitted(self, tenant: str, role: str, query: str) -> None:
+        ...
+
+
+class AllowAllPolicy:
+    """Default policy that allows every request."""
+
+    def ensure_permitted(self, tenant: str, role: str, query: str) -> None:  # noqa: D401
+        """No-op policy that accepts all combinations."""
+
+
+class StaticPolicyGuard:
+    """Static allow-list policy with optional predicate for fine-grained checks."""
+
+    def __init__(
+        self,
+        allow_map: Optional[Mapping[str, Sequence[str]]] = None,
+        predicate: Optional[Callable[[str, str, str], bool]] = None,
+    ) -> None:
+        self._allow_map = {
+            tenant: {role for role in roles}
+            for tenant, roles in (allow_map or {}).items()
+        }
+        self._predicate = predicate
+
+    def ensure_permitted(self, tenant: str, role: str, query: str) -> None:
+        if self._allow_map:
+            allowed_roles = self._allow_map.get(tenant)
+            if not allowed_roles:
+                raise PolicyDeniedError(f"tenant '{tenant}' is not authorised for retrieval")
+            if "*" not in allowed_roles and role not in allowed_roles:
+                raise PolicyDeniedError(
+                    f"role '{role}' is not authorised for tenant '{tenant}'",
+                )
+        if self._predicate and not self._predicate(tenant, role, query):
+            raise PolicyDeniedError("policy predicate rejected request")
+
+
+class RetrievalBroker:
+    """Coordinates retrieval with caching, policy enforcement and observability."""
+
+    def __init__(
+        self,
+        provider: ProviderShim,
+        cache: SemanticCache,
+        *,
+        policy: Optional[PolicyGuard] = None,
+        obs_sink: Optional[Callable[[str], None]] = print,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self.provider = provider
+        self.cache = cache
+        self.policy = policy or AllowAllPolicy()
+        self.obs_sink = obs_sink
+        self.clock = clock
+
+    def retrieve(
+        self,
+        query: str,
+        *,
+        tenant: str,
+        role: str,
+        top_k: int = 3,
+        cache_ttl_seconds: Optional[float] = None,
+    ) -> BrokerResponse:
+        if not query:
+            raise ValueError("query must be non-empty")
+        if top_k <= 0:
+            raise ValueError("top_k must be positive")
+
+        self.policy.ensure_permitted(tenant, role, query)
+
+        cache_text = self._cache_text(query, top_k)
+        start = self.clock()
+        cached_payload = self.cache.get(cache_text, tenant=tenant, role=role)
+        cache_hit = cached_payload is not None
+
+        if cache_hit:
+            payload = cached_payload
+            documents = list(payload["documents"])
+            citations = list(payload["citations"])
+            provider_name = payload["provider"]
+        else:
+            documents = self._fetch_documents(query, tenant=tenant, role=role, top_k=top_k)
+            citations = [doc.source_id for doc in documents]
+            provider_name = getattr(self.provider, "name", self.provider.__class__.__name__)
+            payload = {
+                "documents": tuple(documents),
+                "citations": tuple(citations),
+                "provider": provider_name,
+            }
+            self.cache.set(
+                cache_text,
+                payload,
+                tenant=tenant,
+                role=role,
+                ttl_seconds=cache_ttl_seconds,
+            )
+
+        latency_ms = (self.clock() - start) * 1000.0
+        stats = self.cache.snapshot()
+        path = "semantic-cache" if cache_hit else f"provider:{provider_name}"
+        obs_line = (
+            "route=rag "
+            f"path={path} "
+            f"cache_hit={int(cache_hit)} "
+            f"latency_ms={int(round(latency_ms))} "
+            f"provider={provider_name} "
+            f"cache_hits={stats['hits']} "
+            f"cache_misses={stats['misses']} "
+            f"cache_size={stats['size']}"
+        )
+        if self.obs_sink is not None:
+            self.obs_sink(obs_line)
+
+        return BrokerResponse(
+            documents=tuple(documents),
+            citations=tuple(citations),
+            latency_ms=latency_ms,
+            cache_hit=cache_hit,
+            provider=provider_name,
+            obs_card=obs_line,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _cache_text(self, query: str, top_k: int) -> str:
+        return f"{query}||top_k={top_k}"
+
+    def _fetch_documents(
+        self,
+        query: str,
+        *,
+        tenant: str,
+        role: str,
+        top_k: int,
+    ) -> List[RetrievedDocument]:
+        raw_documents = list(
+            self.provider.retrieve(query=query, top_k=top_k, tenant=tenant, role=role),
+        )
+        if not raw_documents:
+            return []
+
+        documents = [self._to_document(document) for document in raw_documents]
+        documents.sort(key=lambda doc: (-float(doc.score), doc.source_id))
+        return documents[:top_k]
+
+    def _to_document(self, document: Any) -> RetrievedDocument:
+        if isinstance(document, RetrievedDocument):
+            return document
+        if isinstance(document, Mapping):
+            try:
+                source_id = str(document["source_id"])
+            except KeyError as exc:
+                raise ProviderError("provider document missing 'source_id'") from exc
+            content = str(document.get("content", ""))
+            score = float(document.get("score", 0.0))
+            metadata = document.get("metadata", {})
+            if not isinstance(metadata, Mapping):
+                raise ProviderError("metadata must be a mapping")
+            return RetrievedDocument(
+                source_id=source_id,
+                content=content,
+                score=score,
+                metadata=dict(metadata),
+            )
+        raise ProviderError(f"Unsupported document type: {type(document)!r}")

--- a/docs/RAG.md
+++ b/docs/RAG.md
@@ -1,0 +1,65 @@
+# Retrieval-Augmented Generation Broker & Semantic Cache
+
+## Overview
+
+EPIC_RAG_001 introduces a deterministic retrieval broker paired with a semantic
+cache that supports TTL-driven eviction, LFU/LRU policies, and policy-aware
+routing. The implementation targets local determinism and replay performance by
+combining a lightweight provider shim, strict tenant isolation, and observable
+retrieval traces.
+
+## Retrieval Broker
+
+The broker (`alpha/retrieval/broker.py`):
+
+- normalises provider outputs into `RetrievedDocument` objects and sorts them by
+  descending score (and source identifier for ties) to guarantee deterministic
+  citations;
+- enforces tenant/role policy constraints through the `PolicyGuard`
+  abstraction (with a `StaticPolicyGuard` allow-list implementation);
+- integrates with the semantic cache to reuse responses via semantic keys that
+  include the requested `top_k` size;
+- emits an observability card per query in the format
+  `route=rag path=<...> cache_hit=<0/1> latency_ms=<int> provider=<name> cache_hits=<n> cache_misses=<n> cache_size=<n>`
+  so replay diagnostics capture retrieval path and cache statistics.
+
+The broker accepts any provider that implements the simple `ProviderShim`
+protocol (`name` attribute and `retrieve` method). The included tests ship with
+an in-memory seed provider that demonstrates the minimal contract.
+
+## Semantic Cache
+
+The semantic cache (`alpha/cache/semantic.py`) delivers:
+
+- deterministic hashing of embedded query text (default embedder derives a
+  stable vector from token counts and character features);
+- TTL support for every entry (configurable globally and per write);
+- both LRU and LFU eviction strategies with optional metrics hooks;
+- counters for hits/misses plus namespace scoping (`tenant:role`) to prevent
+  cross-tenant leakage.
+
+Consumers can extract stats via `cache.stats()` or a dictionary snapshot for
+observability/metrics pipelines. Hooks receive event payloads for `miss`,
+`store`, `hit`, `evict`, and `clear` transitions.
+
+## Workspace Recipe
+
+Local and CI validation focuses on the dedicated retrieval test suite:
+
+```bash
+pytest tests/retrieval
+```
+
+The tests exercise:
+
+- ≥95% citation accuracy against the bundled seed dataset;
+- retrieval latency p95 below 100 ms (measured with `time.monotonic()`);
+- ≥60% cache hit rate on replay of the seed queries;
+- strict tenant isolation and policy enforcement guardrails.
+
+## Metrics & Observability
+
+The observability card emitted by the broker surfaces cache hits/misses and
+latency in-line with the EPIC acceptance criteria. Cache metrics hooks allow
+exporting counters to custom telemetry sinks without coupling cache lifecycle to
+metrics delivery.

--- a/tests/retrieval/test_broker.py
+++ b/tests/retrieval/test_broker.py
@@ -1,0 +1,187 @@
+"""Tests for the retrieval broker and seed dataset acceptance criteria."""
+from __future__ import annotations
+
+import math
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Sequence, Tuple
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from alpha.cache.semantic import SemanticCache
+from alpha.retrieval.broker import (
+    BrokerResponse,
+    PolicyDeniedError,
+    RetrievedDocument,
+    RetrievalBroker,
+    StaticPolicyGuard,
+)
+
+TENANT = "tenant-alpha"
+ROLE = "researcher"
+
+
+@dataclass
+class SeedQuery:
+    query: str
+    prefix: str
+
+
+SEED_QUERIES: Sequence[SeedQuery] = (
+    SeedQuery("alpha energy roadmap", "energy"),
+    SeedQuery("beta risk controls", "risk"),
+    SeedQuery("gamma product faq", "product"),
+    SeedQuery("delta release checklist", "release"),
+    SeedQuery("epsilon incident review", "incident"),
+    SeedQuery("zeta sla summary", "sla"),
+    SeedQuery("eta observability guide", "observability"),
+    SeedQuery("theta data retention", "data"),
+    SeedQuery("iota compliance matrix", "compliance"),
+    SeedQuery("kappa outage drill", "outage"),
+)
+
+
+def _build_seed_dataset() -> Tuple[Dict[str, List[RetrievedDocument]], Dict[str, List[str]]]:
+    dataset: Dict[str, List[RetrievedDocument]] = {}
+    expectations: Dict[str, List[str]] = {}
+    for index, seed in enumerate(SEED_QUERIES, start=1):
+        primary_score = 0.92 + index * 0.004
+        summary_score = primary_score - 0.045
+        support_score = summary_score - 0.06
+        docs = [
+            RetrievedDocument(
+                source_id=f"{seed.prefix}-support-{index:02d}",
+                content=f"supporting note for {seed.query}",
+                score=support_score,
+                metadata={"section": "support", "topic": seed.prefix},
+            ),
+            RetrievedDocument(
+                source_id=f"{seed.prefix}-primary-{index:02d}",
+                content=f"primary guidance on {seed.query}",
+                score=primary_score,
+                metadata={"section": "primary", "topic": seed.prefix},
+            ),
+            RetrievedDocument(
+                source_id=f"{seed.prefix}-summary-{index:02d}",
+                content=f"summary for {seed.query}",
+                score=summary_score,
+                metadata={"section": "summary", "topic": seed.prefix},
+            ),
+        ]
+        # Intentionally shuffle order to confirm broker sorting logic.
+        dataset[seed.query] = [docs[0], docs[2], docs[1]]
+        expectations[seed.query] = [docs[1].source_id, docs[2].source_id]
+    return dataset, expectations
+
+
+class SeedProvider:
+    """Minimal deterministic provider for tests."""
+
+    name = "seed-provider"
+
+    def __init__(self, dataset: Dict[str, List[RetrievedDocument]]) -> None:
+        self._dataset = dataset
+        self.calls: List[Tuple[str, str, str, int]] = []
+
+    def retrieve(
+        self,
+        *,
+        query: str,
+        top_k: int,
+        tenant: str,
+        role: str,
+    ) -> Iterable[RetrievedDocument]:
+        self.calls.append((query, tenant, role, top_k))
+        return list(self._dataset.get(query, ()))
+
+
+def _percentile(values: Sequence[float], percentile: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    rank = max(0, math.ceil(percentile * len(ordered)) - 1)
+    return ordered[rank]
+
+
+def test_broker_seed_dataset_metrics() -> None:
+    dataset, expectations = _build_seed_dataset()
+    cache = SemanticCache(max_size=64, ttl_seconds=120.0)
+    provider = SeedProvider(dataset)
+    obs_events: List[str] = []
+    policy = StaticPolicyGuard({TENANT: [ROLE], "tenant-beta": [ROLE]})
+    broker = RetrievalBroker(
+        provider,
+        cache,
+        policy=policy,
+        obs_sink=obs_events.append,
+    )
+
+    first_pass: Dict[str, BrokerResponse] = {}
+    latencies: List[float] = []
+    for seed in SEED_QUERIES:
+        response = broker.retrieve(seed.query, tenant=TENANT, role=ROLE, top_k=2)
+        first_pass[seed.query] = response
+        latencies.append(response.latency_ms)
+        assert response.cache_hit is False
+        assert response.provider == provider.name
+        assert len(response.documents) == 2
+        assert tuple(response.citations) == tuple(expectations[seed.query])
+        assert response.documents[0].score >= response.documents[1].score
+        assert response.obs_card.startswith("route=rag ")
+        assert f"provider={provider.name}" in response.obs_card
+        assert "cache_hits=" in response.obs_card
+        assert "cache_hit=0" in response.obs_card
+
+    accuracy_numerator = 0
+    accuracy_denominator = 0
+    for seed in SEED_QUERIES:
+        expected = expectations[seed.query]
+        actual = list(first_pass[seed.query].citations)
+        for idx, expected_citation in enumerate(expected):
+            accuracy_denominator += 1
+            if idx < len(actual) and actual[idx] == expected_citation:
+                accuracy_numerator += 1
+    citation_accuracy = accuracy_numerator / max(1, accuracy_denominator)
+    assert citation_accuracy >= 0.95
+
+    p95_latency = _percentile(latencies, 0.95)
+    assert p95_latency < 100.0
+
+    hits_before = cache.stats().hits
+    for seed in SEED_QUERIES:
+        response = broker.retrieve(seed.query, tenant=TENANT, role=ROLE, top_k=2)
+        assert response.cache_hit is True
+        assert list(response.citations) == expectations[seed.query]
+        assert "cache_hit=1" in response.obs_card
+    hits_after = cache.stats().hits
+    replay_hit_rate = (hits_after - hits_before) / len(SEED_QUERIES)
+    assert replay_hit_rate >= 0.6
+
+    # Tenant isolation: new tenant should miss cache and trigger provider call.
+    isolation_response = broker.retrieve(
+        SEED_QUERIES[0].query,
+        tenant="tenant-beta",
+        role=ROLE,
+        top_k=2,
+    )
+    assert isolation_response.cache_hit is False
+    assert len(provider.calls) == len(SEED_QUERIES) + 1
+
+    # Observability events recorded for each invocation.
+    assert len(obs_events) == len(SEED_QUERIES) * 2 + 1
+
+
+def test_policy_guard_enforced() -> None:
+    dataset, _ = _build_seed_dataset()
+    cache = SemanticCache(max_size=8, ttl_seconds=60.0)
+    provider = SeedProvider(dataset)
+    policy = StaticPolicyGuard({TENANT: [ROLE]})
+    broker = RetrievalBroker(provider, cache, policy=policy)
+
+    with pytest.raises(PolicyDeniedError):
+        broker.retrieve(SEED_QUERIES[0].query, tenant=TENANT, role="viewer", top_k=2)

--- a/tests/retrieval/test_cache.py
+++ b/tests/retrieval/test_cache.py
@@ -1,0 +1,101 @@
+"""Tests for the semantic cache implementation."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Dict, List
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from alpha.cache.semantic import CacheStats, SemanticCache
+
+
+class FakeClock:
+    def __init__(self, start: float = 0.0) -> None:
+        self._now = start
+
+    def __call__(self) -> float:
+        return self._now
+
+    def advance(self, seconds: float) -> None:
+        self._now += seconds
+
+
+def test_semantic_cache_metrics_and_ttl() -> None:
+    events: List[Dict[str, object]] = []
+    clock = FakeClock()
+    cache = SemanticCache(
+        max_size=4,
+        ttl_seconds=5.0,
+        metrics_hook=events.append,
+        clock=clock,
+    )
+
+    assert cache.get("alpha", tenant="tenant-a", role="reader") is None
+    cache.set("alpha", {"payload": 1}, tenant="tenant-a", role="reader")
+    assert cache.get("alpha", tenant="tenant-a", role="reader") == {"payload": 1}
+
+    clock.advance(6.0)
+    assert cache.get("alpha", tenant="tenant-a", role="reader") is None
+
+    stats = cache.stats()
+    assert isinstance(stats, CacheStats)
+    assert stats.hits == 1
+    assert stats.misses == 2
+    assert stats.size == 0
+
+    assert events[0]["event"] == "miss"
+    assert events[0]["namespace"] == "tenant-a:reader"
+    assert events[1]["event"] == "store"
+    assert events[2]["event"] == "hit"
+    assert events[3]["event"] == "miss"
+
+
+def test_semantic_cache_eviction_policies() -> None:
+    clock = FakeClock()
+    cache_lru = SemanticCache(max_size=2, ttl_seconds=50.0, policy="lru", clock=clock)
+    cache_lru.set("q1", 1, tenant="t", role="r")
+    clock.advance(1.0)
+    cache_lru.set("q2", 2, tenant="t", role="r")
+
+    assert cache_lru.get("q1", tenant="t", role="r") == 1
+    clock.advance(1.0)
+    cache_lru.set("q3", 3, tenant="t", role="r")
+
+    assert cache_lru.get("q2", tenant="t", role="r") is None
+    assert cache_lru.get("q1", tenant="t", role="r") == 1
+    assert cache_lru.get("q3", tenant="t", role="r") == 3
+
+    clock_lfu = FakeClock()
+    cache_lfu = SemanticCache(max_size=2, ttl_seconds=50.0, policy="lfu", clock=clock_lfu)
+    cache_lfu.set("a", "A", tenant="t", role="r")
+    cache_lfu.set("b", "B", tenant="t", role="r")
+
+    assert cache_lfu.get("a", tenant="t", role="r") == "A"
+    assert cache_lfu.get("a", tenant="t", role="r") == "A"
+    assert cache_lfu.get("b", tenant="t", role="r") == "B"
+
+    clock_lfu.advance(1.0)
+    cache_lfu.set("c", "C", tenant="t", role="r")
+
+    assert cache_lfu.get("a", tenant="t", role="r") == "A"
+    assert cache_lfu.get("c", tenant="t", role="r") == "C"
+    assert cache_lfu.get("b", tenant="t", role="r") is None
+
+
+def test_semantic_cache_namespace_isolation() -> None:
+    cache = SemanticCache(max_size=4, ttl_seconds=30.0)
+    cache.set("shared", 1, tenant="tenant-a", role="reader")
+    cache.set("shared", 2, tenant="tenant-b", role="reader")
+    cache.set("shared", 3, tenant="tenant-a", role="editor")
+
+    assert cache.get("shared", tenant="tenant-a", role="reader") == 1
+    assert cache.get("shared", tenant="tenant-b", role="reader") == 2
+    assert cache.get("shared", tenant="tenant-a", role="editor") == 3
+
+    cache.clear()
+    assert cache.stats().hits == 0
+    assert cache.stats().misses == 0
+    assert cache.stats().size == 0


### PR DESCRIPTION
## Summary
- add a semantic cache with TTL support, LFU/LRU eviction, and hit/miss metrics hooks
- add a policy-aware retrieval broker that emits deterministic citations and observability cards
- cover the new stack with retrieval/cache tests and documentation for EPIC_RAG_001

## Testing
- pytest tests/retrieval

------
https://chatgpt.com/codex/tasks/task_e_68c86270df0c8329aaa3604ffe18b23e