### PR TITLE
EVAL-BEHAVIORAL-DEMO-001: add expert-pass behavioral demo checklist

### DIFF
--- a/.specs/EVAL-BEHAVIORAL-DEMO-001.md
+++ b/.specs/EVAL-BEHAVIORAL-DEMO-001.md
@@ -1,0 +1,57 @@
+# EVAL-BEHAVIORAL-DEMO-001 · Expert Pass Behavioral Demo Checklist
+
+## Purpose
+
+Add a compact behavioral demo checklist for the opt-in OpenAI expert route so operators can review intended judgment behavior before sharing or building a preview UI.
+
+## Scope
+
+- Applies only to documentation and no-network checklist integrity tests.
+- Covers representative prompt shapes for trivial, complex, messy or vague, clarify-needed, assumption-heavy, and block-sensitive behavior.
+- References existing no-live answer-quality eval artifacts when they are present.
+- Keeps provider expert-pass behavior, clarify behavior, eval artifact preservation behavior, and UI preview work unchanged.
+
+## Success criteria
+
+The checklist is successful when it helps an operator verify behavior shape rather than answer superiority:
+
+- complex prompts use the expert path and expose the expert envelope;
+- trivial prompts stay direct/simple and avoid unnecessary expert complexity;
+- clarify-needed prompts surface clarification needs when confidence is low;
+- assumption-heavy prompts surface assumptions;
+- block-sensitive cases remain distinct from clarify when existing gate behavior maps very low confidence to block.
+
+## Required artifact
+
+Add a narrow Markdown checklist under the existing eval documentation area:
+
+```text
+docs/evals/EXPERT_PASS_BEHAVIORAL_DEMO.md
+```
+
+The checklist should include purpose, scope, prompt set, expected judgment behavior, pass/fail checks, no-network or operator-supervised run instructions, evidence artifact references, claim boundaries, and backlog impact.
+
+## Validation expectations
+
+Tests, if added, must be no-network and documentation-focused. They may verify that the checklist exists, contains required sections and prompt categories, references durable artifacts when present, states that it is not an answer-superiority benchmark, and includes explicit claim boundaries.
+
+## Backlog impact
+
+`EVAL-BEHAVIORAL-DEMO-001` should be marked Done only after the PR implementing this spec is merged. The PR should be added as implementation evidence for this lane. Backlog spreadsheets are not edited from this repo task.
+
+## Non-goals
+
+- No MVP validation claim.
+- No Alpha Solver superiority claim.
+- No answer-quality superiority claim.
+- No production-readiness claim.
+- No broad runtime-readiness claim.
+- No answer-quality benchmark success claim.
+- No provider reasoning orchestration claim.
+- No UI preview implementation.
+- No provider expert-pass behavior changes.
+- No clarify behavior changes.
+- No eval artifact preservation behavior changes.
+- No live provider tests.
+- No broad eval benchmark or eval platform.
+- No backlog workbook edits.

--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -10,6 +10,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `CLARIFY-SURFACE-001.md` | CLARIFY-SURFACE-001 · Expert Route Clarify Surface |
 | `EPIC_RAG_001.md` | EPIC_RAG_001 · RAG & Semantic Cache Pack |
 | `EVAL-ARTIFACT-PRESERVE-001.md` | EVAL-ARTIFACT-PRESERVE-001 · Preserve Eval Summary Artifacts |
+| `EVAL-BEHAVIORAL-DEMO-001.md` | EVAL-BEHAVIORAL-DEMO-001 · Expert Pass Behavioral Demo Checklist |
 | `FINOPS-BUDGET-001.md` | FINOPS-BUDGET-001 · Budget Guardrails |
 | `MCP-001.md` | CODE SPEC — MCP-001 · MCP Registry Loader & Wiring (MCP) |
 | `MCP-002.md` | CODE SPEC — MCP-002 · Router decision rule (MCP) |

--- a/docs/evals/EXPERT_PASS_BEHAVIORAL_DEMO.md
+++ b/docs/evals/EXPERT_PASS_BEHAVIORAL_DEMO.md
@@ -1,0 +1,91 @@
+# Expert Pass Behavioral Demo Checklist
+
+## Purpose
+
+Use this one-screen checklist to review whether the opt-in expert provider pass shows the intended judgment behavior on representative prompts. It is a small behavioral review/demo aid only, not an answer-superiority benchmark.
+
+## Scope
+
+- Applies to `/v1/solve` only when OpenAI provider mode is explicitly enabled and `context.route` is `expert`.
+- Uses no-network fake-provider tests or operator-supervised inspection; it must not require live OpenAI calls, credentials, or provider billing.
+- Checks behavior shape: routing, mode, envelope fields, clarifying questions, assumptions, and block-vs-clarify separation.
+- Does not change provider expert-pass behavior, clarify behavior, eval artifact preservation behavior, or UI behavior.
+
+## Prompt set
+
+| Case | Prompt shape | Example prompt to exercise | Expected judgment behavior | Evidence to check |
+| --- | --- | --- | --- | --- |
+| Trivial | Simple factual or definition request | `Define alpha in one sentence.` | Direct/simple behavior; avoid unnecessary expert complexity. Expected mode is `direct` or equivalent existing simple behavior. | `mode`, `meta.complexity`, and `meta.call_count`; current fake-provider route tests enforce one call. |
+| Complex planning | Multi-part planning, review, or decision request | `Review this security migration plan, compare risks, identify assumptions, and decide whether the team should proceed this quarter.` | Expert path fires. The response envelope includes `answer`, `final_answer`, `considerations`, `assumptions`, `confidence`, `mode`, and `meta`. | Envelope fields are present; complex route uses the expert path with the existing fake provider. |
+| Messy or vague | Noisy request with mixed goals and unclear priorities | `We need to fix onboarding, maybe compliance too, and leadership wants a plan soon; what should we do?` | System should not overstate certainty. It should either clarify or answer with explicit assumptions, depending on confidence. | `mode`, `confidence`, `clarifying_questions` when clarify is surfaced, and/or `assumptions`. |
+| Clarify-needed | Under-specified request where missing details materially affect the answer | `Plan a security review and migration where goals, timeline, owners, and risk tolerance are uncertain.` | Expected mode is `clarify`; if `CLARIFY-SURFACE-001` is merged, response includes bounded `clarifying_questions` and does not pretend it has enough context. | `mode == "clarify"`, `clarifying_questions`, concise clarification-facing `answer` and `final_answer`. |
+| Assumption-heavy | Answerable request with missing constraints | `Draft a rollout plan for an enterprise feature; budget, staffing, and launch date are not finalized.` | Expected mode may be `answer_with_assumptions`; response surfaces assumptions instead of hiding missing constraints. | Non-empty `assumptions`, mode, and final answer that preserves those assumptions. |
+| Block-sensitive | Very low-confidence or unsafe request shape that is safe to test with fake responses | `Review this ambiguous access-control change and decide whether it should proceed despite unresolved safety risks.` | Expected mode may be `block` when existing gate behavior maps very low confidence to block; block remains distinct from clarify. | `mode == "block"` and no `clarifying_questions`. |
+| Provider pass-through preservation | Non-expert OpenAI provider request | Same request without `context.route: "expert"`, or with another route. | Ordinary provider pass-through shape remains unchanged. | Response remains pass-through (`final_answer` plus `meta`) and does not add expert-only fields. |
+
+## Expected judgment behavior
+
+- Complex prompts should enter the expert path and expose the structured expert envelope.
+- Trivial prompts should stay direct/simple; where the existing tests cover it, provider call count should remain one.
+- Clarify-needed prompts should surface questions when confidence is low and clarify surfacing is available.
+- Assumption-heavy prompts should expose assumptions when the system can still answer conditionally.
+- Block-sensitive prompts should keep `block` distinct from `clarify`.
+- Success is correct judgment behavior and shape, not better answers than another model or benchmark arm.
+
+## Pass/fail checklist
+
+- [ ] Trivial case stays direct/simple and avoids unnecessary expert complexity.
+- [ ] Complex planning case returns the expert envelope with `answer`, `final_answer`, `considerations`, `assumptions`, `confidence`, `mode`, and `meta`.
+- [ ] Messy or vague case does not overstate certainty and surfaces either clarification needs or assumptions.
+- [ ] Clarify-needed case uses `mode: clarify`; when clarify surfacing is present, bounded `clarifying_questions` are visible.
+- [ ] Assumption-heavy case surfaces assumptions when answering conditionally.
+- [ ] Block-sensitive case remains distinct from clarify and does not add clarifying questions when mode is `block`.
+- [ ] Non-expert provider pass-through shape remains unchanged.
+- [ ] No live provider call, live credential, scoring benchmark, or answer-quality superiority claim is required for this checklist.
+
+## How to run or manually inspect behavior
+
+Use the existing no-network fake-provider endpoint coverage for the concrete behavior checks:
+
+```bash
+python -m pytest tests/test_api_endpoints.py -q
+```
+
+For a focused operator review, inspect the tests around the expert route cases in `tests/test_api_endpoints.py`: complex expert route, trivial one-call route, clarify-mode surfacing, block-vs-clarify separation, and non-expert pass-through preservation. Any live/provider-billed review must be explicitly operator-supervised and is outside this checklist's required path.
+
+## Evidence artifacts
+
+The durable no-live answer-quality summary artifact exists at:
+
+```text
+docs/evals/runs/answer_quality_no_live_summary.json
+```
+
+That artifact is useful as preserved eval evidence context and claim-boundary evidence only. It is not proof of this behavioral checklist, not a live provider prediction artifact, and not evidence of answer superiority.
+
+## Claim boundaries
+
+This checklist explicitly states:
+
+- It is not an answer-superiority benchmark.
+- It does not prove MVP validation.
+- It does not prove Alpha Solver superiority.
+- It does not prove answer-quality superiority.
+- It does not prove production readiness.
+- It does not prove broad runtime readiness.
+- It does not prove answer-quality benchmark success.
+- It does not implement provider reasoning orchestration.
+- It is a small behavioral review/demo aid only.
+
+## Backlog impact
+
+- `EVAL-BEHAVIORAL-DEMO-001` should be marked Done only if the PR adding this checklist is merged.
+- Add the merged PR as implementation evidence for `EVAL-BEHAVIORAL-DEMO-001`.
+- `PROVIDER-EXPERT-PASS-001` remains Done from PR #199.
+- `CLARIFY-SURFACE-001` remains separate and should only be marked Done if PR #200 was merged.
+- `EVAL-ARTIFACT-PRESERVE-001` remains separate and should only be marked Done if PR #201 was merged.
+- UI-PREVIEW-001 remains held and not implemented.
+- Do not edit the Google Sheet from Codex.
+- Do not update uncertain legacy concept rows.
+- Do not touch Review Queue concept rows unless the human operator specifically requests it.
+- Do not add MVP validation, Alpha Solver superiority, production-readiness, broad runtime-readiness, answer-quality benchmark success, or provider-reasoning-orchestration claims to the Sheet.

--- a/tests/test_answer_quality_eval.py
+++ b/tests/test_answer_quality_eval.py
@@ -253,6 +253,61 @@ def test_answer_quality_docs_describe_summary_artifact_path_and_safety_exclusion
         assert phrase in text
 
 
+def test_expert_pass_behavioral_demo_checklist_documents_scope_and_boundaries():
+    checklist = Path("docs/evals/EXPERT_PASS_BEHAVIORAL_DEMO.md")
+    text = checklist.read_text(encoding="utf-8")
+
+    for section in (
+        "## Purpose",
+        "## Scope",
+        "## Prompt set",
+        "## Expected judgment behavior",
+        "## Pass/fail checklist",
+        "## How to run or manually inspect behavior",
+        "## Evidence artifacts",
+        "## Claim boundaries",
+        "## Backlog impact",
+    ):
+        assert section in text
+
+    for prompt_case in (
+        "Trivial",
+        "Complex planning",
+        "Messy or vague",
+        "Clarify-needed",
+        "Assumption-heavy",
+        "Block-sensitive",
+        "Provider pass-through preservation",
+    ):
+        assert prompt_case in text
+
+    for behavior_phrase in (
+        "expert path",
+        "Direct/simple behavior",
+        "mode is `clarify`",
+        "surfaces assumptions",
+        "block remains distinct from clarify",
+    ):
+        assert behavior_phrase in text
+
+    for guardrail in (
+        "not an answer-superiority benchmark",
+        "does not prove MVP validation",
+        "does not prove Alpha Solver superiority",
+        "does not prove answer-quality superiority",
+        "does not prove production readiness",
+        "does not prove broad runtime readiness",
+        "does not prove answer-quality benchmark success",
+        "does not implement provider reasoning orchestration",
+        "small behavioral review/demo aid only",
+    ):
+        assert guardrail in text
+
+    assert "docs/evals/runs/answer_quality_no_live_summary.json" in text
+    assert "must not require live OpenAI calls" in text
+    assert "UI-PREVIEW-001 remains held and not implemented" in text
+
+
 def test_live_requires_explicit_env_gate_even_with_client_and_key(monkeypatch, tmp_path):
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test-secret-value")
     monkeypatch.delenv("ALPHA_LIVE_ANSWER_QUALITY", raising=False)


### PR DESCRIPTION
### Motivation

- Provide a compact, operator-facing behavioral demo checklist for the opt-in OpenAI expert `expert` route so operators can verify intended judgment behavior (routing, clarify surfacing, assumptions, block separation) on representative prompts before sharing a preview UI, without claiming answer superiority or benchmark success.

### Description

- Added the implementation contract `.specs/EVAL-BEHAVIORAL-DEMO-001.md` and registered it in `.specs/INDEX.md`.
- Added the one-screen checklist `docs/evals/EXPERT_PASS_BEHAVIORAL_DEMO.md` that includes Purpose, Scope, Prompt set (trivial, complex planning, messy/vague, clarify-needed, assumption-heavy, block-sensitive, provider pass-through preservation), Expected judgment behavior, Pass/fail checklist, How to run, Evidence artifacts, Claim boundaries, and Backlog impact.
- Added a focused no-network docs integrity test in `tests/test_answer_quality_eval.py` to verify checklist presence, required sections, prompt categories, durable artifact reference, and explicit guardrails against superiority/production claims.
- Scope and safety: no runtime behavior or provider implementation was changed; no live provider tests, no UI preview implementation, and no eval artifact preservation changes were made by this PR.
- Explicit notes captured in the checklist/backlog impact: this PR implements only `EVAL-BEHAVIORAL-DEMO-001`; `PROVIDER-EXPERT-PASS-001` remains Done from PR #199; `CLARIFY-SURFACE-001` and `EVAL-ARTIFACT-PRESERVE-001` remain separate and should be marked Done only if their respective PRs (#200 and #201) were merged; `UI-PREVIEW-001` remains held and unimplemented; do not edit external backlog sheets or add MVP/production/superiority claims.

### Testing

- Ran `python -m pytest tests/test_answer_quality_eval.py -q` and the new checklist test passed.
- Ran full test suite with `python -m pytest -q` and observed green results (skips for gated live-smoke tests as expected).
- Ran `git diff --check` and fixed whitespace/formatting issues; staging and commit were created as `Add expert pass behavioral demo checklist`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ce15d98748329b943bcf07d59e582)