### PR TITLE
EVAL-ARTIFACT-PRESERVE-001: preserve eval summary artifacts

### DIFF
--- a/.specs/EVAL-ARTIFACT-PRESERVE-001.md
+++ b/.specs/EVAL-ARTIFACT-PRESERVE-001.md
@@ -1,0 +1,62 @@
+# EVAL-ARTIFACT-PRESERVE-001 · Preserve Eval Summary Artifacts
+
+## Purpose
+
+Add a safe committed-documentation path for no-live answer-quality eval summary artifacts so future eval and behavioral-demo review can cite durable repo artifacts rather than ignored local outputs or operator-reported summaries.
+
+## Scope
+
+- Applies only to `scripts/run_answer_quality_eval.py` answer-quality eval summary preservation.
+- Adds an opt-in `--save-summary` CLI path for no-live runs.
+- Writes the safe summary artifact under `docs/evals/runs/` by default.
+- Keeps existing no-live behavior safe and non-live by default.
+- Keeps live provider execution behind the existing `--live`, `ALPHA_LIVE_ANSWER_QUALITY=1`, key, and cost-ceiling gates.
+
+## Artifact path
+
+The default committed artifact path is:
+
+```text
+docs/evals/runs/answer_quality_no_live_summary.json
+```
+
+Tests and local checks may override the destination with `--summary-output PATH` to avoid mutating committed evidence files during automated runs.
+
+## Artifact safety exclusions
+
+The no-live summary artifact must include only summary-level fields such as schema version, no-live mode, dataset path/hash, case count, categories, quality-gate reference, pre-registered success criteria, model/settings metadata, estimated pre-flight cost, skipped/no-live status, safety exclusions, and claim boundaries.
+
+The artifact must not include API keys, auth headers, raw provider payloads, raw request/response bodies, raw prompts, generated answer text, environment dumps, broad telemetry dumps, exception dumps, raw secrets, credentials, or provider raw metadata.
+
+## Validation expectations
+
+Tests should prove:
+
+- no-live eval can write a summary artifact when `--save-summary` is used;
+- the artifact is written under the intended safe path or an injected test path;
+- the artifact excludes obvious sensitive fields and unsafe dump markers;
+- default no-live behavior does not write the committed summary artifact unless opted in;
+- existing no-live eval behavior still makes no provider calls;
+- live-gated behavior is not enabled or broadened;
+- docs mention the artifact path and safety exclusions.
+
+## Backlog impact
+
+`EVAL-ARTIFACT-PRESERVE-001` should be marked Done only after the PR implementing this spec is merged. The PR should be added as implementation evidence for this lane. Backlog spreadsheets are not edited from this repo task.
+
+## Non-goals
+
+- No MVP validation claim.
+- No Alpha Solver superiority claim.
+- No answer-superiority claim.
+- No production-readiness claim.
+- No broad runtime-readiness claim.
+- No answer-quality benchmark success claim.
+- No provider reasoning orchestration claim.
+- No UI preview.
+- No behavioral demo checklist.
+- No live provider tests.
+- No broad eval platform.
+- No provider expert-pass behavior changes.
+- No clarify behavior changes.
+- No backlog workbook edits.

--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -9,6 +9,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `AUTH-SESSION-001.md` | AUTH-SESSION-001 · Dashboard Login + Session |
 | `CLARIFY-SURFACE-001.md` | CLARIFY-SURFACE-001 · Expert Route Clarify Surface |
 | `EPIC_RAG_001.md` | EPIC_RAG_001 · RAG & Semantic Cache Pack |
+| `EVAL-ARTIFACT-PRESERVE-001.md` | EVAL-ARTIFACT-PRESERVE-001 · Preserve Eval Summary Artifacts |
 | `FINOPS-BUDGET-001.md` | FINOPS-BUDGET-001 · Budget Guardrails |
 | `MCP-001.md` | CODE SPEC — MCP-001 · MCP Registry Loader & Wiring (MCP) |
 | `MCP-002.md` | CODE SPEC — MCP-002 · Router decision rule (MCP) |

--- a/docs/evals/ANSWER_QUALITY_EVAL.md
+++ b/docs/evals/ANSWER_QUALITY_EVAL.md
@@ -95,6 +95,41 @@ Interpret `apparent_treatment_advantage_stability` narrowly:
 
 Repeatability measures run-to-run variability in the gated smoke eval. It must not be used to claim Alpha Solver superiority, MVP validation, production readiness, or completed expanded-set live validation until an approved live run produces stable evidence.
 
+
+## Persisting no-live summary artifacts
+
+`EVAL-ARTIFACT-PRESERVE-001` adds an opt-in committed evidence path for
+summary-level no-live answer-quality eval results. The default runner behavior is
+unchanged: no-live runs still avoid provider calls, and committed summary
+persistence happens only when `--save-summary` is passed.
+
+```bash
+python scripts/run_answer_quality_eval.py --no-live --save-summary
+```
+
+By default, the safe summary artifact is written to:
+
+```text
+docs/evals/runs/answer_quality_no_live_summary.json
+```
+
+Tests may inject a different destination with `--summary-output PATH`; operators
+should use the default `docs/evals/runs/` path when they want a durable,
+reviewable artifact that can be committed. The JSON artifact contains only
+summary-level fields such as schema version, mode (`no_live`), dataset path and
+hash, case count, categories, quality-gate reference, pre-registered success
+criteria, model/settings metadata, estimated pre-flight cost, skipped/no-live
+status, safety exclusions, and claim boundaries.
+
+The committed summary artifact intentionally excludes API keys, auth headers,
+raw provider payloads, raw request/response bodies, raw prompts, generated answer
+text, environment dumps, broad telemetry dumps, exception dumps, and other unsafe
+secret-bearing material. Live provider behavior is not enabled by this flag.
+
+These artifacts support evidence reviewability only. They do not prove MVP
+validation, Alpha Solver superiority, answer superiority, production readiness,
+broad runtime readiness, answer-quality benchmark success, or provider reasoning orchestration.
+
 ## Cost ceiling
 
 The default live cost ceiling is `$5.00` estimated total provider cost. Override it only deliberately:

--- a/docs/evals/runs/answer_quality_no_live_summary.json
+++ b/docs/evals/runs/answer_quality_no_live_summary.json
@@ -1,0 +1,50 @@
+{
+  "artifact_kind": "answer_quality_no_live_summary",
+  "artifact_schema_version": "answer_quality_no_live_summary_v1",
+  "case_count": 48,
+  "categories": [
+    "backlog_impact_classification",
+    "lane_selection",
+    "runtime_overclaim_detection",
+    "source_hierarchy_conflict_detection"
+  ],
+  "claim_boundaries": [
+    "reviewability_only",
+    "not_mvp_validation",
+    "not_alpha_solver_superiority",
+    "not_answer_superiority",
+    "not_production_readiness",
+    "not_broad_runtime_readiness",
+    "not_answer_quality_benchmark_success",
+    "not_provider_reasoning_orchestration"
+  ],
+  "dataset_path": "datasets/answer_quality_operator_cases.jsonl",
+  "dataset_sha256": "6ce3dbaf34b51a863e8b3e38ba17dec8381e15a02e8a7cafb26fe859051e1a5a",
+  "dataset_version": "answer_quality_operator_cases_v0.1",
+  "disclaimer": "Evidence, not proof: this gated MVP eval is a small smoke signal only.",
+  "estimated_preflight_cost_usd": 0.159753,
+  "live_predictions_generated": false,
+  "max_tokens": 220,
+  "mode": "no_live",
+  "model": "gpt-5.4-mini",
+  "pre_registered_success_criteria": {
+    "metric": "treatment_accuracy_minus_baseline_accuracy",
+    "minimum_margin": 0.0625,
+    "quality_gate_reference": "config/quality_gate.yaml"
+  },
+  "quality_gate_reference": "config/quality_gate.yaml",
+  "run_id": "answer_quality_no_live_summary",
+  "safety_exclusions": [
+    "credentials",
+    "provider_payloads",
+    "provider_request_response_bodies",
+    "prompts",
+    "process_environment",
+    "exception_dumps",
+    "generated_answer_text"
+  ],
+  "seed": 123,
+  "skipped_status": "no_live_dry_run_no_provider_predictions",
+  "temperature": 0.0,
+  "treatment_version": "alpha_solver_operator_discipline_v0.1"
+}

--- a/scripts/run_answer_quality_eval.py
+++ b/scripts/run_answer_quality_eval.py
@@ -37,6 +37,8 @@ from alpha.providers.openai import OpenAIProviderClient  # noqa: E402
 DATASET_DEFAULT = ROOT / "datasets" / "answer_quality_operator_cases.jsonl"
 QUALITY_GATE_DEFAULT = ROOT / "config" / "quality_gate.yaml"
 ARTIFACT_ROOT_DEFAULT = ROOT / "artifacts" / "eval" / "answer_quality"
+SUMMARY_ARTIFACT_DEFAULT = ROOT / "docs" / "evals" / "runs" / "answer_quality_no_live_summary.json"
+SUMMARY_ARTIFACT_SCHEMA_VERSION = "answer_quality_no_live_summary_v1"
 LIVE_GATE_ENV = "ALPHA_LIVE_ANSWER_QUALITY"
 OPENAI_KEY_ENV = "OPENAI_API_KEY"
 DATASET_VERSION = "answer_quality_operator_cases_v0.1"
@@ -97,6 +99,8 @@ class EvalConfig:
     input_per_1k_usd: float = DEFAULT_PRICE_HINT["input_per_1k"]
     output_per_1k_usd: float = DEFAULT_PRICE_HINT["output_per_1k"]
     limit: int | None = None
+    save_summary: bool = False
+    summary_output: Path = SUMMARY_ARTIFACT_DEFAULT
 
 
 def relative_path_for_artifact(path: Path) -> str:
@@ -426,6 +430,99 @@ def summarize_predictions(
     }
 
 
+def build_no_live_summary_artifact(
+    *,
+    config: EvalConfig,
+    dataset_path: Path,
+    cases: list[EvalCase],
+    summary: dict[str, Any],
+    expected_cost: float,
+) -> dict[str, Any]:
+    """Build a safe committed-docs no-live summary artifact.
+
+    This artifact intentionally keeps only summary-level metadata. It does not
+    include prompts, provider request/response bodies, provider payloads,
+    credentials, process environment dumps, exception dumps, or generated answer
+    text.
+    """
+    success_criteria = summary.get("pre_registered_success_criteria", {})
+    return redact_for_artifact(
+        {
+            "artifact_schema_version": SUMMARY_ARTIFACT_SCHEMA_VERSION,
+            "artifact_kind": "answer_quality_no_live_summary",
+            "run_id": "answer_quality_no_live_summary",
+            "disclaimer": EVIDENCE_DISCLAIMER,
+            "mode": "no_live",
+            "live_predictions_generated": False,
+            "dataset_version": DATASET_VERSION,
+            "dataset_path": relative_path_for_artifact(dataset_path),
+            "dataset_sha256": dataset_sha(dataset_path),
+            "case_count": len(cases),
+            "categories": sorted({case.category for case in cases}),
+            "treatment_version": TREATMENT_VERSION,
+            "quality_gate_reference": summary.get(
+                "quality_gate_reference", relative_path_for_artifact(config.quality_gate)
+            ),
+            "pre_registered_success_criteria": {
+                "metric": success_criteria.get("metric"),
+                "minimum_margin": success_criteria.get("minimum_margin"),
+                "quality_gate_reference": success_criteria.get(
+                    "quality_gate_reference", relative_path_for_artifact(config.quality_gate)
+                ),
+            },
+            "estimated_preflight_cost_usd": expected_cost,
+            "model": config.model,
+            "temperature": config.temperature,
+            "max_tokens": config.max_tokens,
+            "seed": config.seed,
+            "skipped_status": "no_live_dry_run_no_provider_predictions",
+            "safety_exclusions": [
+                "credentials",
+                "provider_payloads",
+                "provider_request_response_bodies",
+                "prompts",
+                "process_environment",
+                "exception_dumps",
+                "generated_answer_text",
+            ],
+            "claim_boundaries": [
+                "reviewability_only",
+                "not_mvp_validation",
+                "not_alpha_solver_superiority",
+                "not_answer_superiority",
+                "not_production_readiness",
+                "not_broad_runtime_readiness",
+                "not_answer_quality_benchmark_success",
+                "not_provider_reasoning_orchestration",
+            ],
+        }
+    )
+
+
+def write_no_live_summary_artifact(
+    *,
+    config: EvalConfig,
+    dataset_path: Path,
+    cases: list[EvalCase],
+    summary: dict[str, Any],
+    expected_cost: float,
+) -> Path:
+    """Write the safe no-live summary artifact under a docs/evals/runs path."""
+    output_path = config.summary_output
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    artifact = build_no_live_summary_artifact(
+        config=config,
+        dataset_path=dataset_path,
+        cases=cases,
+        summary=summary,
+        expected_cost=expected_cost,
+    )
+    output_path.write_text(
+        json.dumps(artifact, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return output_path
+
+
 def write_artifacts(
     *,
     config: EvalConfig,
@@ -512,11 +609,21 @@ def run_eval(config: EvalConfig, *, client: ProviderClient | None = None) -> dic
             dry_run=True,
             expected_cost=expected_cost,
         )
-        return {
+        report = {
             **summary,
             "artifact_dir": str(out_dir),
             "estimated_preflight_cost_usd": expected_cost,
         }
+        if config.save_summary:
+            summary_path = write_no_live_summary_artifact(
+                config=config,
+                dataset_path=config.dataset,
+                cases=cases,
+                summary=summary,
+                expected_cost=expected_cost,
+            )
+            report["summary_artifact_path"] = relative_path_for_artifact(summary_path)
+        return report
 
     provider = client or OpenAIProviderClient(
         max_retries=0,
@@ -822,6 +929,8 @@ def run_repeatability(
             input_per_1k_usd=config.input_per_1k_usd,
             output_per_1k_usd=config.output_per_1k_usd,
             limit=config.limit,
+            save_summary=config.save_summary,
+            summary_output=config.summary_output,
         )
         try:
             report = run_eval(run_config, client=client)
@@ -872,6 +981,8 @@ def config_from_args(args: argparse.Namespace) -> EvalConfig:
         input_per_1k_usd=args.input_per_1k_usd,
         output_per_1k_usd=args.output_per_1k_usd,
         limit=args.limit,
+        save_summary=args.save_summary,
+        summary_output=Path(args.summary_output),
     )
 
 
@@ -880,6 +991,25 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--dataset", default=str(DATASET_DEFAULT))
     parser.add_argument("--quality-gate", default=str(QUALITY_GATE_DEFAULT))
     parser.add_argument("--artifact-root", default=str(ARTIFACT_ROOT_DEFAULT))
+    parser.add_argument(
+        "--save-summary",
+        action="store_true",
+        help=(
+            "Also write a safe no-live summary artifact to docs/evals/runs/. "
+            "This does not enable live provider calls."
+        ),
+    )
+    parser.add_argument(
+        "--summary-output",
+        default=str(SUMMARY_ARTIFACT_DEFAULT),
+        help="Path for --save-summary no-live artifact output.",
+    )
+    parser.add_argument(
+        "--no-live",
+        dest="live",
+        action="store_false",
+        help="Explicitly keep the default no-live dry-run mode.",
+    )
     parser.add_argument("--model", default=os.getenv("ALPHA_AQ_MODEL", DEFAULT_MODEL))
     parser.add_argument("--temperature", type=float, default=DEFAULT_TEMPERATURE)
     parser.add_argument("--max-tokens", type=int, default=DEFAULT_MAX_TOKENS)
@@ -915,6 +1045,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "preserve each run under its own artifact subdirectory, and write an aggregate summary."
         ),
     )
+    parser.set_defaults(live=False)
     return parser.parse_args(argv)
 
 

--- a/tests/test_answer_quality_eval.py
+++ b/tests/test_answer_quality_eval.py
@@ -139,6 +139,7 @@ def test_default_model_uses_known_working_live_mini_model(monkeypatch):
 
     assert aq.DEFAULT_MODEL == "gpt-5.4-mini"
     assert args.model == "gpt-5.4-mini"
+    assert args.live is False
 
 
 def test_default_dry_run_needs_no_key_and_makes_no_provider_calls(monkeypatch, tmp_path):
@@ -154,6 +155,102 @@ def test_default_dry_run_needs_no_key_and_makes_no_provider_calls(monkeypatch, t
     artifact_dir = Path(report["artifact_dir"])
     assert (artifact_dir / "summary.json").exists()
     assert (artifact_dir / "predictions.jsonl").read_text(encoding="utf-8") == ""
+
+
+def test_no_live_save_summary_writes_safe_docs_artifact(monkeypatch, tmp_path):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ALPHA_LIVE_ANSWER_QUALITY", raising=False)
+    summary_path = tmp_path / "docs" / "evals" / "runs" / "answer_quality_no_live_summary.json"
+    client = RecordingClient(["OVERCLAIM"])
+    config = aq.EvalConfig(
+        dataset=aq.DATASET_DEFAULT,
+        quality_gate=aq.QUALITY_GATE_DEFAULT,
+        artifact_root=tmp_path / "ephemeral",
+        limit=1,
+        save_summary=True,
+        summary_output=summary_path,
+    )
+
+    report = aq.run_eval(config, client=client)
+
+    assert client.requests == []
+    assert report["live_predictions_generated"] is False
+    assert report["summary_artifact_path"] == str(summary_path)
+    assert summary_path.exists()
+    artifact = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert artifact["artifact_schema_version"] == aq.SUMMARY_ARTIFACT_SCHEMA_VERSION
+    assert artifact["artifact_kind"] == "answer_quality_no_live_summary"
+    assert artifact["mode"] == "no_live"
+    assert artifact["live_predictions_generated"] is False
+    assert artifact["case_count"] == 1
+    assert artifact["dataset_path"] == "datasets/answer_quality_operator_cases.jsonl"
+    assert artifact["skipped_status"] == "no_live_dry_run_no_provider_predictions"
+
+    combined = json.dumps(artifact, sort_keys=True).lower()
+    for forbidden in (
+        "api key",
+        "authorization",
+        "bearer",
+        "raw request",
+        "raw response",
+        "raw provider payload",
+        "environment dump",
+        "sk-test-secret",
+    ):
+        assert forbidden not in combined
+    assert "provider_payloads" in combined
+    assert "process_environment" in combined
+
+
+def test_default_no_live_does_not_write_summary_artifact(monkeypatch, tmp_path):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ALPHA_LIVE_ANSWER_QUALITY", raising=False)
+    summary_path = tmp_path / "docs" / "evals" / "runs" / "answer_quality_no_live_summary.json"
+    config = aq.EvalConfig(
+        dataset=aq.DATASET_DEFAULT,
+        quality_gate=aq.QUALITY_GATE_DEFAULT,
+        artifact_root=tmp_path / "ephemeral",
+        limit=1,
+        summary_output=summary_path,
+    )
+
+    report = aq.run_eval(config, client=RecordingClient(["OVERCLAIM"]))
+
+    assert "summary_artifact_path" not in report
+    assert not summary_path.exists()
+
+
+def test_save_summary_cli_no_live_alias_and_output_path(tmp_path):
+    summary_path = tmp_path / "summary.json"
+
+    args = aq.parse_args(["--no-live", "--save-summary", "--summary-output", str(summary_path)])
+    config = aq.config_from_args(args)
+
+    assert args.live is False
+    assert config.live is False
+    assert config.save_summary is True
+    assert config.summary_output == summary_path
+
+
+def test_answer_quality_docs_describe_summary_artifact_path_and_safety_exclusions():
+    text = Path("docs/evals/ANSWER_QUALITY_EVAL.md").read_text(encoding="utf-8")
+
+    assert "docs/evals/runs/answer_quality_no_live_summary.json" in text
+    assert "--save-summary" in text
+    for phrase in (
+        "API keys",
+        "auth headers",
+        "raw provider payloads",
+        "raw request/response bodies",
+        "environment dumps",
+        "MVP validation",
+        "Alpha Solver superiority",
+        "production readiness",
+        "broad runtime readiness",
+        "answer-quality benchmark success",
+        "provider reasoning orchestration",
+    ):
+        assert phrase in text
 
 
 def test_live_requires_explicit_env_gate_even_with_client_and_key(monkeypatch, tmp_path):


### PR DESCRIPTION
### Motivation

- Provide a narrow, safe, and reviewable way to persist no-live answer-quality eval summary evidence as committed docs rather than ephemeral local outputs or operator-reported notes.
- Preserve default no-live behavior (no provider calls, no secrets written) while enabling an opt-in committed artifact path for future reviewability and traceability.

### Description

- Added opt-in CLI support to `scripts/run_answer_quality_eval.py`: `--save-summary` (write a safe summary) and `--summary-output` (override destination), plus an explicit `--no-live` alias while keeping `live=False` by default.
- Implemented a minimal safe artifact builder/writer (`build_no_live_summary_artifact` / `write_no_live_summary_artifact`) that emits a summary-only JSON artifact under `docs/evals/runs/` by default and excludes prompts, provider payloads, API keys, auth headers, environment/exception dumps, and generated answer text.
- Updated `docs/evals/ANSWER_QUALITY_EVAL.md` with a short section documenting the command, default artifact path (`docs/evals/runs/answer_quality_no_live_summary.json`), included summary fields, safety exclusions, and explicit non-claim boundaries.
- Added an implementation spec `.specs/EVAL-ARTIFACT-PRESERVE-001.md` and registered it in `.specs/INDEX.md`, created `docs/evals/runs/.gitkeep` and a committed example summary artifact for review, and added focused tests in `tests/test_answer_quality_eval.py` to exercise the writer, CLI parsing, default non-persistence, docs coverage, and sensitive-marker exclusions.

### Testing

- `python -m pytest tests/test_answer_quality_eval.py -q` — passed (including new tests for `--save-summary` behavior and redaction checks).
- `env -u OPENAI_API_KEY -u ALPHA_LIVE_ANSWER_QUALITY python scripts/run_answer_quality_eval.py --no-live --save-summary --limit 1` — exercised CLI path and wrote the safe docs artifact successfully in CI-like environment.
- `python -m pytest -q` (full test suite) — passed after a transient `tests/test_jwt_auth.py::test_rotation` unknown-kid failure was observed and resolved by rerun; final full-suite run succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1cdccb6f508329b98179b22fe428a1)