### PR TITLE
Align CI workflows with Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Install deps
         run: |
           python -m pip install -U pip

--- a/.github/workflows/gates.yml
+++ b/.github/workflows/gates.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install deps
         run: |

--- a/.github/workflows/reliability-slo.yml
+++ b/.github/workflows/reliability-slo.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with: { python-version: "3.11" }
+        with: { python-version: "3.12" }
       - name: Install deps
         run: |
           python -m pip install -U pip


### PR DESCRIPTION
### Motivation
- Align PR-facing GitHub Actions workflows with the repository's declared Python requirement (`pyproject.toml`, README, and Quickstart) to avoid CI/runtime mismatches.

### Description
- Updated `actions/setup-python` `python-version` from `3.11` to `3.12` in `.github/workflows/ci.yml`, `.github/workflows/gates.yml`, and `.github/workflows/reliability-slo.yml`, while preserving job names, triggers, `pytest`/SLO commands, artifact uploads, non-blocking placeholder behavior, and without removing or consolidating workflows.

### Testing
- Ran `git diff --check` (passed), YAML parse for `.github/workflows/*.yml` using `yaml.safe_load` (passed), an `rg` check to confirm no remaining `python-version: 3.11` in the edited files (passed), and `python scripts/preflight.py` (passed); a local `python -m pytest -q` run executed but failed with three unrelated assertion failures under the local Python 3.14 environment (`tests/test_instruction_adapter.py::test_run_instruction_dispatch`, `tests/test_math_exec.py::test_evaluate_success`, and `tests/test_smoke_quickstart.py::test_quickstart_endpoints_and_evidence`), so final verification will be performed by GitHub Actions on Python 3.12.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a2922b8e08329b932579f6d3c343f)