### PR TITLE
Fix domainless MCP allowlist enforcement

### DIFF
--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -16,6 +16,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `MCP-005.md` | CODE SPEC — MCP-005 · Error Taxonomy (MCP) |
 | `MCP-006.md` | CODE SPEC — MCP-006 · Retry & Backoff (MCP) |
 | `MCP-007.md` | CODE SPEC — MCP-007 · MCP Observability hooks (MCP) |
+| `MCP-008.md` | MCP-008 · Domainless MCP Tool Allowlist Enforcement |
 | `NEW-009.md` | CODE SPEC — NEW-009 · Clarify Templates Pack (RES_02) |
 | `NEW-010.md` | CODE SPEC — NEW-010 · Section-Specific Prompt Decks (RES_01) |
 | `NEW-011.md` | CODE SPEC — NEW-011 · Weight-Tuning Harness (RES-03 scoring) (RES_03) |

--- a/.specs/MCP-008.md
+++ b/.specs/MCP-008.md
@@ -1,0 +1,41 @@
+# MCP-008 · Domainless MCP Tool Allowlist Enforcement
+
+## Goal
+Fix `McpAdapter.safe_call()` so domainless tools such as `gsheets_write` are not blocked solely because `allow_domains` is configured, while domain-bearing tools still fail closed on missing or disallowed domains.
+
+## Motivation
+`allow_domains` is a network/domain guard, not a general tool allowlist. The current implementation blocks valid domainless `gsheets_write` calls with `domain_not_allowed:None`, preventing governed non-web tool use.
+
+## Acceptance Criteria
+- Given `allow_domains=["example.com"]`, when `gsheets_write` is called with `sheet_id` and `rows` but no `url` or `domain`, then the call succeeds and returns `domain: None`.
+- Given `allow_domains=["example.com"]`, when `playwright_web_extract` is called with `https://bad.com`, then the call fails with `domain_not_allowed:bad.com`.
+- Given `allow_domains=["example.com"]`, when `playwright_web_extract` is called without `url` or `domain`, then the call fails closed.
+- Given `allow_domains=["example.com"]`, when `gsheets_write` includes an unexpected disallowed `domain` or `url`, then the call fails with `domain_not_allowed:<domain>`.
+
+## Definition of Done
+- Regression test added for domainless `gsheets_write`.
+- Guard tests added proving domain-bearing allowlist behavior is unchanged.
+- Minimal adapter change made only in `alpha/tools/mcp_adapter.py`.
+- Targeted MCP adapter tests pass.
+- `.specs/INDEX.md` includes `MCP-008.md`.
+
+## Code Targets
+- `alpha/tools/mcp_adapter.py`
+- `tests/test_mcp_adapter.py`
+
+## Test Plan
+- `python -m pytest -q tests/test_mcp_adapter.py`
+- Optional related regression sweep:
+  `python -m pytest -q tests/test_mcp_adapter.py tests/test_adapters_gsheets_hardened.py tests/test_adapters_playwright_hardened.py tests/test_mcp_auth.py`
+
+## Out of Scope
+- Reworking `service/adapters/*`.
+- Changing MCP registry schema.
+- Adding per-tool authorization scopes.
+- Changing `alpha/observability/obs_card.py`.
+- Broad MCP refactors.
+
+## Risks
+- Allowing domainless tools through can permit side effects not governed by domain policy.
+- Future tools could incorrectly be classified as domainless while performing hidden network calls.
+- Mitigation: only skip domain allowlist for explicitly named domainless tools when extracted domain is `None`.

--- a/alpha/tools/mcp_adapter.py
+++ b/alpha/tools/mcp_adapter.py
@@ -22,6 +22,7 @@ class McpAdapter:
 
     DEFAULT_TIMEOUT_MS = 10_000
     DEFAULT_REDACT_FIELDS = {"email", "phone_number", "full_name", "address"}
+    DOMAINLESS_TOOLS = {"gsheets_write"}
 
     def __init__(self, config: Optional[Mapping[str, Any]] = None) -> None:
         self.config = dict(config or {})
@@ -53,7 +54,8 @@ class McpAdapter:
 
         call_fn = self._tools[tool_name]
         domain = self._extract_domain(payload)
-        self._enforce_allowlist(domain)
+        if domain is not None or tool_name not in self.DOMAINLESS_TOOLS:
+            self._enforce_allowlist(domain)
 
         start = time.perf_counter()
         redactions: List[str] = []

--- a/tests/test_mcp_adapter.py
+++ b/tests/test_mcp_adapter.py
@@ -1,0 +1,54 @@
+import pytest
+
+from alpha.tools.mcp_adapter import McpAdapter, McpAdapterError
+
+
+def test_gsheets_write_skips_domain_allowlist_when_payload_domainless():
+    adapter = McpAdapter({"allow_domains": ["example.com"]})
+
+    result = adapter.safe_call(
+        "gsheets_write",
+        {"sheet_id": "s1", "rows": [[1]]},
+    )
+
+    assert result["tool"] == "gsheets_write"
+    assert result["domain"] is None
+    assert result["output"]["status"] == "accepted"
+    assert result["output"]["row_count"] == 1
+
+
+def test_playwright_web_extract_still_blocks_disallowed_domain():
+    adapter = McpAdapter({"allow_domains": ["example.com"]})
+
+    with pytest.raises(McpAdapterError, match="domain_not_allowed:bad.com"):
+        adapter.safe_call(
+            "playwright_web_extract",
+            {"url": "https://bad.com", "selector": "main"},
+        )
+
+
+def test_playwright_web_extract_fails_closed_when_domain_missing_with_allowlist():
+    adapter = McpAdapter({"allow_domains": ["example.com"]})
+
+    with pytest.raises(McpAdapterError, match="domain_not_allowed:None"):
+        adapter.safe_call(
+            "playwright_web_extract",
+            {"selector": "main"},
+        )
+
+
+@pytest.mark.parametrize(
+    "domain_payload",
+    [
+        {"domain": "bad.com"},
+        {"url": "https://bad.com/sheet"},
+    ],
+)
+def test_gsheets_write_with_domain_field_still_enforces_allowlist(domain_payload):
+    adapter = McpAdapter({"allow_domains": ["example.com"]})
+
+    with pytest.raises(McpAdapterError, match="domain_not_allowed:bad.com"):
+        adapter.safe_call(
+            "gsheets_write",
+            {"sheet_id": "s1", "rows": [[1]], **domain_payload},
+        )


### PR DESCRIPTION
### Motivation
- The current `McpAdapter.safe_call()` treats a missing extracted domain as a rejection when `allow_domains` is configured, which incorrectly blocks domainless tools like `gsheets_write`.
- The intent is to keep `allow_domains` as a network/domain guard while allowing explicitly domainless tools to operate when no `url`/`domain` is present.

### Description
- Add `DOMAINLESS_TOOLS = {"gsheets_write"}` and adjust `safe_call()` to skip `_enforce_allowlist(domain)` only when the extracted `domain` is `None` and `tool_name` is in `DOMAINLESS_TOOLS` in `alpha/tools/mcp_adapter.py`.
- Preserve allowlist enforcement when a domain is present (including unexpected `url`/`domain` in a normally domainless tool) and preserve fail-closed behavior for domain-bearing tools like `playwright_web_extract`.
- Add a focused bugfix spec `.specs/MCP-008.md` and register it in `.specs/INDEX.md` to document the change.
- Add targeted tests in `tests/test_mcp_adapter.py` verifying domainless `gsheets_write` behavior and domain-bearing fail-closed semantics.

### Testing
- Added tests `tests/test_mcp_adapter.py` and ran `python -m pytest -q tests/test_mcp_adapter.py`, which passed.
- Ran the suggested regression sweep `python -m pytest -q tests/test_mcp_adapter.py tests/test_adapters_gsheets_hardened.py tests/test_adapters_playwright_hardened.py tests/test_mcp_auth.py`, which also passed.
- The changes are intentionally minimal and leave tool-name validation, timeout behavior, redaction, and existing governance logic unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19f5e58ca8832985f1b1877afddc10)