### PR TITLE
Implement dashboard authentication with sessions

### DIFF
--- a/.specs/AUTH-SESSION-001.md
+++ b/.specs/AUTH-SESSION-001.md
@@ -1,0 +1,14 @@
+# AUTH-SESSION-001 · Dashboard Login + Session
+
+## Summary
+- Adds a password-protected login flow for the dashboard UI.
+- Issues signed, secure cookies and CSRF tokens upon successful login.
+- Provides middleware enforcing authentication, CSRF validation, and lockout.
+- Documents integration steps and covers behaviour with automated tests.
+
+## Acceptance Criteria
+- Password gate for dashboard.
+- Secure cookie session handling.
+- Lockout after five bad attempts (lockout window: five minutes).
+- CSRF enforcement on POST routes.
+- Test coverage validating success, failure, CSRF enforcement, cookie presence, and logging hygiene.

--- a/alpha/webapp/routes/auth.py
+++ b/alpha/webapp/routes/auth.py
@@ -1,0 +1,358 @@
+"""Authentication and session management for the dashboard UI."""
+
+from __future__ import annotations
+
+import hmac
+import os
+import secrets
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Optional, Tuple
+from urllib.parse import parse_qs
+
+from fastapi import APIRouter, FastAPI, HTTPException, Request, status
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
+
+__all__ = [
+    "router",
+    "install_dashboard_security",
+    "reset_state",
+    "SESSION_COOKIE_NAME",
+    "CSRF_COOKIE_NAME",
+    "CSRF_HEADER_NAME",
+]
+
+
+# Constants governing cookie and session behaviour.
+SESSION_COOKIE_NAME = "alpha_dashboard_session"
+CSRF_COOKIE_NAME = "alpha_dashboard_csrf"
+CSRF_HEADER_NAME = "x-alpha-csrf"
+
+PASSWORD_ENV_VAR = "ALPHA_DASHBOARD_PASSWORD"
+SECRET_ENV_VAR = "ALPHA_DASHBOARD_SECRET_KEY"
+
+SESSION_TTL_SECONDS = 60 * 60  # one hour
+LOCKOUT_THRESHOLD = 5
+LOCKOUT_DURATION_SECONDS = 5 * 60  # five minutes
+
+_PROTECTED_PREFIXES: Tuple[str, ...] = ("/requests", "/settings", "/run")
+_CSRF_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
+
+_TEMPLATE_DIR = Path(__file__).resolve().parent.parent / "templates"
+_LOGIN_TEMPLATE_PATH = _TEMPLATE_DIR / "login.html"
+
+
+@dataclass
+class SessionData:
+    """Metadata describing an authenticated dashboard session."""
+
+    session_id: str
+    created_at: float
+    expires_at: float
+    csrf_token: str
+
+
+@dataclass
+class AttemptState:
+    """Track failed login attempts for a particular client."""
+
+    failures: int = 0
+    locked_until: float = 0.0
+
+
+router = APIRouter()
+
+
+_SESSIONS: Dict[str, SessionData] = {}
+_SESSIONS_LOCK = threading.Lock()
+
+_ATTEMPTS: Dict[str, AttemptState] = {}
+_ATTEMPTS_LOCK = threading.Lock()
+
+_SECRET_KEY: Optional[str] = None
+
+
+def reset_state() -> None:
+    """Reset in-memory authentication state (used by tests)."""
+
+    global _SECRET_KEY
+    with _SESSIONS_LOCK:
+        _SESSIONS.clear()
+    with _ATTEMPTS_LOCK:
+        _ATTEMPTS.clear()
+    _SECRET_KEY = None
+
+
+def _get_secret_key() -> str:
+    """Return the secret key used to sign session cookies."""
+
+    global _SECRET_KEY
+    if _SECRET_KEY:
+        return _SECRET_KEY
+    env_value = os.getenv(SECRET_ENV_VAR)
+    if env_value:
+        _SECRET_KEY = env_value
+    else:
+        _SECRET_KEY = secrets.token_hex(32)
+    return _SECRET_KEY
+
+
+def _sign_session_id(session_id: str) -> str:
+    secret = _get_secret_key().encode("utf-8")
+    message = session_id.encode("utf-8")
+    digest = hmac.new(secret, message, "sha256").hexdigest()
+    return digest
+
+
+def _serialize_session(session: SessionData) -> str:
+    signature = _sign_session_id(session.session_id)
+    return f"{session.session_id}.{signature}"
+
+
+def _verify_serialized_session(value: str) -> Optional[str]:
+    try:
+        session_id, signature = value.split(".", 1)
+    except ValueError:
+        return None
+    expected = _sign_session_id(session_id)
+    if not hmac.compare_digest(signature, expected):
+        return None
+    return session_id
+
+
+def _create_session() -> SessionData:
+    now = time.monotonic()
+    session_id = secrets.token_hex(32)
+    csrf_token = secrets.token_hex(32)
+    session = SessionData(
+        session_id=session_id,
+        created_at=now,
+        expires_at=now + SESSION_TTL_SECONDS,
+        csrf_token=csrf_token,
+    )
+    with _SESSIONS_LOCK:
+        _SESSIONS[session_id] = session
+    return session
+
+
+def _delete_session(session_id: str) -> None:
+    with _SESSIONS_LOCK:
+        _SESSIONS.pop(session_id, None)
+
+
+def _load_session(session_id: str) -> Optional[SessionData]:
+    now = time.monotonic()
+    with _SESSIONS_LOCK:
+        session = _SESSIONS.get(session_id)
+        if not session:
+            return None
+        if session.expires_at <= now:
+            _SESSIONS.pop(session_id, None)
+            return None
+        return session
+
+
+def _client_identifier(request: Request) -> str:
+    host = getattr(request.client, "host", None)
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        host = forwarded.split(",")[0].strip()
+    return host or "unknown-client"
+
+
+def _is_locked(identifier: str) -> bool:
+    now = time.monotonic()
+    with _ATTEMPTS_LOCK:
+        state = _ATTEMPTS.get(identifier)
+        if not state:
+            return False
+        if state.locked_until and now < state.locked_until:
+            return True
+        if state.locked_until and now >= state.locked_until:
+            _ATTEMPTS.pop(identifier, None)
+        return False
+
+
+def _record_failure(identifier: str) -> None:
+    now = time.monotonic()
+    with _ATTEMPTS_LOCK:
+        state = _ATTEMPTS.setdefault(identifier, AttemptState())
+        if state.locked_until and now < state.locked_until:
+            return
+        state.failures += 1
+        if state.failures >= LOCKOUT_THRESHOLD:
+            state.locked_until = now + LOCKOUT_DURATION_SECONDS
+        else:
+            state.locked_until = 0.0
+
+
+def _record_success(identifier: str) -> None:
+    with _ATTEMPTS_LOCK:
+        _ATTEMPTS.pop(identifier, None)
+
+
+def _render_login_template(error_message: str = "") -> str:
+    base = _LOGIN_TEMPLATE_PATH.read_text(encoding="utf-8")
+    if error_message:
+        error_block = f"<p class=\"error\" role=\"alert\">{error_message}</p>"
+    else:
+        error_block = ""
+    return base.replace("[[ERROR_MESSAGE]]", error_block)
+
+
+async def _extract_login_payload(request: Request) -> Dict[str, str]:
+    content_type = request.headers.get("content-type", "").lower()
+    if "application/json" in content_type:
+        payload = await request.json()
+        if isinstance(payload, dict):
+            return {str(key): "" if value is None else str(value) for key, value in payload.items()}
+        return {}
+
+    body = await request.body()
+    if not body:
+        return {}
+    parsed = parse_qs(body.decode())
+    return {key: values[0] if values else "" for key, values in parsed.items()}
+
+
+def _expected_password() -> str:
+    password = os.getenv(PASSWORD_ENV_VAR)
+    if password is None:
+        return "alpha-dashboard"
+    return password
+
+
+def _build_lockout_response() -> HTMLResponse:
+    html = _render_login_template("Too many failed attempts. Try again later.")
+    return HTMLResponse(content=html, status_code=status.HTTP_429_TOO_MANY_REQUESTS)
+
+
+@router.get("/login", response_class=HTMLResponse)
+async def login_form() -> HTMLResponse:
+    return HTMLResponse(content=_render_login_template())
+
+
+@router.post("/login")
+async def login(request: Request) -> Response:
+    identifier = _client_identifier(request)
+    if _is_locked(identifier):
+        return _build_lockout_response()
+
+    payload = await _extract_login_payload(request)
+    supplied_password = str(payload.get("password", ""))
+    if secrets.compare_digest(supplied_password, _expected_password()):
+        _record_success(identifier)
+        session = _create_session()
+        response = RedirectResponse("/requests", status_code=status.HTTP_303_SEE_OTHER)
+        response.set_cookie(
+            CSRF_COOKIE_NAME,
+            session.csrf_token,
+            secure=True,
+            httponly=False,
+            samesite="strict",
+            max_age=SESSION_TTL_SECONDS,
+        )
+        response.set_cookie(
+            SESSION_COOKIE_NAME,
+            _serialize_session(session),
+            secure=True,
+            httponly=True,
+            samesite="strict",
+            max_age=SESSION_TTL_SECONDS,
+        )
+        return response
+
+    _record_failure(identifier)
+    html = _render_login_template("Invalid credentials")
+    return HTMLResponse(content=html, status_code=status.HTTP_401_UNAUTHORIZED)
+
+
+@router.get("/logout")
+async def logout(request: Request) -> Response:
+    cookie = request.cookies.get(SESSION_COOKIE_NAME)
+    if cookie:
+        session_id = _verify_serialized_session(cookie)
+        if session_id:
+            _delete_session(session_id)
+    response = RedirectResponse("/login", status_code=status.HTTP_303_SEE_OTHER)
+    response.delete_cookie(SESSION_COOKIE_NAME)
+    response.delete_cookie(CSRF_COOKIE_NAME)
+    return response
+
+
+def _is_protected_path(path: str, protected: Iterable[str]) -> bool:
+    for prefix in protected:
+        if path == prefix or path.startswith(prefix + "/"):
+            return True
+    return False
+
+
+def _require_session(request: Request) -> SessionData:
+    cookie = request.cookies.get(SESSION_COOKIE_NAME)
+    if not cookie:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "not authenticated")
+    session_id = _verify_serialized_session(cookie)
+    if not session_id:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "invalid session")
+    session = _load_session(session_id)
+    if not session:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "session expired")
+    request.state.alpha_dashboard_session = session
+    return session
+
+
+def _enforce_csrf(request: Request, session: SessionData) -> None:
+    header_token = request.headers.get(CSRF_HEADER_NAME)
+    if not header_token:
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "missing CSRF token")
+    if not secrets.compare_digest(header_token, session.csrf_token):
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "invalid CSRF token")
+
+
+def install_dashboard_security(
+    app: FastAPI, protected_prefixes: Iterable[str] | None = None
+) -> None:
+    """Install middleware enforcing authentication and CSRF checks."""
+
+    prefixes: Tuple[str, ...]
+    if protected_prefixes is None:
+        prefixes = _PROTECTED_PREFIXES
+    else:
+        prefixes = tuple(sorted(set(protected_prefixes)))
+
+    if getattr(app.state, "alpha_dashboard_security_installed", False):
+        app.state.alpha_dashboard_protected = prefixes
+        return
+
+    app.state.alpha_dashboard_security_installed = True
+    app.state.alpha_dashboard_protected = prefixes
+
+    @app.middleware("http")
+    async def _dashboard_security(request: Request, call_next):  # type: ignore[override]
+        path = request.url.path
+        protected = getattr(app.state, "alpha_dashboard_protected", prefixes)
+        requires_guard = _is_protected_path(path, protected)
+        is_login = path.startswith("/login")
+        is_logout = path.startswith("/logout")
+
+        if requires_guard:
+            try:
+                session = _require_session(request)
+            except HTTPException as exc:
+                if request.method.upper() == "GET":
+                    return RedirectResponse("/login", status_code=status.HTTP_303_SEE_OTHER)
+                return JSONResponse({"detail": exc.detail}, status_code=exc.status_code)
+
+            if request.method.upper() in _CSRF_METHODS:
+                try:
+                    _enforce_csrf(request, session)
+                except HTTPException as exc:
+                    return JSONResponse({"detail": exc.detail}, status_code=exc.status_code)
+
+        elif not (is_login or is_logout):
+            request.state.alpha_dashboard_session = None  # type: ignore[attr-defined]
+
+        response = await call_next(request)
+        return response

--- a/alpha/webapp/templates/login.html
+++ b/alpha/webapp/templates/login.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Alpha Solver Dashboard &mdash; Login</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      :root {
+        color-scheme: light dark;
+      }
+      body {
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: #0f172a;
+        background: linear-gradient(135deg, #0f172a 0%, #1d4ed8 100%);
+        color: #0f172a;
+      }
+      .card {
+        background: #ffffff;
+        border-radius: 12px;
+        padding: 2.5rem;
+        width: min(90vw, 420px);
+        box-shadow: 0 20px 45px rgba(15, 23, 42, 0.25);
+      }
+      h1 {
+        margin-top: 0;
+        margin-bottom: 1.5rem;
+        font-size: 1.8rem;
+        color: #0f172a;
+      }
+      label {
+        display: block;
+        font-weight: 600;
+        margin-bottom: 0.5rem;
+      }
+      input[type="password"] {
+        width: 100%;
+        padding: 0.75rem;
+        font-size: 1rem;
+        border-radius: 8px;
+        border: 1px solid #cbd5f5;
+        box-sizing: border-box;
+      }
+      input[type="password"]:focus {
+        outline: 2px solid #3b82f6;
+        border-color: #3b82f6;
+      }
+      button[type="submit"] {
+        margin-top: 1.25rem;
+        width: 100%;
+        background: #2563eb;
+        color: #fff;
+        border: 0;
+        border-radius: 8px;
+        padding: 0.75rem;
+        font-size: 1rem;
+        font-weight: 600;
+        cursor: pointer;
+      }
+      button[type="submit"]:hover {
+        background: #1d4ed8;
+      }
+      p.error {
+        background: rgba(220, 38, 38, 0.12);
+        border: 1px solid rgba(220, 38, 38, 0.35);
+        color: #b91c1c;
+        padding: 0.75rem 1rem;
+        border-radius: 8px;
+        margin-top: 0;
+        margin-bottom: 1.5rem;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="card">
+      <h1>Sign in to the dashboard</h1>
+      [[ERROR_MESSAGE]]
+      <form method="post" action="/login">
+        <label for="password">Password</label>
+        <input
+          type="password"
+          id="password"
+          name="password"
+          autocomplete="current-password"
+          required
+        />
+        <button type="submit">Sign in</button>
+      </form>
+    </main>
+  </body>
+</html>

--- a/docs/DASHBOARD_AUTH.md
+++ b/docs/DASHBOARD_AUTH.md
@@ -1,0 +1,88 @@
+# Dashboard Authentication & Session Management
+
+The dashboard UI is protected by a lightweight password gate that issues
+signed cookies and CSRF tokens when the user successfully authenticates.
+This document explains how to configure the feature and integrate it with
+custom FastAPI applications.
+
+## Features
+
+- Password-protected login screen at `/login`.
+- Secure, signed session cookie (`alpha_dashboard_session`) marked as
+  `HttpOnly`, `Secure`, and `SameSite=Strict`.
+- Per-session CSRF token exposed via the `alpha_dashboard_csrf` cookie.
+- Middleware that enforces authenticated access to dashboard routes and
+  rejects state-changing requests without a valid CSRF token.
+- Lockout after five consecutive failed password attempts (default lockout
+  window is five minutes).
+
+## Configuration
+
+| Environment variable | Description | Default |
+| -------------------- | ----------- | ------- |
+| `ALPHA_DASHBOARD_PASSWORD` | Password required to sign in. | `alpha-dashboard` |
+| `ALPHA_DASHBOARD_SECRET_KEY` | Secret used to sign session cookies. | Randomly generated at runtime |
+| `ALPHA_DASHBOARD_SECRETS_PATH` | Storage path for provider credentials (used by the settings UI). | `~/.alpha_solver/dashboard_api_keys.json` |
+| `ALPHA_DASHBOARD_AUDIT_LOG` | Path of the audit log file for settings changes. | `~/.alpha_solver/dashboard_audit.log` |
+
+Set the password and secret key in the environment before starting the
+application to ensure deterministic behaviour across restarts. The secret key
+must remain private because it signs session cookies.
+
+## Using the Router and Middleware
+
+```python
+from fastapi import FastAPI
+
+from alpha.webapp.routes import auth, requests, settings
+
+app = FastAPI()
+auth.install_dashboard_security(app)
+app.include_router(auth.router)
+app.include_router(requests.router)
+app.include_router(settings.router)
+```
+
+The middleware installed by `install_dashboard_security` intercepts all
+requests whose path begins with `/requests`, `/settings`, or `/run`. Unauthenticated
+clients receive a redirect to `/login`. POST/PUT/PATCH/DELETE requests to these
+paths also require the `X-Alpha-CSRF` header to match the CSRF token stored in
+the cookie.
+
+## Obtaining the CSRF Token
+
+The CSRF token for the current session is exposed via the
+`alpha_dashboard_csrf` cookie. Browser-based clients should read this cookie and
+send its value in the `X-Alpha-CSRF` header for all state-changing requests.
+
+Example using Fetch:
+
+```javascript
+const csrfToken = getCookie('alpha_dashboard_csrf');
+fetch('/settings/keys', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'X-Alpha-CSRF': csrfToken,
+  },
+  body: JSON.stringify({ provider: 'openai', key: 'sk-demo' })
+});
+```
+
+## Handling Logout
+
+Calling `GET /logout` clears the session and CSRF cookies on the client and
+invalidates the server-side session state. Subsequent dashboard requests will be
+redirected back to `/login`.
+
+## Lockout Behaviour
+
+Failed password attempts are tracked per client address. After five incorrect
+submissions, the login form returns HTTP 429 for five minutes to slow brute-force
+attempts. A successful login immediately clears the failure counter.
+
+## Testing Utilities
+
+The `alpha.webapp.routes.auth.reset_state()` helper clears in-memory sessions and
+failed login counters. Tests should call this function before interacting with
+authentication-sensitive routes to keep suites hermetic.

--- a/tests/ui/test_auth.py
+++ b/tests/ui/test_auth.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from alpha.webapp.routes import auth, requests as request_routes, settings  # noqa: E402
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setenv("ALPHA_DASHBOARD_PASSWORD", "testing-secret")
+    monkeypatch.setenv("ALPHA_DASHBOARD_SECRET_KEY", "unit-test-secret")
+    monkeypatch.setenv("ALPHA_DASHBOARD_SECRETS_PATH", str(tmp_path / "secrets.json"))
+    monkeypatch.setenv("ALPHA_DASHBOARD_AUDIT_LOG", str(tmp_path / "audit.log"))
+
+    auth.reset_state()
+    request_routes.reset_state()
+
+    app = FastAPI()
+    auth.install_dashboard_security(app)
+    app.include_router(auth.router)
+    app.include_router(request_routes.router)
+    app.include_router(settings.router)
+
+    client = TestClient(app, base_url="https://testserver")
+    try:
+        yield client
+    finally:
+        client.close()
+
+
+def _login(client: TestClient) -> str:
+    response = client.post("/login", data={"password": "testing-secret"}, follow_redirects=False)
+    assert response.status_code == 303
+    csrf_token = client.cookies.get(auth.CSRF_COOKIE_NAME)
+    assert csrf_token
+    return csrf_token
+
+
+def test_login_sets_secure_cookie_and_allows_access(client: TestClient) -> None:
+    gate = client.get("/requests", follow_redirects=False)
+    assert gate.status_code == 303
+    assert gate.headers["location"] == "/login"
+
+    response = client.post("/login", data={"password": "testing-secret"}, follow_redirects=False)
+    assert response.status_code == 303
+
+    session_cookie = client.cookies.get(auth.SESSION_COOKIE_NAME)
+    csrf_cookie = client.cookies.get(auth.CSRF_COOKIE_NAME)
+    assert session_cookie
+    assert csrf_cookie
+
+    header_value = response.headers.get("set-cookie", "").lower()
+    assert auth.SESSION_COOKIE_NAME in header_value
+    assert "httponly" in header_value
+    assert "secure" in header_value
+    assert "samesite=strict" in header_value
+
+    page = client.get("/requests")
+    assert page.status_code == 200
+    assert "<form" in page.text
+
+
+def test_failed_logins_trigger_lockout(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(auth, "LOCKOUT_DURATION_SECONDS", 0.5)
+
+    for _ in range(5):
+        response = client.post("/login", data={"password": "wrong"}, follow_redirects=False)
+        assert response.status_code == 401
+
+    locked = client.post("/login", data={"password": "testing-secret"}, follow_redirects=False)
+    assert locked.status_code == 429
+    assert "Try again later" in locked.text
+
+    time.sleep(0.55)
+
+    recovery = client.post("/login", data={"password": "testing-secret"}, follow_redirects=False)
+    assert recovery.status_code == 303
+
+
+def test_csrf_required_for_dashboard_posts(client: TestClient) -> None:
+    csrf_token = _login(client)
+
+    missing = client.post(
+        "/requests",
+        json={"prompt": "hello", "provider": request_routes.AVAILABLE_PROVIDERS[0]},
+    )
+    assert missing.status_code == 403
+    assert missing.json()["detail"] == "missing CSRF token"
+
+    valid = client.post(
+        "/requests",
+        json={"prompt": "hello", "provider": request_routes.AVAILABLE_PROVIDERS[0]},
+        headers={"x-alpha-csrf": csrf_token},
+    )
+    assert valid.status_code == 200
+    assert "id" in valid.json()
+
+    settings_blocked = client.post(
+        "/settings/keys",
+        data={"provider": "openai", "key": "sk-test"},
+        follow_redirects=False,
+    )
+    assert settings_blocked.status_code == 403
+
+    settings_allowed = client.post(
+        "/settings/keys",
+        data={"provider": "openai", "key": "sk-test"},
+        headers={"x-alpha-csrf": csrf_token},
+        follow_redirects=False,
+    )
+    assert settings_allowed.status_code == 303
+
+
+def test_logout_revokes_session(client: TestClient) -> None:
+    _login(client)
+
+    page = client.get("/requests")
+    assert page.status_code == 200
+
+    response = client.get("/logout", follow_redirects=False)
+    assert response.status_code == 303
+    assert response.headers["location"] == "/login"
+
+    gated = client.get("/requests", follow_redirects=False)
+    assert gated.status_code == 303
+    assert gated.headers["location"] == "/login"
+
+
+def test_password_not_logged(client: TestClient, caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level("INFO")
+    _login(client)
+    for record in caplog.records:
+        assert "testing-secret" not in record.getMessage()


### PR DESCRIPTION
## Summary
- add authentication routes with secure session cookies, lockout handling, and CSRF enforcement for protected dashboard paths
- add a styled login template plus documentation describing configuration and integration steps
- cover login, lockout, CSRF, logout, and logging hygiene with dedicated UI tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c8769279c483299bdc02bf00e898ab