### PR TITLE
Implement FinOps budget guardrails

### DIFF
--- a/.specs/FINOPS-BUDGET-001.md
+++ b/.specs/FINOPS-BUDGET-001.md
@@ -1,0 +1,16 @@
+# FINOPS-BUDGET-001 · Budget Guardrails
+
+## Goal
+Implement FinOps budget guardrails that enforce soft/hard caps while
+exporting spend metrics.
+
+## Acceptance Criteria
+- Budget counters maintained for each tenant/project scope.
+- Soft cap emits a warning; hard cap blocks with `BudgetExceeded`.
+- Prometheus counter `budget_spend_cents` records spend in cents.
+- `record_tokens` remains fast (p95 latency under 5ms in tests).
+- All new tests pass.
+
+## Notes
+- Uses an in-memory cost shim with static per-provider token pricing.
+- Metrics should work with the default registry and custom registries.

--- a/alpha/finops/budget.py
+++ b/alpha/finops/budget.py
@@ -1,0 +1,272 @@
+"""Budget guardrails for FinOps workloads.
+
+This module implements in-memory budget tracking with soft and hard
+thresholds. Budgets are scoped by tenant and project identifiers and the
+module exposes helpers to register budgets, record usage and emit
+Prometheus metrics that can be scraped by external systems.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fractions import Fraction
+import logging
+import threading
+from typing import Dict, Iterable, Mapping, MutableMapping, Tuple
+
+from prometheus_client import Counter
+
+__all__ = ["BudgetExceeded", "BudgetManager", "COST_PER_TOKEN_CENTS"]
+
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize_rate(value: Fraction | float | int | str | Tuple[int, int]) -> Fraction:
+    """Normalize a rate specification into a :class:`Fraction`.
+
+    Parameters
+    ----------
+    value:
+        A value accepted by :class:`Fraction` plus ``(numerator, denominator)``
+        tuples. The result represents the cost in cents per token.
+    """
+
+    if isinstance(value, Fraction):
+        return value
+    if isinstance(value, tuple) and len(value) == 2:
+        return Fraction(value[0], value[1])
+    if isinstance(value, float):
+        # ``Fraction`` from a string avoids floating point artefacts.
+        return Fraction(str(value))
+    return Fraction(value)
+
+
+COST_PER_TOKEN_CENTS: Mapping[str, Fraction] = {
+    # The values intentionally favour round numbers to keep the shim simple
+    # for tests. They represent the price in cents per token.
+    "openai:gpt-4": Fraction(6, 10),  # 0.6¢ per token
+    "openai:gpt-4o": Fraction(5, 10),
+    "openai:gpt-3.5": Fraction(2, 10),
+    "anthropic:claude-3-opus": Fraction(8, 10),
+    "anthropic:claude-3-sonnet": Fraction(4, 10),
+}
+
+
+_BUDGET_SPEND_CENTS = Counter(
+    "budget_spend_cents",
+    "Cumulative budget spend in cents per tenant/project/provider.",
+    ("tenant", "project", "provider"),
+)
+
+
+class BudgetExceeded(RuntimeError):
+    """Raised when an operation would push the budget past the hard limit."""
+
+    def __init__(self, tenant: str, project: str, attempted: int, hard_limit: int) -> None:
+        message = (
+            f"Budget exceeded for {tenant}/{project}: "
+            f"attempted {attempted}¢ > hard limit {hard_limit}¢"
+        )
+        super().__init__(message)
+        self.tenant = tenant
+        self.project = project
+        self.attempted_spend_cents = attempted
+        self.hard_limit_cents = hard_limit
+
+
+@dataclass
+class _BudgetRecord:
+    soft_limit_cents: int
+    hard_limit_cents: int
+    spend_cents: int = 0
+    events: int = 0
+    soft_warning_emitted: bool = False
+
+    def snapshot(self) -> Dict[str, int | bool]:
+        return {
+            "soft_limit_cents": self.soft_limit_cents,
+            "hard_limit_cents": self.hard_limit_cents,
+            "spend_cents": self.spend_cents,
+            "events": self.events,
+            "soft_alert_triggered": self.soft_warning_emitted,
+        }
+
+
+class BudgetManager:
+    """Manage in-memory budgets with soft and hard enforcement."""
+
+    def __init__(
+        self,
+        *,
+        cost_table: Mapping[str, Fraction | float | int | str | Tuple[int, int]] | None = None,
+        registry=None,
+        metric: Counter | None = None,
+    ) -> None:
+        if metric is not None and registry is not None:
+            raise ValueError("Provide either a metric or a registry, not both.")
+
+        table = cost_table or COST_PER_TOKEN_CENTS
+        self._cost_table: Dict[str, Fraction] = {
+            provider: _normalize_rate(rate)
+            for provider, rate in table.items()
+        }
+        self._budgets: MutableMapping[Tuple[str, str], _BudgetRecord] = {}
+        self._lock = threading.Lock()
+
+        if metric is not None:
+            self._metric = metric
+        elif registry is not None:
+            self._metric = Counter(
+                "budget_spend_cents",
+                "Cumulative budget spend in cents per tenant/project/provider.",
+                ("tenant", "project", "provider"),
+                registry=registry,
+            )
+        else:
+            self._metric = _BUDGET_SPEND_CENTS
+
+    # ---------------- Budget registration helpers -----------------
+    def register_budget(self, tenant: str, project: str, *, soft_limit_cents: int, hard_limit_cents: int) -> None:
+        """Register or reset a budget for the provided scope."""
+
+        soft = int(soft_limit_cents)
+        hard = int(hard_limit_cents)
+        if soft < 0 or hard < 0:
+            raise ValueError("Budget limits must be non-negative")
+        if soft > hard:
+            raise ValueError("Soft limit cannot exceed hard limit")
+
+        with self._lock:
+            self._budgets[(tenant, project)] = _BudgetRecord(soft_limit_cents=soft, hard_limit_cents=hard)
+
+    # ---------------- Recording helpers -----------------
+    def record_tokens(
+        self,
+        tenant: str,
+        project: str,
+        *,
+        provider: str,
+        tokens: int,
+    ) -> Dict[str, int | bool | str | None]:
+        """Record token usage and convert it into spend."""
+
+        if tokens < 0:
+            raise ValueError("Token count must be non-negative")
+        cost_cents = self.calculate_cost_cents(provider, tokens)
+        return self.record_cost(
+            tenant,
+            project,
+            cost_cents,
+            provider=provider,
+            tokens=tokens,
+        )
+
+    def record_cost(
+        self,
+        tenant: str,
+        project: str,
+        cost_cents: int,
+        *,
+        provider: str = "direct",
+        tokens: int | None = None,
+    ) -> Dict[str, int | bool | str | None]:
+        """Record a direct spend amount and enforce the guardrails."""
+
+        if cost_cents < 0:
+            raise ValueError("Cost must be non-negative")
+
+        key = (tenant, project)
+        with self._lock:
+            record = self._budgets.get(key)
+            if record is None:
+                raise KeyError(f"No budget registered for {tenant}/{project}")
+
+            proposed_total = record.spend_cents + cost_cents
+            if proposed_total > record.hard_limit_cents:
+                raise BudgetExceeded(tenant, project, proposed_total, record.hard_limit_cents)
+
+            record.spend_cents = proposed_total
+            record.events += 1
+            emit_warning = False
+            if (
+                not record.soft_warning_emitted
+                and record.soft_limit_cents > 0
+                and proposed_total >= record.soft_limit_cents
+            ):
+                record.soft_warning_emitted = True
+                emit_warning = True
+
+            snapshot = record.snapshot()
+
+        if cost_cents and self._metric is not None:
+            self._metric.labels(tenant=tenant, project=project, provider=provider).inc(cost_cents)
+
+        if emit_warning:
+            logger.warning(
+                "Budget soft cap reached for %s/%s (provider=%s, spend=%s¢, soft_cap=%s¢)",
+                tenant,
+                project,
+                provider,
+                snapshot["spend_cents"],
+                snapshot["soft_limit_cents"],
+            )
+
+        return {
+            "tenant": tenant,
+            "project": project,
+            "provider": provider,
+            "tokens": tokens,
+            "cost_cents": cost_cents,
+            "total_spend_cents": snapshot["spend_cents"],
+            "soft_limit_cents": snapshot["soft_limit_cents"],
+            "hard_limit_cents": snapshot["hard_limit_cents"],
+            "events": snapshot["events"],
+            "soft_alert_triggered": snapshot["soft_alert_triggered"],
+        }
+
+    # ---------------- Query helpers -----------------
+    def calculate_cost_cents(self, provider: str, tokens: int) -> int:
+        """Calculate the spend (in cents) for a provider/token pair."""
+
+        try:
+            rate = self._cost_table[provider]
+        except KeyError as exc:
+            raise KeyError(f"Unknown provider '{provider}'") from exc
+
+        cost = rate * tokens
+        numerator, denominator = cost.numerator, cost.denominator
+        quotient, remainder = divmod(numerator, denominator)
+        if remainder:
+            quotient += 1
+        return int(quotient)
+
+    def get_usage(self, tenant: str, project: str) -> Dict[str, int | bool]:
+        """Return the current counters for a budget scope."""
+
+        key = (tenant, project)
+        with self._lock:
+            record = self._budgets.get(key)
+            if record is None:
+                raise KeyError(f"No budget registered for {tenant}/{project}")
+            snapshot = record.snapshot()
+        return {
+            "tenant": tenant,
+            "project": project,
+            **snapshot,
+        }
+
+    def snapshot(self) -> Dict[Tuple[str, str], Dict[str, int | bool]]:
+        """Return a snapshot of all tracked budgets."""
+
+        with self._lock:
+            return {
+                key: record.snapshot().copy()
+                for key, record in self._budgets.items()
+            }
+
+    def registered_budgets(self) -> Iterable[Tuple[str, str]]:
+        """Return an iterable with all registered budget scopes."""
+
+        with self._lock:
+            return list(self._budgets.keys())

--- a/docs/FINOPS.md
+++ b/docs/FINOPS.md
@@ -1,0 +1,38 @@
+# FinOps Budget Guardrails
+
+The FinOps budget guardrails keep track of spend for each tenant/project
+pair and enforce soft and hard caps. The implementation focuses on
+in-memory counters so it can be embedded into offline tests while still
+exporting Prometheus metrics for production observability.
+
+## Budget manager
+
+`alpha.finops.budget.BudgetManager` exposes a small API:
+
+1. **`register_budget`** – define the soft and hard limits for a
+   `(tenant, project)` scope.
+2. **`record_tokens`** – convert token usage (per provider) into cents by
+   using a static cost shim and increment the counters. When the soft cap
+   is crossed the manager logs a warning, while exceeding the hard cap
+   raises `BudgetExceeded`.
+3. **`record_cost`** – increment the counters directly with a cents
+   amount, bypassing the cost shim.
+4. **`get_usage` / `snapshot`** – retrieve the current counters for
+   inspection or reporting.
+
+Budgets maintain the total spend, operation count and whether a soft-cap
+warning was triggered. These counters are safe for concurrent access via
+an internal lock.
+
+## Metrics
+
+Every successful spend update increments the Prometheus counter
+`budget_spend_cents{tenant=...,project=...,provider=...}`. The metric is
+available through the default registry and custom registries supplied to
+`BudgetManager`.
+
+## Performance guardrail
+
+The tests include a 95th percentile latency check (target `< 5ms`) for
+`record_tokens` to keep the guardrails light-weight and suitable for
+real-time evaluation.

--- a/prometheus_client/__init__.py
+++ b/prometheus_client/__init__.py
@@ -1,26 +1,414 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
+
 CONTENT_TYPE_LATEST = "text/plain; version=0.0.4"
 
-_REGISTRY = []
+
+class CollectorRegistry:
+    """Very small in-memory collector compatible with the real API subset."""
+
+    def __init__(self) -> None:
+        self._metrics: List[_Metric] = []
+        self._collector_to_names: Dict[_Metric, Set[str]] = {}
+        self._names_to_collectors: Dict[str, Set[_Metric]] = {}
+
+    def register(self, metric: "_Metric") -> None:
+        if metric not in self._metrics:
+            self._metrics.append(metric)
+        previous = self._collector_to_names.get(metric, set())
+        for name in previous:
+            collectors = self._names_to_collectors.get(name)
+            if collectors is None:
+                continue
+            collectors.discard(metric)
+            if not collectors:
+                del self._names_to_collectors[name]
+        names = set(metric._sample_names())
+        self._collector_to_names[metric] = names
+        for name in names:
+            self._names_to_collectors.setdefault(name, set()).add(metric)
+
+    def collect(self) -> List["_CollectedMetric"]:
+        collected: List[_CollectedMetric] = []
+        for metric in self._metrics:
+            if metric not in self._collector_to_names:
+                continue
+            collected.append(metric._collect())
+        return collected
+
+    def get_sample_value(
+        self,
+        name: str,
+        labels: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        for metric in self._metrics:
+            if metric not in self._collector_to_names:
+                continue
+            value = metric.get_sample_value_from_name(name, labels)
+            if value is not None:
+                return value
+        return None
+
+
+_DEFAULT_REGISTRY = CollectorRegistry()
+REGISTRY = _DEFAULT_REGISTRY
+
+
+class _Sample:
+    def __init__(self, metric: "_Metric", key: Tuple[Any, ...]):
+        self._metric = metric
+        self._key = key
+
+    def inc(self, amount: float = 1.0) -> None:
+        self._metric._inc_value(self._key, amount)
+
+    def dec(self, amount: float = 1.0) -> None:
+        self._metric._inc_value(self._key, -amount)
+
+    def observe(self, value: float) -> None:
+        self._metric._observe_sample(self._key, value)
+
+    def set(self, value: float) -> None:
+        self._metric._set_value(self._key, value)
+
 
 class _Metric:
-    def __init__(self, name: str, *args, **kwargs):
+    def __init__(
+        self,
+        name: str,
+        documentation: str = "",
+        labelnames: Optional[Iterable[str]] = None,
+        *,
+        registry: Optional[CollectorRegistry] = None,
+    ) -> None:
         self.name = name
-        self.value = 0
-        _REGISTRY.append(self)
-    def labels(self, *args, **kwargs):  # pragma: no cover - trivial
-        return self
+        self.documentation = documentation
+        if labelnames is None:
+            self._labelnames = ()
+        elif isinstance(labelnames, (list, tuple)):
+            self._labelnames = tuple(labelnames)
+        elif isinstance(labelnames, str):
+            self._labelnames = (labelnames,)
+        else:
+            self._labelnames = tuple(labelnames)
+        self._samples: Dict[Tuple[Any, ...], float] = {}
+        if not self._labelnames:
+            self._samples[()] = 0.0
+        self._registry = registry or _DEFAULT_REGISTRY
+        self._registry.register(self)
+
+    @property
+    def labelnames(self) -> Tuple[str, ...]:
+        return self._labelnames
+
+    def _key_from_labels(self, args: Tuple[Any, ...], kwargs: Dict[str, Any]) -> Tuple[Any, ...]:
+        if not self._labelnames:
+            if args or kwargs:
+                raise ValueError("Metric has no labels")
+            return ()
+        if args and kwargs:
+            raise ValueError("Specify labels either positionally or by name")
+        if args:
+            if len(args) != len(self._labelnames):
+                raise ValueError("Incorrect number of labels")
+            return tuple(args)
+        values = []
+        for name in self._labelnames:
+            if name not in kwargs:
+                raise ValueError(f"Missing label: {name}")
+            values.append(kwargs[name])
+        if len(kwargs) != len(self._labelnames):
+            extra = set(kwargs) - set(self._labelnames)
+            if extra:
+                raise ValueError(f"Unexpected labels: {sorted(extra)}")
+        return tuple(values)
+
+    def labels(self, *args: Any, **kwargs: Any) -> _Sample:
+        key = self._key_from_labels(args, kwargs)
+        if key not in self._samples:
+            self._samples[key] = 0.0
+        return _Sample(self, key)
+
+    def _inc_value(self, key: Tuple[Any, ...], amount: float) -> None:
+        self._samples[key] = float(self._samples.get(key, 0.0)) + float(amount)
+
+    def _set_value(self, key: Tuple[Any, ...], value: float) -> None:
+        self._samples[key] = float(value)
+
+    def _observe_sample(self, key: Tuple[Any, ...], value: float) -> None:
+        self._set_value(key, value)
+
+    def get_sample_value(self, labels: Optional[Dict[str, Any]] = None) -> Any:
+        if not self._labelnames:
+            return self._samples.get(())
+        if labels is None:
+            return None
+        if isinstance(labels, dict):
+            try:
+                key = tuple(labels[name] for name in self._labelnames)
+            except KeyError:
+                return None
+        elif isinstance(labels, (list, tuple)):
+            if len(labels) != len(self._labelnames):
+                return None
+            key = tuple(labels)
+        else:
+            return None
+        return self._samples.get(key)
+
+    def get_sample_value_from_name(
+        self, name: str, labels: Optional[Dict[str, Any]] = None
+    ) -> Any:
+        if name == self.name:
+            return self.get_sample_value(labels)
+        return None
+
+    def _sample_name(self) -> str:
+        return self.name
+
+    def _sample_names(self) -> Iterable[str]:
+        yield self._sample_name()
+
+    def _iter_samples(self) -> Iterable[Tuple[str, Tuple[Any, ...], float]]:
+        for key, value in self._samples.items():
+            yield self._sample_name(), key, value
+
+    def _metric_name(self) -> str:
+        return self.name
+
+    def _collect(self) -> "_CollectedMetric":
+        samples = []
+        for sample_name, labels, value in self._iter_samples():
+            label_map = (
+                dict(zip(self.labelnames, labels)) if self.labelnames else {}
+            )
+            samples.append(_CollectedSample(sample_name, label_map, value))
+        return _CollectedMetric(self._metric_name(), samples)
+
+    # default implementations for unlabeled variants -----------------
+    def inc(self, amount: float = 1.0) -> None:
+        if self._labelnames:
+            raise ValueError("Use labels().inc() on labelled metrics")
+        self._inc_value((), amount)
+
+    def observe(self, value: float) -> None:
+        if self._labelnames:
+            raise ValueError("Use labels().observe() on labelled metrics")
+        self._set_value((), value)
+
+    def set(self, value: float) -> None:
+        if self._labelnames:
+            raise ValueError("Use labels().set() on labelled metrics")
+        self._set_value((), value)
+
 
 class Counter(_Metric):
-    def inc(self, amount: float = 1) -> None:
-        self.value += amount
+    def __init__(
+        self,
+        name: str,
+        documentation: str = "",
+        labelnames: Optional[Iterable[str]] = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        registry = kwargs.pop("registry", None)
+        super().__init__(name, documentation, labelnames, registry=registry)
+
+    def _sample_name(self) -> str:
+        if self.name.endswith("_total"):
+            return self.name
+        return f"{self.name}_total"
+
+    def _sample_names(self) -> Iterable[str]:
+        yield self._sample_name()
+
+    def _metric_name(self) -> str:
+        if self.name.endswith("_total"):
+            return self.name[: -len("_total")]
+        return self.name
+
+    def get_sample_value_from_name(
+        self, name: str, labels: Optional[Dict[str, Any]] = None
+    ) -> Any:
+        if name == self._sample_name():
+            return self.get_sample_value(labels)
+        return super().get_sample_value_from_name(name, labels)
+
+
+class Gauge(_Metric):
+    def __init__(
+        self,
+        name: str,
+        documentation: str = "",
+        labelnames: Optional[Iterable[str]] = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        registry = kwargs.pop("registry", None)
+        super().__init__(name, documentation, labelnames, registry=registry)
+
+    def dec(self, amount: float = 1.0) -> None:
+        if self.labelnames:
+            raise ValueError("Use labels().dec() on labelled metrics")
+        self._inc_value((), -amount)
+
 
 class Histogram(_Metric):
-    def observe(self, value: float) -> None:
+    def __init__(
+        self,
+        name: str,
+        documentation: str = "",
+        labelnames: Optional[Iterable[str]] = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        registry = kwargs.pop("registry", None)
+        buckets = kwargs.pop("buckets", None)
+        super().__init__(name, documentation, labelnames, registry=registry)
+        self._samples.clear()
+        processed = [float(b) for b in buckets] if buckets is not None else []
+        processed.sort()
+        if not processed or processed[-1] != float("inf"):
+            processed.append(float("inf"))
+        self._buckets = processed
+        self._bucket_counts: Dict[Tuple[Any, ...], List[float]] = {}
+        self._sum: Dict[Tuple[Any, ...], float] = {}
+        self._count: Dict[Tuple[Any, ...], int] = {}
+
+    def _ensure_state(self, key: Tuple[Any, ...]) -> None:
+        if key in self._bucket_counts:
+            return
+        self._bucket_counts[key] = [0.0 for _ in self._buckets]
+        self._sum[key] = 0.0
+        self._count[key] = 0
+
+    def _observe_sample(self, key: Tuple[Any, ...], value: float) -> None:
+        self._ensure_state(key)
+        self._sum[key] += float(value)
+        self._count[key] += 1
+        for idx, bound in enumerate(self._buckets):
+            if float(value) <= bound:
+                self._bucket_counts[key][idx] += 1
+
+    def _sample_names(self) -> Iterable[str]:
+        yield f"{self.name}_bucket"
+        yield f"{self.name}_sum"
+        yield f"{self.name}_count"
+
+    def _collect(self) -> "_CollectedMetric":
+        samples: List[_CollectedSample] = []
+        if not self._bucket_counts and not self.labelnames:
+            self._ensure_state(())
+        for key, counts in self._bucket_counts.items():
+            base_labels = (
+                dict(zip(self.labelnames, key)) if self.labelnames else {}
+            )
+            for bound, count in zip(self._buckets, counts):
+                labels = base_labels.copy()
+                labels["le"] = "+Inf" if bound == float("inf") else str(bound)
+                samples.append(
+                    _CollectedSample(f"{self.name}_bucket", labels, count)
+                )
+            samples.append(
+                _CollectedSample(
+                    f"{self.name}_count",
+                    base_labels.copy(),
+                    self._count.get(key, 0),
+                )
+            )
+            samples.append(
+                _CollectedSample(
+                    f"{self.name}_sum",
+                    base_labels.copy(),
+                    self._sum.get(key, 0.0),
+                )
+            )
+        return _CollectedMetric(self._metric_name(), samples)
+
+    def get_sample_value_from_name(
+        self, name: str, labels: Optional[Dict[str, Any]] = None
+    ) -> Any:
+        if name == f"{self.name}_sum":
+            key = self._labels_to_key(labels)
+            if key is None:
+                return None
+            return self._sum.get(key)
+        if name == f"{self.name}_count":
+            key = self._labels_to_key(labels)
+            if key is None:
+                return None
+            return self._count.get(key)
+        if name == f"{self.name}_bucket":
+            if labels is None or "le" not in labels:
+                return None
+            le = labels["le"]
+            key_labels = {k: v for k, v in labels.items() if k != "le"}
+            key = self._labels_to_key(key_labels)
+            if key is None:
+                return None
+            if le == "+Inf":
+                bound = float("inf")
+            else:
+                try:
+                    bound = float(le)
+                except (TypeError, ValueError):
+                    return None
+            self._ensure_state(key)
+            for idx, bucket_bound in enumerate(self._buckets):
+                if bucket_bound == bound:
+                    return self._bucket_counts[key][idx]
+            return None
+        return super().get_sample_value_from_name(name, labels)
+
+    def _labels_to_key(self, labels: Optional[Dict[str, Any]]) -> Optional[Tuple[Any, ...]]:
+        if not self.labelnames:
+            return ()
+        if labels is None:
+            return None
+        try:
+            return tuple(labels[name] for name in self.labelnames)
+        except KeyError:
+            return None
+
+
+class _CollectedSample:
+    def __init__(self, name: str, labels: Dict[str, Any], value: float) -> None:
+        self.name = name
+        self.labels = labels
         self.value = value
 
-def generate_latest() -> bytes:
-    metrics = [f"{m.name} {m.value}" for m in _REGISTRY]
-    return "\n".join(metrics).encode()
+
+class _CollectedMetric:
+    def __init__(self, name: str, samples: List[_CollectedSample]) -> None:
+        self.name = name
+        self.samples = samples
+
+
+def generate_latest(registry: Optional[CollectorRegistry] = None) -> bytes:
+    registry = registry or _DEFAULT_REGISTRY
+    lines = []
+    for metric in registry.collect():
+        for sample in metric.samples:
+            if sample.labels:
+                parts = [f'{key}="{value}"' for key, value in sample.labels.items()]
+                lines.append(f"{sample.name}{{{','.join(parts)}}} {sample.value}")
+            else:
+                lines.append(f"{sample.name} {sample.value}")
+    return "\n".join(lines).encode()
+
 
 def start_http_server(port: int) -> None:  # pragma: no cover - noop
     return None
+
+
+__all__ = [
+    "CollectorRegistry",
+    "Counter",
+    "Gauge",
+    "Histogram",
+    "REGISTRY",
+    "CONTENT_TYPE_LATEST",
+    "generate_latest",
+    "start_http_server",
+]

--- a/tests/finops/test_budget.py
+++ b/tests/finops/test_budget.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import logging
+import sys
+import time
+from pathlib import Path
+
+import pytest
+from prometheus_client import CollectorRegistry
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from alpha.finops.budget import BudgetExceeded, BudgetManager
+
+
+def test_budget_counters_are_scoped() -> None:
+    manager = BudgetManager()
+    manager.register_budget("tenant-a", "project-1", soft_limit_cents=120, hard_limit_cents=400)
+    manager.register_budget("tenant-b", "project-2", soft_limit_cents=300, hard_limit_cents=900)
+
+    first = manager.record_tokens("tenant-a", "project-1", provider="openai:gpt-4", tokens=10)
+    assert first["total_spend_cents"] == manager.calculate_cost_cents("openai:gpt-4", 10)
+
+    second = manager.record_tokens("tenant-a", "project-1", provider="openai:gpt-4", tokens=5)
+    other = manager.record_tokens("tenant-b", "project-2", provider="openai:gpt-3.5", tokens=20)
+
+    usage_a = manager.get_usage("tenant-a", "project-1")
+    usage_b = manager.get_usage("tenant-b", "project-2")
+
+    assert usage_a["spend_cents"] == second["total_spend_cents"]
+    assert usage_b["spend_cents"] == other["total_spend_cents"]
+    assert usage_a["events"] == 2
+    assert usage_b["events"] == 1
+
+    snapshot = manager.snapshot()
+    assert snapshot[("tenant-a", "project-1")]["spend_cents"] != snapshot[("tenant-b", "project-2")]["spend_cents"]
+
+
+def test_soft_cap_emits_warning_once(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.WARNING)
+    manager = BudgetManager()
+    manager.register_budget("tenant", "project", soft_limit_cents=50, hard_limit_cents=200)
+
+    manager.record_tokens("tenant", "project", provider="openai:gpt-3.5", tokens=50)
+
+    caplog.clear()
+    manager.record_tokens("tenant", "project", provider="openai:gpt-4", tokens=80)
+
+    warnings = [record for record in caplog.records if record.levelno == logging.WARNING]
+    assert warnings, "Expected a warning once the soft cap is crossed"
+    assert "soft cap" in warnings[0].message.lower()
+    assert manager.get_usage("tenant", "project")["soft_alert_triggered"] is True
+
+    caplog.clear()
+    manager.record_tokens("tenant", "project", provider="openai:gpt-3.5", tokens=5)
+    assert caplog.records == []
+
+
+def test_hard_cap_blocks_and_preserves_state() -> None:
+    manager = BudgetManager()
+    manager.register_budget("tenant", "project", soft_limit_cents=40, hard_limit_cents=60)
+
+    manager.record_cost("tenant", "project", 40, provider="manual")
+
+    with pytest.raises(BudgetExceeded) as excinfo:
+        manager.record_cost("tenant", "project", 30, provider="manual")
+
+    usage = manager.get_usage("tenant", "project")
+    assert usage["spend_cents"] == 40
+    assert usage["events"] == 1
+
+    err = excinfo.value
+    assert err.attempted_spend_cents == 70
+    assert err.hard_limit_cents == 60
+
+
+def test_metric_records_spend_values() -> None:
+    registry = CollectorRegistry()
+    manager = BudgetManager(registry=registry)
+    manager.register_budget("tenant", "project", soft_limit_cents=100, hard_limit_cents=500)
+
+    result = manager.record_tokens("tenant", "project", provider="openai:gpt-4o", tokens=20)
+
+    metric_value = registry.get_sample_value(
+        "budget_spend_cents_total",
+        labels={"tenant": "tenant", "project": "project", "provider": "openai:gpt-4o"},
+    )
+    assert metric_value == result["total_spend_cents"]
+    assert result["soft_alert_triggered"] is False
+
+
+def test_record_tokens_p95_under_threshold() -> None:
+    manager = BudgetManager()
+    manager.register_budget("tenant", "project", soft_limit_cents=10_000, hard_limit_cents=20_000)
+
+    manager.record_tokens("tenant", "project", provider="openai:gpt-3.5", tokens=1)
+
+    durations: list[float] = []
+    for _ in range(120):
+        start = time.perf_counter()
+        manager.record_tokens("tenant", "project", provider="openai:gpt-3.5", tokens=1)
+        durations.append(time.perf_counter() - start)
+
+    durations.sort()
+    index = max(0, int(len(durations) * 0.95) - 1)
+    p95 = durations[index]
+    assert p95 < 0.005


### PR DESCRIPTION
## Summary
- add a FinOps budget manager with soft/hard caps and metric emission
- cover counters, enforcement, metrics, and latency guardrails with pytest
- document the new FinOps budget module and capture the spec entry

## Testing
- pytest tests/finops/test_budget.py

------
https://chatgpt.com/codex/tasks/task_e_68c876adb2588329879c4f8771b36244