### PR TITLE
Add gated live OpenAI smoke test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,8 @@ markers = [
     "budget",
     "policy",
     "metrics",
+    "live: tests that require explicit live external-service gates",
+    "openai: tests specific to the OpenAI provider",
 ]
 
 

--- a/tests/providers/test_openai_live_smoke.py
+++ b/tests/providers/test_openai_live_smoke.py
@@ -1,0 +1,125 @@
+"""Optional gated live OpenAI smoke test for FastAPI /v1/solve."""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+from alpha.providers import (
+    PROVIDER_COST_RECORDED,
+    PROVIDER_REQUEST_COMPLETED,
+    PROVIDER_REQUEST_STARTED,
+)
+from service.app import app
+
+pytestmark = [pytest.mark.live, pytest.mark.openai]
+
+_LIVE_GATE = os.getenv("ALPHA_LIVE_OPENAI") == "1"
+_HAS_OPENAI_API_KEY = bool(os.getenv("OPENAI_API_KEY", "").strip())
+
+pytestmark.append(
+    pytest.mark.skipif(
+        not (_LIVE_GATE and _HAS_OPENAI_API_KEY),
+        reason="requires ALPHA_LIVE_OPENAI=1 and non-empty OPENAI_API_KEY",
+    )
+)
+
+_FORBIDDEN_OUTPUT_TOKENS = (
+    "OPENAI_API_KEY",
+    "Authorization",
+    "Bearer",
+    "raw_metadata",
+    "raw prompt",
+    "raw system",
+    "provider request",
+    "provider response",
+)
+
+
+def _clear_provider_state() -> None:
+    for name in (
+        "provider_client_factory",
+        "provider_telemetry_sink",
+        "provider_accounting_sink",
+    ):
+        if hasattr(app.state, name):
+            delattr(app.state, name)
+
+
+@pytest.fixture(autouse=True)
+def _live_openai_context(monkeypatch):
+    monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    _clear_provider_state()
+    yield
+    _clear_provider_state()
+
+
+def test_live_openai_solve_emits_success_telemetry_and_cost():
+    provider_events: list[dict[str, object]] = []
+    provider_accounting_records: list[dict[str, object]] = []
+    app.state.provider_telemetry_sink = provider_events.append
+    app.state.provider_accounting_sink = provider_accounting_records.append
+    api_key = "live-openai-smoke-api-key"
+    prompt = "Reply with the single word: ok"
+    original_api_keys = list(app.state.config.auth.keys)
+    app.state.config.auth.keys = [api_key]
+
+    try:
+        client = TestClient(app)
+        response = client.post(
+            "/v1/solve",
+            json={
+                "query": prompt,
+                "context": {
+                    "model_set": "cost_saver",
+                    "max_tokens": 8,
+                },
+            },
+            headers={"X-API-Key": api_key, "X-Request-ID": "live-openai-smoke"},
+            timeout=70,
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["final_answer"].strip()
+        assert body["meta"]["provider"] == "openai"
+        assert body["meta"]["model"]
+        assert body["meta"]["model_set"] == "cost_saver"
+        assert body["meta"]["finish_reason"]
+        assert body["meta"]["usage"]
+        assert "safe_out" not in body
+        assert "error" not in body
+
+        event_names = [event["event"] for event in provider_events]
+        assert event_names == [PROVIDER_REQUEST_STARTED, PROVIDER_REQUEST_COMPLETED]
+        assert provider_events[0]["provider"] == "openai"
+        assert provider_events[0]["status"] == "started"
+        assert provider_events[1]["provider"] == "openai"
+        assert provider_events[1]["status"] == "completed"
+
+        assert provider_accounting_records == [
+            record
+            for record in provider_accounting_records
+            if record.get("event") == PROVIDER_COST_RECORDED
+            and record.get("provider") == "openai"
+            and record.get("budget_status") == "recorded"
+        ]
+        assert len(provider_accounting_records) == 1
+
+        captured = json.dumps(
+            {
+                "response": body,
+                "events": provider_events,
+                "accounting": provider_accounting_records,
+            },
+            sort_keys=True,
+        )
+        for forbidden in (*_FORBIDDEN_OUTPUT_TOKENS, prompt, api_key):
+            assert forbidden not in captured
+        openai_api_key = os.getenv("OPENAI_API_KEY", "").strip()
+        assert openai_api_key and openai_api_key not in captured
+    finally:
+        app.state.config.auth.keys = original_api_keys


### PR DESCRIPTION
### Motivation
- Implement the optional `LIVE-SMOKE-OPENAI-001` gated live smoke test from `.specs/PROVIDER-OPENAI-001.md` while preserving local/offline defaults and credential-free CI.
- Provide a narrowly-scoped, skipped-by-default pytest that can be opt-in by operators to verify the OpenAI-backed FastAPI `/v1/solve` path and minimal provider telemetry/cost accounting.

### Description
- Add a new test `tests/providers/test_openai_live_smoke.py` that is marked `live` and `openai` and is skipped unless `ALPHA_LIVE_OPENAI=1` and a non-empty `OPENAI_API_KEY` are present.
- Register `live` and `openai` pytest markers in `pyproject.toml` to avoid marker warnings from pytest configuration.
- The test sets `MODEL_PROVIDER=openai` in its fixture, calls `/v1/solve` via the existing `TestClient` with a minimal safe prompt and a bounded timeout, and temporarily sets a test API key for the request header in-process.
- The test captures app-state telemetry/accounting sinks and asserts `provider.request.started` and `provider.request.completed` were emitted, and that exactly one `provider.cost.recorded` accounting event exists; it also asserts no secrets or raw provider payloads are present in captured outputs.

### Testing
- Ran `git diff --check` (no issues) and committed the changes.
- Executed the new test file directly; it was skipped as expected without live gates (`SKIPPED: requires ALPHA_LIVE_OPENAI=1 and non-empty OPENAI_API_KEY`).
- Ran targeted provider and API tests: `tests/test_api_endpoints.py`, `tests/providers/test_provider_telemetry.py`, `tests/providers/test_provider_accounting.py`, and `tests/providers/test_openai_provider.py`; these passed in the current environment with no live OpenAI calls.
- Manual live run command for operators: `ALPHA_LIVE_OPENAI=1 MODEL_PROVIDER=openai OPENAI_API_KEY=<set in environment> python -m pytest -q tests/providers/test_openai_live_smoke.py` (do not include the real key in logs or output).
- Limitation: no live OpenAI call was performed in CI or during validation here because the environment did not have the explicit live gates; the test is intentionally gated and opt-in only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1aa73a87e48329b14b7d418f57231e)