### PR TITLE
EVAL-ANSWER-QUALITY-LIVE-FIX-001: clean up live eval model path

### DIFF
--- a/docs/evals/ANSWER_QUALITY_EVAL.md
+++ b/docs/evals/ANSWER_QUALITY_EVAL.md
@@ -64,6 +64,8 @@ ALPHA_LIVE_ANSWER_QUALITY=1 OPENAI_API_KEY=... python scripts/run_answer_quality
 
 This is intentionally separate from CI and from the skipped-by-default live OpenAI smoke test. Do not enable it in default test jobs.
 
+The default answer-quality eval model is `gpt-5.4-mini`, matching the successful gated 2-case live mechanics retry from 2026-05-30. Operators may also set it explicitly with `ALPHA_AQ_MODEL=gpt-5.4-mini` or `--model gpt-5.4-mini`. That 2-case retry only confirmed live mechanics and artifact parsing; it was not the full 16-case answer-quality smoke signal and does not prove Alpha Solver superiority.
+
 ## Cost ceiling
 
 The default live cost ceiling is `$5.00` estimated total provider cost. Override it only deliberately:
@@ -105,11 +107,11 @@ Files:
 
 Safety controls:
 
-- No raw provider request dumps.
-- No raw provider response dumps.
-- No environment dumps.
-- No API keys.
+- Artifacts contain only redacted provider text, scoring metadata, run summaries, and the artifact README.
+- Provider payload captures, process environment captures, and credentials are not written.
 - Common `sk-...`, `Bearer ...`, `OPENAI_API_KEY=...`, and `Authorization: ...` forms are redacted before artifact writes and CLI errors.
+
+For safety scans, scan `summary.json` and `predictions.jsonl` for credentials and raw payload markers. The artifact README is a manifest, not a provider-output artifact, and its wording intentionally avoids secret-scan marker terms that previously caused a false positive.
 
 ## Non-goals
 

--- a/scripts/run_answer_quality_eval.py
+++ b/scripts/run_answer_quality_eval.py
@@ -41,7 +41,7 @@ OPENAI_KEY_ENV = "OPENAI_API_KEY"
 DATASET_VERSION = "answer_quality_operator_cases_v0.1"
 TREATMENT_VERSION = "alpha_solver_operator_discipline_v0.1"
 EVIDENCE_DISCLAIMER = "Evidence, not proof: this gated MVP eval is a small smoke signal only."
-DEFAULT_MODEL = "gpt-5-mini"
+DEFAULT_MODEL = "gpt-5.4-mini"
 DEFAULT_TEMPERATURE = 0.0
 DEFAULT_MAX_TOKENS = 220
 DEFAULT_TIMEOUT_MS = 45_000
@@ -462,7 +462,7 @@ def write_artifacts(
                 f"cases={len(cases)}",
                 f"live={not dry_run}",
                 f"predictions={manifest_predictions}",
-                "Artifacts exclude raw provider request/response dumps, environment dumps, and API keys.",
+                "Artifacts contain only redacted provider text, scoring metadata, and run summaries.",
             ]
         )
         + "\n",

--- a/tests/test_answer_quality_eval.py
+++ b/tests/test_answer_quality_eval.py
@@ -64,6 +64,15 @@ def test_quality_gate_config_is_referenced():
     assert aq.answer_quality_success_criteria(gate)["minimum_margin"] == 0.05
 
 
+def test_default_model_uses_known_working_live_mini_model(monkeypatch):
+    monkeypatch.delenv("ALPHA_AQ_MODEL", raising=False)
+
+    args = aq.parse_args([])
+
+    assert aq.DEFAULT_MODEL == "gpt-5.4-mini"
+    assert args.model == "gpt-5.4-mini"
+
+
 def test_default_dry_run_needs_no_key_and_makes_no_provider_calls(monkeypatch, tmp_path):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("ALPHA_LIVE_ANSWER_QUALITY", raising=False)
@@ -186,6 +195,11 @@ def test_artifact_redaction_excludes_secrets_and_raw_metadata(monkeypatch, tmp_p
     assert "raw_metadata" not in combined
     assert "must-not-be-written" not in combined
     assert "Evidence, not proof" in combined
+    readme = (artifact_dir / "README.txt").read_text(encoding="utf-8")
+    assert "raw provider request" not in readme
+    assert "raw provider response" not in readme
+    assert "environment dump" not in readme
+    assert "OPENAI_API_KEY" not in readme
 
 
 def test_disputed_cases_are_rejected(tmp_path):


### PR DESCRIPTION
### Motivation

- Fix the live eval failure caused by the repo default model (`gpt-5-mini`) which OpenAI rejected while a known-working model (`gpt-5.4-mini`) succeeded in a diagnostic retry. 
- Avoid artifact-safety false positives where the artifact README's manifest wording (mentioning raw provider payloads / env dumps) flagged scanners despite no secrets being present. 
- Keep the operator path explicit, preserve no-live-by-default behavior, and retain cost-ceiling/redaction/evidence-not-proof framing. 

### Description

- Change the answer-quality eval default model from `gpt-5-mini` to `gpt-5.4-mini` by updating `DEFAULT_MODEL` in `scripts/run_answer_quality_eval.py` while preserving `ALPHA_AQ_MODEL` / `--model` override behavior. 
- Reword the artifact README text written by `write_artifacts()` to avoid scanner-triggering phrases and instead describe that artifacts contain only redacted provider text, scoring metadata, and run summaries. 
- Update `docs/evals/ANSWER_QUALITY_EVAL.md` to document the new default operator model (`gpt-5.4-mini`), note that operators can set `ALPHA_AQ_MODEL` or `--model`, and clarify that the successful 2-case mechanics run was only a mechanics check (not the full 16-case smoke signal). 
- Add focused tests in `tests/test_answer_quality_eval.py` to assert the default model/CLI parsing and to ensure the generated README does not contain the previously problematic marker phrases. 

### Testing

- Ran `python -m pytest -q tests/test_answer_quality_eval.py` and the test suite for this module passed. 
- Existing no-live dry-run behavior, explicit live gating, cost-ceiling logic, redaction behavior, and evidence-not-proof framing were preserved and covered by the updated tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b759ff71c8329a228d630b2074c80)