### PR TITLE
Add dashboard request submission UI

### DIFF
--- a/.specs/UI-REQ-001.md
+++ b/.specs/UI-REQ-001.md
@@ -1,0 +1,17 @@
+# UI-REQ-001 · Dashboard Request Submission UI
+
+## Goal
+Provide a lightweight web experience that allows operators to submit a prompt to Alpha Solver, receive an acknowledgement immediately, and poll for completion.
+
+## Functional Requirements
+- Render an HTML form with a textarea for the prompt, a provider dropdown, and a submit button.
+- `POST /requests` enqueues an in-memory job and responds with `{ "id": "<uuid>" }`.
+- `GET /requests/<id>` returns `{ "id", "status", "latency_ms", "provider", "cache_hit" }` reflecting the job state.
+- Background execution is mocked; no external network calls are performed.
+
+## UX Notes
+- Show acknowledgement latency after submit and reveal a status pane that auto-polls until the job completes.
+- Surface validation errors inline without reloading the page.
+
+## Testing
+- `tests/ui/test_requests.py` performs an end-to-end flow verifying the SLA (ack under 500 ms), the job lifecycle, and the status payload contract.

--- a/alpha/webapp/routes/requests.py
+++ b/alpha/webapp/routes/requests.py
@@ -1,0 +1,156 @@
+"""Request submission UI routes for the Alpha Solver dashboard."""
+
+from __future__ import annotations
+
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Optional
+
+from fastapi import APIRouter, BackgroundTasks, HTTPException, Request
+from fastapi.responses import HTMLResponse
+
+AVAILABLE_PROVIDERS = ("mock", "mock-pro")
+
+_TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "templates"
+_REQUEST_TEMPLATE_PATH = _TEMPLATES_DIR / "request.html"
+
+router = APIRouter()
+
+
+@dataclass
+class RequestJob:
+    """In-memory record tracking the lifecycle of a dashboard request."""
+
+    id: str
+    prompt: str
+    provider: str
+    status: str = "pending"
+    latency_ms: Optional[float] = None
+    cache_hit: bool = False
+    submitted_at: float = field(default_factory=time.perf_counter)
+    started_at: Optional[float] = None
+    completed_at: Optional[float] = None
+
+
+_JOBS: Dict[str, RequestJob] = {}
+_JOBS_LOCK = threading.Lock()
+_BASE_TEMPLATE_CACHE: Optional[str] = None
+
+
+def _load_template() -> str:
+    global _BASE_TEMPLATE_CACHE
+    if _BASE_TEMPLATE_CACHE is None:
+        _BASE_TEMPLATE_CACHE = _REQUEST_TEMPLATE_PATH.read_text(encoding="utf-8")
+    return _BASE_TEMPLATE_CACHE
+
+
+def _render_request_form_html() -> str:
+    base_template = _load_template()
+    options = "\n".join(
+        f"            <option value=\"{provider}\">{provider}</option>"
+        for provider in AVAILABLE_PROVIDERS
+    )
+    return base_template.replace("{{provider_options}}", options)
+
+
+def reset_state() -> None:
+    """Clear in-memory job state.
+
+    This helper keeps tests hermetic and is no-op for production usage.
+    """
+
+    with _JOBS_LOCK:
+        _JOBS.clear()
+
+
+def _serialize(job: RequestJob) -> Dict[str, object]:
+    """Serialize a job record for the API response."""
+
+    return {
+        "id": job.id,
+        "status": job.status,
+        "latency_ms": job.latency_ms,
+        "provider": job.provider,
+        "cache_hit": job.cache_hit,
+    }
+
+
+def _mock_provider_latency(prompt: str, provider: str) -> float:
+    """Simulate a provider call and return the elapsed latency in milliseconds."""
+
+    # Keep things deterministic but non-zero by deriving a short delay from the
+    # prompt size and provider name.
+    base_delay = 0.05 if provider == AVAILABLE_PROVIDERS[0] else 0.065
+    jitter = min(len(prompt) / 1000.0, 0.035)
+    start = time.perf_counter()
+    time.sleep(base_delay + jitter)
+    return (time.perf_counter() - start) * 1000.0
+
+
+def _run_job(job_id: str) -> None:
+    """Background execution that marks a request as complete."""
+
+    with _JOBS_LOCK:
+        job = _JOBS.get(job_id)
+        if not job:
+            return
+        job.status = "running"
+        job.started_at = time.perf_counter()
+        prompt = job.prompt
+        provider = job.provider
+
+    latency_ms = _mock_provider_latency(prompt, provider)
+
+    with _JOBS_LOCK:
+        job = _JOBS.get(job_id)
+        if not job:
+            return
+        job.latency_ms = latency_ms
+        job.completed_at = time.perf_counter()
+        job.status = "done"
+
+
+@router.get("/requests", response_class=HTMLResponse)
+async def request_form(request: Request) -> HTMLResponse:
+    """Render the dashboard request submission form."""
+
+    _ = request  # FastAPI requires the request parameter even for static templates.
+    return HTMLResponse(content=_render_request_form_html())
+
+
+@router.post("/requests")
+async def submit_request(payload: Dict[str, str], background_tasks: BackgroundTasks) -> Dict[str, str]:
+    """Submit a new request and schedule background processing."""
+
+    prompt_raw = payload.get("prompt", "") if payload else ""
+    provider = payload.get("provider", AVAILABLE_PROVIDERS[0]) if payload else AVAILABLE_PROVIDERS[0]
+
+    prompt = prompt_raw.strip()
+    if not prompt:
+        raise HTTPException(status_code=422, detail="prompt is required")
+    if provider not in AVAILABLE_PROVIDERS:
+        raise HTTPException(status_code=422, detail="unknown provider")
+
+    job_id = str(uuid.uuid4())
+    job = RequestJob(id=job_id, prompt=prompt, provider=provider)
+
+    with _JOBS_LOCK:
+        _JOBS[job_id] = job
+
+    background_tasks.add_task(_run_job, job_id)
+
+    return {"id": job_id}
+
+
+@router.get("/requests/{request_id}")
+async def request_status(request_id: str) -> Dict[str, object]:
+    """Return the status of a submitted request."""
+
+    with _JOBS_LOCK:
+        job = _JOBS.get(request_id)
+        if not job:
+            raise HTTPException(status_code=404, detail="request not found")
+        return _serialize(job)

--- a/alpha/webapp/templates/request.html
+++ b/alpha/webapp/templates/request.html
@@ -1,0 +1,257 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Alpha Solver · Request Submission</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        line-height: 1.5;
+      }
+      body {
+        margin: 0;
+        background: radial-gradient(circle at top, #f5f7ff, #e4e7f2);
+        min-height: 100vh;
+        color: #1a1c2d;
+      }
+      .container {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 3rem 1.5rem 4rem;
+      }
+      h1 {
+        margin-bottom: 1rem;
+        font-size: 2rem;
+      }
+      form {
+        display: grid;
+        gap: 1rem;
+        background: rgba(255, 255, 255, 0.9);
+        border-radius: 16px;
+        padding: 1.5rem;
+        box-shadow: 0 20px 60px rgba(31, 35, 71, 0.08);
+        backdrop-filter: blur(12px);
+      }
+      label {
+        font-weight: 600;
+        font-size: 0.95rem;
+      }
+      textarea {
+        width: 100%;
+        resize: vertical;
+        min-height: 140px;
+        border-radius: 12px;
+        border: 1px solid #cdd5ef;
+        padding: 0.75rem 1rem;
+        font-size: 1rem;
+        color: inherit;
+        background: rgba(255, 255, 255, 0.7);
+        box-shadow: inset 0 1px 2px rgba(45, 55, 105, 0.05);
+      }
+      select,
+      button {
+        font-size: 1rem;
+        padding: 0.65rem 0.9rem;
+        border-radius: 10px;
+        border: 1px solid #cdd5ef;
+        background: #ffffff;
+        color: inherit;
+      }
+      button {
+        cursor: pointer;
+        border: none;
+        background: linear-gradient(135deg, #445df5, #8261f7);
+        color: #fff;
+        font-weight: 600;
+        transition: transform 0.15s ease, box-shadow 0.15s ease;
+      }
+      button:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 14px 30px rgba(68, 93, 245, 0.25);
+      }
+      section {
+        margin-top: 2rem;
+        background: rgba(255, 255, 255, 0.85);
+        border-radius: 16px;
+        padding: 1.5rem;
+        box-shadow: 0 20px 60px rgba(31, 35, 71, 0.06);
+      }
+      section[hidden] {
+        display: none;
+      }
+      dl {
+        margin: 0;
+        display: grid;
+        gap: 0.75rem;
+      }
+      dt {
+        font-size: 0.85rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: #5a60a1;
+      }
+      dd {
+        margin: 0;
+        font-size: 1rem;
+      }
+      .error {
+        margin-top: 1rem;
+        padding: 0.75rem 1rem;
+        border-radius: 12px;
+        background: rgba(244, 67, 54, 0.12);
+        color: #c62828;
+        border: 1px solid rgba(244, 67, 54, 0.2);
+      }
+      @media (max-width: 600px) {
+        .container {
+          padding: 2rem 1rem 3rem;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <h1>Submit a request</h1>
+      <form id="request-form" autocomplete="off">
+        <div>
+          <label for="prompt">Prompt</label>
+          <textarea id="prompt" name="prompt" placeholder="Describe the task you want Alpha Solver to run" required></textarea>
+        </div>
+        <div>
+          <label for="provider">Provider</label>
+          <select id="provider" name="provider">
+            {{provider_options}}
+          </select>
+        </div>
+        <div>
+          <button type="submit">Submit request</button>
+        </div>
+      </form>
+      <section id="ack" hidden>
+        <h2>Submission</h2>
+        <dl>
+          <div>
+            <dt>Request ID</dt>
+            <dd id="request-id">—</dd>
+          </div>
+          <div>
+            <dt>Ack latency</dt>
+            <dd><span id="ack-ms">—</span> ms</dd>
+          </div>
+        </dl>
+      </section>
+      <section id="status" hidden>
+        <h2>Status</h2>
+        <dl>
+          <div>
+            <dt>State</dt>
+            <dd id="status-value">pending</dd>
+          </div>
+          <div>
+            <dt>Provider</dt>
+            <dd id="status-provider">—</dd>
+          </div>
+          <div>
+            <dt>Latency</dt>
+            <dd id="status-latency">—</dd>
+          </div>
+          <div>
+            <dt>Cache hit</dt>
+            <dd id="status-cache">—</dd>
+          </div>
+        </dl>
+      </section>
+      <div id="error" class="error" role="alert" hidden></div>
+    </main>
+    <script>
+      const form = document.getElementById("request-form");
+      const ackSection = document.getElementById("ack");
+      const statusSection = document.getElementById("status");
+      const errorBox = document.getElementById("error");
+      let pollHandle = null;
+
+      function resetStatusView() {
+        document.getElementById("request-id").textContent = "—";
+        document.getElementById("ack-ms").textContent = "—";
+        document.getElementById("status-value").textContent = "pending";
+        document.getElementById("status-provider").textContent = "—";
+        document.getElementById("status-latency").textContent = "—";
+        document.getElementById("status-cache").textContent = "—";
+        errorBox.textContent = "";
+        errorBox.hidden = true;
+      }
+
+      function renderStatus(payload) {
+        document.getElementById("status-value").textContent = payload.status;
+        document.getElementById("status-provider").textContent = payload.provider;
+        document.getElementById("status-cache").textContent = payload.cache_hit ? "yes" : "no";
+        document.getElementById("status-latency").textContent =
+          payload.latency_ms === null || payload.latency_ms === undefined
+            ? "pending"
+            : `${payload.latency_ms.toFixed(1)} ms`;
+        statusSection.hidden = false;
+      }
+
+      async function pollStatus(id) {
+        try {
+          const response = await fetch(`/requests/${id}`);
+          if (!response.ok) {
+            throw new Error("Failed to load status");
+          }
+          const payload = await response.json();
+          renderStatus(payload);
+          if (payload.status !== "done") {
+            pollHandle = setTimeout(() => {
+              pollStatus(id).catch((error) => showError(error));
+            }, 750);
+          }
+        } catch (error) {
+          showError(error);
+        }
+      }
+
+      function showError(error) {
+        errorBox.textContent = error?.message || "Unexpected error";
+        errorBox.hidden = false;
+      }
+
+      form.addEventListener("submit", async (event) => {
+        event.preventDefault();
+        if (pollHandle) {
+          clearTimeout(pollHandle);
+          pollHandle = null;
+        }
+        resetStatusView();
+        ackSection.hidden = false;
+        const prompt = document.getElementById("prompt").value.trim();
+        if (!prompt) {
+          showError(new Error("Prompt is required"));
+          return;
+        }
+        const provider = document.getElementById("provider").value;
+        try {
+          const start = performance.now();
+          const response = await fetch("/requests", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ prompt, provider }),
+          });
+          const ackLatency = performance.now() - start;
+          document.getElementById("ack-ms").textContent = ackLatency.toFixed(1);
+          if (!response.ok) {
+            const payload = await response.json().catch(() => ({}));
+            const message = payload.detail || response.statusText || "Unable to submit request";
+            throw new Error(message);
+          }
+          const data = await response.json();
+          document.getElementById("request-id").textContent = data.id;
+          await pollStatus(data.id);
+        } catch (error) {
+          showError(error);
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/tests/ui/test_requests.py
+++ b/tests/ui/test_requests.py
@@ -1,0 +1,60 @@
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from alpha.webapp.routes import requests as request_routes
+
+
+def create_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(request_routes.router)
+    return app
+
+
+def test_request_submission_flow():
+    request_routes.reset_state()
+    app = create_app()
+    with TestClient(app) as client:
+        # Verify the form renders with the expected controls.
+        form_response = client.get("/requests")
+        assert form_response.status_code == 200
+        html = form_response.text
+        assert "<textarea" in html
+        assert "<select" in html
+
+        # Submit a job and ensure the acknowledgement arrives within the SLA.
+        start = time.perf_counter()
+        submit_response = client.post(
+            "/requests",
+            json={"prompt": "demo prompt", "provider": request_routes.AVAILABLE_PROVIDERS[0]},
+        )
+        ack_latency_ms = (time.perf_counter() - start) * 1000
+        assert submit_response.status_code == 200
+        job_id = submit_response.json()["id"]
+        assert isinstance(job_id, str) and job_id
+        assert ack_latency_ms < 500
+
+        # Poll until the request is marked done.
+        deadline = time.perf_counter() + 5.0
+        final_payload = None
+        while time.perf_counter() < deadline:
+            status_response = client.get(f"/requests/{job_id}")
+            assert status_response.status_code == 200
+            final_payload = status_response.json()
+            if final_payload["status"] == "done":
+                break
+            time.sleep(0.05)
+        assert final_payload is not None, "no status response recorded"
+        assert final_payload["status"] == "done"
+        assert final_payload["id"] == job_id
+        assert final_payload["provider"] == request_routes.AVAILABLE_PROVIDERS[0]
+        assert final_payload["cache_hit"] is False
+        assert isinstance(final_payload["latency_ms"], float)
+        assert final_payload["latency_ms"] >= 0


### PR DESCRIPTION
## Summary
- add a FastAPI router that queues mock jobs, exposes submission and status endpoints, and renders the new dashboard request form
- build the request.html template with styling, acknowledgement messaging, and JavaScript polling against the status API
- cover the end-to-end flow with a UI test and capture the spec details in .specs/UI-REQ-001.md

## Testing
- pytest tests/ui/test_requests.py


------
https://chatgpt.com/codex/tasks/task_e_68c872121ca48329be9d161a97433f52