### PR TITLE
Implement UI-RUN-001 dashboard demo run

### DIFF
--- a/.specs/UI-RUN-001.md
+++ b/.specs/UI-RUN-001.md
@@ -1,0 +1,16 @@
+# UI-RUN-001 · Dashboard One-click Demo Run
+
+## Goal
+Implement a dashboard entry point that lets operators trigger a canned Alpha Solver demo request and immediately review the outcome with latency and cache metadata.
+
+## Functional Requirements
+- `GET /run` renders an HTML page with a single "Run Demo" control backed by the provided template (`ui_run_button_v1`).
+- `POST /run` executes the canned workflow through the in-memory broker/cache mock and responds with `{ "result", "latency_ms", "cache_hit" }`.
+- Subsequent posts hit the cache path and return the same result text while toggling `cache_hit` to `true`.
+
+## UX Notes
+- Surface the latest demo output in place without leaving the page and show latency/cache values alongside the snippet.
+- Keep the first paint lightweight so the button renders well under the 2-second SLA.
+
+## Testing
+- `tests/ui/test_run.py` issues end-to-end requests covering the GET render timing, the POST payload contract, and cache-hit behaviour without performing any external network calls.

--- a/alpha/webapp/routes/run.py
+++ b/alpha/webapp/routes/run.py
@@ -1,0 +1,115 @@
+"""Routes powering the dashboard one-click demo run page."""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
+
+router = APIRouter()
+
+_TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "templates"
+_RUN_TEMPLATE_PATH = _TEMPLATES_DIR / "run.html"
+_TEMPLATE_CACHE: Optional[str] = None
+
+
+@dataclass
+class DemoRunResult:
+    """Structured payload returned by the mock demo broker."""
+
+    result: str
+    latency_ms: float
+    cache_hit: bool
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "result": self.result,
+            "latency_ms": float(self.latency_ms),
+            "cache_hit": self.cache_hit,
+        }
+
+
+class _MockDemoBroker:
+    """A lightweight broker that simulates executing a canned request."""
+
+    _CACHE_KEY = "demo"
+
+    def __init__(self) -> None:
+        self._cache: Dict[str, str] = {}
+        self._lock = threading.Lock()
+
+    def run(self) -> DemoRunResult:
+        with self._lock:
+            cached_result = self._cache.get(self._CACHE_KEY)
+
+        if cached_result is not None:
+            latency_ms = _simulate_latency(cache_hit=True)
+            return DemoRunResult(result=cached_result, latency_ms=latency_ms, cache_hit=True)
+
+        latency_ms = _simulate_latency(cache_hit=False)
+        result_text = _render_demo_result()
+        with self._lock:
+            self._cache[self._CACHE_KEY] = result_text
+        return DemoRunResult(result=result_text, latency_ms=latency_ms, cache_hit=False)
+
+    def reset(self) -> None:
+        with self._lock:
+            self._cache.clear()
+
+
+_BROKER = _MockDemoBroker()
+
+
+def _simulate_latency(cache_hit: bool) -> float:
+    """Return a deterministic latency budget in milliseconds."""
+
+    base_seconds = 0.11 if not cache_hit else 0.008
+    time.sleep(base_seconds)
+    return round(base_seconds * 1000.0, 2)
+
+
+def _render_demo_result() -> str:
+    """Produce the canned result snippet displayed in the UI."""
+
+    return (
+        "Alpha Solver demo completed successfully.\n"
+        "\n"
+        "Highlights:\n"
+        "- Validated retrieval pipeline across two corpora.\n"
+        "- Generated actionable next steps for the research team.\n"
+        "- Confirmed observability hooks are emitting latency metrics."
+    )
+
+
+def _load_template() -> str:
+    global _TEMPLATE_CACHE
+    if _TEMPLATE_CACHE is None:
+        _TEMPLATE_CACHE = _RUN_TEMPLATE_PATH.read_text(encoding="utf-8")
+    return _TEMPLATE_CACHE
+
+
+def reset_state() -> None:
+    """Reset broker state for hermetic tests."""
+
+    _BROKER.reset()
+
+
+@router.get("/run", response_class=HTMLResponse)
+async def run_page(request: Request) -> HTMLResponse:
+    """Serve the dashboard page with the demo run button."""
+
+    _ = request  # FastAPI expects the request argument even for static templates.
+    return HTMLResponse(content=_load_template())
+
+
+@router.post("/run")
+async def trigger_demo(_: Optional[Dict[str, object]] = None) -> Dict[str, object]:
+    """Execute the canned demo request via the mock broker."""
+
+    result = _BROKER.run()
+    return result.to_dict()

--- a/alpha/webapp/templates/run.html
+++ b/alpha/webapp/templates/run.html
@@ -1,0 +1,185 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Alpha Solver · Demo Run</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        line-height: 1.5;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: radial-gradient(circle at top, #f4f6ff, #dde2f3);
+        color: #1d2038;
+      }
+      .container {
+        max-width: 680px;
+        margin: 0 auto;
+        padding: 3rem 1.5rem 4rem;
+      }
+      h1 {
+        margin-bottom: 0.75rem;
+        font-size: 2rem;
+      }
+      .lede {
+        margin-top: 0;
+        margin-bottom: 2rem;
+        font-size: 1.05rem;
+        color: #4a4f83;
+      }
+      button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0.75rem 1.5rem;
+        border-radius: 999px;
+        border: none;
+        font-size: 1rem;
+        font-weight: 600;
+        background: linear-gradient(135deg, #5661f6, #7b5ff4);
+        color: #fff;
+        cursor: pointer;
+        transition: transform 0.15s ease, box-shadow 0.15s ease;
+        box-shadow: 0 16px 40px rgba(76, 88, 214, 0.3);
+      }
+      button:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 18px 45px rgba(76, 88, 214, 0.35);
+      }
+      button:disabled {
+        cursor: progress;
+        opacity: 0.8;
+        box-shadow: none;
+        transform: none;
+      }
+      section {
+        margin-top: 2.5rem;
+        background: rgba(255, 255, 255, 0.9);
+        border-radius: 16px;
+        padding: 1.75rem;
+        box-shadow: 0 24px 70px rgba(26, 32, 74, 0.12);
+        backdrop-filter: blur(10px);
+      }
+      section[hidden] {
+        display: none;
+      }
+      pre {
+        margin: 0 0 1.5rem 0;
+        padding: 1rem 1.25rem;
+        border-radius: 14px;
+        background: rgba(237, 240, 255, 0.7);
+        border: 1px solid rgba(86, 97, 246, 0.2);
+        font-size: 0.95rem;
+        white-space: pre-wrap;
+      }
+      dl {
+        margin: 0;
+        display: grid;
+        gap: 1rem;
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+      }
+      dt {
+        font-size: 0.85rem;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: #565b8f;
+        font-weight: 600;
+      }
+      dd {
+        margin: 0;
+        font-size: 1.05rem;
+        font-weight: 500;
+      }
+      .error {
+        margin-top: 1.5rem;
+        padding: 0.85rem 1rem;
+        border-radius: 14px;
+        background: rgba(244, 67, 54, 0.12);
+        border: 1px solid rgba(244, 67, 54, 0.2);
+        color: #b71c1c;
+        font-weight: 500;
+      }
+      @media (max-width: 640px) {
+        .container {
+          padding: 2.5rem 1.25rem 3rem;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <h1>One-click demo run</h1>
+      <p class="lede">
+        Launch the canned Alpha Solver workflow end-to-end and review the result, recorded latency, and cache activity without
+        leaving the dashboard.
+      </p>
+      <button id="run-demo" type="button">Run Demo</button>
+      <section id="demo-output" hidden>
+        <h2>Latest demo result</h2>
+        <pre id="demo-result"></pre>
+        <dl class="metrics">
+          <div>
+            <dt>Latency</dt>
+            <dd><span id="demo-latency">—</span> ms</dd>
+          </div>
+          <div>
+            <dt>Cache hit</dt>
+            <dd id="demo-cache">—</dd>
+          </div>
+        </dl>
+      </section>
+      <div id="demo-error" class="error" role="alert" hidden></div>
+    </main>
+    <script>
+      const runButton = document.getElementById("run-demo");
+      const outputSection = document.getElementById("demo-output");
+      const resultBox = document.getElementById("demo-result");
+      const latencyField = document.getElementById("demo-latency");
+      const cacheField = document.getElementById("demo-cache");
+      const errorBox = document.getElementById("demo-error");
+      const defaultLabel = runButton.textContent;
+
+      function resetButton() {
+        runButton.disabled = false;
+        runButton.textContent = defaultLabel;
+      }
+
+      runButton.addEventListener("click", async () => {
+        runButton.disabled = true;
+        runButton.textContent = "Running…";
+        errorBox.hidden = true;
+        errorBox.textContent = "";
+
+        try {
+          const response = await fetch("/run", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ trigger: "demo" }),
+          });
+
+          if (!response.ok) {
+            throw new Error(`Server responded with ${response.status}`);
+          }
+
+          const payload = await response.json();
+          resultBox.textContent = payload.result || "";
+
+          const latencyValue = typeof payload.latency_ms === "number" ? payload.latency_ms : Number(payload.latency_ms);
+          latencyField.textContent = Number.isFinite(latencyValue) ? latencyValue.toFixed(1) : "—";
+          cacheField.textContent = payload.cache_hit ? "yes" : "no";
+
+          outputSection.hidden = false;
+        } catch (error) {
+          const message = error instanceof Error ? error.message : "Unknown error";
+          errorBox.textContent = `Demo run failed: ${message}`;
+          errorBox.hidden = false;
+        } finally {
+          resetButton();
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/tests/ui/test_run.py
+++ b/tests/ui/test_run.py
@@ -1,0 +1,60 @@
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from alpha.webapp.routes import run as run_route
+
+
+def create_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(run_route.router)
+    return app
+
+
+def test_run_page_renders_quickly_and_has_button():
+    run_route.reset_state()
+    app = create_app()
+    with TestClient(app) as client:
+        start = time.perf_counter()
+        response = client.get("/run")
+        elapsed_ms = (time.perf_counter() - start) * 1000.0
+
+        assert response.status_code == 200
+        html = response.text
+        assert "<button" in html
+        assert "Run Demo" in html
+        assert "demo-latency" in html
+        assert "demo-cache" in html
+        assert elapsed_ms < 2000
+
+
+def test_demo_run_roundtrip_and_cache_behavior():
+    run_route.reset_state()
+    app = create_app()
+    with TestClient(app) as client:
+        first_response = client.post("/run", json={"trigger": "demo"})
+        assert first_response.status_code == 200
+
+        first_payload = first_response.json()
+        assert first_payload["cache_hit"] is False
+        assert isinstance(first_payload["latency_ms"], float)
+        assert first_payload["latency_ms"] >= 80.0
+        assert "Alpha Solver" in first_payload["result"]
+        assert "Highlights" in first_payload["result"]
+
+        second_response = client.post("/run", json={"trigger": "demo"})
+        assert second_response.status_code == 200
+
+        second_payload = second_response.json()
+        assert second_payload["cache_hit"] is True
+        assert second_payload["result"] == first_payload["result"]
+        assert isinstance(second_payload["latency_ms"], float)
+        assert second_payload["latency_ms"] > 0
+        assert second_payload["latency_ms"] < first_payload["latency_ms"]


### PR DESCRIPTION
## Summary
- add a one-click demo route that serves /run and executes the canned broker workflow
- build the run.html template that renders the Run Demo button and displays result metadata
- cover the new flow with an end-to-end UI test and document the spec entry

## Testing
- pytest tests/ui/test_run.py

------
https://chatgpt.com/codex/tasks/task_e_68c8768977708329928a7c84cd2835b6