### PR TITLE
Wire OpenAI provider into /v1/solve

### DIFF
--- a/docs/RUNTIME_READINESS.md
+++ b/docs/RUNTIME_READINESS.md
@@ -4,7 +4,7 @@ A practical status matrix for Alpha Solver runtime surfaces. This document tells
 
 This document does not replace `.specs/`. Specs define intended behavior. This document summarizes current runtime truth.
 
-Provider environment validation does not prove live provider usability. Remote-provider modes can require the presence of API-key environment variables, but current validated paths do not perform live LLM provider API calls by default.
+Provider environment validation does not prove live provider usability. Remote-provider modes can require the presence of API-key environment variables, but default validated paths do not perform live LLM provider API calls. OpenAI provider execution in FastAPI `/v1/solve` is explicitly opt-in via `MODEL_PROVIDER=openai` and still requires `OPENAI_API_KEY` for live use.
 
 ## Status Legend
 
@@ -27,10 +27,10 @@ Provider environment validation does not prove live provider usability. Remote-p
 | Root CLI: `alpha_solver_cli.py` | Verified local/offline | Root Tree-of-Thought CLI invokes local `_tree_of_thought` behavior and prints JSON. | No live provider client execution. | None for local CLI use. | `docs/ENTRYPOINTS.md`, `docs/CLI.md`, and CLI smoke tests. |
 | Package CLI: `python -m alpha.cli` | Verified local/offline | Package CLI supports local solve/eval/gate/budget/router commands from repo checkout. | No live provider client execution. | None for local CLI use; dataset/report inputs may be needed for specific subcommands. | `docs/CLI.md`, `alpha/cli/main.py`, and CLI tests. |
 | Command CLI: `cli/alpha_solver_cli.py` | Verified local/offline | Command-oriented CLI supports local run/replay/gates/finops/traces-style workflows. | No live provider client execution. | None for local CLI use; replay input files may be needed for replay. | `docs/ENTRYPOINTS.md`, `docs/CLI.md`, and CLI tests. |
-| FastAPI service `/v1/solve` | Verified local/offline / Partial | Existing route calls local deterministic ToT/ReAct-style runtime paths and is covered by service/API tests. | Live OpenAI provider execution is specified for the future but is not implemented in `/v1/solve` yet. | None for local API tests; service runtime dependencies depend on deployment mode. | Service tests and `.specs/PROVIDER-OPENAI-001.md` for future provider behavior. |
+| FastAPI service `/v1/solve` | Verified local/offline / Partial | Existing route calls local deterministic ToT/ReAct-style runtime paths by default and is covered by service/API tests. When `MODEL_PROVIDER=openai` is explicitly selected, the route can execute through the OpenAI provider client foundation. | Deeper provider telemetry, budget accounting, replay integration, and full SAFE-OUT/fallback orchestration remain follow-up work. | None for local API tests; live OpenAI use requires `OPENAI_API_KEY`. Default CI uses fake/mocked provider tests and makes no live calls. | Service tests and `.specs/PROVIDER-OPENAI-001.md`. |
 | `.env.example` | Verified local/offline | Defaults to `MODEL_PROVIDER=local`, the safe local/offline environment value. | Placeholder key examples do not enable or prove real remote LLM execution. | None when left at `MODEL_PROVIDER=local`. | `.env.example` and `scripts/check_env.py`. |
 | `scripts/check_env.py` | Env-validation only | Validates `MODEL_PROVIDER`, expected key-variable presence, and basic config invariants. | It does not perform remote provider API pings or prove provider usability. | Provider-specific key variables are required only for remote-provider env-validation modes. | `scripts/check_env.py`; keep default checks credential-free. |
-| OpenAI provider mode | Env-validation only / Placeholder / future | `MODEL_PROVIDER=openai` can require/check `OPENAI_API_KEY` presence through `scripts/check_env.py`. | No real OpenAI provider execution is implemented yet. | `OPENAI_API_KEY` for env validation only; no key is required for default local/offline mode. | `.specs/PROVIDER-OPENAI-001.md`. |
+| OpenAI provider mode | Partial / explicitly opt-in | `MODEL_PROVIDER=openai` can require/check `OPENAI_API_KEY` through `scripts/check_env.py`; `alpha.providers.openai` provides the client foundation; FastAPI `/v1/solve` can route through that client only when OpenAI is explicitly selected. | Default local/offline workflows do not call OpenAI; live smoke tests and deeper runtime integrations remain follow-up. | `OPENAI_API_KEY` for live OpenAI use; no key is required for default local/offline mode or default CI. | `.specs/PROVIDER-OPENAI-001.md`, `alpha/providers/`, and service API tests. |
 | Anthropic provider mode | Env-validation only / Placeholder / future | `MODEL_PROVIDER=anthropic` can require/check `ANTHROPIC_API_KEY` presence through `scripts/check_env.py`. | No real Anthropic provider execution is implemented. | `ANTHROPIC_API_KEY` for env validation only. | Future provider spec would be required before behavior changes. |
 | Gemini/Google provider mode | Env-validation only / Placeholder / future | `MODEL_PROVIDER=gemini` or `MODEL_PROVIDER=google` can require/check `GOOGLE_API_KEY` presence through `scripts/check_env.py`. | No real Gemini/Google provider execution is implemented. | `GOOGLE_API_KEY` for env validation only. | Future provider spec would be required before behavior changes. |
 | Deepseek adapter | Mocked / simulated / Placeholder / future | A Deepseek prompt adapter can render prompt dictionaries. | `deepseek` is not accepted by the current env checker and no real Deepseek provider execution is implemented. | None for prompt-rendering tests; live execution is not available. | Existing adapter code/tests; future provider spec required for real execution. |
@@ -57,7 +57,7 @@ Provider environment validation does not prove live provider usability. Remote-p
 | ------------- | ------------------------ | ------------- | -------------------------- | ----------- | ----- |
 | `local` | Yes | No | No | Yes | Safe verified default for local/offline checks. |
 | `none` | Yes | No | No | Acceptable for no-key validation | Accepted by the env checker for no-key local validation. |
-| `openai` | Yes | `OPENAI_API_KEY` | Provider client foundation only | No | A minimal `alpha.providers.openai` client exists with fake/mocked tests; `/v1/solve` live OpenAI integration and default live calls remain not implemented. |
+| `openai` | Yes | `OPENAI_API_KEY` | Explicit opt-in for `/v1/solve` | No | A minimal `alpha.providers.openai` client exists with fake/mocked tests; `/v1/solve` uses it only when `MODEL_PROVIDER=openai`. Default CI and local/offline tests make no live calls. |
 | `anthropic` | Yes | `ANTHROPIC_API_KEY` | No | No | Env validation requires key presence only; no live Anthropic execution is implemented. |
 | `gemini` | Yes | `GOOGLE_API_KEY` | No | No | Env validation requires key presence only; no live Gemini execution is implemented. |
 | `google` | Yes | `GOOGLE_API_KEY` | No | No | Alias-style env-check mode for Google/Gemini key validation; no live Google provider execution is implemented. |
@@ -66,9 +66,9 @@ Provider environment validation does not prove live provider usability. Remote-p
 
 ## Known Gaps
 
-1. The minimal OpenAI provider client foundation exists, but `/v1/solve` live OpenAI integration and production remote execution remain follow-up work.
-2. Runtime readiness should be updated after provider implementation PRs.
-3. Remote provider modes currently validate env-var presence only; they do not prove live provider usability.
+1. The minimal OpenAI provider client foundation exists and `/v1/solve` has explicit opt-in OpenAI provider integration, but production hardening remains follow-up work.
+2. Default local/offline behavior remains unchanged and default CI still uses fake/mocked provider tests with no live calls.
+3. Remote provider env validation does not prove live provider usability.
 4. Some external-tool surfaces may be simulated, credentialed, or service-dependent.
 5. Placeholder health/rate-limit targets should not be mistaken for complete implementations.
 6. Rate limiting needs separate follow-up for the Redis/SlowAPI mismatch if still relevant.

--- a/service/app.py
+++ b/service/app.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import csv
 import json
 import logging
+import os
 import time
 import uuid
 from collections import defaultdict, deque
@@ -43,6 +44,9 @@ from pydantic import BaseModel, Field
 from prometheus_client import generate_latest, start_http_server
 
 from alpha_solver_entry import _tree_of_thought
+from alpha.providers import OpenAIProviderClient, ProviderError, ProviderRequest, ProviderResult
+from service.models.modelset_registry import ModelSet, ModelSetRegistry
+from service.models.modelset_resolver import ModelSetResolver
 from alpha.core.config import APISettings
 from alpha.core.telemetry import record_rate_limit, record_request, record_safe_out
 from .security import validate_api_key, sanitize_query
@@ -143,6 +147,128 @@ app.add_middleware(
 )
 
 
+def _is_openai_provider_enabled() -> bool:
+    """Return True only for explicit OpenAI provider opt-in."""
+    return os.getenv("MODEL_PROVIDER", "local").strip().lower() == "openai"
+
+
+def _get_model_set(request: Request, params: Dict[str, Any]) -> ModelSet:
+    requested = params.get("model_set") or os.getenv("MODEL_SET")
+    route_explain: Dict[str, str] = {}
+    registry = getattr(request.app.state, "model_set_registry", None)
+    if registry is None:
+        registry = ModelSetRegistry()
+        request.app.state.model_set_registry = registry
+    resolver = ModelSetResolver(registry)
+    model_set, _reason = resolver.resolve(
+        requested=str(requested) if requested else None,
+        headers=request.headers,
+        tenant_default=params.get("tenant_model_set"),
+        route_explain=route_explain,
+    )
+    return model_set
+
+
+def _provider_client_factory(model_set: ModelSet) -> OpenAIProviderClient:
+    return OpenAIProviderClient(price_hint=model_set.price_hint)
+
+
+def _get_provider_client(request: Request, model_set: ModelSet) -> Any:
+    factory = getattr(request.app.state, "provider_client_factory", None)
+    if factory is None:
+        factory = _provider_client_factory
+    return factory(model_set)
+
+
+def _optional_number(params: Dict[str, Any], key: str) -> Any:
+    value = params.get(key)
+    return value if isinstance(value, (int, float)) and not isinstance(value, bool) else None
+
+
+def _optional_int(params: Dict[str, Any], key: str) -> int | None:
+    value = params.get(key)
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _build_provider_request(
+    *,
+    query: str,
+    params: Dict[str, Any],
+    strategy: Any,
+    request: Request,
+    model_set: ModelSet,
+) -> ProviderRequest:
+    route = str(strategy or params.get("route") or "tot")
+    tenant = params.get("tenant") or request.headers.get("X-Tenant-ID")
+    system = params.get("system")
+    return ProviderRequest(
+        prompt=query,
+        system=system if isinstance(system, str) and system else None,
+        model=model_set.model,
+        max_tokens=model_set.max_tokens,
+        timeout_ms=model_set.timeout_ms,
+        temperature=_optional_number(params, "temperature"),
+        seed=_optional_int(params, "seed"),
+        metadata={
+            "request_id": getattr(request.state, "request_id", None),
+            "route": route,
+            "model_set": model_set.name,
+            "tenant": str(tenant) if tenant else None,
+        },
+    )
+
+
+def _provider_success_response(result: ProviderResult, model_set: ModelSet) -> Dict[str, Any]:
+    return {
+        "final_answer": result.text,
+        "meta": {
+            "provider": result.provider,
+            "model": result.model,
+            "model_set": model_set.name,
+            "finish_reason": result.finish_reason,
+            "request_id": result.request_id,
+            "usage": {
+                "input_tokens": result.usage.input_tokens,
+                "output_tokens": result.usage.output_tokens,
+                "total_tokens": result.usage.total_tokens,
+            },
+            "cost": {
+                "estimated_usd": result.cost.estimated_usd,
+                "source": result.cost.source,
+            },
+            "latency_ms": result.latency_ms,
+        },
+    }
+
+
+def _provider_error_status(error: ProviderError) -> int:
+    return {
+        "missing_credentials": 503,
+        "auth": 502,
+        "rate_limit": 429,
+        "timeout": 504,
+        "network": 503,
+        "provider_5xx": 502,
+        "invalid_request": 400,
+        "content_filter": 400,
+        "unknown": 502,
+    }.get(error.category, 502)
+
+
+def _provider_error_response(error: ProviderError) -> JSONResponse:
+    return JSONResponse(
+        status_code=_provider_error_status(error),
+        content={
+            "final_answer": f"SAFE-OUT: {error.safe_message}",
+            "error": {
+                "provider": error.provider,
+                "category": error.category,
+                "retryable": error.retryable,
+            },
+        },
+    )
+
+
 class StrategyEnum(str, Enum):
     cot = "cot"
     react = "react"
@@ -234,6 +360,34 @@ async def solve(req: SolveRequest, request: Request) -> JSONResponse:
     params = req.context or {}
     strategy = req.strategy or params.get("strategy")
     request.state.strategy = strategy
+
+    if _is_openai_provider_enabled():
+        model_set = _get_model_set(request, params)
+        provider_request = _build_provider_request(
+            query=query,
+            params=params,
+            strategy=strategy,
+            request=request,
+            model_set=model_set,
+        )
+        try:
+            provider_client = _get_provider_client(request, model_set)
+            provider_result = provider_client.execute(provider_request)
+        except ProviderError as exc:
+            record_safe_out(request.url.path)
+            return _provider_error_response(exc)
+        except Exception:
+            record_safe_out(request.url.path)
+            safe_error = ProviderError(
+                provider="openai",
+                category="unknown",
+                retryable=False,
+                safe_message="OpenAI request failed.",
+                request_id=provider_request.request_id,
+            )
+            return _provider_error_response(safe_error)
+        return JSONResponse(_provider_success_response(provider_result, model_set))
+
     start = time.time()
     if strategy == "react":
         from alpha.reasoning.react_lite import run_react_lite

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -1,14 +1,34 @@
 import os
 import uuid
 
-import os
-import uuid
+import pytest
 
 os.environ.setdefault("API_KEY", "test")
 os.environ.setdefault("RATE_LIMIT_PER_MINUTE", "2")
 
 from fastapi.testclient import TestClient
+
+from alpha.providers import (
+    FakeProviderClient,
+    ProviderCost,
+    ProviderError,
+    ProviderResult,
+    ProviderUsage,
+)
 from service.app import app
+
+
+def _clear_provider_factory():
+    if hasattr(app.state, "provider_client_factory"):
+        delattr(app.state, "provider_client_factory")
+
+
+@pytest.fixture(autouse=True)
+def _default_local_provider(monkeypatch):
+    monkeypatch.setenv("MODEL_PROVIDER", "local")
+    _clear_provider_factory()
+    yield
+    _clear_provider_factory()
 
 
 def _client():
@@ -58,3 +78,146 @@ def test_solve_endpoint_react(monkeypatch):
     body = resp.json()
     assert body["final_answer"] == "ok"
     assert body["meta"]["strategy"] == "react"
+
+
+def test_solve_local_mode_ignores_provider_factory(monkeypatch):
+    monkeypatch.setenv("MODEL_PROVIDER", "local")
+    app.state.provider_client_factory = lambda _model_set: (_ for _ in ()).throw(
+        AssertionError("provider should not be used in local mode")
+    )
+
+    def fake_solver(query: str, **kwargs):
+        return {"final_answer": f"local:{query}"}
+
+    monkeypatch.setattr("service.app._tree_of_thought", fake_solver)
+    client, key = _client()
+    resp = client.post("/v1/solve", json={"query": "hi"}, headers={"X-API-Key": key})
+
+    assert resp.status_code == 200
+    assert resp.json() == {"final_answer": "local:hi"}
+    _clear_provider_factory()
+
+
+def test_solve_openai_mode_uses_fake_provider_and_returns_normalized_text(monkeypatch):
+    monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    fake = FakeProviderClient(
+        [
+            ProviderResult(
+                provider="openai",
+                model="gpt-test",
+                text="provider answer",
+                finish_reason="stop",
+                usage=ProviderUsage(input_tokens=3, output_tokens=5, total_tokens=8),
+                cost=ProviderCost(estimated_usd=0.001, source="price_hint"),
+                latency_ms=12,
+                request_id="req-test",
+                raw_metadata={"raw": "must-not-leak"},
+            )
+        ]
+    )
+    app.state.provider_client_factory = lambda _model_set: fake
+    client, key = _client()
+
+    resp = client.post(
+        "/v1/solve",
+        json={
+            "query": "hello provider",
+            "context": {
+                "system": "system prompt",
+                "temperature": 0.2,
+                "seed": 123,
+                "tenant": "tenant-a",
+                "model_set": "cost_saver",
+            },
+        },
+        headers={"X-API-Key": key, "X-Request-ID": "req-test"},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["final_answer"] == "provider answer"
+    assert body["meta"]["provider"] == "openai"
+    assert body["meta"]["model"] == "gpt-test"
+    assert body["meta"]["model_set"] == "cost_saver"
+    assert body["meta"]["usage"] == {
+        "input_tokens": 3,
+        "output_tokens": 5,
+        "total_tokens": 8,
+    }
+    assert "raw" not in str(body)
+
+    assert len(fake.requests) == 1
+    provider_request = fake.requests[0]
+    assert provider_request.prompt == "hello provider"
+    assert provider_request.system == "system prompt"
+    assert provider_request.model == "gpt-5-mini"
+    assert provider_request.max_tokens == 1024
+    assert provider_request.timeout_ms == 45000
+    assert provider_request.temperature == 0.2
+    assert provider_request.seed == 123
+    assert provider_request.metadata["request_id"] == "req-test"
+    assert provider_request.metadata["route"] == "tot"
+    assert provider_request.metadata["model_set"] == "cost_saver"
+    assert provider_request.metadata["tenant"] == "tenant-a"
+    _clear_provider_factory()
+
+
+def test_solve_openai_missing_credentials_returns_safe_response(monkeypatch):
+    secret = "sk-test-should-not-appear"
+    monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    _clear_provider_factory()
+    client, key = _client()
+
+    resp = client.post(
+        "/v1/solve",
+        json={"query": "hi"},
+        headers={"X-API-Key": key, "X-Request-ID": "req-missing"},
+    )
+
+    body_text = resp.text
+    assert resp.status_code == 503
+    assert "SAFE-OUT" in body_text
+    assert "missing_credentials" in body_text
+    assert "OPENAI_API_KEY" in body_text
+    assert secret not in body_text
+
+
+@pytest.mark.parametrize(
+    ("category", "status"),
+    [
+        ("timeout", 504),
+        ("rate_limit", 429),
+        ("network", 503),
+    ],
+)
+def test_solve_openai_provider_errors_return_safe_responses(monkeypatch, category, status):
+    monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    secret = "sk-test-secret-value"
+    fake = FakeProviderClient(
+        [
+            ProviderError(
+                provider="openai",
+                category=category,
+                retryable=True,
+                safe_message=f"safe {category} message",
+                request_id="req-error",
+            )
+        ]
+    )
+    app.state.provider_client_factory = lambda _model_set: fake
+    client, key = _client()
+
+    resp = client.post(
+        "/v1/solve",
+        json={"query": f"do not leak {secret}"},
+        headers={"X-API-Key": key, "X-Request-ID": "req-error"},
+    )
+
+    body_text = resp.text
+    assert resp.status_code == status
+    assert "SAFE-OUT" in body_text
+    assert category in body_text
+    assert secret not in body_text
+    assert len(fake.requests) == 1
+    _clear_provider_factory()


### PR DESCRIPTION
### Motivation

- Implement an explicit opt-in OpenAI provider execution path for FastAPI `/v1/solve` using the existing `alpha.providers` client foundation and the `.specs/PROVIDER-OPENAI-001.md` contract. 
- Preserve the default local/offline solver behavior and ensure CI remains credential-free unless `MODEL_PROVIDER=openai` is explicitly selected. 

### Description

- Added an explicit opt-in gate to `service/app.py` (`_is_openai_provider_enabled`) so `/v1/solve` only invokes provider execution when `MODEL_PROVIDER=openai`. 
- Introduced a minimal service-local provider injection seam via `app.state.provider_client_factory` with a default factory that returns `OpenAIProviderClient`, allowing tests to inject `FakeProviderClient`. 
- Constructed `ProviderRequest` from the sanitized API query, resolved model set (`ModelSetResolver`), optional `system`/`temperature`/`seed`, `max_tokens`/`timeout_ms` from model-set, and safe `metadata` (`request_id`, `route`, `model_set`, `tenant`). 
- Mapped `ProviderResult` into the existing response shape (`final_answer` + safe `meta`) and normalized `ProviderError` into SAFE-OUT JSON with safe messages and status-code mapping to avoid leaking secrets or raw provider exceptions. 
- Updated `docs/RUNTIME_READINESS.md` to note that `/v1/solve` has explicit opt-in OpenAI integration while local/offline remains the safe default; added focused tests in `tests/test_api_endpoints.py` to exercise the new behavior. 

### Testing

- Ran focused provider/unit and API tests: `python -m pytest tests/providers -q`, `python -m pytest tests/test_api_endpoints.py -q`, `python -m pytest tests/test_config_validation.py -q`, and `python -m pytest tests/test_instruction_adapters.py tests/test_prompt_writer.py -q`, and these targeted suites passed. 
- Executed env checks `MODEL_PROVIDER=local python scripts/check_env.py` and `MODEL_PROVIDER=openai OPENAI_API_KEY=placeholder python scripts/check_env.py`, both reporting success for env-only validation. 
- Performed `python -m pytest -q` and observed pre-existing unrelated failures on Python 3.14 in `tests/test_instruction_adapter.py::test_run_instruction_dispatch`, `tests/test_math_exec.py::test_evaluate_success`, and `tests/test_smoke_quickstart.py::test_quickstart_endpoints_and_evidence`, while the provider/API changes and their tests passed. 
- Confirmations: local/offline remains default, default tests make no live OpenAI calls, no real API keys or SDK dependencies were added, and portable/CLI behavior was not modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a50bede048329a843745dc47c2104)