### PR TITLE
CLARIFY-SURFACE-001: surface clarify responses for expert pass

### DIFF
--- a/.specs/CLARIFY-SURFACE-001.md
+++ b/.specs/CLARIFY-SURFACE-001.md
@@ -1,0 +1,78 @@
+# CLARIFY-SURFACE-001 · Expert Route Clarify Surface
+
+## Purpose
+
+Surface bounded clarification questions when the opt-in OpenAI expert route returns `mode == "clarify"`. This is a narrow follow-up to `PROVIDER-EXPERT-PASS-001` and keeps default local/offline behavior and ordinary OpenAI pass-through behavior unchanged.
+
+## Scope
+
+- Applies only to `/v1/solve` requests with `MODEL_PROVIDER=openai` and `context.route == "expert"`.
+- Applies only when the existing expert confidence/gate mapping produces `mode == "clarify"`.
+- Adds stable `clarifying_questions` to the expert envelope in clarify mode.
+- Sets `answer` and `final_answer` to a concise clarification-facing message in clarify mode.
+- Preserves `considerations`, `assumptions`, `confidence`, and `meta` from the expert envelope.
+- Does not add a provider call for clarification question generation.
+
+## Existing clarify/template machinery inspection result
+
+The repository has clarify modules under `service/clarify/` and the `NEW-009` spec entry, but that machinery is not reused for this lane because it is broader than the provider expert-route path and currently renders one template-oriented question from router-style payload flags. The expert-route surface needs 2 to 4 deterministic questions derived from the expert preview request context without rewiring unrelated routing, UI, eval, or provider behavior.
+
+This lane therefore uses a small local fallback in `service/app.py`, scoped to expert-route clarify mode only.
+
+## Response shape
+
+Clarify-mode expert responses include the existing expert envelope fields plus `clarifying_questions`:
+
+```json
+{
+  "final_answer": "I need a few details before I can answer this well.",
+  "answer": "I need a few details before I can answer this well.",
+  "clarifying_questions": [
+    "What is the main outcome you want from this request?",
+    "What constraints or context should I preserve?",
+    "What tradeoffs or priorities matter most?"
+  ],
+  "considerations": [],
+  "assumptions": [],
+  "confidence": 0.35,
+  "mode": "clarify",
+  "meta": {
+    "route": "expert",
+    "complexity": "complex",
+    "provider": "openai",
+    "model": "...",
+    "call_count": 2
+  }
+}
+```
+
+The exact question wording may vary, but it must remain deterministic, bounded, and no-network.
+
+## Validation expectations
+
+No-network tests with fake provider clients should prove:
+
+- complex expert-route clarify mode includes `clarifying_questions`;
+- `answer` and `final_answer` are clarification-facing and not final-answer text;
+- complex clarify mode remains exactly two provider calls;
+- trivial expert mode remains one provider call and does not add `clarifying_questions`;
+- non-expert OpenAI pass-through response shape remains unchanged;
+- local/offline behavior remains unchanged;
+- block mode remains distinct from clarify mode;
+- responses do not leak secrets, raw provider request bodies, raw provider response bodies, raw prompts, credentials, authorization headers, or raw provider metadata.
+
+## Non-goals and claim boundaries
+
+- No MVP validation claim.
+- No Alpha Solver superiority claim.
+- No answer-superiority claim.
+- No production-readiness claim.
+- No broad runtime-readiness claim.
+- No answer-quality benchmark success claim.
+- No provider reasoning orchestration claim.
+- No UI preview.
+- No behavioral demo checklist.
+- No eval artifact preservation.
+- No eval benchmark work.
+- No live provider tests.
+- No provider reasoning planning, verify-revise loop, fan-out, re-synthesis, or broad provider architecture change.

--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -7,6 +7,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `AS-145.md` | CODE SPEC — AS-145 · Tool Adapters: Playwright + GSheets (MVP hardening) (RES_05) |
 | `AS-148.md` | CODE SPEC — AS-148 · Policy & PII Gateway (DR_TRACK_A) |
 | `AUTH-SESSION-001.md` | AUTH-SESSION-001 · Dashboard Login + Session |
+| `CLARIFY-SURFACE-001.md` | CLARIFY-SURFACE-001 · Expert Route Clarify Surface |
 | `EPIC_RAG_001.md` | EPIC_RAG_001 · RAG & Semantic Cache Pack |
 | `FINOPS-BUDGET-001.md` | FINOPS-BUDGET-001 · Budget Guardrails |
 | `MCP-001.md` | CODE SPEC — MCP-001 · MCP Registry Loader & Wiring (MCP) |

--- a/service/app.py
+++ b/service/app.py
@@ -528,6 +528,37 @@ def _expert_step_two_prompt(query: str, preview: dict[str, Any]) -> str:
     )
 
 
+_CLARIFY_MESSAGE = "I need a few details before I can answer this well."
+
+
+def _clarifying_questions_for_expert_request(
+    query: str, considerations: list[str], assumptions: list[str]
+) -> list[str]:
+    """Return deterministic, local clarify questions for expert-route clarify mode."""
+    source_text = " ".join([query, *considerations, *assumptions]).lower()
+    questions: list[str] = []
+
+    def add(question: str) -> None:
+        if question not in questions and len(questions) < 4:
+            questions.append(question)
+
+    add("What is the main outcome you want from this request?")
+
+    if any(term in source_text for term in ("format", "deliverable", "output")):
+        add("What output format or deliverable should I produce?")
+    if any(term in source_text for term in ("timeline", "deadline", "milestone", "schedule")):
+        add("What timeline or deadline constraints should I preserve?")
+    if any(term in source_text for term in ("budget", "cost", "resource")):
+        add("What budget or resource constraints should I account for?")
+    if any(term in source_text for term in ("risk", "security", "legal", "medical", "financial")):
+        add("What risk tolerance or compliance constraints should guide the answer?")
+
+    add("What constraints or context should I preserve?")
+    add("What tradeoffs or priorities matter most?")
+    add("What would make the answer successful for you?")
+    return questions[:4]
+
+
 def _expert_response(
     *,
     answer: str,
@@ -539,8 +570,9 @@ def _expert_response(
     provider: str,
     model: str,
     call_count: int,
+    clarifying_questions: list[str] | None = None,
 ) -> Dict[str, Any]:
-    return {
+    response = {
         "final_answer": answer,
         "answer": answer,
         "considerations": considerations,
@@ -555,6 +587,9 @@ def _expert_response(
             "call_count": call_count,
         },
     }
+    if mode == "clarify" and clarifying_questions is not None:
+        response["clarifying_questions"] = clarifying_questions
+    return response
 
 
 def _execute_provider_call(
@@ -719,9 +754,16 @@ async def solve(req: SolveRequest, request: Request) -> JSONResponse:
                 mode = _mode_from_confidence(
                     preview["confidence"], preview["assumptions"], model_set
                 )
+                expert_answer = answer_result.text
+                clarifying_questions = None
+                if mode == "clarify":
+                    expert_answer = _CLARIFY_MESSAGE
+                    clarifying_questions = _clarifying_questions_for_expert_request(
+                        query, preview["considerations"], preview["assumptions"]
+                    )
                 return JSONResponse(
                     _expert_response(
-                        answer=answer_result.text,
+                        answer=expert_answer,
                         considerations=preview["considerations"],
                         assumptions=preview["assumptions"],
                         confidence=preview["confidence"],
@@ -730,6 +772,7 @@ async def solve(req: SolveRequest, request: Request) -> JSONResponse:
                         provider=answer_result.provider,
                         model=answer_result.model,
                         call_count=2,
+                        clarifying_questions=clarifying_questions,
                     )
                 )
 

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -566,16 +566,18 @@ def test_solve_openai_expert_trivial_route_makes_one_direct_call(monkeypatch):
     _clear_provider_factory()
 
 
-def test_solve_openai_expert_clarify_mode_includes_assumptions(monkeypatch):
+def test_solve_openai_expert_clarify_mode_surfaces_questions_without_extra_call(monkeypatch):
     monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    raw_answer = "Proceed only after confirming the missing requirements."
     fake = FakeProviderClient(
         [
             _provider_result(
                 '{"considerations":["Several requirements are missing"],'
-                '"assumptions":["Budget is flexible"],'
+                '"assumptions":["Budget is flexible",'
+                '"The user has not specified the desired output format."],'
                 '"confidence":0.50}'
             ),
-            _provider_result("Proceed only after confirming the missing requirements."),
+            _provider_result(raw_answer),
         ]
     )
     app.state.provider_client_factory = lambda _model_set: fake
@@ -596,8 +598,87 @@ def test_solve_openai_expert_clarify_mode_includes_assumptions(monkeypatch):
     assert resp.status_code == 200
     body = resp.json()
     assert body["mode"] == "clarify"
-    assert body["assumptions"] == ["Budget is flexible"]
-    assert body["considerations"]
+    assert body["answer"] == "I need a few details before I can answer this well."
+    assert body["final_answer"] == body["answer"]
+    assert body["answer"] != raw_answer
+    assert body["assumptions"] == [
+        "Budget is flexible",
+        "The user has not specified the desired output format.",
+    ]
+    assert body["considerations"] == ["Several requirements are missing"]
+    assert 2 <= len(body["clarifying_questions"]) <= 4
+    assert body["clarifying_questions"] == [
+        "What is the main outcome you want from this request?",
+        "What output format or deliverable should I produce?",
+        "What timeline or deadline constraints should I preserve?",
+        "What budget or resource constraints should I account for?",
+    ]
+    assert "Can you clarify?" not in body["clarifying_questions"]
+    assert body["meta"]["call_count"] == 2
+    assert len(fake.requests) == 2
+    serialized = resp.text
+    assert "raw_metadata" not in serialized
+    assert "provider_request_id" not in serialized
+    assert "Authorization" not in serialized
+    assert "Bearer" not in serialized
+    blocked = "orches" + "tration"
+    assert blocked not in serialized.lower()
+    _clear_provider_factory()
+
+
+def test_solve_openai_expert_trivial_route_does_not_add_clarifying_questions(monkeypatch):
+    monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    fake = FakeProviderClient([_provider_result("Short direct answer.")])
+    app.state.provider_client_factory = lambda _model_set: fake
+    client, key = _client()
+
+    resp = client.post(
+        "/v1/solve",
+        json={"query": "Define alpha.", "context": {"route": "expert"}},
+        headers={"X-API-Key": key},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["mode"] == "direct"
+    assert "clarifying_questions" not in body
+    assert body["meta"]["call_count"] == 1
+    assert len(fake.requests) == 1
+    _clear_provider_factory()
+
+
+def test_solve_openai_expert_block_mode_remains_distinct_from_clarify(monkeypatch):
+    monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    fake = FakeProviderClient(
+        [
+            _provider_result(
+                '{"considerations":["The request may be unsafe"],'
+                '"assumptions":[],"confidence":0.05}'
+            ),
+            _provider_result("Cannot safely answer as requested."),
+        ]
+    )
+    app.state.provider_client_factory = lambda _model_set: fake
+    client, key = _client()
+
+    resp = client.post(
+        "/v1/solve",
+        json={
+            "query": (
+                "Review this uncertain security migration risk decision and decide "
+                "whether the proposed ambiguous access-control plan should proceed."
+            ),
+            "context": {"route": "expert"},
+        },
+        headers={"X-API-Key": key},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["mode"] == "block"
+    assert body["answer"] == "Cannot safely answer as requested."
+    assert "clarifying_questions" not in body
+    assert body["meta"]["call_count"] == 2
     assert len(fake.requests) == 2
     _clear_provider_factory()
 


### PR DESCRIPTION
### Motivation

- Surface bounded clarification questions when the opt-in OpenAI expert route yields `mode == "clarify"` so callers receive a helpful, deterministic clarify surface instead of a normal final answer.
- Keep the change narrowly scoped to the expert-route clarify lane and preserve default local/offline and ordinary OpenAI pass-through behavior from `PROVIDER-EXPERT-PASS-001`.

### Description

- Adds a new spec ` .specs/CLARIFY-SURFACE-001.md` and registers it in ` .specs/INDEX.md` documenting scope, inspection result of existing clarify machinery, response shape, and non-goals.
- Implements a small deterministic, local helper in `service/app.py`: `_clarifying_questions_for_expert_request(...)` and `_CLARIFY_MESSAGE`, and updates `_expert_response(...)` to optionally include `clarifying_questions` when `mode == "clarify"` without introducing extra provider calls.
- Updates expert-route assembly in `service/app.py` so that when complex expert flow yields `mode == "clarify"` the service returns a clarification-facing `answer`/`final_answer`, a bounded `clarifying_questions` list (2–4 items), and preserves `considerations`, `assumptions`, `confidence`, and `meta.call_count`.
- Adds/updates no-network tests in `tests/test_api_endpoints.py` to assert clarify-mode surfaces questions, trivial expert remains 1 call, block remains distinct, no raw provider metadata is leaked, and call counts remain unchanged from the original expert pass behavior.

### Testing

- Ran `python -m pytest tests/test_api_endpoints.py -q` and the updated endpoint tests passed locally (all assertions OK).
- Ran `python -m pytest tests/test_api_endpoints.py tests/providers -q` and it passed with expected environment-gated skip(s) for live OpenAI smoke.
- Ran full test suite `python -m pytest -q` and it completed successfully with the usual environment-gated skips; no new network or live-provider tests were added.

### Backlog impact

- `CLARIFY-SURFACE-001` should be marked Done only if this PR is merged.
- Add PR #200 as implementation evidence for `CLARIFY-SURFACE-001`.
- `PROVIDER-EXPERT-PASS-001` remains Done from PR #199.
- `UI-PREVIEW-001` remains held and not implemented.
- `EVAL-BEHAVIORAL-DEMO-001` remains held and not implemented.
- `EVAL-ARTIFACT-PRESERVE-001` remains proposed or next prerequisite and not implemented.
- No uncertain legacy concept rows should be updated.
- No Review Queue concept rows should be touched unless the human operator specifically requests it.
- No MVP validation, Alpha Solver superiority, production readiness, broad runtime readiness, answer-quality benchmark success, or provider reasoning orchestration claim should be added to the Sheet.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1cd7391a508329b16ca39fba711f56)