### PR TITLE
Clarify OpenAI provider telemetry scope

### DIFF
--- a/.specs/PROVIDER-OPENAI-001.md
+++ b/.specs/PROVIDER-OPENAI-001.md
@@ -154,13 +154,23 @@ ProviderError(
 
 ## 10. Telemetry
 
-Implementations must emit structured telemetry events without secrets:
+The first telemetry implementation is scoped to the FastAPI `/v1/solve` OpenAI
+branch only when `MODEL_PROVIDER=openai` is explicitly configured. Local/offline
+execution remains unchanged, and default CI must continue to use fake/mocked
+provider tests without credentials or live provider calls.
+
+The first implementation must emit structured provider lifecycle telemetry events
+without secrets:
 
 - `provider.request.started`
 - `provider.request.completed`
 - `provider.request.failed`
 - `provider.request.timeout`
-- `provider.fallback.local`
+
+`provider.fallback.local` is conditional/deferred. It must be emitted only when
+an actual local fallback path executes. It must not be emitted for the current
+FastAPI `/v1/solve` OpenAI provider error path, where provider errors are
+safe-normalized into SAFE-OUT responses rather than executing a local fallback.
 
 Telemetry payloads should include:
 
@@ -174,7 +184,16 @@ Telemetry payloads should include:
 - retry_count
 - request_id
 
-Prompt text is excluded by default unless a future explicit redaction policy allows sanitized prompt capture. Telemetry must not contain API keys, authorization headers, raw request bodies, full provider exception strings, or other secret-bearing fields.
+`retry_count` may be surfaced safely on `ProviderResult` and `ProviderError` with
+a default of `0`, or otherwise must be available to telemetry without exposing
+raw provider internals. This does not require a broad provider contract refactor.
+
+Prompt text and raw system prompt text are excluded by default unless a future
+explicit redaction policy allows sanitized prompt capture. Telemetry must not
+contain API keys, Authorization headers, raw provider request bodies, raw
+provider response bodies, full raw provider exception strings, raw prompt text by
+default, raw system prompt text by default, secret-bearing environment values,
+secret-bearing config values, or other secret-bearing fields.
 
 ## 11. SAFE-OUT and fallback
 


### PR DESCRIPTION
### Motivation

- Planning audits agreed provider telemetry should be implemented next but the spec mixed lifecycle events and a fallback event which is not executed by the current `/v1/solve` OpenAI path, so the spec must be clarified before implementation. 
- The goal is to permit an initial, credential-safe telemetry implementation limited to the OpenAI provider branch while preserving local/offline defaults and SAFE-OUT semantics.

### Description

- Files changed: `.specs/PROVIDER-OPENAI-001.md` with a focused clarification to the Telemetry section. 
- Clarifies the first telemetry implementation scope to FastAPI `/v1/solve` when `MODEL_PROVIDER=openai` and confirms local/offline paths and default CI remain credential-free and unchanged. 
- Explicitly authorizes lifecycle events `provider.request.started`, `provider.request.completed`, `provider.request.failed`, and `provider.request.timeout`, and marks `provider.fallback.local` as conditional/deferred to be emitted only when an actual local fallback path executes (not for current SAFE-OUT-only provider errors). 
- Reaffirms no-secret/no-raw-payload rules and that `retry_count` may be surfaced safely with default `0` without requiring a broad provider contract refactor; suggested squash title: `Clarify OpenAI provider telemetry scope`; suggested squash extended description included in this PR commit message.

### Testing

- Validation commands run: `git diff --check` (no issues) and `rg -n "provider.request.started|provider.request.completed|provider.request.failed|provider.request.timeout|provider.fallback.local|SAFE-OUT|fallback|Authorization|raw provider|prompt text" .specs/PROVIDER-OPENAI-001.md` (matches found and updated as expected). 
- The spec file was committed (`Clarify OpenAI provider telemetry scope`) and no pytest was required for this spec-only change. 
- Confirmation: this is a spec/docs-only change and no source code, tests, CI workflows, env files, package metadata, backlog files, provider runtime behavior, or other runtime changes were made.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a72b034ac8329bb37aa8016781018)