### PR TITLE
Clarify registry export versus backlog files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ This file gives repo-level operating instructions for AI coding agents working o
 - Existing specs should not be moved or renamed casually.
 - New feature or bugfix work should start from or update a spec unless the user explicitly requests exploratory work.
 - Backlog spreadsheets are external planning/status ledgers, not repo implementation contracts.
-- `data/alpha_solver_master_table_v0_7_0.*` is a registry export, not a backlog.
+- `data/alpha_solver_master_table_v0_7_0.*` is a registry export/provenance artifact, not a backlog; see `data/README.md` before using or moving it.
 
 ## Agent Workflow
 

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,48 @@
+# Data Exports
+
+This directory contains generated or imported data artifacts that can support
+registry work, audits, and historical provenance. Files here are not the active
+planning backlog unless a future document explicitly says so.
+
+## Alpha Solver master table v0.7.0
+
+The following files are registry/tool-model catalog exports:
+
+- `alpha_solver_master_table_v0_7_0.csv`
+- `alpha_solver_master_table_v0_7_0.xlsx`
+
+They are **not the active task backlog**. Do not use these files to decide
+implementation status, PR status, backlog priority, or the next development
+action for the repository. They may still be useful as registry provenance,
+source material, audit context, or historical export data for tool/model catalog
+work.
+
+## Source-of-truth boundaries
+
+Use the following boundaries when deciding which artifact answers which kind of
+question:
+
+| Artifact | Role |
+| --- | --- |
+| External backlog workbook | Planning and status ledger maintained outside the repository. |
+| `.specs/` | Repository implementation contracts for approved behavior changes. |
+| GitHub PRs, commits, and test results | Implementation evidence and review history. |
+| `registries/` and `schemas/` | Runtime and governance registry assets. |
+| `data/alpha_solver_master_table_v0_7_0.*` | Registry export/provenance data, not backlog. |
+
+## Quick identification guide
+
+Backlog rows usually include planning fields such as `status`, `priority`,
+`spec path`, `PR URL`, `implementation evidence`, and `next action`.
+
+Registry export rows usually include catalog fields such as `id`, `name`,
+`type`, `bucket`, `ecosystem`, `modality`, `registry_file`,
+`primary_use_case`, `capabilities`, `limitations`, `pricing`, `compliance`,
+and `latency`.
+
+## Rename, deletion, and migration warning
+
+Do not delete, rename, archive, or move `alpha_solver_master_table_v0_7_0.csv`
+or `alpha_solver_master_table_v0_7_0.xlsx` without a separate migration and
+reference check. If these files are renamed later, update all documentation and
+any scripts or manual workflows that reference them.

--- a/docs/REGISTRY.md
+++ b/docs/REGISTRY.md
@@ -14,3 +14,35 @@ python scripts/preflight.py --fix-ids
 The script checks for required fields, duplicate ids, and that priors
 are in the `[0,1]` range. Set `ALPHA_MIN_TOOLS` to require a minimum
 count of tools.
+
+## Registry exports versus backlog
+
+`data/alpha_solver_master_table_v0_7_0.csv` and
+`data/alpha_solver_master_table_v0_7_0.xlsx` are registry/tool-model catalog
+exports. They are **not the active task backlog** and should not be used to
+decide implementation status, PR status, backlog priority, or the next
+development action. Treat them as registry provenance, source material, audit
+context, or historical export data.
+
+Source-of-truth boundaries:
+
+- External backlog workbook: planning/status ledger maintained outside this
+  repository.
+- `.specs/`: implementation contracts for approved behavior changes.
+- GitHub PRs, commits, and test results: implementation evidence and review
+  history.
+- `registries/` and `schemas/`: runtime and governance registry assets.
+- `data/alpha_solver_master_table_v0_7_0.*`: registry export/provenance data,
+  not backlog.
+
+Quick identification guide:
+
+- Backlog rows usually have fields such as `status`, `priority`, `spec path`,
+  `PR URL`, `implementation evidence`, and `next action`.
+- Registry export rows usually have fields such as `id`, `name`, `type`,
+  `bucket`, `ecosystem`, `modality`, `registry_file`, `primary_use_case`,
+  `capabilities`, `limitations`, `pricing`, `compliance`, and `latency`.
+
+Do not delete, rename, archive, or move these `data/` files without a separate
+migration and reference check. If they are renamed later, update all docs and
+any scripts or manual workflows that reference them.


### PR DESCRIPTION
### Motivation

- The `data/alpha_solver_master_table_v0_7_0.*` filenames have been misinterpreted as an active backlog; document their true role to avoid using them for implementation or prioritization decisions. 
- Establish clear source-of-truth boundaries so contributors know where to look for planning, specs, and runtime registry assets.

### Description

- Added `data/README.md` explaining that `data/alpha_solver_master_table_v0_7_0.csv` and `data/alpha_solver_master_table_v0_7_0.xlsx` are registry/tool-model catalog exports and are **not the active task backlog**. 
- Updated `docs/REGISTRY.md` with a "Registry exports versus backlog" section that includes source-of-truth boundaries, a quick identification guide (backlog vs registry fields), and warnings not to delete/rename/move the `data/` export files without a migration/reference check. 
- Small clarification in `AGENTS.md` pointing to `data/README.md` for provenance guidance. 
- No code behavior, schema, or spec changes were made, and no files were deleted, renamed, moved, or archived.

Files changed: `data/README.md`, `docs/REGISTRY.md`, `AGENTS.md`.

Suggested squash merge title: `Clarify registry export versus backlog files`.

Suggested squash merge extended description: Document that `data/alpha_solver_master_table_v0_7_0.csv` and `.xlsx` are registry/tool-model catalog export and provenance artifacts (not the active backlog), add source-of-truth boundaries, a quick field-based identification guide, and warnings against deleting/renaming/moving these data exports without a separate migration/reference check.

### Testing

- Ran `git diff --check` and fixed a trailing-EOF warning; final `git diff --check` passed with no issues. 
- Searched the repo for the new wording with `rg` to confirm the docs contain clear "not the active task backlog" language and references to `data/README.md`, and the search returned the expected matches. 
- Inspected `data/alpha_solver_master_table_v0_7_0.csv` header and confirmed the file contains registry/catalog columns (e.g., `id`, `name`, `type`, `registry_file`, `status`) to validate the characterization as a registry export. 

All automated checks listed above succeeded; no full test suite run was required for this docs-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a0a5cf94883298cba1ef75662c821)