### PR TITLE
Clarify spec index titles and flag copied spec bodies

### DIFF
--- a/.specs/EPIC_RAG_001.md
+++ b/.specs/EPIC_RAG_001.md
@@ -7,6 +7,8 @@ priority: P2A
 track: RES_RAG
 spec_version: 1.0
 ---
+# EPIC_RAG_001 · RAG & Semantic Cache Pack
+
 ## Goal
 Deterministic RAG broker with semantic cache (TTL + LFU/LRU) and policy guardrails.
 

--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -7,7 +7,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `AS-145.md` | CODE SPEC — AS-145 · Tool Adapters: Playwright + GSheets (MVP hardening) (RES_05) |
 | `AS-148.md` | CODE SPEC — AS-148 · Policy & PII Gateway (DR_TRACK_A) |
 | `AUTH-SESSION-001.md` | AUTH-SESSION-001 · Dashboard Login + Session |
-| `EPIC_RAG_001.md` | Goal |
+| `EPIC_RAG_001.md` | EPIC_RAG_001 · RAG & Semantic Cache Pack |
 | `FINOPS-BUDGET-001.md` | FINOPS-BUDGET-001 · Budget Guardrails |
 | `MCP-001.md` | CODE SPEC — MCP-001 · MCP Registry Loader & Wiring (MCP) |
 | `MCP-002.md` | CODE SPEC — MCP-002 · Router decision rule (MCP) |
@@ -28,8 +28,8 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `NEW-017.md` | CODE SPEC — NEW-017 · Prompt Quality Pack (rubrics + evaluator) (RES_01) |
 | `NEW-024.md` | CODE SPEC — NEW-024 · JWT Service-to-Service Authentication (DR_TRACK_A) |
 | `NEW-045.md` | Spec: NEW-045 · Pilot Readiness & Release v0.1 |
-| `NEW-HEALTH-001.md` | Goal |
-| `NEW-RATE-001.md` | Goal |
+| `NEW-HEALTH-001.md` | NEW-HEALTH-001 · Health Check Endpoints |
+| `NEW-RATE-001.md` | NEW-RATE-001 · API Rate Limiting |
 | `OBS-ALERTS-001.md` | CODE SPEC — OBS-ALERTS-001 · Prometheus Alerts + CI Validation (RES_Dash) |
 | `RES-03.md` | CODE SPEC — RES-03 · Decision Rules & Scoring (RES) |
 | `RES-04.md` | CODE SPEC — RES-04 · Confidence & Budget Gates (RES) |

--- a/.specs/MCP-001.md
+++ b/.specs/MCP-001.md
@@ -1,5 +1,7 @@
 # CODE SPEC — MCP-001 · MCP Registry Loader & Wiring (MCP)
 
+> Hygiene note: The Goal, Acceptance Criteria, Design, and Tests sections below appear copied from MCP-005 · Error Taxonomy and do not match this spec’s registry loader/wiring title/code targets. Treat this spec as requiring reconciliation before using it for implementation scope.
+
 ## Goal
 Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
 

--- a/.specs/NEW-016.md
+++ b/.specs/NEW-016.md
@@ -1,5 +1,7 @@
 # CODE SPEC — NEW-016 · Grafana Dashboards Pack (metrics + sample boards) (RES_07)
 
+> Hygiene note: The Goal, Acceptance Criteria, Design, and Tests sections below appear copied from MCP-005 · Error Taxonomy and do not match this spec’s Grafana dashboard title/code targets. Treat this spec as requiring reconciliation before using it for implementation scope.
+
 ## Goal
 Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
 

--- a/.specs/NEW-HEALTH-001.md
+++ b/.specs/NEW-HEALTH-001.md
@@ -7,6 +7,8 @@ priority: P2A
 track: RES_Infra
 spec_version: 1.0
 ---
+# NEW-HEALTH-001 · Health Check Endpoints
+
 ## Goal
 Expose /health with dependency checks (Redis, VectorDB, provider ping).
 ## Acceptance Criteria

--- a/.specs/NEW-RATE-001.md
+++ b/.specs/NEW-RATE-001.md
@@ -7,6 +7,8 @@ priority: P2A
 track: RES_Infra
 spec_version: 1.0
 ---
+# NEW-RATE-001 · API Rate Limiting
+
 ## Goal
 Introduce Redis-backed token bucket rate limiting for tenant/global scopes.
 ## Acceptance Criteria


### PR DESCRIPTION
### Motivation

- The specs index contained three entries whose title was literally `Goal`, which obscures their true titles despite correct YAML frontmatter in the target files.
- An inspect-only pass found that `NEW-016.md` and `MCP-001.md` contain copied MCP error-taxonomy body text that does not match their filenames/code targets and should be flagged before any implementation is attempted.

### Description

- Add top-level H1 headings after YAML frontmatter to `.specs/EPIC_RAG_001.md`, `.specs/NEW-HEALTH-001.md`, and `.specs/NEW-RATE-001.md` reflecting their frontmatter titles.
- Update `.specs/INDEX.md` to replace the three `Goal` rows with the explicit titles `EPIC_RAG_001 · RAG & Semantic Cache Pack`, `NEW-HEALTH-001 · Health Check Endpoints`, and `NEW-RATE-001 · API Rate Limiting` while preserving filenames and ordering.
- Insert hygiene caution notes immediately below the existing H1 in `.specs/NEW-016.md` and `.specs/MCP-001.md` warning that the body text appears copied from `MCP-005` and requires reconciliation before being used as implementation scope, without rewriting those bodies.
- No implementation files, tests, backlog workbooks, spec renames, or deletions were performed and `MCP-005.md` was left unchanged.

### Testing

- Ran `git diff --check` with no issues reported (passed).
- Executed the provided Python spec hygiene check script which printed `spec hygiene checks passed` (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a0fd3de28832996fd848dc2518b67)