### PR TITLE
Ignore local environment files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ bench_out/
 .codespaces/
 clients/python/dist/
 clients/python/*.egg-info/
+
+# Local environment files
+.env
+.env.local


### PR DESCRIPTION
### Motivation
- Prevent accidental commits of real local secrets by ignoring local `.env` files while preserving the tracked `.env.example` template.

### Description
- Update `.gitignore` to add `# Local environment files` and ignore `.env` and `.env.local` without changing any code or tracked templates.
- Files changed: `.gitignore`.
- Suggested branch: `chore/ignore-local-env-files`, suggested squash merge title: `Ignore local environment files`, and suggested squash merge extended description: `Adds local environment files to .gitignore so real .env files containing provider keys or local configuration are not accidentally committed. Preserves .env.example as the tracked template for safe configuration documentation.`

### Testing
- Ran `git diff --check` with no issues reported.
- Verified `git check-ignore .env` reports `.env` as ignored.
- Verified `git check-ignore .env.example && exit 1 || true` does not report `.env.example` as ignored, confirming it remains trackable.
- Confirmations: no code behavior changed and no specs, tests, docs, or runtime files were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a21b0801083298737bec12be8f972)