### PR TITLE
Add dashboard job history view

### DIFF
--- a/.specs/UI-JOBS-001.md
+++ b/.specs/UI-JOBS-001.md
@@ -1,0 +1,20 @@
+# UI-JOBS-001 · Dashboard Job History & Metrics (RES_Dash)
+
+## Goal
+Implement the dashboard job history and metrics view that surfaces the most recent execution records and lightweight observability for operators.
+
+## Functional Requirements
+- Provide a server-rendered page at `GET /jobs` that displays the last 100 dashboard jobs (id, provider, status, latency_ms, cache_hit).
+- Support sorting the visible jobs by submission time (ascending/descending) and latency (ascending/descending).
+- Each table row must link to `/jobs/<id>` for downstream detail and log views.
+- Include a status summary component with counts of the displayed jobs grouped by status.
+
+## Performance Notes
+- The page should render in under two seconds locally. Keep the implementation in-memory without external I/O.
+
+## UX Notes
+- Present the data in a tabular layout with clear headers and action-oriented sort controls.
+- Surface the status summary adjacent to the table for quick at-a-glance diagnostics.
+
+## Testing
+- `tests/ui/test_jobs.py` validates table shape, limiting to 100 rows, sorting behaviour, status summaries, cache hit rendering, and link construction.

--- a/alpha/webapp/routes/jobs.py
+++ b/alpha/webapp/routes/jobs.py
@@ -1,0 +1,213 @@
+"""Job history dashboard routes for the Alpha Solver UI."""
+
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+from typing import List, Sequence
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
+
+from . import requests as request_routes
+
+__all__ = ["router"]
+
+
+router = APIRouter()
+
+_TEMPLATE_PATH = Path(__file__).resolve().parent.parent / "templates" / "jobs.html"
+_TEMPLATE_CACHE: str | None = None
+_MAX_ROWS = 100
+_DEFAULT_SORT_FIELD = "time"
+_DEFAULT_SORT_DIRECTION = "desc"
+_VALID_SORT_FIELDS = {"time", "latency"}
+_VALID_DIRECTIONS = {"asc", "desc"}
+
+
+def _load_template() -> str:
+    global _TEMPLATE_CACHE
+    if _TEMPLATE_CACHE is None:
+        _TEMPLATE_CACHE = _TEMPLATE_PATH.read_text(encoding="utf-8")
+    return _TEMPLATE_CACHE
+
+
+def _snapshot_jobs() -> List[request_routes.RequestJob]:
+    """Return jobs ordered by submission time (newest first)."""
+
+    with request_routes._JOBS_LOCK:
+        jobs = list(request_routes._JOBS.values())
+    return sorted(jobs, key=lambda job: job.submitted_at, reverse=True)
+
+
+def _normalize_sort_field(value: str | None) -> str:
+    if not value:
+        return _DEFAULT_SORT_FIELD
+    value_lower = value.lower()
+    if value_lower in _VALID_SORT_FIELDS:
+        return value_lower
+    return _DEFAULT_SORT_FIELD
+
+
+def _normalize_direction(value: str | None) -> str:
+    if not value:
+        return _DEFAULT_SORT_DIRECTION
+    value_lower = value.lower()
+    if value_lower in _VALID_DIRECTIONS:
+        return value_lower
+    return _DEFAULT_SORT_DIRECTION
+
+
+def _sort_jobs(
+    jobs: Sequence[request_routes.RequestJob],
+    field: str,
+    direction: str,
+) -> List[request_routes.RequestJob]:
+    if field == "latency":
+        if direction == "asc":
+            return sorted(
+                jobs,
+                key=lambda job: (
+                    job.latency_ms is None,
+                    job.latency_ms if job.latency_ms is not None else float("inf"),
+                    -job.submitted_at,
+                    job.id,
+                ),
+            )
+        return sorted(
+            jobs,
+            key=lambda job: (
+                job.latency_ms is None,
+                -(job.latency_ms or 0.0),
+                -job.submitted_at,
+                job.id,
+            ),
+        )
+    if direction == "asc":
+        return sorted(jobs, key=lambda job: (job.submitted_at, job.id))
+    return sorted(jobs, key=lambda job: (-job.submitted_at, job.id))
+
+
+def _format_latency(job: request_routes.RequestJob) -> tuple[str, str]:
+    if job.latency_ms is None:
+        return "—", "pending"
+    return f"{job.latency_ms:.1f} ms", f"{job.latency_ms:.6f}"
+
+
+def _render_rows(jobs: Sequence[request_routes.RequestJob]) -> str:
+    if not jobs:
+        return """
+            <tr class=\"empty\">
+              <td colspan=\"5\">No jobs recorded yet.</td>
+            </tr>
+        """.strip()
+
+    rows: list[str] = []
+    for job in jobs:
+        latency_display, latency_attr = _format_latency(job)
+        cache_display = "yes" if job.cache_hit else "no"
+        rows.append(
+            """
+            <tr data-job-id=\"{job_id}\" data-status=\"{status}\" data-submitted=\"{submitted:.6f}\" data-latency=\"{latency_attr}\">
+              <td class=\"col-id\"><a href=\"/jobs/{job_id}\" class=\"job-link\">{job_id}</a></td>
+              <td class=\"col-provider\">{provider}</td>
+              <td class=\"col-status\">{status}</td>
+              <td class=\"col-latency\">{latency}</td>
+              <td class=\"col-cache\">{cache}</td>
+            </tr>
+            """.format(
+                job_id=job.id,
+                provider=job.provider,
+                status=job.status,
+                latency=latency_display,
+                cache=cache_display,
+                latency_attr=latency_attr,
+                submitted=job.submitted_at,
+            ).strip()
+        )
+    return "\n".join(rows)
+
+
+def _render_status_summary(jobs: Sequence[request_routes.RequestJob]) -> str:
+    if not jobs:
+        return "          <li class=\"empty\">No jobs recorded yet.</li>"
+    counts = Counter(job.status for job in jobs)
+    items: list[str] = []
+    for status, count in sorted(counts.items()):
+        items.append(
+            f"          <li data-status=\"{status}\"><span class=\"status-label\">{status}</span><span class=\"status-count\">{count}</span></li>"
+        )
+    return "\n".join(items)
+
+
+def _sort_link(field: str, label: str, current_field: str, current_direction: str) -> tuple[str, str, str]:
+    is_active = field == current_field
+    if is_active:
+        next_direction = "asc" if current_direction == "desc" else "desc"
+        arrow = "↓" if current_direction == "desc" else "↑"
+        href = f"/jobs?sort={field}&direction={next_direction}"
+        full_label = f"{label} {arrow}"
+        active_suffix = " active"
+    else:
+        href = f"/jobs?sort={field}&direction=desc"
+        full_label = f"{label} ↕"
+        active_suffix = ""
+    return href, full_label, active_suffix
+
+
+def _summarize_count(display_count: int, total_count: int) -> str:
+    if display_count == 0:
+        return "No jobs recorded yet."
+    if total_count > display_count:
+        return f"Showing last {display_count} of {total_count} jobs."
+    if display_count == 1:
+        return "Showing 1 job."
+    return f"Showing {display_count} jobs."
+
+
+def _render_jobs_page(
+    jobs: Sequence[request_routes.RequestJob],
+    sort_field: str,
+    sort_direction: str,
+    display_count: int,
+    total_count: int,
+) -> str:
+    base = _load_template()
+    rows_html = _render_rows(jobs)
+    status_summary = _render_status_summary(jobs)
+    time_href, time_label, time_class = _sort_link("time", "Time", sort_field, sort_direction)
+    latency_href, latency_label, latency_class = _sort_link("latency", "Latency", sort_field, sort_direction)
+    summary_line = _summarize_count(display_count, total_count)
+
+    replacements = {
+        "job_count": str(display_count),
+        "total_jobs": str(total_count),
+        "rows": rows_html,
+        "status_items": status_summary,
+        "time_sort_href": time_href,
+        "time_sort_label": time_label,
+        "time_sort_active_class": time_class,
+        "latency_sort_href": latency_href,
+        "latency_sort_label": latency_label,
+        "latency_sort_active_class": latency_class,
+        "summary_line": summary_line,
+    }
+    rendered = base
+    for key, value in replacements.items():
+        rendered = rendered.replace(f"{{{{{key}}}}}", value)
+    return rendered
+
+
+@router.get("/jobs", response_class=HTMLResponse)
+async def jobs_dashboard(request: Request) -> HTMLResponse:
+    """Render the dashboard job history view."""
+
+    sort_field = _normalize_sort_field(request.query_params.get("sort"))
+    sort_direction = _normalize_direction(request.query_params.get("direction"))
+
+    snapshot = _snapshot_jobs()
+    total_count = len(snapshot)
+    recent_jobs = snapshot[:_MAX_ROWS]
+    sorted_jobs = _sort_jobs(recent_jobs, sort_field, sort_direction)
+    html = _render_jobs_page(sorted_jobs, sort_field, sort_direction, len(recent_jobs), total_count)
+    return HTMLResponse(content=html)

--- a/alpha/webapp/templates/jobs.html
+++ b/alpha/webapp/templates/jobs.html
@@ -1,0 +1,227 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Alpha Solver · Job History</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        line-height: 1.5;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: radial-gradient(circle at 10% 20%, rgba(73, 93, 255, 0.16), transparent 60%),
+          radial-gradient(circle at 90% 10%, rgba(130, 97, 247, 0.22), transparent 55%),
+          #f6f7fb;
+        color: #1d2142;
+      }
+      .container {
+        max-width: 1000px;
+        margin: 0 auto;
+        padding: 3rem 1.5rem 4rem;
+        display: grid;
+        gap: 1.5rem;
+      }
+      .page-header h1 {
+        margin: 0 0 0.5rem;
+        font-size: 2.25rem;
+      }
+      .page-header p {
+        margin: 0;
+        font-size: 1rem;
+        color: #4e538b;
+      }
+      .card {
+        background: rgba(255, 255, 255, 0.88);
+        border-radius: 20px;
+        padding: 1.75rem;
+        box-shadow: 0 24px 60px rgba(43, 51, 128, 0.08);
+        backdrop-filter: blur(18px);
+      }
+      .stats-card h2,
+      .table-card h2 {
+        margin: 0;
+        font-size: 1.25rem;
+      }
+      .status-list {
+        list-style: none;
+        margin: 1rem 0 0;
+        padding: 0;
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+        gap: 0.75rem;
+      }
+      .status-list li {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.5rem;
+        padding: 0.75rem 0.85rem;
+        border-radius: 12px;
+        background: rgba(79, 86, 142, 0.08);
+        color: inherit;
+        font-weight: 600;
+        letter-spacing: 0.02em;
+      }
+      .status-list li.empty {
+        justify-content: center;
+        font-weight: 500;
+        color: #5f6593;
+      }
+      .status-label {
+        text-transform: uppercase;
+        font-size: 0.75rem;
+      }
+      .status-count {
+        font-size: 1.1rem;
+      }
+      .table-card {
+        display: grid;
+        gap: 1rem;
+      }
+      .table-header {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+      }
+      .count-badge {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 2.25rem;
+        margin-left: 0.5rem;
+        padding: 0.2rem 0.75rem;
+        border-radius: 999px;
+        background: linear-gradient(135deg, #445df5, #8261f7);
+        color: #fff;
+        font-size: 0.85rem;
+        font-weight: 600;
+      }
+      .sort-controls {
+        display: inline-flex;
+        gap: 0.5rem;
+      }
+      .sort-button {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        padding: 0.45rem 0.85rem;
+        border-radius: 999px;
+        border: 1px solid rgba(76, 88, 154, 0.25);
+        background: rgba(255, 255, 255, 0.9);
+        color: inherit;
+        font-size: 0.95rem;
+        font-weight: 600;
+        text-decoration: none;
+        transition: transform 0.12s ease, box-shadow 0.12s ease;
+      }
+      .sort-button:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 12px 30px rgba(76, 88, 154, 0.2);
+      }
+      .sort-button.active {
+        border-color: rgba(68, 93, 245, 0.6);
+        background: linear-gradient(135deg, rgba(68, 93, 245, 0.12), rgba(130, 97, 247, 0.12));
+        color: #27359a;
+      }
+      .table-wrapper {
+        overflow-x: auto;
+        border-radius: 16px;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        background: rgba(255, 255, 255, 0.92);
+      }
+      thead {
+        background: rgba(68, 93, 245, 0.12);
+      }
+      th,
+      td {
+        padding: 0.85rem 1rem;
+        text-align: left;
+        border-bottom: 1px solid rgba(86, 92, 138, 0.1);
+      }
+      th {
+        font-size: 0.85rem;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: #4a4f81;
+      }
+      tbody tr:last-child td {
+        border-bottom: none;
+      }
+      tbody tr:hover {
+        background: rgba(68, 93, 245, 0.08);
+      }
+      .job-link {
+        color: #2f3bd1;
+        font-weight: 600;
+        text-decoration: none;
+      }
+      .job-link:hover {
+        text-decoration: underline;
+      }
+      .summary-line {
+        margin-top: 0.5rem;
+        font-size: 0.95rem;
+        color: #5d629a;
+      }
+      @media (max-width: 720px) {
+        .container {
+          padding: 2.5rem 1rem 3rem;
+        }
+        .table-header {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+        table {
+          min-width: 600px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="container" data-total-jobs="{{total_jobs}}">
+      <header class="page-header card">
+        <h1>Job history</h1>
+        <p class="summary-line">{{summary_line}}</p>
+      </header>
+      <section class="stats-card card">
+        <h2>Status summary</h2>
+        <ul class="status-list">
+{{status_items}}
+        </ul>
+      </section>
+      <section class="table-card card" data-visible-jobs="{{job_count}}">
+        <div class="table-header">
+          <h2>Recent jobs <span class="count-badge">{{job_count}}</span></h2>
+          <div class="sort-controls">
+            <a class="sort-button{{time_sort_active_class}}" href="{{time_sort_href}}">{{time_sort_label}}</a>
+            <a class="sort-button{{latency_sort_active_class}}" href="{{latency_sort_href}}">{{latency_sort_label}}</a>
+          </div>
+        </div>
+        <div class="table-wrapper">
+          <table data-total="{{total_jobs}}">
+            <thead>
+              <tr>
+                <th scope="col">Job ID</th>
+                <th scope="col">Provider</th>
+                <th scope="col">Status</th>
+                <th scope="col">Latency (ms)</th>
+                <th scope="col">Cache hit</th>
+              </tr>
+            </thead>
+            <tbody>
+{{rows}}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/tests/ui/test_jobs.py
+++ b/tests/ui/test_jobs.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import re
+import sys
+import time
+from pathlib import Path
+from typing import Iterable
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from alpha.webapp.routes import jobs as jobs_routes  # noqa: E402
+from alpha.webapp.routes import requests as request_routes  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_jobs_state():
+    request_routes.reset_state()
+    yield
+    request_routes.reset_state()
+
+
+@pytest.fixture()
+def client() -> Iterable[TestClient]:
+    app = FastAPI()
+    app.include_router(jobs_routes.router)
+    client = TestClient(app)
+    try:
+        yield client
+    finally:
+        client.close()
+
+
+def _record_job(
+    job_id: str,
+    *,
+    provider: str = "mock",
+    status: str = "done",
+    latency_ms: float | None = None,
+    cache_hit: bool = False,
+    submitted_at: float,
+) -> None:
+    job = request_routes.RequestJob(
+        id=job_id,
+        prompt="demo",
+        provider=provider,
+        status=status,
+        latency_ms=latency_ms,
+        cache_hit=cache_hit,
+        submitted_at=submitted_at,
+    )
+    job.started_at = submitted_at + 0.001
+    if latency_ms is not None:
+        job.completed_at = job.started_at + latency_ms / 1000.0
+    with request_routes._JOBS_LOCK:
+        request_routes._JOBS[job_id] = job
+
+
+def _extract_row_ids(html: str) -> list[str]:
+    return re.findall(r'data-job-id="([^"]+)"', html)
+
+
+def test_jobs_page_limits_to_100_rows_and_fast(client: TestClient) -> None:
+    base = 1_000.0
+    for index in range(120):
+        latency = 25.0 + index if index % 7 else None
+        status = "done" if index % 3 == 0 else ("failed" if index % 3 == 1 else "pending")
+        cache_hit = index % 2 == 0
+        provider = "mock" if index % 2 == 0 else "mock-pro"
+        _record_job(
+            f"job-{index:03d}",
+            provider=provider,
+            status=status,
+            latency_ms=latency,
+            cache_hit=cache_hit,
+            submitted_at=base + index,
+        )
+
+    start = time.perf_counter()
+    response = client.get("/jobs")
+    elapsed = time.perf_counter() - start
+    assert response.status_code == 200
+    assert elapsed < 2.0
+
+    html = response.text
+    assert "<th scope=\"col\">Job ID</th>" in html
+    assert "<th scope=\"col\">Provider</th>" in html
+
+    rows = _extract_row_ids(html)
+    assert len(rows) == 100
+    assert rows[0] == "job-119"
+    assert rows[-1] == "job-020"
+
+
+def test_jobs_page_default_sort_is_time_desc(client: TestClient) -> None:
+    _record_job("alpha", submitted_at=100.0)
+    _record_job("bravo", submitted_at=200.0)
+    _record_job("charlie", submitted_at=150.0)
+
+    response = client.get("/jobs")
+    assert response.status_code == 200
+    html = response.text
+    assert "Time ↓" in html
+    assert "Latency ↕" in html
+    assert _extract_row_ids(html)[:3] == ["bravo", "charlie", "alpha"]
+
+
+def test_jobs_page_time_sort_ascending(client: TestClient) -> None:
+    _record_job("early", submitted_at=50.0)
+    _record_job("mid", submitted_at=75.0)
+    _record_job("late", submitted_at=100.0)
+
+    response = client.get("/jobs?sort=time&direction=asc")
+    assert response.status_code == 200
+    html = response.text
+    assert _extract_row_ids(html)[:3] == ["early", "mid", "late"]
+    assert "Time ↑" in html
+    assert "sort=time&direction=desc" in html
+
+
+def test_jobs_page_latency_sort_desc_places_missing_last(client: TestClient) -> None:
+    _record_job("slow", submitted_at=10.0, latency_ms=120.0)
+    _record_job("fast", submitted_at=20.0, latency_ms=45.0)
+    _record_job("pending", submitted_at=30.0, latency_ms=None, status="running")
+
+    response = client.get("/jobs?sort=latency&direction=desc")
+    assert response.status_code == 200
+    html = response.text
+    rows = _extract_row_ids(html)
+    assert rows == ["slow", "fast", "pending"]
+    assert "Latency ↓" in html
+    assert "sort=latency&direction=asc" in html
+
+
+def test_jobs_page_latency_sort_ascending(client: TestClient) -> None:
+    _record_job("fast", submitted_at=10.0, latency_ms=20.0)
+    _record_job("medium", submitted_at=20.0, latency_ms=65.0)
+    _record_job("slow", submitted_at=30.0, latency_ms=100.0)
+    _record_job("pending", submitted_at=40.0, latency_ms=None, status="queued")
+
+    response = client.get("/jobs?sort=latency&direction=asc")
+    assert response.status_code == 200
+    rows = _extract_row_ids(response.text)
+    assert rows == ["fast", "medium", "slow", "pending"]
+
+
+def test_jobs_status_summary_counts(client: TestClient) -> None:
+    _record_job("done-1", submitted_at=1.0, status="done")
+    _record_job("done-2", submitted_at=2.0, status="done")
+    _record_job("pending", submitted_at=3.0, status="pending")
+    _record_job("failed", submitted_at=4.0, status="failed")
+
+    html = client.get("/jobs").text
+    summary_pairs = re.findall(
+        r'data-status="([^"]+)"><span class="status-label">[^<]+</span><span class="status-count">(\d+)</span>',
+        html,
+    )
+    summary = {status: int(count) for status, count in summary_pairs}
+    assert summary == {"done": 2, "failed": 1, "pending": 1}
+
+
+def test_jobs_row_links_to_detail_page(client: TestClient) -> None:
+    _record_job("link-test", submitted_at=1.0)
+    html = client.get("/jobs").text
+    assert '<a href="/jobs/link-test" class="job-link">link-test</a>' in html
+
+
+def test_jobs_cache_hit_display(client: TestClient) -> None:
+    _record_job("cache-yes", submitted_at=1.0, cache_hit=True)
+    _record_job("cache-no", submitted_at=2.0, cache_hit=False)
+
+    html = client.get("/jobs").text
+    assert re.search(r'data-job-id="cache-yes"[\s\S]*?<td class="col-cache">yes</td>', html)
+    assert re.search(r'data-job-id="cache-no"[\s\S]*?<td class="col-cache">no</td>', html)
+
+
+def test_jobs_handles_unknown_sort_params(client: TestClient) -> None:
+    _record_job("first", submitted_at=1.0)
+    _record_job("second", submitted_at=2.0)
+    _record_job("third", submitted_at=3.0)
+
+    response = client.get("/jobs?sort=unknown&direction=sideways")
+    assert response.status_code == 200
+    assert _extract_row_ids(response.text) == ["third", "second", "first"]
+
+
+def test_jobs_page_shows_empty_state_when_no_jobs(client: TestClient) -> None:
+    html = client.get("/jobs").text
+    assert "No jobs recorded yet." in html
+    assert "data-visible-jobs=\"0\"" in html


### PR DESCRIPTION
## Summary
- implement a server-rendered `/jobs` dashboard view that snapshots the last 100 jobs with sorting controls and status metrics
- add a dedicated HTML template for the job history table, summary cards, and detail links
- document the UI spec and add UI tests covering row limits, sorting behaviour, status summaries, cache display, and link targets

## Testing
- pytest tests/ui/test_jobs.py
- pytest tests/ui

------
https://chatgpt.com/codex/tasks/task_e_68c87547489483299b6b04aa8a8f9a83