### PR TITLE
Reconcile package runtime dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,20 @@ classifiers = [
   "Programming Language :: Python :: 3",
   "License :: OSI Approved :: MIT License",
 ]
-dependencies = []
+dependencies = [
+  "jsonschema",
+  "pyyaml",
+  "prometheus-client>=0.20,<1",
+  "fastapi>=0.111,<0.113",
+  "starlette<0.38",
+  "pydantic>=2.7,<3",
+  "httpx>=0.27,<0.28",
+  "uvicorn[standard]>=0.30,<0.32",
+]
+
+[project.optional-dependencies]
+test = ["pytest"]
+dev = ["pytest"]
 
 [project.scripts]
 alpha-solver = "alpha.cli:main"


### PR DESCRIPTION
### Motivation

- `pyproject.toml` declared an empty `dependencies = []` while source files (notably `alpha.providers.openai` and the FastAPI service) import runtime packages such as `httpx` and `fastapi`, which can make `pip install .` incomplete. 
- Align project metadata with the runtime requirements already listed in `requirements.txt` so normal package installs are truthful and usable for the API/service surface.

### Description

- Updated `pyproject.toml` to populate `[project].dependencies` with the runtime packages currently required by the code: `jsonschema`, `pyyaml`, `prometheus-client>=0.20,<1`, `fastapi>=0.111,<0.113`, `starlette<0.38`, `pydantic>=2.7,<3`, `httpx>=0.27,<0.28`, and `uvicorn[standard]>=0.30,<0.32`.
- Added a minimal `[project.optional-dependencies]` section with `test = ["pytest"]` and `dev = ["pytest"]` to keep test-only deps separated from runtime.
- Left `requirements.txt` and all source/provider code unchanged to preserve existing setup paths and runtime behavior.
- Committed the change to the branch (file changed: `pyproject.toml`).

### Testing

- Ran the requested test suites which completed successfully: `python -m pytest tests/providers -q`, `python -m pytest tests/test_api_endpoints.py -q`, `python -m pytest tests/test_config_validation.py -q`, and `python -m pytest tests/test_instruction_adapters.py tests/test_prompt_writer.py -q`.
- Verified environment checks with `MODEL_PROVIDER=local python scripts/check_env.py` and `MODEL_PROVIDER=openai OPENAI_API_KEY=placeholder python scripts/check_env.py`, both returning expected env-validation-only results.
- Attempted editable install metadata checks: `python -m pip install -e . --no-deps` and related editable installs were attempted but failed due to the ephemeral environment not being able to resolve/import build-time `setuptools` (`setuptools>=68` resolution returned network errors / 403 and the runtime lacked an importable `setuptools`), so an isolated install with network could not be completed here.
- As a no-network smoke check, parsed `pyproject.toml` with `tomllib` to confirm the new `dependencies` and `optional-dependencies` entries were present.

No runtime or provider behavior was changed, no OpenAI SDK or live provider calls were added, no API keys were added, and no specs/backlog/CI workflows were modified.

Suggested squash merge title: Reconcile package runtime dependencies

Suggested squash merge extended description: Reconciles `pyproject.toml` package metadata with Alpha Solver’s runtime dependency needs after the OpenAI provider client and `/v1/solve` integration work; lists required runtime dependencies in project metadata while preserving `requirements.txt` and keeping test-only deps separate.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a598cf2c88329a255e098d7caf2ba)