### PR TITLE
PROVIDER-EXPERT-PASS-001: add opt-in expert pass

### DIFF
--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -32,6 +32,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `NEW-RATE-001.md` | NEW-RATE-001 · API Rate Limiting |
 | `OBS-ALERTS-001.md` | CODE SPEC — OBS-ALERTS-001 · Prometheus Alerts + CI Validation (RES_Dash) |
 | `PROVIDER-BUDGET-001.md` | PROVIDER-BUDGET-001 · Post-call Provider Cost Accounting |
+| `PROVIDER-EXPERT-PASS-001.md` | PROVIDER-EXPERT-PASS-001 · Opt-in Expert Provider Pass |
 | `PROVIDER-OPENAI-001.md` | PROVIDER-OPENAI-001 · Real OpenAI Provider Execution |
 | `PROVIDER-SAFEOUT-001.md` | PROVIDER-SAFEOUT-001 · Structured Provider SAFE-OUT Responses |
 | `RES-03.md` | CODE SPEC — RES-03 · Decision Rules & Scoring (RES) |

--- a/.specs/PROVIDER-EXPERT-PASS-001.md
+++ b/.specs/PROVIDER-EXPERT-PASS-001.md
@@ -1,0 +1,121 @@
+# PROVIDER-EXPERT-PASS-001 · Opt-in Expert Provider Pass
+
+## Purpose
+
+Add an explicitly opt-in expert pass for complex OpenAI provider requests. The pass is a supervised preview surface for callers that ask for the `expert` route and does not change local/offline defaults or ordinary OpenAI provider pass-through.
+
+## Non-goals
+
+- No production readiness claim.
+- No MVP validation claim.
+- No answer-superiority claim.
+- No provider multi-step planning system beyond the fixed pass described here.
+- No verify-revise loop.
+- No fan-out.
+- No re-synthesis.
+- No UI work.
+- No eval benchmark work.
+- No clarify-template rendering or full clarify surface behavior.
+- No portable provider, CLI, hosting, billing, budget persistence, fallback, or observability expansion.
+
+## Boundary
+
+- Complex expert requests make exactly two fixed model calls.
+- Trivial expert requests make exactly one provider call.
+- There are no loops.
+- There is no per-sub-question fan-out.
+- There is no re-synthesis.
+- The complexity decision is deterministic and uses local heuristics only.
+- Default `MODEL_PROVIDER=local` behavior remains local/offline.
+- OpenAI provider pass-through remains unchanged unless the caller explicitly requests the expert route.
+
+## Opt-in behavior
+
+The initial seam is `context.route == "expert"` on `/v1/solve` while `MODEL_PROVIDER=openai` is explicitly enabled. This seam is already accepted by the request context and maps onto existing provider request metadata, so it avoids adding `expert` to the `strategy` enum and preserves the existing OpenAPI strategy contract.
+
+No environment flag is added in this lane. The context route is explicit, request-scoped, and testable with fake provider clients.
+
+## Complexity gate
+
+The gate is cheap, deterministic, and no-network. It may consider:
+
+- prompt length;
+- multi-part markers;
+- decision, review, and planning markers;
+- domain or expert markers;
+- ambiguity and uncertainty markers.
+
+Gate outcomes:
+
+- `trivial`: one direct provider call;
+- `complex`: one preview call followed by one answer call conditioned on the preview.
+
+## Complex expert path
+
+Step 1 requests compact JSON containing:
+
+- considerations;
+- assumptions;
+- self-rated confidence from `0` to `1`.
+
+Step 2 answers the user request using the normalized Step 1 considerations and assumptions.
+
+The pass reuses the configured provider client, `ProviderRequest`, `ProviderResult`, provider telemetry, provider accounting, and provider SAFE-OUT handling used by the existing OpenAI provider path.
+
+## Self-rating caveat
+
+The confidence value is a model self-rating for supervised preview. It is not calibrated. Gate behavior and assumption surfacing are the hedges for this MVP lane. Calibration is out of scope.
+
+## Confidence-to-mode mapping
+
+The expert envelope exposes one of:
+
+- `direct`;
+- `answer_with_assumptions`;
+- `clarify`;
+- `block`.
+
+The service adapts the existing gate helper where practical. Very low self-ratings may map to `block`; low or mid-band self-ratings may map to `clarify`; higher ratings with assumptions may map to `answer_with_assumptions`; otherwise the mode is `direct`.
+
+If mode is `clarify`, this lane only returns the mode in the envelope. It does not render clarify templates or implement the full clarify surface.
+
+## Response envelope
+
+Expert-route responses return a structured envelope and retain `final_answer` as a compatibility alias:
+
+```json
+{
+  "final_answer": "...",
+  "answer": "...",
+  "considerations": [],
+  "assumptions": [],
+  "confidence": 0.0,
+  "mode": "direct",
+  "meta": {
+    "route": "expert",
+    "complexity": "trivial",
+    "provider": "openai",
+    "model": "...",
+    "call_count": 1
+  }
+}
+```
+
+The envelope must not include secrets, raw provider request bodies, raw provider response bodies, raw prompts, credentials, authorization headers, exception dumps, or provider raw metadata.
+
+## Forbidden wording
+
+The response envelope, code comments, tests, and this spec must not emit the prohibited multi-step-provider label named in the lane request. This spec avoids spelling that label out so repository search can detect accidental drift.
+
+## Validation expectations
+
+Tests must use fake provider clients and must not require OpenAI credentials or network calls. Coverage should prove:
+
+- complex expert route call count is exactly two;
+- trivial expert route call count is exactly one;
+- complex expert envelopes include non-empty answer, considerations, confidence, and mode;
+- assumption-bearing modes include assumptions;
+- OpenAI opt-out pass-through shape remains unchanged;
+- local/offline behavior remains unchanged;
+- expert envelopes do not leak secrets or raw provider metadata;
+- expert responses do not emit the prohibited label.

--- a/service/app.py
+++ b/service/app.py
@@ -700,7 +700,6 @@ async def solve(req: SolveRequest, request: Request) -> JSONResponse:
                 preview_request = replace(
                     provider_request,
                     prompt=_expert_step_one_prompt(query),
-                    system=None,
                 )
                 preview_result = _execute_provider_call(
                     request=request,
@@ -711,7 +710,6 @@ async def solve(req: SolveRequest, request: Request) -> JSONResponse:
                 answer_request = replace(
                     provider_request,
                     prompt=_expert_step_two_prompt(query, preview),
-                    system=None,
                 )
                 answer_result = _execute_provider_call(
                     request=request,

--- a/service/app.py
+++ b/service/app.py
@@ -7,8 +7,10 @@ import json
 import logging
 import os
 import time
+import re
 import uuid
 from collections import defaultdict, deque
+from dataclasses import replace
 from pathlib import Path
 from typing import Any, Deque, DefaultDict, Dict, Optional
 from enum import Enum
@@ -67,6 +69,7 @@ from alpha.core.telemetry import record_rate_limit, record_request, record_safe_
 from .security import validate_api_key, sanitize_query
 from .otel import init_tracer
 from .health import healthcheck
+from .gating.gates import evaluate_gates
 
 
 class JsonFormatter(logging.Formatter):
@@ -372,6 +375,203 @@ def _provider_error_response(error: ProviderError) -> JSONResponse:
     )
 
 
+_MULTI_PART_MARKERS = (
+    "first",
+    "second",
+    "third",
+    "compare",
+    "tradeoff",
+    "trade-off",
+    "pros and cons",
+    "step-by-step",
+    "plan",
+    "review",
+    "decide",
+    "decision",
+    "risk",
+    "risks",
+    "assumption",
+    "assumptions",
+    "ambiguous",
+    "uncertain",
+    "unknown",
+    "legal",
+    "medical",
+    "financial",
+    "architecture",
+    "migration",
+    "security",
+    "expert",
+)
+
+
+_CONFIDENCE_RE = re.compile(r"(?i)confidence[^0-9%]*(\d+(?:\.\d+)?)\s*(%)?")
+
+
+def _is_expert_route(params: Dict[str, Any]) -> bool:
+    return str(params.get("route", "")).strip().lower() == "expert"
+
+
+def _expert_complexity(query: str) -> str:
+    text = query.strip().lower()
+    score = 0
+    word_count = len(text.split())
+    if word_count >= 45 or len(text) >= 280:
+        score += 2
+    elif word_count >= 25 or len(text) >= 160:
+        score += 1
+    if any(marker in text for marker in _MULTI_PART_MARKERS):
+        score += 1
+    if text.count("?") >= 2 or "\n" in text or ";" in text:
+        score += 1
+    if any(token in text for token in (" and ", " or ", " vs ", " versus ")) and word_count >= 12:
+        score += 1
+    return "complex" if score >= 2 else "trivial"
+
+
+def _as_string_list(value: Any) -> list[str]:
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    if isinstance(value, str):
+        parts = [part.strip(" -•\t") for part in re.split(r"[\n;]+", value)]
+        return [part for part in parts if part]
+    return []
+
+
+def _confidence_value(value: Any) -> float:
+    raw: float | None = None
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        raw = float(value)
+    elif isinstance(value, str):
+        match = _CONFIDENCE_RE.search(value) or re.search(r"(\d+(?:\.\d+)?)\s*%", value)
+        if match:
+            raw = float(match.group(1))
+            if match.lastindex and match.group(match.lastindex) == "%":
+                raw /= 100.0
+        else:
+            try:
+                raw = float(value.strip())
+            except ValueError:
+                raw = None
+    if raw is None:
+        return 0.0
+    if raw > 1.0:
+        raw /= 100.0
+    return max(0.0, min(1.0, raw))
+
+
+def _parse_expert_preview(text: str) -> dict[str, Any]:
+    data: dict[str, Any] = {}
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        parsed = None
+    if isinstance(parsed, dict):
+        data = parsed
+    confidence_source = data.get("confidence", text)
+    considerations = _as_string_list(data.get("considerations"))
+    assumptions = _as_string_list(data.get("assumptions"))
+    if not considerations:
+        considerations = _extract_section_list(text, "considerations")
+    if not assumptions:
+        assumptions = _extract_section_list(text, "assumptions")
+    return {
+        "considerations": considerations,
+        "assumptions": assumptions,
+        "confidence": _confidence_value(confidence_source),
+    }
+
+
+def _extract_section_list(text: str, section: str) -> list[str]:
+    pattern = re.compile(
+        rf"(?ims)^\s*{re.escape(section)}\s*:?\s*(.*?)(?=^\s*(?:considerations|assumptions|confidence)\s*:?|\Z)"
+    )
+    match = pattern.search(text)
+    if not match:
+        return []
+    return _as_string_list(match.group(1))
+
+
+def _mode_from_confidence(confidence: float, assumptions: list[str], model_set: ModelSet) -> str:
+    if confidence <= 0.10:
+        return "block"
+    decision, _info = evaluate_gates(
+        confidence=confidence,
+        budget_tokens=model_set.max_tokens,
+        policy_flags={},
+    )
+    if decision == "block":
+        return "block"
+    if decision == "clarify":
+        return "clarify"
+    if assumptions and confidence < 0.75:
+        return "answer_with_assumptions"
+    return "direct"
+
+
+def _expert_step_one_prompt(query: str) -> str:
+    return (
+        "For the request below, identify expert-style considerations, assumptions, "
+        "and a self-rated confidence from 0 to 1. Return compact JSON with keys "
+        "considerations, assumptions, and confidence.\n\nRequest:\n"
+        f"{query}"
+    )
+
+
+def _expert_step_two_prompt(query: str, preview: dict[str, Any]) -> str:
+    return (
+        "Answer the request below using the provided considerations and assumptions. "
+        "Do not include raw provider metadata.\n\n"
+        f"Considerations: {json.dumps(preview['considerations'], ensure_ascii=False)}\n"
+        f"Assumptions: {json.dumps(preview['assumptions'], ensure_ascii=False)}\n"
+        f"Self-rated confidence: {preview['confidence']}\n\nRequest:\n{query}"
+    )
+
+
+def _expert_response(
+    *,
+    answer: str,
+    considerations: list[str],
+    assumptions: list[str],
+    confidence: float,
+    mode: str,
+    complexity: str,
+    provider: str,
+    model: str,
+    call_count: int,
+) -> Dict[str, Any]:
+    return {
+        "final_answer": answer,
+        "answer": answer,
+        "considerations": considerations,
+        "assumptions": assumptions,
+        "confidence": confidence,
+        "mode": mode,
+        "meta": {
+            "route": "expert",
+            "complexity": complexity,
+            "provider": provider,
+            "model": model,
+            "call_count": call_count,
+        },
+    }
+
+
+def _execute_provider_call(
+    *,
+    request: Request,
+    provider_client: Any,
+    provider_request: ProviderRequest,
+) -> ProviderResult:
+    _emit_provider_telemetry(request, _provider_request_started_event(provider_request))
+    result = provider_client.execute(provider_request)
+    _emit_provider_telemetry(
+        request, _provider_request_completed_event(provider_request, result)
+    )
+    _emit_provider_accounting(request, _provider_accounting_record(provider_request, result))
+    return result
+
+
 class StrategyEnum(str, Enum):
     cot = "cot"
     react = "react"
@@ -475,10 +675,71 @@ async def solve(req: SolveRequest, request: Request) -> JSONResponse:
         )
         try:
             provider_client = _get_provider_client(request, model_set)
-            _emit_provider_telemetry(
-                request, _provider_request_started_event(provider_request)
+            if _is_expert_route(params):
+                complexity = _expert_complexity(query)
+                if complexity == "trivial":
+                    provider_result = _execute_provider_call(
+                        request=request,
+                        provider_client=provider_client,
+                        provider_request=provider_request,
+                    )
+                    return JSONResponse(
+                        _expert_response(
+                            answer=provider_result.text,
+                            considerations=[],
+                            assumptions=[],
+                            confidence=0.0,
+                            mode="direct",
+                            complexity=complexity,
+                            provider=provider_result.provider,
+                            model=provider_result.model,
+                            call_count=1,
+                        )
+                    )
+
+                preview_request = replace(
+                    provider_request,
+                    prompt=_expert_step_one_prompt(query),
+                    system=None,
+                )
+                preview_result = _execute_provider_call(
+                    request=request,
+                    provider_client=provider_client,
+                    provider_request=preview_request,
+                )
+                preview = _parse_expert_preview(preview_result.text)
+                answer_request = replace(
+                    provider_request,
+                    prompt=_expert_step_two_prompt(query, preview),
+                    system=None,
+                )
+                answer_result = _execute_provider_call(
+                    request=request,
+                    provider_client=provider_client,
+                    provider_request=answer_request,
+                )
+                mode = _mode_from_confidence(
+                    preview["confidence"], preview["assumptions"], model_set
+                )
+                return JSONResponse(
+                    _expert_response(
+                        answer=answer_result.text,
+                        considerations=preview["considerations"],
+                        assumptions=preview["assumptions"],
+                        confidence=preview["confidence"],
+                        mode=mode,
+                        complexity=complexity,
+                        provider=answer_result.provider,
+                        model=answer_result.model,
+                        call_count=2,
+                    )
+                )
+
+            provider_result = _execute_provider_call(
+                request=request,
+                provider_client=provider_client,
+                provider_request=provider_request,
             )
-            provider_result = provider_client.execute(provider_request)
         except ProviderError as exc:
             _emit_provider_telemetry(
                 request, _provider_request_error_event(provider_request, exc)
@@ -498,12 +759,6 @@ async def solve(req: SolveRequest, request: Request) -> JSONResponse:
                 request, _provider_request_error_event(provider_request, safe_error)
             )
             return _provider_error_response(safe_error)
-        _emit_provider_telemetry(
-            request, _provider_request_completed_event(provider_request, provider_result)
-        )
-        _emit_provider_accounting(
-            request, _provider_accounting_record(provider_request, provider_result)
-        )
         return JSONResponse(_provider_success_response(provider_result, model_set))
 
     start = time.time()

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -505,6 +505,41 @@ def test_solve_openai_expert_complex_route_makes_two_calls_and_returns_envelope(
     _clear_provider_factory()
 
 
+def test_solve_openai_expert_complex_route_preserves_system_prompt(monkeypatch):
+    monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    fake = FakeProviderClient(
+        [
+            _provider_result(
+                '{"considerations":["Follow caller constraints"],'
+                '"assumptions":["System instruction remains authoritative"],'
+                '"confidence":0.8}'
+            ),
+            _provider_result("Answer constrained by system prompt."),
+        ]
+    )
+    app.state.provider_client_factory = lambda _model_set: fake
+    client, key = _client()
+    system_prompt = "You must answer in exactly two bullet points."
+
+    resp = client.post(
+        "/v1/solve",
+        json={
+            "query": (
+                "Review this security migration plan, compare risks and tradeoffs, "
+                "and decide whether the team should proceed this quarter."
+            ),
+            "context": {"route": "expert", "system": system_prompt},
+        },
+        headers={"X-API-Key": key, "X-Request-ID": "req-expert-system"},
+    )
+
+    assert resp.status_code == 200
+    assert len(fake.requests) == 2
+    assert fake.requests[0].system == system_prompt
+    assert fake.requests[1].system == system_prompt
+    _clear_provider_factory()
+
+
 def test_solve_openai_expert_trivial_route_makes_one_direct_call(monkeypatch):
     monkeypatch.setenv("MODEL_PROVIDER", "openai")
     fake = FakeProviderClient([_provider_result("Short direct answer.")])

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -439,3 +439,216 @@ def test_solve_openai_unknown_provider_exception_emits_no_accounting(monkeypatch
     _clear_provider_factory()
     _clear_provider_telemetry_sink()
     _clear_provider_accounting_sink()
+
+
+def _provider_result(text, *, request_id="req-expert", model="gpt-test"):
+    return ProviderResult(
+        provider="openai",
+        model=model,
+        text=text,
+        finish_reason="stop",
+        usage=ProviderUsage(input_tokens=1, output_tokens=1, total_tokens=2),
+        cost=ProviderCost(estimated_usd=0.0, source="price_hint"),
+        latency_ms=1,
+        request_id=request_id,
+        raw_metadata={"provider_request_id": f"provider-{request_id}"},
+    )
+
+
+def test_solve_openai_expert_complex_route_makes_two_calls_and_returns_envelope(monkeypatch):
+    monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    fake = FakeProviderClient(
+        [
+            _provider_result(
+                '{"considerations":["Check migration risk"],'
+                '"assumptions":["Traffic can be shifted gradually"],'
+                '"confidence":0.72}'
+            ),
+            _provider_result("Use a staged migration with rollback checkpoints."),
+        ]
+    )
+    app.state.provider_client_factory = lambda _model_set: fake
+    client, key = _client()
+
+    resp = client.post(
+        "/v1/solve",
+        json={
+            "query": (
+                "Review this database migration plan, compare risks and tradeoffs, "
+                "and decide whether the team should proceed this quarter."
+            ),
+            "context": {"route": "expert"},
+        },
+        headers={"X-API-Key": key, "X-Request-ID": "req-expert"},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["answer"] == "Use a staged migration with rollback checkpoints."
+    assert body["final_answer"] == body["answer"]
+    assert body["considerations"] == ["Check migration risk"]
+    assert body["assumptions"] == ["Traffic can be shifted gradually"]
+    assert body["confidence"] == 0.72
+    assert body["mode"] == "answer_with_assumptions"
+    assert body["meta"] == {
+        "route": "expert",
+        "complexity": "complex",
+        "provider": "openai",
+        "model": "gpt-test",
+        "call_count": 2,
+    }
+    assert len(fake.requests) == 2
+    assert fake.requests[0].metadata["route"] == "expert"
+    assert fake.requests[1].metadata["route"] == "expert"
+    blocked = "orches" + "tration"
+    assert blocked not in resp.text.lower()
+    _clear_provider_factory()
+
+
+def test_solve_openai_expert_trivial_route_makes_one_direct_call(monkeypatch):
+    monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    fake = FakeProviderClient([_provider_result("Short direct answer.")])
+    app.state.provider_client_factory = lambda _model_set: fake
+    client, key = _client()
+
+    resp = client.post(
+        "/v1/solve",
+        json={"query": "Define alpha.", "context": {"route": "expert"}},
+        headers={"X-API-Key": key},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["answer"] == "Short direct answer."
+    assert body["final_answer"] == "Short direct answer."
+    assert body["considerations"] == []
+    assert body["assumptions"] == []
+    assert body["confidence"] == 0.0
+    assert body["mode"] == "direct"
+    assert body["meta"]["complexity"] == "trivial"
+    assert body["meta"]["call_count"] == 1
+    assert len(fake.requests) == 1
+    _clear_provider_factory()
+
+
+def test_solve_openai_expert_clarify_mode_includes_assumptions(monkeypatch):
+    monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    fake = FakeProviderClient(
+        [
+            _provider_result(
+                '{"considerations":["Several requirements are missing"],'
+                '"assumptions":["Budget is flexible"],'
+                '"confidence":0.50}'
+            ),
+            _provider_result("Proceed only after confirming the missing requirements."),
+        ]
+    )
+    app.state.provider_client_factory = lambda _model_set: fake
+    client, key = _client()
+
+    resp = client.post(
+        "/v1/solve",
+        json={
+            "query": (
+                "Plan a security review and architecture migration where the goals, "
+                "timeline, owners, and risk tolerance are uncertain."
+            ),
+            "context": {"route": "expert"},
+        },
+        headers={"X-API-Key": key},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["mode"] == "clarify"
+    assert body["assumptions"] == ["Budget is flexible"]
+    assert body["considerations"]
+    assert len(fake.requests) == 2
+    _clear_provider_factory()
+
+
+def test_solve_openai_non_expert_route_preserves_pass_through_shape(monkeypatch):
+    monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    fake = FakeProviderClient([_provider_result("provider answer")])
+    app.state.provider_client_factory = lambda _model_set: fake
+    client, key = _client()
+
+    resp = client.post(
+        "/v1/solve",
+        json={"query": "hello provider", "context": {"route": "tot"}},
+        headers={"X-API-Key": key, "X-Request-ID": "req-pass"},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert set(body) == {"final_answer", "meta"}
+    assert body["final_answer"] == "provider answer"
+    assert "answer" not in body
+    assert len(fake.requests) == 1
+    assert fake.requests[0].metadata["route"] == "tot"
+    _clear_provider_factory()
+
+
+def test_solve_expert_route_local_mode_preserves_local_response(monkeypatch):
+    monkeypatch.setenv("MODEL_PROVIDER", "local")
+    app.state.provider_client_factory = lambda _model_set: (_ for _ in ()).throw(
+        AssertionError("provider should not be used in local mode")
+    )
+
+    def fake_solver(query: str, **kwargs):
+        return {"final_answer": f"local:{query}"}
+
+    monkeypatch.setattr("service.app._tree_of_thought", fake_solver)
+    client, key = _client()
+    resp = client.post(
+        "/v1/solve",
+        json={"query": "hi", "context": {"route": "expert"}},
+        headers={"X-API-Key": key},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json() == {"final_answer": "local:hi"}
+    _clear_provider_factory()
+
+
+def test_solve_openai_expert_envelope_does_not_leak_secrets_or_raw_metadata(monkeypatch):
+    monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    secret = "sk-test-expert-secret"
+    fake = FakeProviderClient(
+        [
+            ProviderResult(
+                provider="openai",
+                model="gpt-test",
+                text='{"considerations":["Use safe metadata"],"assumptions":[],"confidence":0.9}',
+                finish_reason="stop",
+                usage=ProviderUsage(input_tokens=1, output_tokens=1, total_tokens=2),
+                cost=ProviderCost(estimated_usd=0.0, source="price_hint"),
+                latency_ms=1,
+                request_id="req-leak",
+                raw_metadata={"raw": secret, "provider_request_id": "provider-req-leak"},
+            ),
+            _provider_result("Safe final answer.", request_id="req-leak"),
+        ]
+    )
+    app.state.provider_client_factory = lambda _model_set: fake
+    client, key = _client()
+
+    resp = client.post(
+        "/v1/solve",
+        json={
+            "query": "Review a security architecture migration with uncertain risks.",
+            "context": {"route": "expert"},
+        },
+        headers={"X-API-Key": key, "X-Request-ID": "req-leak"},
+    )
+
+    assert resp.status_code == 200
+    serialized = resp.text
+    assert secret not in serialized
+    assert "raw_metadata" not in serialized
+    assert "provider_request_id" not in serialized
+    assert "Authorization" not in serialized
+    assert "Bearer" not in serialized
+    blocked = "orches" + "tration"
+    assert blocked not in serialized.lower()
+    _clear_provider_factory()


### PR DESCRIPTION
### Motivation

* Provide an opt-in expert pass for explicitly requested complex OpenAI requests while preserving existing local defaults and the current OpenAI pass-through behavior.
* Surface operator-style considerations, assumptions, and a model self-rated confidence as a supervised preview before answering complex requests, without adding loops, fan-out, UI work, eval work, or clarify-template rendering.
* Preserve caller-provided system prompts in expert-route provider calls so expert mode does not weaken constraints that ordinary OpenAI pass-through already honors.

### Description

* Adds a new spec `.specs/PROVIDER-EXPERT-PASS-001.md` and registers it in `.specs/INDEX.md` describing opt-in behavior, boundaries, envelope shape, and validation expectations.
* Implements a deterministic, no-network complexity gate and expert path in `service/app.py` that uses `context.route == "expert"` as the opt-in seam and reuses the existing provider client, `ProviderRequest`, `ProviderResult`, telemetry, accounting, and SAFE-OUT helpers.
* Expert behavior: trivial expert requests invoke the existing single provider call; complex expert requests run exactly two fixed provider calls:

  * Step 1: preview for considerations, assumptions, and self-rated confidence.
  * Step 2: answer conditioned on the normalized preview.
* Returns the structured expert envelope with `answer`, `final_answer`, `considerations`, `assumptions`, `confidence`, `mode`, and `meta` including `call_count`.
* Preserves caller-provided `context.system` instructions across expert preview and answer calls.
* Adds parsing, normalization, and a minimal confidence-to-mode adapter using `evaluate_gates`.
* Adds no-network tests in `tests/test_api_endpoints.py` using `FakeProviderClient` for:

  * complex expert route call count and envelope shape;
  * system-prompt preservation;
  * trivial expert route one-call behavior;
  * clarify-mode envelope behavior;
  * non-expert OpenAI pass-through shape preservation;
  * local-mode behavior preservation;
  * leakage checks for secrets and raw metadata;
  * forbidden multi-step-provider wording drift.

### Testing

* Ran `git diff --check` with no whitespace or index errors.
* Ran `python -m pytest -q`; all non-live tests passed, and live-gated OpenAI smoke remained skipped as expected.
* Ran focused suites:

  * `python -m pytest tests/test_api_endpoints.py -q`
  * `python -m pytest tests/test_api_endpoints.py tests/providers -q`
* Confirmed the new expert-path tests pass with no-network `FakeProviderClient`.
* Searched repository for the forbidden multi-step-provider wording and confirmed this PR did not introduce new occurrences; any matches are pre-existing historical references outside the new spec/code/tests.

### Scope Boundaries

* Does not implement `CLARIFY-SURFACE-001`.
* Does not implement `UI-PREVIEW-001`.
* Does not implement `EVAL-BEHAVIORAL-DEMO-001`.
* Does not start fast-follow lanes.
* Does not add live provider tests.
* Does not claim MVP validation, answer-quality superiority, production readiness, broad runtime readiness, or provider reasoning orchestration.

---

[[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1cc59cd05c8329b80587083a61f8c2)](https://chatgpt.com/codex/cloud/tasks/task_e_6a1cc59cd05c8329b80587083a61f8c2)