### PR TITLE
Implement minimal OpenAI provider client

### DIFF
--- a/alpha/providers/__init__.py
+++ b/alpha/providers/__init__.py
@@ -1,0 +1,23 @@
+"""Provider client abstractions for real execution lanes."""
+
+from .base import (
+    ProviderCost,
+    ProviderError,
+    ProviderErrorCategory,
+    ProviderRequest,
+    ProviderResult,
+    ProviderUsage,
+)
+from .fake import FakeProviderClient
+from .openai import OpenAIProviderClient
+
+__all__ = [
+    "FakeProviderClient",
+    "OpenAIProviderClient",
+    "ProviderCost",
+    "ProviderError",
+    "ProviderErrorCategory",
+    "ProviderRequest",
+    "ProviderResult",
+    "ProviderUsage",
+]

--- a/alpha/providers/base.py
+++ b/alpha/providers/base.py
@@ -1,0 +1,86 @@
+"""Provider client contracts for real LLM execution lanes.
+
+These contracts are intentionally separate from ``alpha.adapters`` prompt
+renderers. Provider implementations may perform network I/O, while adapters only
+render prompts for local/offline workflows.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal, Mapping
+
+ProviderErrorCategory = Literal[
+    "missing_credentials",
+    "auth",
+    "rate_limit",
+    "timeout",
+    "network",
+    "provider_5xx",
+    "invalid_request",
+    "content_filter",
+    "unknown",
+]
+
+ProviderCostSource = Literal["price_hint", "provider", "unknown"]
+
+
+@dataclass(frozen=True)
+class ProviderUsage:
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    total_tokens: int | None = None
+
+
+@dataclass(frozen=True)
+class ProviderCost:
+    estimated_usd: float | None = None
+    source: ProviderCostSource = "unknown"
+
+
+@dataclass(frozen=True)
+class ProviderRequest:
+    prompt: str
+    model: str
+    max_tokens: int
+    timeout_ms: int
+    system: str | None = None
+    temperature: float | None = None
+    seed: int | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    @property
+    def request_id(self) -> str | None:
+        value = self.metadata.get("request_id")
+        return str(value) if value is not None else None
+
+
+@dataclass(frozen=True)
+class ProviderResult:
+    provider: str
+    model: str
+    text: str
+    finish_reason: str
+    usage: ProviderUsage
+    cost: ProviderCost
+    latency_ms: int
+    request_id: str | None = None
+    raw_metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ProviderError(Exception):
+    provider: str
+    category: ProviderErrorCategory
+    retryable: bool
+    safe_message: str
+    status_code: int | None = None
+    request_id: str | None = None
+
+    def __post_init__(self) -> None:
+        Exception.__init__(self, self.safe_message)
+
+
+RETRYABLE_CATEGORIES: frozenset[ProviderErrorCategory] = frozenset(
+    {"rate_limit", "timeout", "network", "provider_5xx"}
+)

--- a/alpha/providers/fake.py
+++ b/alpha/providers/fake.py
@@ -1,0 +1,24 @@
+"""Test helper provider implementations."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from .base import ProviderError, ProviderRequest, ProviderResult
+
+
+class FakeProviderClient:
+    """Deterministic provider client useful for narrow unit tests."""
+
+    def __init__(self, outcomes: Iterable[ProviderResult | ProviderError]):
+        self._outcomes = list(outcomes)
+        self.requests: list[ProviderRequest] = []
+
+    def execute(self, request: ProviderRequest) -> ProviderResult:
+        self.requests.append(request)
+        if not self._outcomes:
+            raise AssertionError("FakeProviderClient has no configured outcomes")
+        outcome = self._outcomes.pop(0)
+        if isinstance(outcome, ProviderError):
+            raise outcome
+        return outcome

--- a/alpha/providers/openai.py
+++ b/alpha/providers/openai.py
@@ -1,0 +1,341 @@
+"""Minimal OpenAI provider client.
+
+This module is the first real provider execution lane. It deliberately lives
+outside ``alpha.adapters.openai`` so prompt-rendering adapters remain local and
+side-effect free.
+
+The live-capable path uses the OpenAI Responses API (``POST /v1/responses``)
+via ``httpx``. Tests inject a fake ``httpx`` transport/client and never require
+network access or real credentials.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Callable, Mapping
+from typing import Any
+
+import httpx
+
+from .base import (
+    RETRYABLE_CATEGORIES,
+    ProviderCost,
+    ProviderError,
+    ProviderRequest,
+    ProviderResult,
+    ProviderUsage,
+)
+
+_OPENAI_PROVIDER = "openai"
+_DEFAULT_BASE_URL = "https://api.openai.com/v1"
+_MISSING_KEY_MESSAGE = "Missing required environment variable OPENAI_API_KEY."
+
+
+class OpenAIProviderClient:
+    """Small synchronous OpenAI client with deterministic retry semantics."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str = _DEFAULT_BASE_URL,
+        client: httpx.Client | None = None,
+        transport: httpx.BaseTransport | None = None,
+        max_retries: int = 1,
+        backoff: Callable[[int], None] | None = None,
+        price_hint: Mapping[str, float] | None = None,
+    ) -> None:
+        self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
+        self._client = client
+        self._transport = transport
+        self._max_retries = max(0, max_retries)
+        self._backoff = backoff or (lambda _attempt: None)
+        self._price_hint = dict(price_hint or {})
+
+    def execute(self, request: ProviderRequest) -> ProviderResult:
+        """Execute an OpenAI request or raise a safe typed ``ProviderError``."""
+        api_key = self._api_key if self._api_key is not None else os.getenv("OPENAI_API_KEY")
+        if not api_key or not api_key.strip():
+            raise ProviderError(
+                provider=_OPENAI_PROVIDER,
+                category="missing_credentials",
+                retryable=False,
+                safe_message=_MISSING_KEY_MESSAGE,
+                request_id=request.request_id,
+            )
+
+        attempts = self._max_retries + 1
+        last_error: ProviderError | None = None
+        for attempt in range(attempts):
+            started = time.monotonic()
+            try:
+                response = self._post(request, api_key)
+                latency_ms = int((time.monotonic() - started) * 1000)
+                if response.status_code >= 400:
+                    raise self._error_from_response(response, request.request_id)
+                return self._result_from_response(response, request, latency_ms)
+            except ProviderError as exc:
+                last_error = exc
+            except httpx.TimeoutException:
+                last_error = ProviderError(
+                    provider=_OPENAI_PROVIDER,
+                    category="timeout",
+                    retryable=True,
+                    safe_message="OpenAI request timed out.",
+                    request_id=request.request_id,
+                )
+            except httpx.RequestError:
+                last_error = ProviderError(
+                    provider=_OPENAI_PROVIDER,
+                    category="network",
+                    retryable=True,
+                    safe_message="OpenAI request failed due to a network error.",
+                    request_id=request.request_id,
+                )
+            except ValueError:
+                last_error = ProviderError(
+                    provider=_OPENAI_PROVIDER,
+                    category="unknown",
+                    retryable=False,
+                    safe_message="OpenAI response could not be decoded safely.",
+                    request_id=request.request_id,
+                )
+
+            if (
+                attempt < attempts - 1
+                and last_error is not None
+                and last_error.category in RETRYABLE_CATEGORIES
+                and last_error.retryable
+            ):
+                self._backoff(attempt + 1)
+                continue
+            break
+
+        if last_error is None:  # pragma: no cover - defensive guard
+            last_error = ProviderError(
+                provider=_OPENAI_PROVIDER,
+                category="unknown",
+                retryable=False,
+                safe_message="OpenAI request failed.",
+                request_id=request.request_id,
+            )
+        raise last_error
+
+    def _post(self, request: ProviderRequest, api_key: str) -> httpx.Response:
+        payload: dict[str, Any] = {
+            "model": request.model,
+            "input": self._responses_input(request),
+            "max_output_tokens": request.max_tokens,
+        }
+        if request.temperature is not None:
+            payload["temperature"] = request.temperature
+        # ``seed`` is carried in ProviderRequest for deterministic-capable
+        # providers. The current Responses API request body is kept minimal and
+        # does not send seed until a later spec validates endpoint support.
+
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+        timeout = httpx.Timeout(max(request.timeout_ms, 1) / 1000.0)
+
+        if self._client is not None:
+            return self._client.post(
+                f"{self._base_url}/responses", json=payload, headers=headers, timeout=timeout
+            )
+        with httpx.Client(transport=self._transport) as client:
+            return client.post(
+                f"{self._base_url}/responses", json=payload, headers=headers, timeout=timeout
+            )
+
+    @staticmethod
+    def _responses_input(request: ProviderRequest) -> list[dict[str, Any]]:
+        messages: list[dict[str, Any]] = []
+        if request.system:
+            messages.append(
+                {
+                    "role": "system",
+                    "content": [{"type": "input_text", "text": request.system}],
+                }
+            )
+        messages.append(
+            {"role": "user", "content": [{"type": "input_text", "text": request.prompt}]}
+        )
+        return messages
+
+    def _result_from_response(
+        self, response: httpx.Response, request: ProviderRequest, latency_ms: int
+    ) -> ProviderResult:
+        data = response.json()
+        usage = _usage_from_payload(data)
+        return ProviderResult(
+            provider=_OPENAI_PROVIDER,
+            model=str(data.get("model") or request.model),
+            text=_text_from_payload(data),
+            finish_reason=_finish_reason_from_payload(data),
+            usage=usage,
+            cost=_cost_from_payload(data, usage, self._price_hint),
+            latency_ms=latency_ms,
+            request_id=request.request_id,
+            raw_metadata=_safe_raw_metadata(data, response),
+        )
+
+    @staticmethod
+    def _error_from_response(response: httpx.Response, request_id: str | None) -> ProviderError:
+        category = _category_from_response(response)
+        return ProviderError(
+            provider=_OPENAI_PROVIDER,
+            category=category,
+            retryable=category in RETRYABLE_CATEGORIES,
+            safe_message=_safe_error_message(category),
+            status_code=response.status_code,
+            request_id=request_id,
+        )
+
+
+def _text_from_payload(data: Mapping[str, Any]) -> str:
+    output_text = data.get("output_text")
+    if isinstance(output_text, str):
+        return output_text
+
+    choices = data.get("choices")
+    if isinstance(choices, list) and choices:
+        first = choices[0] if isinstance(choices[0], Mapping) else {}
+        message = first.get("message") if isinstance(first, Mapping) else None
+        if isinstance(message, Mapping) and isinstance(message.get("content"), str):
+            return message["content"]
+        if isinstance(first.get("text"), str):
+            return first["text"]
+
+    output = data.get("output")
+    if isinstance(output, list):
+        parts: list[str] = []
+        for item in output:
+            if not isinstance(item, Mapping):
+                continue
+            content = item.get("content")
+            if not isinstance(content, list):
+                continue
+            for content_item in content:
+                if not isinstance(content_item, Mapping):
+                    continue
+                text = content_item.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+        if parts:
+            return "".join(parts)
+    return ""
+
+
+def _finish_reason_from_payload(data: Mapping[str, Any]) -> str:
+    choices = data.get("choices")
+    if isinstance(choices, list) and choices and isinstance(choices[0], Mapping):
+        reason = choices[0].get("finish_reason")
+        if isinstance(reason, str):
+            return reason
+    output = data.get("output")
+    if isinstance(output, list) and output and isinstance(output[0], Mapping):
+        reason = output[0].get("finish_reason")
+        if isinstance(reason, str):
+            return reason
+    status = data.get("status")
+    if status == "completed":
+        return "stop"
+    if isinstance(status, str) and status:
+        return status
+    return "unknown"
+
+
+def _usage_from_payload(data: Mapping[str, Any]) -> ProviderUsage:
+    raw = data.get("usage")
+    if not isinstance(raw, Mapping):
+        return ProviderUsage()
+    input_tokens = _int_or_none(raw.get("input_tokens", raw.get("prompt_tokens")))
+    output_tokens = _int_or_none(raw.get("output_tokens", raw.get("completion_tokens")))
+    total_tokens = _int_or_none(raw.get("total_tokens"))
+    return ProviderUsage(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=total_tokens,
+    )
+
+
+def _cost_from_payload(
+    data: Mapping[str, Any], usage: ProviderUsage, price_hint: Mapping[str, float]
+) -> ProviderCost:
+    provider_cost = data.get("cost")
+    if isinstance(provider_cost, Mapping):
+        estimated = provider_cost.get("estimated_usd") or provider_cost.get("usd")
+        if isinstance(estimated, (int, float)):
+            return ProviderCost(estimated_usd=float(estimated), source="provider")
+    if usage.input_tokens is None or usage.output_tokens is None:
+        return ProviderCost(estimated_usd=None, source="unknown")
+    input_price = price_hint.get("input_per_1k")
+    output_price = price_hint.get("output_per_1k")
+    if not isinstance(input_price, (int, float)) or not isinstance(output_price, (int, float)):
+        return ProviderCost(estimated_usd=None, source="unknown")
+    estimated = (usage.input_tokens / 1000.0 * float(input_price)) + (
+        usage.output_tokens / 1000.0 * float(output_price)
+    )
+    return ProviderCost(estimated_usd=estimated, source="price_hint")
+
+
+def _safe_raw_metadata(data: Mapping[str, Any], response: httpx.Response) -> dict[str, Any]:
+    metadata: dict[str, Any] = {
+        "response_id": data.get("id"),
+        "created": data.get("created"),
+        "status": data.get("status"),
+        "http_status": response.status_code,
+    }
+    provider_request_id = response.headers.get("x-request-id") or response.headers.get(
+        "openai-request-id"
+    )
+    if provider_request_id:
+        metadata["provider_request_id"] = provider_request_id
+    return {k: v for k, v in metadata.items() if v is not None}
+
+
+def _category_from_response(response: httpx.Response) -> str:
+    status = response.status_code
+    error_code = ""
+    error_type = ""
+    try:
+        data = response.json()
+    except ValueError:
+        data = {}
+    if isinstance(data, Mapping):
+        error = data.get("error")
+        if isinstance(error, Mapping):
+            error_code = str(error.get("code") or "").lower()
+            error_type = str(error.get("type") or "").lower()
+    if "content_filter" in {error_code, error_type}:
+        return "content_filter"
+    if status in {401, 403}:
+        return "auth"
+    if status == 429:
+        return "rate_limit"
+    if 500 <= status <= 599:
+        return "provider_5xx"
+    if 400 <= status <= 499:
+        return "invalid_request"
+    return "unknown"
+
+
+def _safe_error_message(category: str) -> str:
+    messages = {
+        "auth": "OpenAI authentication failed.",
+        "rate_limit": "OpenAI rate limit exceeded.",
+        "timeout": "OpenAI request timed out.",
+        "network": "OpenAI request failed due to a network error.",
+        "provider_5xx": "OpenAI provider returned a server error.",
+        "invalid_request": "OpenAI rejected the request.",
+        "content_filter": "OpenAI blocked the response due to content filtering.",
+        "unknown": "OpenAI request failed.",
+    }
+    return messages.get(category, messages["unknown"])
+
+
+def _int_or_none(value: Any) -> int | None:
+    return value if isinstance(value, int) else None

--- a/docs/RUNTIME_READINESS.md
+++ b/docs/RUNTIME_READINESS.md
@@ -57,7 +57,7 @@ Provider environment validation does not prove live provider usability. Remote-p
 | ------------- | ------------------------ | ------------- | -------------------------- | ----------- | ----- |
 | `local` | Yes | No | No | Yes | Safe verified default for local/offline checks. |
 | `none` | Yes | No | No | Acceptable for no-key validation | Accepted by the env checker for no-key local validation. |
-| `openai` | Yes | `OPENAI_API_KEY` | No | No | Env validation requires key presence, but real OpenAI execution is specified and not implemented. |
+| `openai` | Yes | `OPENAI_API_KEY` | Provider client foundation only | No | A minimal `alpha.providers.openai` client exists with fake/mocked tests; `/v1/solve` live OpenAI integration and default live calls remain not implemented. |
 | `anthropic` | Yes | `ANTHROPIC_API_KEY` | No | No | Env validation requires key presence only; no live Anthropic execution is implemented. |
 | `gemini` | Yes | `GOOGLE_API_KEY` | No | No | Env validation requires key presence only; no live Gemini execution is implemented. |
 | `google` | Yes | `GOOGLE_API_KEY` | No | No | Alias-style env-check mode for Google/Gemini key validation; no live Google provider execution is implemented. |
@@ -66,7 +66,7 @@ Provider environment validation does not prove live provider usability. Remote-p
 
 ## Known Gaps
 
-1. Real OpenAI provider execution is specified in `.specs/PROVIDER-OPENAI-001.md` but not implemented.
+1. The minimal OpenAI provider client foundation exists, but `/v1/solve` live OpenAI integration and production remote execution remain follow-up work.
 2. Runtime readiness should be updated after provider implementation PRs.
 3. Remote provider modes currently validate env-var presence only; they do not prove live provider usability.
 4. Some external-tool surfaces may be simulated, credentialed, or service-dependent.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ packages = [
     "alpha",
     "alpha.core",
     "alpha.adapters",
+    "alpha.providers",
     "alpha.executors",
     "alpha.reasoning",
     "alpha.router",

--- a/tests/providers/test_openai_provider.py
+++ b/tests/providers/test_openai_provider.py
@@ -1,0 +1,293 @@
+import json
+
+import httpx
+import pytest
+
+from alpha.providers import OpenAIProviderClient, ProviderError, ProviderRequest
+
+SECRET = "sk-test-secret-value"
+
+
+def _request(**overrides):
+    values = {
+        "prompt": "Hello",
+        "system": "Be concise",
+        "model": "gpt-test",
+        "max_tokens": 32,
+        "timeout_ms": 250,
+        "temperature": 0.0,
+        "seed": 123,
+        "metadata": {
+            "request_id": "req-123",
+            "route": "unit",
+            "model_set": "default",
+            "tenant": "tenant-a",
+        },
+    }
+    values.update(overrides)
+    return ProviderRequest(**values)
+
+
+def _client_for(handler, *, api_key=SECRET, **kwargs):
+    transport = httpx.MockTransport(handler)
+    return OpenAIProviderClient(api_key=api_key, transport=transport, **kwargs)
+
+
+def _json_response(status_code, payload, headers=None):
+    return httpx.Response(status_code, json=payload, headers=headers or {})
+
+
+def test_missing_openai_api_key_is_safe(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    client = OpenAIProviderClient()
+
+    with pytest.raises(ProviderError) as excinfo:
+        client.execute(_request())
+
+    err = excinfo.value
+    assert err.category == "missing_credentials"
+    assert err.retryable is False
+    assert "OPENAI_API_KEY" in err.safe_message
+    assert SECRET not in repr(err)
+    assert SECRET not in str(err)
+
+
+def test_openai_api_key_can_come_from_environment(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", SECRET)
+    seen = {}
+
+    def handler(request):
+        seen["authorization"] = request.headers.get("authorization")
+        return _json_response(200, {"id": "resp-1", "model": "gpt-test", "output_text": "ok"})
+
+    result = OpenAIProviderClient(transport=httpx.MockTransport(handler)).execute(_request())
+
+    assert result.text == "ok"
+    assert seen["authorization"] == f"Bearer {SECRET}"
+    assert SECRET not in repr(result)
+    assert SECRET not in json.dumps(result.raw_metadata)
+
+
+def test_successful_responses_api_payload_normalizes_usage_and_unknown_cost():
+    def handler(request):
+        body = json.loads(request.content)
+        assert body["model"] == "gpt-test"
+        assert body["max_output_tokens"] == 32
+        assert body["temperature"] == 0.0
+        assert "seed" not in body
+        assert body["input"][0]["role"] == "system"
+        assert body["input"][1]["role"] == "user"
+        return _json_response(
+            200,
+            {
+                "id": "resp-1",
+                "model": "gpt-test",
+                "status": "completed",
+                "output_text": "normalized text",
+                "usage": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+            },
+            headers={"x-request-id": "openai-req-1"},
+        )
+
+    result = _client_for(handler).execute(_request())
+
+    assert result.provider == "openai"
+    assert result.model == "gpt-test"
+    assert result.text == "normalized text"
+    assert result.finish_reason == "stop"
+    assert result.usage.input_tokens == 10
+    assert result.usage.output_tokens == 5
+    assert result.usage.total_tokens == 15
+    assert result.cost.estimated_usd is None
+    assert result.cost.source == "unknown"
+    assert result.request_id == "req-123"
+    assert result.raw_metadata == {
+        "response_id": "resp-1",
+        "status": "completed",
+        "http_status": 200,
+        "provider_request_id": "openai-req-1",
+    }
+
+
+def test_chat_completions_style_payload_normalizes_text_and_usage():
+    def handler(request):
+        return _json_response(
+            200,
+            {
+                "id": "chatcmpl-1",
+                "model": "gpt-chat",
+                "choices": [{"message": {"content": "chat text"}, "finish_reason": "length"}],
+                "usage": {"prompt_tokens": 11, "completion_tokens": 7, "total_tokens": 18},
+            },
+        )
+
+    result = _client_for(handler).execute(_request(model="gpt-chat"))
+
+    assert result.text == "chat text"
+    assert result.finish_reason == "length"
+    assert result.usage.input_tokens == 11
+    assert result.usage.output_tokens == 7
+    assert result.usage.total_tokens == 18
+
+
+def test_price_hint_estimates_cost_only_when_usage_available():
+    def handler(request):
+        return _json_response(
+            200,
+            {
+                "model": "gpt-test",
+                "output_text": "ok",
+                "usage": {"input_tokens": 1000, "output_tokens": 500, "total_tokens": 1500},
+            },
+        )
+
+    result = _client_for(
+        handler, price_hint={"input_per_1k": 0.005, "output_per_1k": 0.015}
+    ).execute(_request())
+
+    assert result.cost.source == "price_hint"
+    assert result.cost.estimated_usd == pytest.approx(0.0125)
+
+
+def test_provider_reported_cost_takes_precedence():
+    def handler(request):
+        return _json_response(
+            200,
+            {"model": "gpt-test", "output_text": "ok", "cost": {"estimated_usd": 0.123}},
+        )
+
+    result = _client_for(handler, price_hint={"input_per_1k": 1, "output_per_1k": 1}).execute(
+        _request()
+    )
+
+    assert result.cost.source == "provider"
+    assert result.cost.estimated_usd == pytest.approx(0.123)
+
+
+def test_retry_behavior_is_bounded_for_retryable_failures():
+    calls = []
+    backoffs = []
+
+    def handler(request):
+        calls.append(request)
+        if len(calls) == 1:
+            return _json_response(429, {"error": {"type": "rate_limit_error"}})
+        return _json_response(200, {"model": "gpt-test", "output_text": "ok"})
+
+    result = _client_for(handler, backoff=backoffs.append).execute(_request())
+
+    assert result.text == "ok"
+    assert len(calls) == 2
+    assert backoffs == [1]
+
+
+def test_retry_stops_after_one_retry():
+    calls = []
+
+    def handler(request):
+        calls.append(request)
+        return _json_response(500, {"error": {"type": "server_error"}})
+
+    with pytest.raises(ProviderError) as excinfo:
+        _client_for(handler).execute(_request())
+
+    assert excinfo.value.category == "provider_5xx"
+    assert excinfo.value.retryable is True
+    assert len(calls) == 2
+
+
+def test_non_retryable_failure_is_not_retried():
+    calls = []
+
+    def handler(request):
+        calls.append(request)
+        return _json_response(401, {"error": {"type": "auth"}})
+
+    with pytest.raises(ProviderError) as excinfo:
+        _client_for(handler).execute(_request())
+
+    assert excinfo.value.category == "auth"
+    assert excinfo.value.retryable is False
+    assert len(calls) == 1
+
+
+def test_timeout_maps_to_safe_typed_error_without_hanging():
+    calls = []
+
+    def handler(request):
+        calls.append(request)
+        raise httpx.TimeoutException(f"timeout with {SECRET}", request=request)
+
+    with pytest.raises(ProviderError) as excinfo:
+        _client_for(handler, max_retries=0).execute(_request())
+
+    err = excinfo.value
+    assert err.category == "timeout"
+    assert err.retryable is True
+    assert SECRET not in str(err)
+    assert SECRET not in repr(err)
+    assert len(calls) == 1
+
+
+@pytest.mark.parametrize(
+    ("status", "payload", "category", "retryable"),
+    [
+        (403, {"error": {"type": "auth"}}, "auth", False),
+        (429, {"error": {"type": "rate_limit_error"}}, "rate_limit", True),
+        (500, {"error": {"type": "server_error"}}, "provider_5xx", True),
+        (400, {"error": {"type": "invalid_request_error"}}, "invalid_request", False),
+        (400, {"error": {"type": "content_filter"}}, "content_filter", False),
+        (418, {"error": {"type": "teapot"}}, "invalid_request", False),
+    ],
+)
+def test_http_failures_map_to_categories(status, payload, category, retryable):
+    calls = []
+
+    def handler(request):
+        calls.append(request)
+        return _json_response(status, payload)
+
+    with pytest.raises(ProviderError) as excinfo:
+        _client_for(handler).execute(_request())
+
+    assert excinfo.value.category == category
+    assert excinfo.value.retryable is retryable
+    assert excinfo.value.status_code == status
+    assert len(calls) == (2 if retryable else 1)
+
+
+def test_network_and_unknown_errors_are_safe():
+    def network_handler(request):
+        raise httpx.ConnectError(f"connect failed with {SECRET}", request=request)
+
+    with pytest.raises(ProviderError) as network_exc:
+        _client_for(network_handler, max_retries=0).execute(_request())
+    assert network_exc.value.category == "network"
+    assert SECRET not in str(network_exc.value)
+    assert SECRET not in repr(network_exc.value)
+
+    def invalid_json_handler(request):
+        return httpx.Response(200, content=b"not-json")
+
+    with pytest.raises(ProviderError) as unknown_exc:
+        _client_for(invalid_json_handler).execute(_request())
+    assert unknown_exc.value.category == "unknown"
+    assert SECRET not in str(unknown_exc.value)
+    assert SECRET not in repr(unknown_exc.value)
+
+
+def test_api_key_value_never_appears_in_returned_safe_shapes():
+    def handler(request):
+        return _json_response(
+            400,
+            {"error": {"message": f"bad request includes {SECRET}", "type": "invalid_request_error"}},
+            headers={"authorization": f"Bearer {SECRET}"},
+        )
+
+    with pytest.raises(ProviderError) as excinfo:
+        _client_for(handler).execute(_request())
+
+    err = excinfo.value
+    assert SECRET not in err.safe_message
+    assert SECRET not in str(err)
+    assert SECRET not in repr(err)

--- a/tests/providers/test_provider_contract.py
+++ b/tests/providers/test_provider_contract.py
@@ -1,0 +1,41 @@
+from alpha.providers import ProviderCost, ProviderError, ProviderRequest, ProviderResult, ProviderUsage
+
+
+def test_provider_contract_shapes_are_inspectable():
+    req = ProviderRequest(
+        prompt="hello",
+        system="system",
+        model="gpt-test",
+        max_tokens=64,
+        timeout_ms=1000,
+        temperature=0.1,
+        seed=7,
+        metadata={"request_id": "req-1", "route": "unit", "model_set": "default", "tenant": "t"},
+    )
+    assert req.request_id == "req-1"
+    assert req.metadata["route"] == "unit"
+
+    result = ProviderResult(
+        provider="openai",
+        model="gpt-test",
+        text="ok",
+        finish_reason="stop",
+        usage=ProviderUsage(input_tokens=1, output_tokens=2, total_tokens=3),
+        cost=ProviderCost(estimated_usd=None, source="unknown"),
+        latency_ms=4,
+        request_id=req.request_id,
+        raw_metadata={"response_id": "resp-1"},
+    )
+    assert result.usage.total_tokens == 3
+    assert result.cost.source == "unknown"
+
+    err = ProviderError(
+        provider="openai",
+        category="rate_limit",
+        retryable=True,
+        safe_message="OpenAI rate limit exceeded.",
+        status_code=429,
+        request_id=req.request_id,
+    )
+    assert str(err) == "OpenAI rate limit exceeded."
+    assert err.category == "rate_limit"


### PR DESCRIPTION
### Motivation

- Provide the minimal, testable OpenAI provider client foundation required by `.specs/PROVIDER-OPENAI-001.md` while keeping local/offline the safe default and avoiding live API calls in default CI.

### Description

- Add a new `alpha.providers` package with typed dataclasses for `ProviderRequest`, `ProviderResult`, `ProviderError`, `ProviderUsage`, and `ProviderCost` and an explicit set of error categories and retryable categories (`alpha/providers/base.py`).
- Implement `OpenAIProviderClient` that uses `httpx`, supports injectable `httpx` transports/clients for fake/mocked tests, enforces `OPENAI_API_KEY` handling safely, implements bounded retry (one retry for retryable classes) and deterministic no-op backoff, and normalizes Responses/ChatCompletions-style payloads into `ProviderResult` (including usage and safe raw metadata) (`alpha/providers/openai.py`).
- Add a deterministic `FakeProviderClient` for unit tests and export providers via `alpha/providers/__init__.py`, and update packaging metadata to include `alpha.providers` (`alpha/providers/fake.py`, `alpha/providers/__init__.py`, `pyproject.toml`).
- Add focused unit tests validating contract shapes, missing-credential behavior, mocked success/error normalization, cost/price-hint handling, bounded retry, timeout/network handling, and no-secret guarantees, and update `docs/RUNTIME_READINESS.md` to note the provider client foundation exists (`tests/providers/*`, `docs/RUNTIME_READINESS.md`).

### Testing

- Ran provider unit tests with mocked transport: `python -m pytest tests/providers -q`, all new provider tests passed.
- Ran focused regressions and smoke checks: `python -m pytest tests/test_config_validation.py -q`, `python -m pytest tests/test_instruction_adapters.py tests/test_prompt_writer.py -q`, and `python -m pytest tests/test_api_endpoints.py -q` all passed, and `scripts/check_env.py` succeeded for both `MODEL_PROVIDER=local` and `MODEL_PROVIDER=openai OPENAI_API_KEY=placeholder` invocations.
- A full `python -m pytest -q` run surfaced unrelated pre-existing failures (3 tests) due to a Python 3.14 `ast.Num` compatibility issue in `alpha.executors.math_exec`, which is orthogonal to this provider work; the provider tests and the targeted validation matrix for this PR passed.
- Confirmations: no OpenAI SDK or other new runtime dependency was added beyond existing `httpx`, no real API keys were added, default local/offline behavior and prompt adapters were left unchanged, and default CI does not require network or credentials.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a4d4f96308329b4fdde6a0c1eb31e)