### PR TITLE
Add Alpha Solver operating guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,9 @@ This file gives repo-level operating instructions for AI coding agents working o
 - New feature or bugfix work should start from or update a spec unless the user explicitly requests exploratory work.
 - Backlog spreadsheets are external planning/status ledgers, not repo implementation contracts.
 - `data/alpha_solver_master_table_v0_7_0.*` is a registry export/provenance artifact, not a backlog; see `data/README.md` before using or moving it.
+- `docs/OPERATING_GUIDE.md` describes the operator workflow (roles, spec rules,
+  inspect-only vs implement, backlog updates). This file (`AGENTS.md`) remains
+  the canonical agent instruction set; the Operating Guide does not override it.
 
 ## Agent Workflow
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Topics: reasoning, router, mcp, observability, replay, determinism, budget, prom
 
 Alpha Solver is a reasoning/routing layer with optional MCP tool calls. It ships gates, scoring, observability, replay, determinism, and a budget guard.
 
+See [docs/OPERATING_GUIDE.md](docs/OPERATING_GUIDE.md) for the working
+process: roles, when specs are required, and how PRs are reviewed and merged.
+
 ## Status
 
 MVP ready; P0 & P1 merged:

--- a/docs/OPERATING_GUIDE.md
+++ b/docs/OPERATING_GUIDE.md
@@ -1,0 +1,109 @@
+# Operating Guide
+
+A practical workflow for a solo, non-developer operator running an AI-assisted
+project. The goal is high-quality, narrowly-scoped, reviewed PRs with low
+overhead. This is not a governance manual. If a rule here adds ceremony without
+reducing risk, the rule is wrong.
+
+## 1. Purpose
+
+Lock a simple, repeatable loop: plan → scope → implement → review → merge →
+record. Keep it light enough for one person to run without drift.
+
+## 2. Source of Truth
+
+- **GitHub repo** — code, docs, tests, commits, PRs, history.
+- **`.specs/`** — implementation contracts. The authority for *what behavior is
+  intended*.
+- **`AGENTS.md`** — the single canonical instruction file for AI agents. Any
+  future tool-specific file (e.g. `CLAUDE.md`, `.cursorrules`) must be a thin
+  pointer back to `AGENTS.md`, never a separate policy.
+- **External backlog workbook** — planning, status, evidence, next action. A
+  ledger, not the codebase.
+- **`data/alpha_solver_master_table_v0_7_0.*`** — registry export, *not* a
+  backlog. See `data/README.md`.
+
+When two sources disagree, the repo wins for code/behavior; `.specs/` wins for
+intent; the workbook never overrides repo evidence.
+
+## 3. Who Does What
+
+- **ChatGPT** — planning, triage, scope clarification, writing Codex prompts,
+  PR review support, explaining what happened.
+- **Codex** — repo inspection, narrowly-scoped implementation, tests, branch
+  and PR creation. Follows `AGENTS.md`.
+- **GitHub Web UI** — final PR review, CI visibility, squash merge.
+- **You** — approve scope, approve merges, hold final judgment.
+
+## 4. When a Spec Is Required
+
+A spec in `.specs/` is required **before changing behavior** — for example (not
+exhaustive): features, behavior-changing bugfixes, API/solver/routing/SAFE-OUT/
+budget-guard/determinism/observability/replay behavior, and auth/policy/
+rate-limit behavior.
+
+A spec is **not** required for docs-only or process-only changes — for example:
+README cleanup, `AGENTS.md` edits, this guide, registry/backlog clarification,
+typo fixes, link updates.
+
+If a "docs-only" change actually changes expected behavior, it is not docs-only
+— write or update the spec first.
+
+## 5. Tests & CI
+
+CI runs the test suite on every PR. Trust a green CI as the signal.
+
+- **Code or test changes** — CI must pass; add or update focused tests for the
+  change.
+- **Docs-only / process-only PRs** — no manual full test run is needed. `git
+  diff --check`, and a quick smoke/help command only if the docs reference an
+  executable command.
+
+Do not run the full suite by hand as ceremony when CI already covers it.
+
+## 6. Inspect-Only vs Implement
+
+Use **Codex inspect-only** (no file changes) when something is genuinely
+unclear: repo evidence is uncertain, a row may already be implemented, a spec
+may be drifted or copied, a placeholder may be mistaken for finished work,
+deletion/rename/archiving is being considered, or sources of truth conflict.
+
+Use **Codex implementation** when the change is confirmed, the scope is narrow,
+the target files are known, acceptance criteria are clear, and unrelated cleanup
+is excluded.
+
+Inspect-only is for ambiguity, not for every task.
+
+## 7. Backlog & Live Queue
+
+- A row is **not "implemented"** without PR + merge commit + spec/test evidence.
+- Record an update **immediately** after: implementation PRs, spec changes,
+  source-of-truth/process docs, and PRs that close or change a backlog item.
+- Trivial docs-only updates may be **batched**.
+- Use **one PR changelog table**. Do not create a new sheet per PR.
+- The workbook is the planning/evidence ledger. Keep the actionable live items
+  short and clean; park research and long-horizon items separately so the live
+  list stays readable.
+
+Automation candidates (validators, link checkers, drift checks) belong in the
+backlog as rows, not in this guide.
+
+## 8. Tool Stack
+
+- **Primary now:** ChatGPT, Codex, GitHub Web UI, `.specs/`, the backlog
+  workbook, `AGENTS.md`.
+- **Later (after local Mac setup):** VS Code, GitHub Desktop.
+- **Not now:** Cursor, Claude Code, GitHub Copilot as primary agents; Devin,
+  Replit, Windsurf, Notion, Linear, Jira; full backlog migration to GitHub
+  Issues. A small Issues pilot for a live queue may be considered later.
+
+Codex remains the primary implementation agent. Adding a second agent is a
+later experiment, only if a clear need appears.
+
+## 9. Security
+
+- Never commit `.env`. `.env.example` may be tracked.
+- API/provider keys live only in: local environment, local `.env`, or GitHub
+  Actions secrets.
+- Agents must never paste real keys into docs, tests, logs, PR bodies, or
+  sample output.


### PR DESCRIPTION
### Motivation

- Provide a short, practical operating workflow for a solo, non-developer operator to produce high-quality, narrowly-scoped PRs with low overhead.
- Complement and preserve `AGENTS.md` as the canonical agent instruction file so operator guidance does not override agent rules.

### Description

- Add `docs/OPERATING_GUIDE.md` describing source-of-truth boundaries, ChatGPT/Codex/GitHub/user roles, when `.specs/` is required, inspect-only vs implement guidance, backlog update rules, tool-stack boundaries, and security rules.
- Update `README.md` with a short pointer to `docs/OPERATING_GUIDE.md` placed near the project description.
- Update `AGENTS.md` to reference `docs/OPERATING_GUIDE.md` while explicitly preserving `AGENTS.md` as the canonical AI agent instruction set.
- Files changed: `docs/OPERATING_GUIDE.md`, `README.md`, and `AGENTS.md`; suggested squash merge title: `Add Alpha Solver operating guide`; suggested squash merge extended description: Adds `docs/OPERATING_GUIDE.md` to document the practical Alpha Solver operating workflow for a solo, non-developer operator and links it from `README.md` and `AGENTS.md` while preserving `AGENTS.md` as the canonical agent instructions.

### Testing

- Ran `git diff --check` with no reported issues.
- Confirmed references via `rg -n "docs/OPERATING_GUIDE.md" README.md AGENTS.md` and confirmed the file exists via `test -f docs/OPERATING_GUIDE.md`.
- This is a docs-only change and no code behavior, `.specs/` specs, tests, CI workflows, backlog workbooks, runtime files, or tool-specific instruction files were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a241cf0ac8329a8857668d7f7df70)