### PR TITLE
EVAL-REPEATABILITY-001: add answer-quality repeatability runner

### DIFF
--- a/docs/evals/ANSWER_QUALITY_EVAL.md
+++ b/docs/evals/ANSWER_QUALITY_EVAL.md
@@ -66,6 +66,35 @@ This is intentionally separate from CI and from the skipped-by-default live Open
 
 The default answer-quality eval model is `gpt-5.4-mini`, matching the successful gated 2-case live mechanics retry from 2026-05-30. Operators may also set it explicitly with `ALPHA_AQ_MODEL=gpt-5.4-mini` or `--model gpt-5.4-mini`. That 2-case retry only confirmed live mechanics and artifact parsing; it was not the full 16-case answer-quality smoke signal and does not prove Alpha Solver superiority.
 
+
+## Repeatability mode
+
+`EVAL-REPEATABILITY-001` adds opt-in repeatability around the same runner rather than a new eval framework. Use `--repeat-runs N` with `N > 1` to run the existing answer-quality eval repeatedly and write an aggregate summary.
+
+No-live repeatability remains the default and makes no provider calls:
+
+```bash
+env -u OPENAI_API_KEY -u ALPHA_LIVE_ANSWER_QUALITY python scripts/run_answer_quality_eval.py --artifact-root /tmp/aq_repeatability_no_live_repeat --limit 2 --repeat-runs 3
+```
+
+Live repeatability requires all live gates plus an explicit repeat count:
+
+```bash
+ALPHA_LIVE_ANSWER_QUALITY=1 OPENAI_API_KEY=... python scripts/run_answer_quality_eval.py --live --repeat-runs 5 --cost-ceiling-usd 5.00
+```
+
+Before live repeatability makes provider calls, the runner estimates the cost of one complete two-arm eval and multiplies it by the requested repeat count. It refuses live repeatability before the first provider call when the estimated total exceeds `--cost-ceiling-usd`. During live repeatability, each completed run keeps its own artifact subdirectory, and the runner also tracks returned known cost estimates so an interrupted or cost-aborted repeatability attempt records how many runs completed and why it stopped.
+
+Repeatability artifacts are written under `artifacts/eval/answer_quality/<timestamp>_repeatability/` unless `--artifact-root` is overridden. The aggregate file is `repeatability_summary.json`; each run is preserved below `run_001/`, `run_002/`, and so on. The aggregate includes requested and completed run counts, per-run baseline accuracy, treatment accuracy, observed margin, mean margin, margin standard deviation when at least two scored runs exist, min/max spread, success count by run, per-case hit rates by arm, dedicated `aq-lane-003` tracking, an evidence-not-proof disclaimer, and a concise stability field.
+
+Interpret `apparent_treatment_advantage_stability` narrowly:
+
+- `stable` means every completed scored repeatability run met the pre-registered margin. This is still evidence, not proof.
+- `unstable` means at least one completed scored run met the margin and at least one did not.
+- `inconclusive` means there were no scored runs, only one scored run, or no repeatable treatment-margin pass.
+
+Repeatability measures run-to-run variability in this small 16-case smoke eval. It must not be used to claim Alpha Solver superiority, MVP validation, production readiness, or a completed case-set expansion.
+
 ## Cost ceiling
 
 The default live cost ceiling is `$5.00` estimated total provider cost. Override it only deliberately:

--- a/docs/evals/ANSWER_QUALITY_EVAL_PLAN.md
+++ b/docs/evals/ANSWER_QUALITY_EVAL_PLAN.md
@@ -151,6 +151,7 @@ Add a real prediction-producer, not a parallel eval framework. It should:
 - Save redacted outputs as JSONL rows compatible with the existing scorer/rubric conventions, then feed those rows into `alpha/eval` and/or scenario-rubric scoring.
 - Record actual token usage, latency, model, model_set, temperature, max_tokens, seed support, treatment version, dataset version, and cost estimate when available.
 - Include a result disclaimer: results are evidence, not proof, and may vary with model snapshots, prompts, case selection, and live-provider conditions.
+- For repeatability checks, rerun the same gated prediction producer multiple times with preserved per-run artifacts and an aggregate summary; this measures run-to-run variability and must not be framed as proof of superiority.
 
 ## Required Phase 1 rigor
 

--- a/scripts/run_answer_quality_eval.py
+++ b/scripts/run_answer_quality_eval.py
@@ -17,6 +17,7 @@ import hashlib
 import json
 import os
 import re
+import statistics
 import sys
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -49,6 +50,7 @@ DEFAULT_SEED = 123
 DEFAULT_COST_CEILING_USD = 5.00
 DEFAULT_PRICE_HINT = {"input_per_1k": 0.0015, "output_per_1k": 0.004}
 DEFAULT_MIN_TREATMENT_MARGIN = 0.05
+REPEATABILITY_TRACKED_CASE_ID = "aq-lane-003"
 REQUIRED_FIELDS = {"id", "category", "input", "choices", "gold_label", "rubric"}
 ALLOWED_CATEGORIES = {
     "runtime_overclaim_detection",
@@ -95,6 +97,11 @@ class EvalConfig:
     input_per_1k_usd: float = DEFAULT_PRICE_HINT["input_per_1k"]
     output_per_1k_usd: float = DEFAULT_PRICE_HINT["output_per_1k"]
     limit: int | None = None
+
+
+def relative_path_for_artifact(path: Path) -> str:
+    """Return a repository-relative path when possible for safe artifacts."""
+    return str(path.relative_to(ROOT) if path.is_relative_to(ROOT) else path)
 
 
 def redact_text(value: str) -> str:
@@ -271,22 +278,28 @@ def estimate_expected_cost(cases: Iterable[EvalCase], config: EvalConfig) -> flo
     return total
 
 
-def ensure_live_allowed(config: EvalConfig, cases: list[EvalCase], expected_cost: float) -> None:
+def ensure_live_allowed(
+    config: EvalConfig,
+    cases: list[EvalCase],
+    expected_cost: float,
+    *,
+    context: str = "eval",
+) -> None:
     if not config.live:
         return
     if os.getenv(LIVE_GATE_ENV) != "1":
-        raise RuntimeError(f"live eval requires {LIVE_GATE_ENV}=1")
+        raise RuntimeError(f"live {context} requires {LIVE_GATE_ENV}=1")
     if not os.getenv(OPENAI_KEY_ENV, "").strip():
-        raise RuntimeError(f"live eval requires non-empty {OPENAI_KEY_ENV}")
+        raise RuntimeError(f"live {context} requires non-empty {OPENAI_KEY_ENV}")
     if config.cost_ceiling_usd <= 0:
-        raise RuntimeError("live eval cost ceiling must be greater than zero")
+        raise RuntimeError(f"live {context} cost ceiling must be greater than zero")
     if expected_cost > config.cost_ceiling_usd:
         raise RuntimeError(
-            "refusing live eval because estimated cost "
+            f"refusing live {context} because estimated cost "
             f"${expected_cost:.4f} exceeds ceiling ${config.cost_ceiling_usd:.2f}"
         )
     if not cases:
-        raise RuntimeError("live eval requires at least one case")
+        raise RuntimeError(f"live {context} requires at least one case")
 
 
 def build_request(case: EvalCase, *, arm: str, config: EvalConfig) -> ProviderRequest:
@@ -430,11 +443,7 @@ def write_artifacts(
         {
             **summary,
             "dry_run": dry_run,
-            "dataset_path": str(
-                dataset_path.relative_to(ROOT)
-                if dataset_path.is_relative_to(ROOT)
-                else dataset_path
-            ),
+            "dataset_path": relative_path_for_artifact(dataset_path),
             "dataset_sha256": dataset_sha(dataset_path),
             "model": config.model,
             "temperature": config.temperature,
@@ -542,6 +551,312 @@ def run_eval(config: EvalConfig, *, client: ProviderClient | None = None) -> dic
     return {**summary, "artifact_dir": str(out_dir), "estimated_preflight_cost_usd": expected_cost}
 
 
+
+def _empty_hit_rate(case_id: str, case: EvalCase | None) -> dict[str, Any]:
+    return {
+        "case_id": case_id,
+        "category": case.category if case else None,
+        "gold_label": case.gold_label if case else None,
+        "runs_with_prediction": 0,
+        "correct": 0,
+        "hit_rate": None,
+    }
+
+
+def build_repeatability_summary(
+    *,
+    config: EvalConfig,
+    cases: list[EvalCase],
+    requested_runs: int,
+    completed_reports: list[dict[str, Any]],
+    completed_predictions: list[list[dict[str, Any]]],
+    expected_cost_per_run: float,
+    aggregate_artifact_dir: Path,
+    stopped_reason: str | None = None,
+) -> dict[str, Any]:
+    """Build an evidence-not-proof aggregate over completed answer-quality eval runs."""
+    per_run: list[dict[str, Any]] = []
+    margins: list[float] = []
+    success_count = 0
+    for idx, report in enumerate(completed_reports, start=1):
+        baseline = report.get("arms", {}).get("baseline", {})
+        treatment = report.get("arms", {}).get("treatment", {})
+        margin = report.get("observed_margin")
+        if isinstance(margin, (int, float)):
+            margins.append(float(margin))
+        success_met = report.get("success_criteria_met")
+        if success_met is True:
+            success_count += 1
+        per_run.append(
+            {
+                "run_index": idx,
+                "artifact_dir": report.get("artifact_dir"),
+                "baseline_accuracy": baseline.get("accuracy"),
+                "treatment_accuracy": treatment.get("accuracy"),
+                "observed_margin": margin,
+                "success_criteria_met": success_met,
+                "live_predictions_generated": report.get("live_predictions_generated", True),
+            }
+        )
+
+    predictions_flat = [row for run_rows in completed_predictions for row in run_rows]
+    cases_by_id = {case.id: case for case in cases}
+    per_case_hit_rates: dict[str, dict[str, dict[str, Any]]] = {}
+    for case in cases:
+        per_case_hit_rates[case.id] = {
+            "baseline": _empty_hit_rate(case.id, case),
+            "treatment": _empty_hit_rate(case.id, case),
+        }
+    for row in predictions_flat:
+        case_id = str(row.get("case_id"))
+        arm = str(row.get("arm"))
+        if arm not in {"baseline", "treatment"}:
+            continue
+        case = cases_by_id.get(case_id)
+        per_case_hit_rates.setdefault(
+            case_id,
+            {
+                "baseline": _empty_hit_rate(case_id, case),
+                "treatment": _empty_hit_rate(case_id, case),
+            },
+        )
+        arm_row = per_case_hit_rates[case_id][arm]
+        arm_row["runs_with_prediction"] += 1
+        if row.get("correct") is True:
+            arm_row["correct"] += 1
+    for arms in per_case_hit_rates.values():
+        for arm_row in arms.values():
+            count = arm_row["runs_with_prediction"]
+            arm_row["hit_rate"] = arm_row["correct"] / count if count else None
+
+    min_margin = min(margins) if margins else None
+    max_margin = max(margins) if margins else None
+    mean_margin = statistics.fmean(margins) if margins else None
+    margin_stddev = statistics.stdev(margins) if len(margins) > 1 else None
+    minimum_margin = answer_quality_success_criteria(load_quality_gate(config.quality_gate))[
+        "minimum_margin"
+    ]
+    completed_runs = len(completed_reports)
+    if completed_runs == 0:
+        stability = "inconclusive"
+        conclusion = "No completed runs are available; repeatability evidence is inconclusive."
+    elif completed_runs == 1:
+        stability = "inconclusive"
+        conclusion = (
+            "One completed run is not enough to assess run-to-run stability; treat the result as "
+            "evidence, not proof."
+        )
+    elif margins and all(margin >= minimum_margin for margin in margins):
+        stability = "stable"
+        conclusion = (
+            "The apparent treatment advantage met the pre-registered margin in every completed "
+            "repeatability run, but this remains evidence, not proof."
+        )
+    elif margins and any(margin >= minimum_margin for margin in margins):
+        stability = "unstable"
+        conclusion = (
+            "The apparent treatment advantage did not meet the pre-registered margin consistently "
+            "across completed runs; treat the evidence as unstable."
+        )
+    else:
+        stability = "inconclusive"
+        conclusion = (
+            "Completed runs did not show a repeatable treatment-margin pass; the evidence is "
+            "inconclusive and does not prove superiority."
+        )
+
+    return redact_for_artifact(
+        {
+            "disclaimer": EVIDENCE_DISCLAIMER,
+            "mode": "answer_quality_repeatability",
+            "requested_runs": requested_runs,
+            "completed_runs": completed_runs,
+            "stopped_reason": stopped_reason,
+            "live": config.live,
+            "dataset_version": DATASET_VERSION,
+            "dataset_path": relative_path_for_artifact(config.dataset),
+            "dataset_sha256": dataset_sha(config.dataset),
+            "case_count": len(cases),
+            "model": config.model,
+            "temperature": config.temperature,
+            "max_tokens": config.max_tokens,
+            "seed": config.seed,
+            "seed_support": "carried_in_provider_request_not_sent_by_current_openai_client",
+            "pre_registered_success_criteria": answer_quality_success_criteria(
+                load_quality_gate(config.quality_gate)
+            ),
+            "estimated_preflight_cost_per_run_usd": expected_cost_per_run,
+            "estimated_preflight_cost_total_usd": expected_cost_per_run * requested_runs,
+            "cost_ceiling_usd": config.cost_ceiling_usd,
+            "per_run": per_run,
+            "mean_margin": mean_margin,
+            "margin_stddev": margin_stddev,
+            "margin_min": min_margin,
+            "margin_max": max_margin,
+            "success_count_by_run": success_count,
+            "per_case_hit_rates_by_arm": per_case_hit_rates,
+            "tracked_case": {
+                "case_id": REPEATABILITY_TRACKED_CASE_ID,
+                "by_arm": per_case_hit_rates.get(
+                    REPEATABILITY_TRACKED_CASE_ID,
+                    {
+                        "baseline": _empty_hit_rate(
+                            REPEATABILITY_TRACKED_CASE_ID,
+                            cases_by_id.get(REPEATABILITY_TRACKED_CASE_ID),
+                        ),
+                        "treatment": _empty_hit_rate(
+                            REPEATABILITY_TRACKED_CASE_ID,
+                            cases_by_id.get(REPEATABILITY_TRACKED_CASE_ID),
+                        ),
+                    },
+                ),
+            },
+            "apparent_treatment_advantage_stability": stability,
+            "conclusion": conclusion,
+            "artifact_dir": str(aggregate_artifact_dir),
+        }
+    )
+
+
+def _read_predictions_jsonl(artifact_dir: Path) -> list[dict[str, Any]]:
+    path = artifact_dir / "predictions.jsonl"
+    if not path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            if line.strip():
+                rows.append(json.loads(line))
+    return rows
+
+
+def write_repeatability_artifacts(summary: dict[str, Any], aggregate_dir: Path) -> None:
+    aggregate_dir.mkdir(parents=True, exist_ok=True)
+    (aggregate_dir / "repeatability_summary.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    (aggregate_dir / "README.txt").write_text(
+        "\n".join(
+            [
+                EVIDENCE_DISCLAIMER,
+                "Repeatability measures run-to-run variability; it does not prove superiority, MVP validation, or production readiness.",
+                f"requested_runs={summary['requested_runs']}",
+                f"completed_runs={summary['completed_runs']}",
+                f"stability={summary['apparent_treatment_advantage_stability']}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def run_repeatability(
+    config: EvalConfig,
+    *,
+    repeat_runs: int,
+    client: ProviderClient | None = None,
+) -> dict[str, Any]:
+    """Run the existing answer-quality eval repeatedly and aggregate completed runs."""
+    if repeat_runs < 1:
+        raise ValueError("repeat_runs must be at least 1")
+    if repeat_runs == 1:
+        return run_eval(config, client=client)
+
+    cases = load_cases(config.dataset, limit=config.limit)
+    expected_cost_per_run = estimate_expected_cost(cases, config)
+    expected_total_cost = expected_cost_per_run * repeat_runs
+    stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    aggregate_dir = config.artifact_root / f"{stamp}_repeatability"
+    aggregate_dir.mkdir(parents=True, exist_ok=False)
+
+    stopped_reason: str | None = None
+    if config.live:
+        try:
+            ensure_live_allowed(
+                config,
+                cases,
+                expected_total_cost,
+                context=f"repeatability ({repeat_runs} runs)",
+            )
+        except Exception as exc:  # noqa: BLE001 - preserve aggregate for operator diagnosis.
+            stopped_reason = redact_text(str(exc))
+            summary = build_repeatability_summary(
+                config=config,
+                cases=cases,
+                requested_runs=repeat_runs,
+                completed_reports=[],
+                completed_predictions=[],
+                expected_cost_per_run=expected_cost_per_run,
+                aggregate_artifact_dir=aggregate_dir,
+                stopped_reason=stopped_reason,
+            )
+            write_repeatability_artifacts(summary, aggregate_dir)
+            return summary
+
+    completed_reports: list[dict[str, Any]] = []
+    completed_predictions: list[list[dict[str, Any]]] = []
+    cumulative_known_cost = 0.0
+    for run_index in range(1, repeat_runs + 1):
+        run_cost_ceiling = config.cost_ceiling_usd
+        if config.live:
+            remaining_ceiling = config.cost_ceiling_usd - cumulative_known_cost
+            if remaining_ceiling <= 0:
+                stopped_reason = (
+                    "repeatability stopped before run "
+                    f"{run_index}: observed known cost estimate reached ceiling "
+                    f"${config.cost_ceiling_usd:.2f}"
+                )
+                break
+            run_cost_ceiling = remaining_ceiling
+        run_config = EvalConfig(
+            dataset=config.dataset,
+            quality_gate=config.quality_gate,
+            artifact_root=aggregate_dir / f"run_{run_index:03d}",
+            model=config.model,
+            temperature=config.temperature,
+            max_tokens=config.max_tokens,
+            timeout_ms=config.timeout_ms,
+            seed=config.seed,
+            live=config.live,
+            cost_ceiling_usd=run_cost_ceiling,
+            input_per_1k_usd=config.input_per_1k_usd,
+            output_per_1k_usd=config.output_per_1k_usd,
+            limit=config.limit,
+        )
+        try:
+            report = run_eval(run_config, client=client)
+        except Exception as exc:  # noqa: BLE001 - write aggregate for interrupted/aborted live runs.
+            stopped_reason = f"run {run_index} stopped: {redact_text(str(exc))}"
+            break
+        completed_reports.append(report)
+        completed_predictions.append(_read_predictions_jsonl(Path(str(report["artifact_dir"]))))
+        if config.live:
+            for arm in ("baseline", "treatment"):
+                cumulative_known_cost += (
+                    report.get("arms", {}).get(arm, {}).get("known_cost_estimate_usd") or 0.0
+                )
+            if cumulative_known_cost > config.cost_ceiling_usd:
+                stopped_reason = (
+                    "repeatability stopped after run "
+                    f"{run_index}: observed known cost estimate ${cumulative_known_cost:.4f} "
+                    f"exceeds ceiling ${config.cost_ceiling_usd:.2f}"
+                )
+                break
+
+    summary = build_repeatability_summary(
+        config=config,
+        cases=cases,
+        requested_runs=repeat_runs,
+        completed_reports=completed_reports,
+        completed_predictions=completed_predictions,
+        expected_cost_per_run=expected_cost_per_run,
+        aggregate_artifact_dir=aggregate_dir,
+        stopped_reason=stopped_reason,
+    )
+    write_repeatability_artifacts(summary, aggregate_dir)
+    return summary
+
+
 def config_from_args(args: argparse.Namespace) -> EvalConfig:
     return EvalConfig(
         dataset=Path(args.dataset),
@@ -591,13 +906,22 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help=f"Call OpenAI only when {LIVE_GATE_ENV}=1 and {OPENAI_KEY_ENV} is set.",
     )
+    parser.add_argument(
+        "--repeat-runs",
+        type=int,
+        default=1,
+        help=(
+            "Opt-in repeatability mode. Values greater than 1 run the existing eval N times, "
+            "preserve each run under its own artifact subdirectory, and write an aggregate summary."
+        ),
+    )
     return parser.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     try:
-        report = run_eval(config_from_args(args))
+        report = run_repeatability(config_from_args(args), repeat_runs=args.repeat_runs)
     except Exception as exc:  # noqa: BLE001 - CLI must emit safe concise failures.
         print(f"answer_quality_eval: {redact_text(str(exc))}", file=sys.stderr)
         return 2

--- a/tests/test_answer_quality_eval.py
+++ b/tests/test_answer_quality_eval.py
@@ -223,3 +223,123 @@ def test_disputed_cases_are_rejected(tmp_path):
 
     with pytest.raises(ValueError, match="marked disputed"):
         aq.load_cases(dataset)
+
+
+def test_no_live_repeatability_writes_aggregate_without_provider_calls(monkeypatch, tmp_path):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ALPHA_LIVE_ANSWER_QUALITY", raising=False)
+    client = RecordingClient(["OVERCLAIM"])
+
+    report = aq.run_repeatability(_config(tmp_path, limit=2), repeat_runs=3, client=client)
+
+    assert report["mode"] == "answer_quality_repeatability"
+    assert report["requested_runs"] == 3
+    assert report["completed_runs"] == 3
+    assert report["live"] is False
+    assert report["mean_margin"] is None
+    assert report["margin_stddev"] is None
+    assert report["apparent_treatment_advantage_stability"] == "inconclusive"
+    assert "evidence" in report["conclusion"].lower()
+    assert "proof" in report["disclaimer"].lower()
+    assert client.requests == []
+
+    artifact_dir = Path(report["artifact_dir"])
+    assert (artifact_dir / "repeatability_summary.json").exists()
+    assert (artifact_dir / "README.txt").exists()
+    assert len(list(artifact_dir.glob("run_*/**/summary.json"))) == 3
+    assert report["tracked_case"]["case_id"] == "aq-lane-003"
+    assert report["tracked_case"]["by_arm"]["baseline"]["hit_rate"] is None
+
+
+def test_live_repeatability_aggregates_per_run_case_hits_and_tracked_case(monkeypatch, tmp_path):
+    monkeypatch.setenv("ALPHA_LIVE_ANSWER_QUALITY", "1")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-secret-value")
+    dataset = tmp_path / "tracked_cases.jsonl"
+    dataset.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "id": "aq-runtime-001",
+                        "category": "runtime_overclaim_detection",
+                        "input": "x",
+                        "choices": ["OVERCLAIM", "SUPPORTED"],
+                        "gold_label": "OVERCLAIM",
+                        "rubric": "x",
+                        "dataset_version": aq.DATASET_VERSION,
+                    }
+                ),
+                json.dumps(
+                    {
+                        "id": "aq-lane-003",
+                        "category": "lane_selection",
+                        "input": "x",
+                        "choices": [
+                            "LIVE_GATED_PROVIDER_PREDICTIONS",
+                            "SIMULATED_COMPARE_BASELINE",
+                        ],
+                        "gold_label": "LIVE_GATED_PROVIDER_PREDICTIONS",
+                        "rubric": "x",
+                        "dataset_version": aq.DATASET_VERSION,
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    config = aq.EvalConfig(
+        dataset=dataset,
+        quality_gate=aq.QUALITY_GATE_DEFAULT,
+        artifact_root=tmp_path / "artifacts",
+        live=True,
+    )
+    client = RecordingClient(
+        [
+            "OVERCLAIM\nReason",
+            "OVERCLAIM\nReason",
+            "LIVE_GATED_PROVIDER_PREDICTIONS\nReason",
+            "LIVE_GATED_PROVIDER_PREDICTIONS\nReason",
+            "OVERCLAIM\nReason",
+            "OVERCLAIM\nReason",
+            "LIVE_GATED_PROVIDER_PREDICTIONS\nReason",
+            "SIMULATED_COMPARE_BASELINE\nReason",
+        ]
+    )
+
+    report = aq.run_repeatability(config, repeat_runs=2, client=client)
+
+    assert report["requested_runs"] == 2
+    assert report["completed_runs"] == 2
+    assert len(client.requests) == 8
+    assert [row["baseline_accuracy"] for row in report["per_run"]] == [1.0, 1.0]
+    assert [row["treatment_accuracy"] for row in report["per_run"]] == [1.0, 0.5]
+    assert [row["observed_margin"] for row in report["per_run"]] == [0.0, -0.5]
+    assert report["mean_margin"] == -0.25
+    assert report["margin_min"] == -0.5
+    assert report["margin_max"] == 0.0
+    assert report["margin_stddev"] is not None
+    assert report["success_count_by_run"] == 0
+    first_case = report["per_case_hit_rates_by_arm"]["aq-runtime-001"]
+    assert first_case["baseline"]["hit_rate"] == 1.0
+    assert first_case["treatment"]["hit_rate"] == 1.0
+    tracked = report["tracked_case"]["by_arm"]
+    assert tracked["baseline"]["hit_rate"] == 1.0
+    assert tracked["treatment"]["hit_rate"] == 0.5
+    assert report["apparent_treatment_advantage_stability"] == "inconclusive"
+
+
+def test_live_repeatability_total_cost_ceiling_refuses_before_provider_call(monkeypatch, tmp_path):
+    monkeypatch.setenv("ALPHA_LIVE_ANSWER_QUALITY", "1")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-secret-value")
+    client = RecordingClient(["OVERCLAIM"])
+
+    report = aq.run_repeatability(
+        _config(tmp_path, live=True, limit=1, ceiling=0.000001), repeat_runs=3, client=client
+    )
+
+    assert report["requested_runs"] == 3
+    assert report["completed_runs"] == 0
+    assert "estimated cost" in report["stopped_reason"]
+    assert client.requests == []
+    assert (Path(report["artifact_dir"]) / "repeatability_summary.json").exists()


### PR DESCRIPTION
### Motivation

- Provide an opt-in repeatability mode around the existing answer-quality eval so operators can measure run-to-run variability without creating a new eval framework.  
- Keep existing single-run dry-run defaults (no-live, no-key, no-network) while allowing gated live repeat runs with cost safety checks.  
- Produce an aggregate, evidence-not-proof summary after N runs that preserves per-run artifacts and tracks the interesting case `aq-lane-003` across runs.

### Description

- Adds `--repeat-runs N` to `scripts/run_answer_quality_eval.py` and implements `run_repeatability(...)` which runs the existing eval N times (default `1`) and preserves each run under `run_001/`, `run_002/`, etc., plus an aggregate `repeatability_summary.json`.  
- Repeatability is opt-in and no-live by default; live repeatability requires `--live`, `ALPHA_LIVE_ANSWER_QUALITY=1`, and a non-empty `OPENAI_API_KEY`, and performs a preflight cost estimate = one-run cost * N and refuses the live attempt if it exceeds `--cost-ceiling-usd`.  During live runs the runner also accumulates returned known cost estimates and stops if the observed known cost exceeds the ceiling.  
- Aggregate summary includes per-run baseline/treatment accuracy and margin, mean/min/max and stddev (when applicable), success counts, per-case hit rates by arm, dedicated `aq-lane-003` tracking, a concise `apparent_treatment_advantage_stability` field (`stable` / `unstable` / `inconclusive`), and an evidence-not-proof conclusion; all provider text and secrets are redacted in artifacts.  
- Updated docs (`docs/evals/ANSWER_QUALITY_EVAL.md`, `docs/evals/ANSWER_QUALITY_EVAL_PLAN.md`) to document repeatability usage, gating, interpretation, and to emphasize the "evidence, not proof" framing; added focused tests to validate no-live behavior and repeatability aggregation without requiring `OPENAI_API_KEY`.

### Testing

- Ran `python -m pytest -q tests/test_answer_quality_eval.py` and all tests passed.  
- Verified dry-run single eval: `env -u OPENAI_API_KEY -u ALPHA_LIVE_ANSWER_QUALITY python scripts/run_answer_quality_eval.py --artifact-root /tmp/aq_repeatability_no_live --limit 2` produced the expected no-live artifacts.  
- Verified no-live repeatability: `env -u OPENAI_API_KEY -u ALPHA_LIVE_ANSWER_QUALITY python scripts/run_answer_quality_eval.py --artifact-root /tmp/aq_repeatability_no_live_repeat --limit 2 --repeat-runs 3` produced per-run subdirectories and `repeatability_summary.json`; tests assert aggregate fields (requested/completed runs, per-run metrics, `aq-lane-003` tracking).  
- Confirmed cost ceiling checks and live gating logic are enforced in code and covered by tests (tests simulate live client calls using injected recording client; no real network calls were made during CI).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b891db6b48329af83b34af1fae810)