### PR TITLE
Fix Python 3.14 math evaluator compatibility

### DIFF
--- a/alpha/executors/math_exec.py
+++ b/alpha/executors/math_exec.py
@@ -20,15 +20,22 @@ _ALLOWED_UNARY = {
     ast.USub: lambda a: -a,
 }
 
+_LEGACY_NUM = getattr(ast, "Num", None)
+
+
+def _numeric(value: Any) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError("unsupported constant")
+    return float(value)
+
+
 def _eval(node: ast.AST) -> float:
     if isinstance(node, ast.Expression):
         return _eval(node.body)
     if isinstance(node, ast.Constant):
-        if isinstance(node.value, (int, float)):
-            return float(node.value)
-        raise ValueError("unsupported constant")
-    if isinstance(node, ast.Num):  # pragma: no cover
-        return float(node.n)
+        return _numeric(node.value)
+    if _LEGACY_NUM is not None and isinstance(node, _LEGACY_NUM):  # pragma: no cover
+        return _numeric(node.n)
     if isinstance(node, ast.BinOp):
         op_type = type(node.op)
         if op_type not in _ALLOWED_BINOPS:

--- a/docs/OPERATOR_TECHNOLOGY_MANUAL.md
+++ b/docs/OPERATOR_TECHNOLOGY_MANUAL.md
@@ -204,7 +204,7 @@ python -m pytest tests/cli/test_alpha_solver_cli.py -q
 
 Use focused commands for the PR scope first. For docs-only changes, `git diff --check` plus existence or heading checks is usually enough unless the docs add or change runnable commands.
 
-Full `python -m pytest -q` is useful when practical, but do not overstate it. If a full run fails because of a known unrelated issue, such as Python 3.14 math AST compatibility, report the exact command, environment, and failure summary instead of hiding it.
+Full `python -m pytest -q` is useful when practical, but do not overstate it. If a full run fails because of a known unrelated issue, report the exact command, environment, and failure summary instead of hiding it.
 
 ## 12. Testing and Validation Workflow
 
@@ -359,7 +359,6 @@ Evidence should point back to repo artifacts: merged PRs, commit hashes, specs, 
 
 Known gaps and future work include:
 
-- Python 3.14 math AST compatibility.
 - Provider telemetry.
 - Provider budget/cost accounting.
 - Provider SAFE-OUT and fallback hardening.
@@ -378,15 +377,14 @@ Do not claim live production readiness from placeholders, docs, fake tests, env 
 
 Ranked remaining roadmap:
 
-1. Python 3.14 math compatibility.
-2. Provider telemetry.
-3. Provider budget/cost accounting.
-4. Provider SAFE-OUT/fallback orchestration.
-5. Optional gated live OpenAI smoke test.
-6. Rate-limit/health placeholder cleanup.
-7. Metrics/Grafana/runtime hardening.
-8. Simulated adapter live-readiness decisions.
-9. SDK/auth hardening.
+1. Provider telemetry.
+2. Provider budget/cost accounting.
+3. Provider SAFE-OUT/fallback orchestration.
+4. Optional gated live OpenAI smoke test.
+5. Rate-limit/health placeholder cleanup.
+6. Metrics/Grafana/runtime hardening.
+7. Simulated adapter live-readiness decisions.
+8. SDK/auth hardening.
 
 Decision rule:
 
@@ -416,7 +414,6 @@ Do not let credit pressure create broad manual edits, untested code changes, or 
 | Broad PRs mix docs, code, specs, tests, and CI. | Review becomes hard and regressions hide. | Split into narrow PRs. |
 | Workbook treated as repo truth. | Planning rows may be stale. | Confirm with repo files, PRs, commits, tests, and CI. |
 | Claude read-only mistaken for repo write access. | Drafts may be mistaken for committed changes. | Require branch, commit, PR URL, and CI evidence. |
-| Full pytest failure from known Python 3.14 issue. | A known unrelated issue can distract from the PR. | Report exact environment and failure, then scope a separate fix. |
 | Secrets pasted into prompts/logs. | Credentials can leak outside the repo. | Use placeholders and rotate any exposed secret. |
 | Portable solver edited as if disposable. | It is a behavior contract. | Touch only with explicit scope and review SAFE-OUT/routing/envelope effects. |
 | Prompt adapters mistaken for provider clients. | Prompt rendering can be confused with live provider execution. | Keep provider execution in provider client paths. |

--- a/tests/test_math_exec.py
+++ b/tests/test_math_exec.py
@@ -1,4 +1,7 @@
-import os
+import ast
+
+import pytest
+
 from alpha.executors import math_exec
 
 
@@ -6,6 +9,43 @@ def test_evaluate_success():
     res = math_exec.evaluate("2+2")
     assert res["ok"]
     assert res["result"] == 4
+
+
+def test_evaluate_constant_numeric_literal_regression():
+    parsed = ast.parse("3.5", mode="eval")
+    assert isinstance(parsed.body, ast.Constant)
+
+    res = math_exec.evaluate("3.5")
+
+    assert res == {"ok": True, "result": 3.5, "error": None}
+
+
+def test_evaluate_rejects_boolean_constant():
+    res = math_exec.evaluate("True")
+
+    assert not res["ok"]
+    assert res["result"] is None
+    assert res["error"] == "unsupported constant"
+
+
+@pytest.mark.parametrize(
+    "expr",
+    [
+        "__import__('os').system('echo unsafe')",
+        "open('/etc/passwd').read()",
+        "(1).__class__",
+        "[1, 2, 3]",
+        "[1][0]",
+        "lambda: 1",
+        "x + 1",
+    ],
+)
+def test_evaluate_rejects_unsafe_constructs(expr):
+    res = math_exec.evaluate(expr)
+
+    assert not res["ok"]
+    assert res["result"] is None
+    assert res["error"]
 
 
 def test_evaluate_invalid():


### PR DESCRIPTION
### Motivation
- Python 3.14 removed the legacy `ast.Num` attribute and the math evaluator raised `module 'ast' has no attribute 'Num'`, causing failures in math/instruction-adapter/smoke tests such as `test_run_instruction_dispatch`, `test_evaluate_success`, and `test_quickstart_endpoints_and_evidence`.
- The change must be narrow: restore version-neutral numeric literal handling without weakening the evaluator's safety model.

### Description
- Added guarded legacy-node detection with `_LEGACY_NUM = getattr(ast, "Num", None)` and a `_numeric` helper that accepts only `int`/`float` and explicitly rejects `bool` to centralize numeric literal handling (`alpha/executors/math_exec.py`).
- Kept existing allowed binary/unary operators and the restrictive AST-based evaluator semantics; legacy `ast.Num` support is conditional so older Python versions remain supported.
- Added regression and safety tests for `ast.Constant` numeric literals, boolean rejection, unsafe-construct rejection, and preserved `evaluate("2+2")` behavior (`tests/test_math_exec.py`).
- Narrow docs cleanup: removed the Python 3.14 math-compatibility known-gap mention to reflect the fix (`docs/OPERATOR_TECHNOLOGY_MANUAL.md`).

### Testing
- Ran `git diff --check` and focused pytest commands: `python -m pytest tests/test_math_exec.py -q`, `python -m pytest tests/test_instruction_adapter.py -q`, and `python -m pytest tests/test_smoke_quickstart.py -q`, and also `python -m pytest tests/test_instruction_adapters.py tests/test_prompt_writer.py -q`, `python -m pytest tests/test_api_endpoints.py -q`; all ran and passed in this environment.
- Ran a full `python -m pytest -q` and observed a green run (no remaining failures related to the change) with only unrelated deprecation warnings from third-party libs.
- Evaluator safety preserved: no new AST node kinds were allowed, function calls/attributes/imports/comprehensions/lambdas/indexing/names/statements remain rejected; boolean constants are rejected as required.
- Provider/runtime confirmation: no provider code, OpenAI integration, `/v1/solve` behavior, specs, CI workflows, env files, package metadata, or backlog files were changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a60f8e424832996d9d53096579201)