### PR TITLE
EVAL-ANSWER-QUALITY-DESIGN-FIX-001: equalize eval context

### DIFF
--- a/config/quality_gate.yaml
+++ b/config/quality_gate.yaml
@@ -3,3 +3,6 @@ max_p95_ms: 750
 max_p99_ms: 1200
 max_cost_per_call: 0.01
 primary_metric: em
+answer_quality_eval:
+  metric: treatment_accuracy_minus_baseline_accuracy
+  minimum_margin: 0.05

--- a/docs/evals/ANSWER_QUALITY_EVAL.md
+++ b/docs/evals/ANSWER_QUALITY_EVAL.md
@@ -1,6 +1,6 @@
 # EVAL-ANSWER-QUALITY-001: Gated MVP Answer Quality Eval
 
-Status: initial gated MVP implementation. This eval is a prompt-level treatment comparison unless a future change actually wires live reasoning orchestration onto `/v1/solve`.
+Status: gated MVP implementation with context-equalized arm design. This eval is a prompt-level treatment comparison unless a future change actually wires live reasoning orchestration onto `/v1/solve`.
 
 This eval produces smoke evidence, not proof. A passing run must not be described as production readiness, budget enforcement, fallback support, or proof that Alpha Solver is categorically better than a frontier model.
 
@@ -35,12 +35,14 @@ If a gold label is disputed, mark the row with `"disputed": true` or remove the 
 
 The runner uses the same provider primitive for both arms: `OpenAIProviderClient.execute(ProviderRequest(...))`.
 
+Both arms now receive the same shared Alpha Solver project context needed to answer the repo-native cases. That shared context includes source hierarchy, current `/v1/solve` OpenAI pass-through behavior, no-live/no-key defaults, evidence-not-proof framing, absent budget enforcement/billing/fallback support, no `provider.fallback.local`, no backlog workbook edits unless explicitly requested, no secret exposure, and no simulated baseline evidence. This fixes the context-confound risk where the treatment could win mainly because it had project rules that the baseline lacked.
+
 | Arm | Definition |
 | --- | --- |
-| Baseline | Raw/direct OpenAI with a minimal careful-assistant system prompt. |
-| Treatment | The same OpenAI model/settings plus the Alpha Solver operator-discipline system prompt: source hierarchy, SAFE-OUT framing, no unsupported claims, workflow constraints, no simulated evidence, no secret exposure, and no backlog workbook edits unless explicitly requested. |
+| Baseline | Direct OpenAI provider primitive with a careful-assistant system prompt, the shared project context, and the same output-format task instruction. |
+| Treatment | The same OpenAI model/settings, the same shared project context, and an additional Alpha Solver operator-discipline checklist that structures source selection, overclaim checks, workflow-constraint checks, and label selection. |
 
-Controlled settings include model, temperature, max tokens, seed value carried in `ProviderRequest`, input case order, redaction policy, and artifact schema. The current OpenAI client keeps seed in the provider request but does not send seed to the Responses API until endpoint support is validated.
+The intended treatment variable is structured operator discipline and checking behavior, not possession of project rules. Controlled settings include model, temperature, max tokens, seed value carried in `ProviderRequest`, input case order, redaction policy, artifact schema, and the user case prompt. The current OpenAI client keeps seed in the provider request but does not send seed to the Responses API until endpoint support is validated.
 
 ## Live gating and default behavior
 
@@ -83,9 +85,13 @@ These are pre-flight controls, not billing integration or budget enforcement.
 
 Primary smoke metric: treatment accuracy minus baseline accuracy.
 
-Pre-registered margin: treatment must beat baseline by at least `0.05` absolute accuracy on this dataset to count as a positive smoke signal.
+Pre-registered margin: treatment must beat baseline by at least `0.05` absolute accuracy on this dataset to count as a positive smoke signal. The operative answer-quality eval margin is mirrored in `config/quality_gate.yaml` under `answer_quality_eval.minimum_margin` so reports can cite an auditable gate source.
 
 The runner references `config/quality_gate.yaml` for existing quality-gate context but does not repurpose simulated `compare_baseline` token or latency behavior as answer-quality evidence.
+
+## Label parsing
+
+Scoring intentionally accepts only an unambiguous first-line label. The first line may be exactly an allowed label or `Label: <allowed label>`. The scorer does not search the full response body for broad fallback matches, because negated or ambiguous text such as `not OVERCLAIM` can otherwise be counted as a false positive. Outputs without a clear first-line label are scored as missing labels.
 
 ## Artifacts and safety
 

--- a/scripts/run_answer_quality_eval.py
+++ b/scripts/run_answer_quality_eval.py
@@ -48,7 +48,7 @@ DEFAULT_TIMEOUT_MS = 45_000
 DEFAULT_SEED = 123
 DEFAULT_COST_CEILING_USD = 5.00
 DEFAULT_PRICE_HINT = {"input_per_1k": 0.0015, "output_per_1k": 0.004}
-MIN_TREATMENT_MARGIN = 0.05
+DEFAULT_MIN_TREATMENT_MARGIN = 0.05
 REQUIRED_FIELDS = {"id", "category", "input", "choices", "gold_label", "rubric"}
 ALLOWED_CATEGORIES = {
     "runtime_overclaim_detection",
@@ -185,6 +185,37 @@ def load_quality_gate(path: Path) -> dict[str, Any]:
     return data
 
 
+def shared_project_context() -> str:
+    return (
+        "Shared Alpha Solver project context for both eval arms:\n"
+        "- Source hierarchy: direct user instructions and checked-in repo/spec docs outrank "
+        "external backlog ledgers, planning spreadsheets, marketing drafts, and convenience notes.\n"
+        "- Current /v1/solve OpenAI behavior: the live OpenAI path is a single provider "
+        "execute call, not wired live Tree-of-Thought or reasoning orchestration.\n"
+        "- Default behavior: local/offline and no-key/no-network defaults must be preserved; "
+        "live provider calls require explicit gates.\n"
+        "- Evidence framing: smoke tests and small evals are evidence, not proof of production "
+        "readiness or categorical model superiority.\n"
+        "- Current constraints: budget enforcement, budget persistence, billing integration, "
+        "local fallback after provider failure, and provider.fallback.local are not implemented.\n"
+        "- Workflow constraints: do not edit backlog workbooks unless explicitly requested; "
+        "do not expose secrets; do not treat simulated baseline token or latency behavior as "
+        "live answer-quality evidence."
+    )
+
+
+def answer_quality_success_criteria(quality_gate: dict[str, Any]) -> dict[str, Any]:
+    configured = quality_gate.get("answer_quality_eval")
+    minimum_margin = DEFAULT_MIN_TREATMENT_MARGIN
+    if isinstance(configured, dict) and "minimum_margin" in configured:
+        minimum_margin = float(configured["minimum_margin"])
+    return {
+        "metric": "treatment_accuracy_minus_baseline_accuracy",
+        "minimum_margin": minimum_margin,
+        "quality_gate_reference": str(QUALITY_GATE_DEFAULT.relative_to(ROOT)),
+    }
+
+
 def case_prompt(case: EvalCase) -> str:
     choices = ", ".join(case.choices)
     return (
@@ -199,17 +230,25 @@ def case_prompt(case: EvalCase) -> str:
 
 
 def baseline_system_prompt() -> str:
-    return "You are a careful assistant. Follow the user instructions and answer with the requested label."
+    return (
+        "You are a careful assistant. Use the shared project context below when it is relevant.\n\n"
+        f"{shared_project_context()}\n\n"
+        "Task instruction: return exactly one allowed label on the first line, then one concise reason."
+    )
 
 
 def treatment_system_prompt() -> str:
     return (
-        "You are applying the Alpha Solver operator-discipline treatment. Preserve source hierarchy: "
-        "direct user instructions and checked-in repo/spec docs outrank external backlog ledgers and drafts. "
-        "Use SAFE-OUT framing: avoid unsupported claims, do not infer production readiness from smoke evidence, "
-        "and state uncertainty when evidence is insufficient. Maintain workflow constraints: no default live calls, "
-        "no secret exposure, no backlog workbook edits unless explicitly requested, and no simulated baseline evidence. "
-        "For this eval, return exactly one allowed label on the first line, then one concise reason."
+        "You are applying the Alpha Solver operator-discipline treatment. Use the same shared project "
+        "context as the baseline, then apply the structured discipline checklist below.\n\n"
+        f"{shared_project_context()}\n\n"
+        "Alpha Solver operator discipline checklist:\n"
+        "1. Identify the controlling source in the prompt and reject lower-priority conflicts.\n"
+        "2. Check whether a claim overstates current implementation, evidence, readiness, or scope.\n"
+        "3. Preserve no-live, no-secret, no-workbook-edit, and no-simulated-evidence constraints.\n"
+        "4. Choose only from the allowed labels; if evidence is insufficient, prefer the label that "
+        "avoids unsupported claims.\n\n"
+        "Task instruction: return exactly one allowed label on the first line, then one concise reason."
     )
 
 
@@ -275,13 +314,18 @@ def build_request(case: EvalCase, *, arm: str, config: EvalConfig) -> ProviderRe
 
 def extract_label(text: str, choices: list[str]) -> str | None:
     first_line = text.strip().splitlines()[0].strip() if text.strip() else ""
-    normalized = re.sub(r"[^A-Za-z0-9_\-]", "", first_line).upper()
-    for choice in choices:
-        if normalized == choice.upper():
-            return choice
-    for choice in choices:
-        if re.search(rf"\b{re.escape(choice)}\b", text, re.IGNORECASE):
-            return choice
+    if not first_line:
+        return None
+    candidates = [first_line]
+    label_match = re.fullmatch(r"(?i)label\s*[:=]\s*(.+)", first_line)
+    if label_match:
+        candidates.append(label_match.group(1).strip())
+
+    for candidate in candidates:
+        normalized = re.sub(r"[^A-Za-z0-9_\-]", "", candidate).upper()
+        matches = [choice for choice in choices if normalized == choice.upper()]
+        if len(matches) == 1:
+            return matches[0]
     return None
 
 
@@ -327,7 +371,9 @@ def execute_arm(
 
 
 def summarize_predictions(
-    predictions: list[dict[str, Any]], cases: list[EvalCase]
+    predictions: list[dict[str, Any]],
+    cases: list[EvalCase],
+    success_criteria: dict[str, Any],
 ) -> dict[str, Any]:
     by_arm: dict[str, list[dict[str, Any]]] = {"baseline": [], "treatment": []}
     for prediction in predictions:
@@ -361,13 +407,9 @@ def summarize_predictions(
         "case_count": len(cases),
         "categories": sorted({case.category for case in cases}),
         "arms": arm_summary,
-        "pre_registered_success_criteria": {
-            "metric": "treatment_accuracy_minus_baseline_accuracy",
-            "minimum_margin": MIN_TREATMENT_MARGIN,
-            "quality_gate_reference": str(QUALITY_GATE_DEFAULT.relative_to(ROOT)),
-        },
+        "pre_registered_success_criteria": success_criteria,
         "observed_margin": observed_margin,
-        "success_criteria_met": observed_margin >= MIN_TREATMENT_MARGIN,
+        "success_criteria_met": observed_margin >= success_criteria["minimum_margin"],
     }
 
 
@@ -433,6 +475,7 @@ def run_eval(config: EvalConfig, *, client: ProviderClient | None = None) -> dic
     cases = load_cases(config.dataset, limit=config.limit)
     quality_gate = load_quality_gate(config.quality_gate)
     expected_cost = estimate_expected_cost(cases, config)
+    success_criteria = answer_quality_success_criteria(quality_gate)
     ensure_live_allowed(config, cases, expected_cost)
 
     if not config.live:
@@ -445,8 +488,7 @@ def run_eval(config: EvalConfig, *, client: ProviderClient | None = None) -> dic
             "quality_gate_reference": str(config.quality_gate.relative_to(ROOT)),
             "quality_gate_primary_metric": quality_gate.get("primary_metric"),
             "pre_registered_success_criteria": {
-                "metric": "treatment_accuracy_minus_baseline_accuracy",
-                "minimum_margin": MIN_TREATMENT_MARGIN,
+                **success_criteria,
                 "quality_gate_reference": str(config.quality_gate.relative_to(ROOT)),
             },
             "live_predictions_generated": False,
@@ -487,7 +529,7 @@ def run_eval(config: EvalConfig, *, client: ProviderClient | None = None) -> dic
                 )
             predictions.append(prediction)
 
-    summary = summarize_predictions(predictions, cases)
+    summary = summarize_predictions(predictions, cases, success_criteria)
     out_dir = write_artifacts(
         config=config,
         dataset_path=config.dataset,

--- a/tests/test_answer_quality_eval.py
+++ b/tests/test_answer_quality_eval.py
@@ -60,6 +60,8 @@ def test_quality_gate_config_is_referenced():
 
     assert gate["primary_metric"] == "em"
     assert gate["max_cost_per_call"] == 0.01
+    assert gate["answer_quality_eval"]["minimum_margin"] == 0.05
+    assert aq.answer_quality_success_criteria(gate)["minimum_margin"] == 0.05
 
 
 def test_default_dry_run_needs_no_key_and_makes_no_provider_calls(monkeypatch, tmp_path):
@@ -111,10 +113,51 @@ def test_live_producer_calls_baseline_and_treatment_with_controlled_settings(mon
     assert baseline.seed == treatment.seed == aq.DEFAULT_SEED
     assert baseline.prompt == treatment.prompt
     assert baseline.system != treatment.system
+    assert aq.shared_project_context() in baseline.system
+    assert aq.shared_project_context() in treatment.system
+    assert "Alpha Solver operator discipline checklist" not in baseline.system
+    assert "Alpha Solver operator discipline checklist" in treatment.system
+    for shared_rule in (
+        "Source hierarchy",
+        "not wired live Tree-of-Thought",
+        "no-key/no-network defaults",
+        "evidence, not proof",
+        "provider.fallback.local are not implemented",
+        "do not edit backlog workbooks",
+    ):
+        assert shared_rule in baseline.system
+        assert shared_rule in treatment.system
     assert baseline.metadata["eval_arm"] == "baseline"
     assert treatment.metadata["eval_arm"] == "treatment"
     assert report["arms"]["baseline"]["accuracy"] == 1.0
     assert report["arms"]["treatment"]["accuracy"] == 1.0
+
+
+def test_label_parser_requires_unambiguous_first_line_label():
+    choices = ["OVERCLAIM", "SUPPORTED"]
+
+    assert aq.extract_label("OVERCLAIM\nReason", choices) == "OVERCLAIM"
+    assert aq.extract_label("Label: SUPPORTED\nReason", choices) == "SUPPORTED"
+    assert aq.extract_label("Not OVERCLAIM; the claim is SUPPORTED.", choices) is None
+    assert aq.extract_label("SUPPORTED or OVERCLAIM depending on interpretation", choices) is None
+    assert aq.extract_label("Reason: this is OVERCLAIM", choices) is None
+
+
+def test_negated_or_ambiguous_label_text_is_not_scored_correct():
+    case = aq.EvalCase(
+        id="parse-case",
+        category="runtime_overclaim_detection",
+        input="x",
+        choices=["OVERCLAIM", "SUPPORTED"],
+        gold_label="OVERCLAIM",
+        rubric="x",
+        dataset_version=aq.DATASET_VERSION,
+    )
+
+    assert aq.score_prediction("Not OVERCLAIM; probably SUPPORTED", case) == {
+        "label": None,
+        "correct": False,
+    }
 
 
 def test_artifact_redaction_excludes_secrets_and_raw_metadata(monkeypatch, tmp_path):


### PR DESCRIPTION
### Motivation
- Fix a context-confound in the gated answer-quality eval where the treatment prompt contained authoritative project rules that the baseline did not, which could make treatment wins reflect possession of rules rather than operator discipline.
- Equalize project information available to both arms while keeping the treatment variable focused on structured Alpha Solver operator discipline and checking behavior.

### Description
- Added a shared `shared_project_context()` block and injected it into both `baseline_system_prompt()` and `treatment_system_prompt()` in `scripts/run_answer_quality_eval.py`, and made the treatment add a structured Alpha Solver checklist on top of that shared context.
- Tightened label parsing by changing `extract_label()` to accept only an unambiguous first-line label (exact label or `Label: <label>`) and refuse broad fallback matches that can yield false positives from negated or ambiguous text.
- Introduced `answer_quality_success_criteria()` to read an auditable `answer_quality_eval.minimum_margin` from `config/quality_gate.yaml` (mirrored the default 0.05 margin into that file) and wired the runner to use that configured gate when evaluating success.
- Updated docs in `docs/evals/ANSWER_QUALITY_EVAL.md` to document the equalized shared context, the intended treatment variable, and the tightened label-parsing rules, and added tests in `tests/test_answer_quality_eval.py` to assert both arms receive the shared context while treatment gets the checklist and to cover the new parser behavior.

### Testing
- Ran `python -m pytest -q tests/test_answer_quality_eval.py` and the test suite passed (all tests succeeded).
- Executed the dry-run validation `env -u OPENAI_API_KEY -u ALPHA_LIVE_ANSWER_QUALITY python scripts/run_answer_quality_eval.py --artifact-root /tmp/aq_design_fix_dry_run --limit 2` and it produced the no-live artifact successfully.
- Ran `git diff --check` and `python -m black --check scripts/run_answer_quality_eval.py tests/test_answer_quality_eval.py` and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b5e27fa888329a05fa375d698b1dd)