### PR TITLE
Implement RES_Dash alert rules and CI validation

### DIFF
--- a/.specs/OBS-ALERTS-001.md
+++ b/.specs/OBS-ALERTS-001.md
@@ -1,0 +1,23 @@
+# CODE SPEC — OBS-ALERTS-001 · Prometheus Alerts + CI Validation (RES_Dash)
+
+## Goal
+Implement Prometheus Alerts + CI Validation in track RES_Dash with enforceable tests.
+
+## Acceptance Criteria
+- Alert rules for retry_p95>=2, breaker_p95>=100ms, 5xx>1%.
+- Rules validate in CI.
+- 10/10 tests parse rule files.
+- Docs list rule semantics.
+
+## Code Targets
+- alpha/dashboard/alerts.json
+- tests/dashboard/test_alerts.py
+- docs/DASHBOARDS.md
+
+## Template
+- dashboards_alerts_v1
+
+## Notes
+- Alerts for: retry_p95>=2, breaker_open_p95_ms>=100, http_5xx_ratio>0.01.
+- tests/dashboard/test_alerts.py loads alerts.json, checks required keys, and basic expression sanity.
+- Update docs/DASHBOARDS.md with alert meanings + how to import.

--- a/alpha/dashboard/alerts.json
+++ b/alpha/dashboard/alerts.json
@@ -1,4 +1,5 @@
 {
+  "template": "dashboards_alerts_v1",
   "alerts": [
     {
       "name": "Gate Decision Denial Spike",
@@ -6,7 +7,8 @@
       "for": "5m",
       "labels": {
         "severity": "warning",
-        "team": "release"
+        "team": "release",
+        "service": "res_dash"
       },
       "annotations": {
         "summary": "Gate denials exceeded 20% over the last 5 minutes.",
@@ -19,7 +21,8 @@
       "for": "10m",
       "labels": {
         "severity": "critical",
-        "team": "adapters"
+        "team": "adapters",
+        "service": "res_dash"
       },
       "annotations": {
         "summary": "Adapter latency P95 breached 750ms threshold.",
@@ -32,11 +35,57 @@
       "for": "30m",
       "labels": {
         "severity": "critical",
-        "team": "reliability"
+        "team": "reliability",
+        "service": "res_dash"
       },
       "annotations": {
         "summary": "Composite reliability SLO dipped below 99.5% over the last 30 minutes.",
         "runbook": "https://runbooks.alpha/observability/reliability"
+      }
+    },
+    {
+      "name": "Retry Saturation P95 High",
+      "expr": "sum(max_over_time(retry_p95{environment=\"prod\"}[10m])) >= 2",
+      "for": "15m",
+      "labels": {
+        "severity": "warning",
+        "service": "res_dash",
+        "team": "reliability"
+      },
+      "annotations": {
+        "summary": "Retry P95 has stayed above 2 attempts across the last 10 minutes.",
+        "description": "Sustained high retry percentiles indicate downstream stress or misconfiguration.",
+        "runbook": "https://runbooks.alpha/observability/retries"
+      }
+    },
+    {
+      "name": "Breaker Open Duration P95 High",
+      "expr": "sum(max_over_time(breaker_open_p95_ms{environment=\"prod\"}[10m])) >= 100",
+      "for": "15m",
+      "labels": {
+        "severity": "critical",
+        "service": "res_dash",
+        "team": "reliability"
+      },
+      "annotations": {
+        "summary": "Circuit breaker open duration P95 exceeded 100ms.",
+        "description": "Persistent breaker openings degrade request throughput and should be mitigated quickly.",
+        "runbook": "https://runbooks.alpha/observability/breakers"
+      }
+    },
+    {
+      "name": "HTTP 5xx Ratio High",
+      "expr": "sum(avg_over_time(http_5xx_ratio{environment=\"prod\"}[5m])) > 0.01",
+      "for": "10m",
+      "labels": {
+        "severity": "critical",
+        "service": "res_dash",
+        "team": "reliability"
+      },
+      "annotations": {
+        "summary": "HTTP 5xx responses are above 1% across the last five minutes.",
+        "description": "Elevated 5xx error ratio signals regressions in upstream dependencies or new deployments.",
+        "runbook": "https://runbooks.alpha/observability/http-errors"
       }
     }
   ]

--- a/docs/DASHBOARDS.md
+++ b/docs/DASHBOARDS.md
@@ -24,11 +24,19 @@ The Alpha Production Observability dashboard ships a curated slice of the core r
 
 ## Alert Coverage
 
-The companion alert rules mirror the dashboard metrics:
+The companion alert rules mirror the dashboard metrics and add high-signal reliability guardrails. Each rule is delivered in `alpha/dashboard/alerts.json` under the `dashboards_alerts_v1` template so it can be imported directly into Grafana alerting.
+
+### Core Dashboard Alerts
 
 - **Gate Decision Denial Spike** – Watches the ratio of `gate_decisions_total` with `decision="denied"` exceeding 20% for five minutes.
 - **Adapter Latency Regression** – Triggers when `quantile_over_time(0.95, adapter_latency_ms[5m])` rises above 750 ms for ten minutes.
 - **Reliability SLO Burn** – Guards the SLO using retry and breaker counters to ensure the 99.5% target is met across a 30-minute window.
+
+### Reliability Guardrail Alerts
+
+- **Retry Saturation P95 High** – Uses `sum(max_over_time(retry_p95[10m]))` to detect when the 95th percentile retry count stays at or above two attempts for 15 minutes. Sustained high retries suggest downstream pressure or configuration drift.
+- **Breaker Open Duration P95 High** – Tracks `sum(max_over_time(breaker_open_p95_ms[10m]))` and pages when the circuit breaker open duration P95 stays at or above 100 ms for 15 minutes, highlighting availability risk.
+- **HTTP 5xx Ratio High** – Averages `http_5xx_ratio` via `sum(avg_over_time(http_5xx_ratio[5m]))` and fires when responses stay above the 1% error budget threshold for 10 minutes, signalling service regressions.
 
 ## Obs-card Snippet
 

--- a/tests/dashboard/test_alerts.py
+++ b/tests/dashboard/test_alerts.py
@@ -1,0 +1,121 @@
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ALERTS_PATH = REPO_ROOT / "alpha" / "dashboard" / "alerts.json"
+
+
+@pytest.fixture(scope="module")
+def alerts_config():
+    raw = ALERTS_PATH.read_text(encoding="utf-8")
+    data = json.loads(raw)
+    assert isinstance(data, dict), "alerts.json must be a JSON object"
+    assert "alerts" in data and isinstance(data["alerts"], list), "alerts.json requires an alerts list"
+    return data
+
+
+def validate_promql(expr: str) -> None:
+    assert isinstance(expr, str), "PromQL expression must be a string"
+    stripped = expr.strip()
+    assert stripped, "PromQL expression should not be empty"
+    assert stripped == expr, "PromQL expression should not contain leading/trailing whitespace"
+
+    pairs = {")": "(",
+        "]": "[",
+        "}": "{",
+    }
+    openers = set(pairs.values())
+    stack = []
+    for char in expr:
+        if char in openers:
+            stack.append(char)
+        elif char in pairs:
+            assert stack, f"Unbalanced bracket near {char}"
+            opener = stack.pop()
+            assert opener == pairs[char], f"Mismatched {opener} and {char}"
+    assert not stack, "PromQL expression has unclosed brackets"
+
+    tokens = re.split(r"[^A-Za-z0-9_]+", stripped)
+    assert any(token and token[0].isalpha() for token in tokens), "PromQL expression should reference at least one metric"
+    assert any(operator in expr for operator in ("sum", "rate", "increase", "quantile", "histogram_quantile", "max_over_time", "avg_over_time", "+", "-", "/", "*", ">", "<", ">=", "<=")), "PromQL expression missing expected functions"
+
+
+def get_alert_by_name(alerts, name):
+    for alert in alerts:
+        if alert.get("name") == name:
+            return alert
+    return None
+
+
+def test_alerts_file_structure(alerts_config):
+    assert alerts_config.get("template") == "dashboards_alerts_v1", "alerts.json must declare the dashboards_alerts_v1 template"
+    assert alerts_config["alerts"], "alerts.json must contain at least one alert"
+
+
+def test_alert_entries_have_required_keys(alerts_config):
+    for alert in alerts_config["alerts"]:
+        assert set(alert.keys()) >= {"name", "expr", "for", "labels", "annotations"}, "Every alert must declare core fields"
+
+
+def test_alert_names_unique(alerts_config):
+    names = [alert["name"] for alert in alerts_config["alerts"]]
+    assert len(names) == len(set(names)), "Alert rule names should be unique"
+
+
+def test_expected_alerts_present(alerts_config):
+    alerts = alerts_config["alerts"]
+    expected = {
+        "Retry Saturation P95 High": "sum(max_over_time(retry_p95{environment=\"prod\"}[10m])) >= 2",
+        "Breaker Open Duration P95 High": "sum(max_over_time(breaker_open_p95_ms{environment=\"prod\"}[10m])) >= 100",
+        "HTTP 5xx Ratio High": "sum(avg_over_time(http_5xx_ratio{environment=\"prod\"}[5m])) > 0.01",
+    }
+    for name, expr in expected.items():
+        alert = get_alert_by_name(alerts, name)
+        assert alert is not None, f"Missing required alert: {name}"
+        assert alert["expr"] == expr, f"Unexpected PromQL for {name}"
+
+
+def test_retry_alert_threshold(alerts_config):
+    alert = get_alert_by_name(alerts_config["alerts"], "Retry Saturation P95 High")
+    assert alert is not None, "Retry Saturation alert must exist"
+    assert ">=" in alert["expr"], "Retry alert must compare against a threshold"
+    assert ">= 2" in alert["expr"], "Retry alert threshold must be 2 attempts"
+    assert alert["for"] == "15m", "Retry alert must require 15m confirmation window"
+
+
+def test_breaker_alert_threshold(alerts_config):
+    alert = get_alert_by_name(alerts_config["alerts"], "Breaker Open Duration P95 High")
+    assert alert is not None, "Breaker alert must exist"
+    assert ">= 100" in alert["expr"], "Breaker alert threshold must be 100ms"
+    assert alert["for"] == "15m", "Breaker alert must require 15m confirmation window"
+
+
+def test_http_5xx_alert_threshold(alerts_config):
+    alert = get_alert_by_name(alerts_config["alerts"], "HTTP 5xx Ratio High")
+    assert alert is not None, "HTTP 5xx alert must exist"
+    assert "> 0.01" in alert["expr"], "HTTP 5xx alert threshold must be 1%"
+    assert alert["for"] == "10m", "HTTP 5xx alert must require 10m confirmation window"
+
+
+def test_alert_labels_include_severity(alerts_config):
+    for alert in alerts_config["alerts"]:
+        labels = alert["labels"]
+        assert isinstance(labels, dict) and labels, "Alert labels must be a dict"
+        assert "severity" in labels, "Alert labels must include severity"
+        assert labels.get("service") == "res_dash", "Alerts must be tagged with the res_dash service"
+
+
+def test_alert_annotations_have_summary(alerts_config):
+    for alert in alerts_config["alerts"]:
+        annotations = alert["annotations"]
+        assert isinstance(annotations, dict) and annotations, "Alert annotations must be a dict"
+        assert "summary" in annotations, "Alert annotations must include a summary"
+        assert "runbook" in annotations, "Alert annotations must link to a runbook"
+
+
+def test_promql_expressions_are_balanced(alerts_config):
+    for alert in alerts_config["alerts"]:
+        validate_promql(alert["expr"])


### PR DESCRIPTION
## Summary
- add res_dash template metadata and reliability guardrail alerts for retry, breaker, and 5xx metrics
- ensure alerts carry service labels and document rule semantics in DASHBOARDS.md
- add dashboard alert validation tests covering structure, thresholds, and PromQL hygiene

## Testing
- pytest tests/dashboard -q

------
https://chatgpt.com/codex/tasks/task_e_68c876c3fe6883298a4b8bac1836ab52