### PR TITLE
Implement dashboard API key management settings

### DIFF
--- a/.specs/UI-KEYS-001.md
+++ b/.specs/UI-KEYS-001.md
@@ -1,0 +1,20 @@
+# UI-KEYS-001 · Dashboard: API Keys Management
+
+## Goal
+Implement Dashboard: API Keys Management in track RES_Dash with enforceable tests.
+
+## Acceptance Criteria
+- Create, update and delete provider API keys (OpenAI/Claude/etc.).
+- Mask provider secrets on read (****last4) and persist via a secrets backend shim.
+- Emit an audit log entry for every change while keeping plaintext out of the log.
+- Provide automated tests that verify the UI behaviour (10/10 passing).
+
+## Code Targets
+- `alpha/webapp/routes/settings.py`
+- `alpha/webapp/templates/settings.html`
+- `tests/ui/test_settings.py`
+
+## Notes
+- Settings page supports provider API key lifecycle management.
+- Persistence occurs through a lightweight secrets backend (env/kv, gitignored).
+- Templates follow `ui_keys_v1` baseline.

--- a/alpha/webapp/routes/settings.py
+++ b/alpha/webapp/routes/settings.py
@@ -1,0 +1,268 @@
+"""Dashboard settings routes for managing provider API keys."""
+
+from __future__ import annotations
+
+import json
+import os
+from urllib.parse import parse_qs
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+
+from fastapi import APIRouter, HTTPException, Request, status
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+__all__ = [
+    "router",
+    "FileSecretsBackend",
+    "AuditLogger",
+    "mask_secret",
+]
+
+
+def _resolve_path(env_var: str, default_name: str) -> Path:
+    """Resolve a filesystem path for persistent storage.
+
+    The location can be overridden through an environment variable. When no
+    override is provided we fall back to a directory inside the user's home so
+    that persisted data remains outside of version control.
+    """
+
+    env_value = os.getenv(env_var)
+    if env_value:
+        return Path(env_value).expanduser()
+    return Path.home() / ".alpha_solver" / default_name
+
+
+@dataclass(frozen=True)
+class ProviderKeyDisplay:
+    """View model for representing a stored provider key in the UI."""
+
+    provider: str
+    masked_key: str
+
+
+class SecretsBackend:
+    """Abstract interface for a secrets backend."""
+
+    def list(self) -> Dict[str, str]:
+        raise NotImplementedError
+
+    def get(self, provider: str) -> Optional[str]:
+        raise NotImplementedError
+
+    def set(self, provider: str, key: str) -> None:
+        raise NotImplementedError
+
+    def delete(self, provider: str) -> None:
+        raise NotImplementedError
+
+
+class FileSecretsBackend(SecretsBackend):
+    """Simple file-based secrets backend storing JSON data."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = Path(path)
+
+    def list(self) -> Dict[str, str]:
+        return dict(self._read())
+
+    def get(self, provider: str) -> Optional[str]:
+        return self._read().get(provider)
+
+    def set(self, provider: str, key: str) -> None:
+        data = self._read()
+        data[provider] = key
+        self._write(data)
+
+    def delete(self, provider: str) -> None:
+        data = self._read()
+        if provider in data:
+            data.pop(provider)
+            self._write(data)
+
+    def _read(self) -> Dict[str, str]:
+        if not self.path.exists():
+            return {}
+        with self.path.open("r", encoding="utf-8") as file:
+            try:
+                payload = json.load(file)
+            except json.JSONDecodeError:
+                payload = {}
+        if not isinstance(payload, dict):
+            return {}
+        return {str(key): str(value) for key, value in payload.items()}
+
+    def _write(self, data: Dict[str, str]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("w", encoding="utf-8") as file:
+            json.dump(data, file, indent=2, sort_keys=True)
+
+
+class AuditLogger:
+    """File backed audit logger that stores masked change events."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = Path(path)
+
+    def log(self, action: str, provider: str, masked_key: str) -> None:
+        timestamp = datetime.now(timezone.utc).isoformat()
+        line = f"{timestamp} | {action.upper()} | {provider} | {masked_key}\n"
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("a", encoding="utf-8") as file:
+            file.write(line)
+
+
+def mask_secret(raw_key: Optional[str]) -> str:
+    """Return a masked representation of a secret value."""
+
+    if not raw_key:
+        return "****"
+    if len(raw_key) <= 4:
+        return "****"
+    return f"****{raw_key[-4:]}"
+
+
+class SettingsService:
+    """Domain logic for manipulating provider API keys."""
+
+    def __init__(self, backend: SecretsBackend, audit_logger: AuditLogger) -> None:
+        self._backend = backend
+        self._audit = audit_logger
+
+    def list_masked(self) -> Iterable[ProviderKeyDisplay]:
+        items = self._backend.list()
+        for provider in sorted(items):
+            yield ProviderKeyDisplay(provider=provider, masked_key=mask_secret(items[provider]))
+
+    def set_key(self, provider: str, key: str) -> None:
+        provider = provider.strip()
+        key = key.strip()
+        if not provider:
+            raise ValueError("provider is required")
+        if not key:
+            raise ValueError("key is required")
+        existing = self._backend.get(provider)
+        self._backend.set(provider, key)
+        action = "UPDATED" if existing is not None else "CREATED"
+        self._audit.log(action, provider, mask_secret(key))
+
+    def delete_key(self, provider: str) -> bool:
+        provider = provider.strip()
+        if not provider:
+            raise ValueError("provider is required")
+        existing = self._backend.get(provider)
+        if existing is None:
+            return False
+        self._backend.delete(provider)
+        self._audit.log("DELETED", provider, mask_secret(existing))
+        return True
+
+
+TEMPLATE_PATH = Path(__file__).resolve().parent.parent / "templates" / "settings.html"
+router = APIRouter()
+
+
+def _service() -> SettingsService:
+    backend_path = _resolve_path("ALPHA_DASHBOARD_SECRETS_PATH", "dashboard_api_keys.json")
+    audit_path = _resolve_path("ALPHA_DASHBOARD_AUDIT_LOG", "dashboard_audit.log")
+    backend = FileSecretsBackend(backend_path)
+    audit_logger = AuditLogger(audit_path)
+    return SettingsService(backend, audit_logger)
+
+
+def _render_settings_template(providers: Iterable[ProviderKeyDisplay]) -> str:
+    base = TEMPLATE_PATH.read_text(encoding="utf-8")
+    rows: list[str] = []
+    for item in providers:
+        rows.append(
+            """
+        <tr>
+          <td class="provider">{provider}</td>
+          <td class="masked">{masked}</td>
+          <td>
+            <form method="post" action="/settings/keys" class="inline-form update-form">
+              <input type="hidden" name="provider" value="{provider}" />
+              <label>
+                Update key
+                <input type="text" name="key" placeholder="Enter new key" />
+              </label>
+              <button type="submit">Save</button>
+            </form>
+            <form method="post" action="/settings/keys/delete" class="inline-form delete-form">
+              <input type="hidden" name="provider" value="{provider}" />
+              <button type="submit">Delete</button>
+            </form>
+          </td>
+        </tr>
+        """.format(provider=item.provider, masked=item.masked_key)
+        )
+
+    if rows:
+        table_html = """
+    <table id="keys-table">
+      <thead>
+        <tr>
+          <th scope="col">Provider</th>
+          <th scope="col">Masked API key</th>
+          <th scope="col">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+    {rows}
+      </tbody>
+    </table>
+    """.format(rows="\n".join(row.strip("\n") for row in rows))
+    else:
+        table_html = '<p id="empty-state">No API keys configured.</p>'
+
+    return base.replace("[[KEYS_TABLE]]", table_html)
+
+
+@router.get("/settings", response_class=HTMLResponse)
+async def settings_page() -> HTMLResponse:
+    service = _service()
+    providers = list(service.list_masked())
+    html = _render_settings_template(providers)
+    return HTMLResponse(content=html)
+
+
+async def _extract_payload(request: Request) -> Dict[str, str]:
+    content_type = request.headers.get("content-type", "").lower()
+    if "application/json" in content_type:
+        payload = await request.json()
+        if isinstance(payload, dict):
+            return {str(k): "" if v is None else str(v) for k, v in payload.items()}
+        return {}
+
+    body = await request.body()
+    if not body:
+        return {}
+    parsed = parse_qs(body.decode())
+    return {key: values[0] if values else "" for key, values in parsed.items()}
+
+
+@router.post("/settings/keys")
+async def create_or_update_key(request: Request) -> RedirectResponse:
+    service = _service()
+    payload = await _extract_payload(request)
+    provider = payload.get("provider", "")
+    key = payload.get("key", "")
+    try:
+        service.set_key(provider, key)
+    except ValueError as exc:  # pragma: no cover - defensive branch
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(exc)) from exc
+    return RedirectResponse("/settings", status_code=status.HTTP_303_SEE_OTHER)
+
+
+@router.post("/settings/keys/delete")
+async def delete_key(request: Request) -> RedirectResponse:
+    service = _service()
+    payload = await _extract_payload(request)
+    provider = payload.get("provider", "")
+    try:
+        service.delete_key(provider)
+    except ValueError as exc:  # pragma: no cover - defensive branch
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(exc)) from exc
+    return RedirectResponse("/settings", status_code=status.HTTP_303_SEE_OTHER)

--- a/alpha/webapp/templates/settings.html
+++ b/alpha/webapp/templates/settings.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Provider API Keys</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2rem; }
+    table { border-collapse: collapse; width: 100%; margin-bottom: 2rem; }
+    th, td { border: 1px solid #ddd; padding: 0.5rem; text-align: left; }
+    th { background-color: #f2f2f2; }
+    .inline-form { display: inline-block; margin-right: 0.5rem; }
+    #empty-state { font-style: italic; color: #666; }
+  </style>
+</head>
+<body>
+  <h1>Provider API Keys</h1>
+
+  <section id="keys">
+    [[KEYS_TABLE]]
+  </section>
+
+  <section id="add-key">
+    <h2>Add provider key</h2>
+    <form method="post" action="/settings/keys">
+      <label>
+        Provider
+        <input type="text" name="provider" required />
+      </label>
+      <label>
+        API key
+        <input type="text" name="key" required />
+      </label>
+      <button type="submit">Add key</button>
+    </form>
+  </section>
+</body>
+</html>

--- a/tests/ui/test_settings.py
+++ b/tests/ui/test_settings.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from alpha.webapp.routes import settings
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    secrets_path = tmp_path / "secrets.json"
+    audit_path = tmp_path / "audit.log"
+    monkeypatch.setenv("ALPHA_DASHBOARD_SECRETS_PATH", str(secrets_path))
+    monkeypatch.setenv("ALPHA_DASHBOARD_AUDIT_LOG", str(audit_path))
+
+    app = FastAPI()
+    app.include_router(settings.router)
+    client = TestClient(app)
+    try:
+        yield client, secrets_path, audit_path
+    finally:
+        client.close()
+
+
+def _post_key(client: TestClient, provider: str, key: str) -> None:
+    response = client.post(
+        "/settings/keys",
+        data={"provider": provider, "key": key},
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+
+
+def _delete_key(client: TestClient, provider: str) -> None:
+    response = client.post(
+        "/settings/keys/delete",
+        data={"provider": provider},
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+
+
+def _read_json(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_create_key_persists_and_masks_display(client):
+    client_app, secrets_path, audit_path = client
+
+    _post_key(client_app, "openai", "sk-openai-12345678")
+
+    stored = _read_json(secrets_path)
+    assert stored == {"openai": "sk-openai-12345678"}
+
+    page = client_app.get("/settings")
+    assert page.status_code == 200
+    assert "****5678" in page.text
+    assert "sk-openai-12345678" not in page.text
+
+    log_lines = audit_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(log_lines) == 1
+    assert "CREATED" in log_lines[0]
+    assert "****5678" in log_lines[0]
+
+
+def test_update_key_overwrites_value_and_audits(client):
+    client_app, secrets_path, audit_path = client
+
+    first = "sk-openai-11112222"
+    updated = "sk-openai-33334444"
+    _post_key(client_app, "openai", first)
+    _post_key(client_app, "openai", updated)
+
+    stored = _read_json(secrets_path)
+    assert stored["openai"] == updated
+
+    log_lines = audit_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(log_lines) == 2
+    assert "CREATED" in log_lines[0]
+    assert "UPDATED" in log_lines[1]
+    assert updated not in log_lines[1]
+    assert "****4444" in log_lines[1]
+
+
+def test_delete_key_removes_key_and_logs(client):
+    client_app, secrets_path, audit_path = client
+
+    _post_key(client_app, "openai", "sk-openai-55556666")
+    _delete_key(client_app, "openai")
+
+    stored = _read_json(secrets_path)
+    assert stored == {}
+
+    log_lines = audit_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(log_lines) == 2
+    assert "CREATED" in log_lines[0]
+    assert "DELETED" in log_lines[1]
+    assert "****6666" in log_lines[1]
+    assert "sk-openai-55556666" not in " ".join(log_lines)
+
+
+def test_masking_hides_short_keys(client):
+    client_app, _, _ = client
+
+    _post_key(client_app, "claude", "abcd")
+
+    page = client_app.get("/settings")
+    assert page.status_code == 200
+    assert "****" in page.text
+    assert "abcd" not in page.text
+
+
+def test_audit_log_never_contains_plaintext_key(client):
+    client_app, _, audit_path = client
+
+    original = "sk-claude-ABCDE12345"
+    updated = "sk-claude-ZYXW98765"
+
+    _post_key(client_app, "claude", original)
+    _post_key(client_app, "claude", updated)
+    _delete_key(client_app, "claude")
+
+    log_text = audit_path.read_text(encoding="utf-8")
+    assert original not in log_text
+    assert updated not in log_text
+    assert log_text.count("CREATED") == 1
+    assert log_text.count("UPDATED") == 1
+    assert log_text.count("DELETED") == 1
+    assert "****8765" in log_text


### PR DESCRIPTION
## Summary
- add a FastAPI settings route backed by a file-based secrets backend and audit logger
- provide an HTML dashboard view for listing, updating and deleting provider API keys with masked display
- create UI tests covering API key create, update, delete flows and audit log redaction

## Testing
- pytest tests/ui/test_settings.py

------
https://chatgpt.com/codex/tasks/task_e_68c87277c24883299e66b4d618ff0079