### PR TITLE
CHANGELOG-SYNC-001: sync changelog after operator guide refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@
 - AlphaSolver v2.2.6 P3 moved to `alpha.solver.observability` and is wrapped by the single `alpha-solver-v91-python` entrypoint.
 - Diagnostics now include scorer details, config snapshot and accounting summary.
 
+### Documentation
+- Synced the Operator & Technology Manual baseline refresh from PR #182 and the final post-placeholder-cleanup refresh from PR #187.
+- Recorded PR #183's initial `LIVE-SMOKE-OPENAI-001` contract and PR #185's alignment of that spec with the implemented skipped-by-default live smoke.
+- Captured PR #186's health/readiness and rate-limit placeholder truth cleanup, keeping `NEW-HEALTH-001` and `NEW-RATE-001` as future/placeholder targets rather than implemented richer dependency checks or Redis-backed rate limiting.
+
+### Tests
+- Recorded PR #184's skipped-by-default live OpenAI smoke test for FastAPI `/v1/solve` and the registered `live` / `openai` pytest markers; default pytest/CI remains credential-free and network-free, operator verification may still be pending, and any gated pass proves only that credentialed environment at that time.
+
 ## [2025-09-09]
 ### Added
 - SAFE-OUT v1.1 state machine with structured recovery and phased JSONL logging.


### PR DESCRIPTION
### Motivation
- Keep the Unreleased section of `CHANGELOG.md` in sync with merged documentation/spec/test cleanup PRs #182–#187 while avoiding any runtime or production-readiness claims.

### Description
- Updated `CHANGELOG.md` (Unreleased) to add concise Documentation and Tests bullets describing PR #182 (Operator & Technology Manual baseline refresh), PR #183 (initial `LIVE-SMOKE-OPENAI-001` spec), PR #184 (skipped-by-default live OpenAI smoke test and `live`/`openai` pytest markers), PR #185 (spec alignment with the implemented skipped-by-default smoke), PR #186 (health/readiness and rate-limit placeholder truth cleanup, preserving `NEW-HEALTH-001` and `NEW-RATE-001` as future/placeholder targets), and PR #187 (final Operator & Technology Manual refresh after placeholder cleanup).
- Change is docs-only and preserves existing changelog style and repo behavior boundaries (no claims of budget enforcement, fallback, Redis-backed rate limiting, CLI/portable remote execution, replay/determinism integration, or production readiness).

### Testing
- Ran `git diff --check` as a quick validation and found no whitespace/merge issues (passed).
- Searched `CHANGELOG.md` for the expected references with `rg -n "182|183|184|185|186|187|LIVE-SMOKE-OPENAI-001|skipped-by-default|Operator & Technology Manual|NEW-HEALTH-001|NEW-RATE-001|production readiness|budget enforcement|provider\.fallback\.local|Redis-backed|CLI remote|portable solver"` and the new entries were detected (passed).
- Ran the lightweight release-notes smoke test with `python -m pytest -q tests/test_release_notes.py` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b1a810128832994457411ea9e2486)