### PR TITLE
Clarify placeholder health and rate-limit docs

### DIFF
--- a/docs/HEALTH.md
+++ b/docs/HEALTH.md
@@ -1,2 +1,30 @@
 # Health Endpoint (NEW-HEALTH-001)
-This file will be completed by the Codex patch.
+
+## Status
+
+`NEW-HEALTH-001` remains an unresolved alpha-layer placeholder/spec target. It is not implemented as written by the current service-layer health and readiness behavior.
+
+The currently implemented service-layer `/health` and `/ready` behavior is documented in [`docs/HEALTH_READINESS.md`](HEALTH_READINESS.md) and implemented through the service references below. That implemented behavior has different schema and dependency expectations from `NEW-HEALTH-001`.
+
+## Related placeholder targets
+
+- `alpha/api/health.py`
+- `tests/api/test_health.py`
+
+These placeholder code, test, and documentation targets should not be treated as completed coverage for `NEW-HEALTH-001`.
+
+## Current implemented references
+
+- `service/health.py`
+- `service/app.py`
+- `tests/test_health_ready.py`
+- `docs/HEALTH_READINESS.md`
+
+## Future decision needed
+
+Future work must decide whether `NEW-HEALTH-001` should:
+
+- wrap the existing service health/readiness behavior,
+- revise its schema and dependency expectations,
+- implement a new alpha-layer health contract,
+- or be retired/superseded.

--- a/docs/RATE_LIMITING.md
+++ b/docs/RATE_LIMITING.md
@@ -1,2 +1,32 @@
 # Rate Limiting (NEW-RATE-001)
-This file will be completed by the Codex patch.
+
+## Status
+
+`NEW-RATE-001` remains unresolved/partial as a Redis-backed alpha-layer middleware target. It is not implemented as written by the current in-memory service and tenant rate limiting behavior.
+
+The currently implemented in-memory tenant limiter behavior is documented in [`docs/TENANCY_LIMITS.md`](TENANCY_LIMITS.md). Current service API-key rate limiting exists in `service/app.py`. These existing in-memory service and tenant limiters are not the same as the Redis-backed tenant/global token bucket behavior described by `NEW-RATE-001`.
+
+## Related placeholder targets
+
+- `alpha/middleware/ratelimit.py`
+- `tests/middleware/test_ratelimit.py`
+
+These placeholder code, test, and documentation targets should not be treated as completed coverage for `NEW-RATE-001`.
+
+## Current implemented references
+
+- `service/app.py`
+- `service/tenancy/limiter.py`
+- `service/middleware/tenant_middleware.py`
+- `tests/test_rate_limits.py`
+- `tests/test_api_auth_ratelimit.py`
+- `docs/TENANCY_LIMITS.md`
+
+## Future decision needed
+
+Future work must decide whether `NEW-RATE-001` should:
+
+- remain a Redis-backed distributed rate-limit implementation target,
+- be revised to document the current in-memory limiters,
+- be split into existing limiter documentation and a future Redis implementation,
+- or be retired/superseded.


### PR DESCRIPTION
### Motivation

- The repo contained placeholder stubs for health and rate-limit targets which could be mistaken for completed implementations, so the docs need to clarify current service behavior and unresolved alpha-layer spec targets.

### Description

- Updated `docs/HEALTH.md` to replace the placeholder stub with a status note that `NEW-HEALTH-001` remains an unresolved alpha-layer placeholder/spec target, to point readers to `docs/HEALTH_READINESS.md`, to list related placeholder targets (`alpha/api/health.py`, `tests/api/test_health.py`) and current implemented references (`service/health.py`, `service/app.py`, `tests/test_health_ready.py`), and to document future decision options for the spec target.
- Updated `docs/RATE_LIMITING.md` to replace the placeholder stub with a status note that `NEW-RATE-001` remains unresolved/partial as a Redis-backed alpha-layer middleware target, to point readers to `docs/TENANCY_LIMITS.md`, to list related placeholder targets (`alpha/middleware/ratelimit.py`, `tests/middleware/test_ratelimit.py`) and current implemented references (`service/app.py`, `service/tenancy/limiter.py`, `service/middleware/tenant_middleware.py`, `tests/test_rate_limits.py`, `tests/test_api_auth_ratelimit.py`), and to document future decision options for the spec target.
- Files changed: `docs/HEALTH.md` and `docs/RATE_LIMITING.md`.
- Confirmations: this is a docs-only change, no runtime behavior was modified, no specs or tests were edited, and no placeholder files or backlog workbooks were deleted, renamed, or rewritten.
- Suggested squash merge title: `Clarify placeholder health and rate-limit docs`.
- Suggested squash merge extended description: Clarifies that the health and rate-limit placeholder docs are not completed implementations of `NEW-HEALTH-001` or `NEW-RATE-001` and points to current service-layer documentation (`docs/HEALTH_READINESS.md`, `docs/TENANCY_LIMITS.md`) and implemented references.

### Testing

- Ran `git diff --check` which reported no issues.
- Ran `python -m pytest -q tests/api/test_health.py tests/middleware/test_ratelimit.py tests/test_health_ready.py tests/test_rate_limits.py tests/test_api_auth_ratelimit.py` and all tests passed (9 tests passed) with only deprecation/warning output; no failures occurred.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a141c903c83299675940a8d3676ae)