### PR TITLE
UI-PREVIEW-001: add authenticated expert preview UI

### DIFF
--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -46,6 +46,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `RES-08.md` | CODE SPEC — RES-08 · Budget Simulator + Evidence Pack (RES) |
 | `REVIEW-P0P1.md` | CODE SPEC — REVIEW-P0P1 · P0 + P1 Bulk Review (MVP Readiness) (RES_06) |
 | `UI-JOBS-001.md` | UI-JOBS-001 · Dashboard Job History & Metrics (RES_Dash) |
+| `UI-PREVIEW-001.md` | UI-PREVIEW-001 · Authenticated Expert Preview UI |
 | `UI-KEYS-001.md` | UI-KEYS-001 · Dashboard: API Keys Management |
 | `UI-REQ-001.md` | UI-REQ-001 · Dashboard Request Submission UI |
 | `UI-RUN-001.md` | UI-RUN-001 · Dashboard One-click Demo Run |

--- a/.specs/UI-PREVIEW-001.md
+++ b/.specs/UI-PREVIEW-001.md
@@ -1,0 +1,88 @@
+# UI-PREVIEW-001 · Authenticated Expert Preview UI
+
+## Purpose
+
+Add a compact authenticated dashboard preview that lets an operator compare an ordinary same-provider answer with the Alpha Solver expert-framed answer for the same prompt.
+
+The preview is for supervised operator review only. It is not evidence of benchmarked answer quality or broad runtime readiness.
+
+## Scope
+
+- Add a protected dashboard route at `/dashboard/expert-preview`.
+- Reuse the existing dashboard password/session/CSRF middleware.
+- Reuse the existing `/v1/solve` request model and solve logic internally.
+- Submit the plain pane as a same-provider request without `context.route == "expert"`.
+- Submit the expert pane as a same-provider request with `context.route == "expert"`.
+- Render the result as two compact panes:
+  - `Plain provider output`
+  - `Alpha Solver expert preview`
+- Surface operator-friendly expert fields where present:
+  - mode
+  - confidence
+  - complexity
+  - call count
+  - considerations
+  - assumptions
+  - clarifying questions
+- Keep raw or engineering metadata out of the default view; details are limited to a small public metadata subset.
+- Display an explicit supervised-preview disclaimer near the top of the page.
+
+## Auth boundary
+
+The preview route is under `/dashboard`, which is included in the existing dashboard protected prefixes. Logged-out users follow the existing dashboard auth-block behavior. State-changing preview submissions continue to require the existing CSRF header.
+
+No second authentication mechanism is added.
+
+## UI fields
+
+The UI includes:
+
+- prompt input box;
+- compare submit button;
+- required supervised-preview disclaimer;
+- plain same-provider output pane;
+- Alpha Solver expert preview pane;
+- mode, confidence, complexity, and call-count labels;
+- considerations list;
+- assumptions list;
+- clarifying questions list when present;
+- a `Details` disclosure for limited public metadata.
+
+## Validation expectations
+
+No-network route-level tests should prove:
+
+- logged-out users are blocked by the existing auth convention;
+- logged-in users can load the preview page;
+- the disclaimer is visible;
+- fake provider calls render both plain and expert outputs;
+- the plain pane uses the non-expert route;
+- the expert pane uses `context.route == "expert"`;
+- expert fields are surfaced;
+- raw provider metadata, secrets, auth headers, API keys, raw request bodies, and raw response bodies are not displayed;
+- UI copy stays within claim boundaries;
+- existing `/v1/solve` behavior remains covered by existing endpoint tests.
+
+## Backlog impact
+
+`UI-PREVIEW-001` should be marked Done only after the PR implementing this spec is merged. The PR should be added as implementation evidence for this lane. Backlog spreadsheets are not edited from this repo task.
+
+`PROVIDER-EXPERT-PASS-001` remains Done from PR #199. `CLARIFY-SURFACE-001`, `EVAL-ARTIFACT-PRESERVE-001`, and `EVAL-BEHAVIORAL-DEMO-001` remain separate lanes and should only be marked Done if their corresponding PRs were merged.
+
+## Non-goals
+
+- No MVP validation claim.
+- No Alpha Solver superiority claim.
+- No answer-quality superiority claim.
+- No production-readiness claim.
+- No broad runtime-readiness claim.
+- No answer-quality benchmark success claim.
+- No provider reasoning orchestration claim.
+- No live provider tests.
+- No broad eval benchmark.
+- No provider orchestration, loops, fan-out, verify-revise behavior, or re-synthesis.
+- No provider expert-pass behavior changes.
+- No clarify behavior changes.
+- No eval artifact preservation behavior changes.
+- No behavioral demo checklist changes.
+- No backlog workbook edits.

--- a/alpha/webapp/routes/auth.py
+++ b/alpha/webapp/routes/auth.py
@@ -37,7 +37,7 @@ SESSION_TTL_SECONDS = 60 * 60  # one hour
 LOCKOUT_THRESHOLD = 5
 LOCKOUT_DURATION_SECONDS = 5 * 60  # five minutes
 
-_PROTECTED_PREFIXES: Tuple[str, ...] = ("/requests", "/settings", "/run")
+_PROTECTED_PREFIXES: Tuple[str, ...] = ("/requests", "/settings", "/run", "/dashboard")
 _CSRF_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
 
 _TEMPLATE_DIR = Path(__file__).resolve().parent.parent / "templates"

--- a/alpha/webapp/routes/expert_preview.py
+++ b/alpha/webapp/routes/expert_preview.py
@@ -1,0 +1,238 @@
+"""Authenticated expert preview UI routes for same-provider comparison."""
+
+from __future__ import annotations
+
+import html
+import json
+from typing import Any, Dict, Iterable, Mapping
+from urllib.parse import parse_qs
+
+from fastapi import APIRouter, Request, status
+from fastapi.responses import HTMLResponse
+
+router = APIRouter()
+
+DISCLAIMER = (
+    "This preview is for supervised operator review. It does not prove Alpha Solver "
+    "superiority, MVP validation, production readiness, broad runtime readiness, or "
+    "answer-quality benchmark success."
+)
+
+_ROUTE = "/dashboard/expert-preview"
+def _escape(value: Any) -> str:
+    return html.escape("" if value is None else str(value), quote=True)
+
+
+def _as_list(value: Any) -> list[str]:
+    if isinstance(value, list):
+        return [str(item) for item in value if str(item).strip()]
+    if isinstance(value, str) and value.strip():
+        return [value.strip()]
+    return []
+
+
+def _answer(payload: Mapping[str, Any]) -> str:
+    value = payload.get("answer", payload.get("final_answer", ""))
+    return str(value) if value is not None else ""
+
+
+def _public_meta(payload: Mapping[str, Any]) -> Dict[str, Any]:
+    meta = payload.get("meta")
+    if not isinstance(meta, Mapping):
+        return {}
+    allowed = ("route", "complexity", "provider", "model", "model_set", "call_count")
+    return {key: meta[key] for key in allowed if key in meta}
+
+
+def _render_list(items: Iterable[str]) -> str:
+    values = list(items)
+    if not values:
+        return '<p class="empty">None surfaced.</p>'
+    return "<ul>" + "".join(f"<li>{_escape(item)}</li>" for item in values) + "</ul>"
+
+
+def _render_plain_payload(payload: Mapping[str, Any] | None) -> str:
+    if payload is None:
+        return '<p class="empty">Submit a prompt to render the plain same-provider output.</p>'
+    meta = _public_meta(payload)
+    details = json.dumps(meta, indent=2, sort_keys=True) if meta else "{}"
+    return f"""
+      <p class="answer">{_escape(_answer(payload))}</p>
+      <details>
+        <summary>Details</summary>
+        <pre>{_escape(details)}</pre>
+      </details>
+    """
+
+
+def _render_expert_payload(payload: Mapping[str, Any] | None) -> str:
+    if payload is None:
+        return '<p class="empty">Submit a prompt to render the Alpha Solver expert preview.</p>'
+    meta = _public_meta(payload)
+    rows = [
+        ("Mode", payload.get("mode", "—")),
+        ("Confidence", payload.get("confidence", "—")),
+        ("Complexity", meta.get("complexity", "—")),
+        ("Call count", meta.get("call_count", "—")),
+    ]
+    details = json.dumps(meta, indent=2, sort_keys=True) if meta else "{}"
+    rows_html = "".join(
+        f"<div><dt>{_escape(label)}</dt><dd>{_escape(value)}</dd></div>" for label, value in rows
+    )
+    return f"""
+      <p class="answer">{_escape(_answer(payload))}</p>
+      <dl class="metadata">{rows_html}</dl>
+      <h3>Considerations</h3>
+      {_render_list(_as_list(payload.get('considerations')))}
+      <h3>Assumptions</h3>
+      {_render_list(_as_list(payload.get('assumptions')))}
+      <h3>Clarifying questions</h3>
+      {_render_list(_as_list(payload.get('clarifying_questions')))}
+      <details>
+        <summary>Details</summary>
+        <pre>{_escape(details)}</pre>
+      </details>
+    """
+
+
+def _render_page(
+    *,
+    prompt: str = "",
+    plain: Mapping[str, Any] | None = None,
+    expert: Mapping[str, Any] | None = None,
+    error: str = "",
+) -> str:
+    error_html = f'<p class="error" role="alert">{_escape(error)}</p>' if error else ""
+    return f"""<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Alpha Solver · Expert Preview</title>
+    <style>
+      :root {{ color-scheme: light dark; font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; line-height: 1.5; }}
+      body {{ margin: 0; min-height: 100vh; background: radial-gradient(circle at top, #f6f8ff, #e4e8f4); color: #1d2038; }}
+      .container {{ max-width: 1080px; margin: 0 auto; padding: 2.5rem 1.25rem 4rem; }}
+      h1 {{ margin-bottom: 0.5rem; }}
+      .disclaimer {{ border: 1px solid #c7d2fe; background: rgba(238, 242, 255, 0.9); border-radius: 14px; padding: 1rem; color: #30365f; }}
+      form, .pane {{ background: rgba(255, 255, 255, 0.92); border-radius: 16px; padding: 1.25rem; box-shadow: 0 18px 55px rgba(31, 35, 71, 0.08); }}
+      form {{ display: grid; gap: 0.85rem; margin: 1.5rem 0; }}
+      label {{ font-weight: 700; }}
+      textarea {{ min-height: 130px; resize: vertical; border: 1px solid #cdd5ef; border-radius: 12px; padding: 0.85rem 1rem; font: inherit; color: inherit; background: rgba(255,255,255,0.78); }}
+      button {{ justify-self: start; border: 0; border-radius: 999px; padding: 0.7rem 1.25rem; font: inherit; font-weight: 700; color: white; background: linear-gradient(135deg, #5661f6, #7b5ff4); cursor: pointer; }}
+      .panes {{ display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 1rem; }}
+      .pane h2 {{ margin-top: 0; }}
+      .answer, pre {{ white-space: pre-wrap; overflow-wrap: anywhere; }}
+      .answer {{ border: 1px solid rgba(86, 97, 246, 0.16); background: rgba(237, 240, 255, 0.65); border-radius: 12px; padding: 1rem; }}
+      .metadata {{ display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.75rem; }}
+      dt {{ color: #565b8f; font-size: 0.8rem; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; }}
+      dd {{ margin: 0; font-weight: 600; }}
+      details {{ margin-top: 1rem; }}
+      summary {{ cursor: pointer; font-weight: 700; }}
+      pre {{ background: #111827; color: #e5e7eb; border-radius: 12px; padding: 0.85rem; }}
+      .empty {{ color: #5f668f; }}
+      .error {{ padding: 0.85rem 1rem; border-radius: 12px; background: rgba(244, 67, 54, 0.12); color: #9f1239; }}
+      @media (max-width: 760px) {{ .panes {{ grid-template-columns: 1fr; }} }}
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <h1>Supervised preview only</h1>
+      <p class="disclaimer">{_escape(DISCLAIMER)}</p>
+      {error_html}
+      <form method="post" action="{_ROUTE}">
+        <label for="prompt">Prompt</label>
+        <textarea id="prompt" name="prompt" required>{_escape(prompt)}</textarea>
+        <button type="submit">Compare same-provider outputs</button>
+      </form>
+      <section class="panes" aria-label="same-provider comparison">
+        <article class="pane" id="plain-pane">
+          <h2>Plain provider output</h2>
+          {_render_plain_payload(plain)}
+        </article>
+        <article class="pane" id="expert-pane">
+          <h2>Alpha Solver expert preview</h2>
+          {_render_expert_payload(expert)}
+        </article>
+      </section>
+    </main>
+    <script>
+      const form = document.querySelector("form");
+      function cookieValue(name) {{
+        return document.cookie
+          .split(";")
+          .map((part) => part.trim())
+          .find((part) => part.startsWith(name + "="))
+          ?.slice(name.length + 1) || "";
+      }}
+      form.addEventListener("submit", async (event) => {{
+        event.preventDefault();
+        const response = await fetch(form.action, {{
+          method: "POST",
+          headers: {{ "X-Alpha-CSRF": cookieValue("alpha_dashboard_csrf") }},
+          body: new FormData(form),
+        }});
+        const html = await response.text();
+        document.open();
+        document.write(html);
+        document.close();
+      }});
+    </script>
+  </body>
+</html>"""
+
+
+async def _extract_prompt(request: Request) -> str:
+    content_type = request.headers.get("content-type", "").lower()
+    if "application/json" in content_type:
+        payload = await request.json()
+        if isinstance(payload, Mapping):
+            return str(payload.get("prompt", "")).strip()
+        return ""
+    body = await request.body()
+    if not body:
+        return ""
+    parsed = parse_qs(body.decode())
+    return (parsed.get("prompt") or [""])[0].strip()
+
+
+async def _solve_preview(request: Request, prompt: str, *, expert: bool) -> Dict[str, Any]:
+    # Import lazily so tests can monkeypatch service.app without importing the
+    # API application when they only render the page.
+    from service.app import SolveRequest, solve
+
+    context: Dict[str, Any] = {}
+    if expert:
+        context["route"] = "expert"
+    response = await solve(SolveRequest(query=prompt, context=context), request)
+    body = response.body.decode("utf-8")
+    payload = json.loads(body) if body else {}
+    if not isinstance(payload, dict):
+        return {"final_answer": str(payload)}
+    return payload
+
+
+@router.get(_ROUTE, response_class=HTMLResponse)
+async def expert_preview_page() -> HTMLResponse:
+    return HTMLResponse(content=_render_page())
+
+
+@router.post(_ROUTE, response_class=HTMLResponse)
+async def expert_preview_submit(request: Request) -> HTMLResponse:
+    prompt = await _extract_prompt(request)
+    if not prompt:
+        return HTMLResponse(
+            content=_render_page(error="Prompt is required."),
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+    try:
+        plain = await _solve_preview(request, prompt, expert=False)
+        expert = await _solve_preview(request, prompt, expert=True)
+    except Exception:
+        return HTMLResponse(
+            content=_render_page(prompt=prompt, error="Preview request failed."),
+            status_code=status.HTTP_502_BAD_GATEWAY,
+        )
+    return HTMLResponse(content=_render_page(prompt=prompt, plain=plain, expert=expert))
+
+
+__all__ = ["router", "DISCLAIMER"]

--- a/docs/DASHBOARD_AUTH.md
+++ b/docs/DASHBOARD_AUTH.md
@@ -34,20 +34,36 @@ must remain private because it signs session cookies.
 ```python
 from fastapi import FastAPI
 
-from alpha.webapp.routes import auth, requests, settings
+from alpha.webapp.routes import auth, expert_preview, requests, settings
 
 app = FastAPI()
 auth.install_dashboard_security(app)
 app.include_router(auth.router)
 app.include_router(requests.router)
 app.include_router(settings.router)
+app.include_router(expert_preview.router)
 ```
 
 The middleware installed by `install_dashboard_security` intercepts all
-requests whose path begins with `/requests`, `/settings`, or `/run`. Unauthenticated
-clients receive a redirect to `/login`. POST/PUT/PATCH/DELETE requests to these
-paths also require the `X-Alpha-CSRF` header to match the CSRF token stored in
+requests whose path begins with `/requests`, `/settings`, `/run`, or `/dashboard`.
+Unauthenticated clients receive a redirect to `/login`. POST/PUT/PATCH/DELETE
+requests to these paths also require the `X-Alpha-CSRF` header to match the CSRF token stored in
 the cookie.
+
+
+## Expert Preview Route
+
+The authenticated expert preview UI is available at `/dashboard/expert-preview`
+when `alpha.webapp.routes.expert_preview.router` is included. Operators can enter
+one prompt and compare two same-provider panes: `Plain provider output` uses the
+ordinary non-expert solve path, while `Alpha Solver expert preview` opts into the
+existing expert route with `context.route == "expert"`.
+
+The page is for supervised operator review only. It includes an explicit
+disclaimer that the preview does not prove Alpha Solver superiority, MVP
+validation, production readiness, broad runtime readiness, or answer-quality
+benchmark success. The behavioral demo checklist remains the review aid for
+behavior shape, and this UI does not replace eval evidence.
 
 ## Obtaining the CSRF Token
 

--- a/tests/ui/test_expert_preview.py
+++ b/tests/ui/test_expert_preview.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from alpha.providers import FakeProviderClient, ProviderCost, ProviderResult, ProviderUsage  # noqa: E402
+from alpha.webapp.routes import auth, expert_preview  # noqa: E402
+
+
+def _provider_result(text: str, *, raw_secret: str | None = None) -> ProviderResult:
+    return ProviderResult(
+        provider="openai",
+        model="gpt-test",
+        text=text,
+        finish_reason="stop",
+        usage=ProviderUsage(input_tokens=1, output_tokens=1, total_tokens=2),
+        cost=ProviderCost(estimated_usd=0.0, source="price_hint"),
+        latency_ms=1,
+        request_id="req-preview",
+        raw_metadata={"raw": raw_secret or "hidden", "provider_request_id": "provider-hidden"},
+    )
+
+
+@pytest.fixture()
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setenv("ALPHA_DASHBOARD_PASSWORD", "testing-secret")
+    monkeypatch.setenv("ALPHA_DASHBOARD_SECRET_KEY", "unit-test-secret")
+    monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    auth.reset_state()
+
+    app = FastAPI()
+    auth.install_dashboard_security(app)
+    app.include_router(auth.router)
+    app.include_router(expert_preview.router)
+
+    test_client = TestClient(app, base_url="https://testserver")
+    try:
+        yield test_client
+    finally:
+        test_client.close()
+        os.environ.pop("MODEL_PROVIDER", None)
+
+
+def _login(client: TestClient) -> str:
+    response = client.post("/login", data={"password": "testing-secret"}, follow_redirects=False)
+    assert response.status_code == 303
+    csrf_token = client.cookies.get(auth.CSRF_COOKIE_NAME)
+    assert csrf_token
+    return csrf_token
+
+
+def test_expert_preview_requires_authentication(client: TestClient) -> None:
+    response = client.get("/dashboard/expert-preview", follow_redirects=False)
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/login"
+
+
+def test_authenticated_user_can_access_preview_page(client: TestClient) -> None:
+    _login(client)
+
+    response = client.get("/dashboard/expert-preview")
+
+    assert response.status_code == 200
+    assert "Supervised preview only" in response.text
+    assert expert_preview.DISCLAIMER in response.text
+    assert "Plain provider output" in response.text
+    assert "Alpha Solver expert preview" in response.text
+
+
+def test_preview_submission_renders_plain_and_expert_outputs(client: TestClient) -> None:
+    csrf_token = _login(client)
+    raw_secret = "sk-preview-should-not-render"
+    fake = FakeProviderClient(
+        [
+            _provider_result("plain same-provider answer", raw_secret=raw_secret),
+            _provider_result(
+                '{"considerations":["Check timeline risk"],'
+                '"assumptions":["Budget is constrained"],"confidence":0.35}',
+                raw_secret=raw_secret,
+            ),
+            _provider_result("draft expert answer that clarify mode replaces", raw_secret=raw_secret),
+        ]
+    )
+    client.app.state.provider_client_factory = lambda _model_set: fake
+
+    response = client.post(
+        "/dashboard/expert-preview",
+        data={
+            "prompt": (
+                "Review this uncertain security migration plan with budget and timeline "
+                "risk, then decide the safest next step."
+            )
+        },
+        headers={auth.CSRF_HEADER_NAME: csrf_token},
+    )
+
+    assert response.status_code == 200
+    html = response.text
+    assert "plain same-provider answer" in html
+    assert "I need a few details before I can answer this well." in html
+    assert "Mode" in html
+    assert "clarify" in html
+    assert "Confidence" in html
+    assert "0.35" in html
+    assert "Complexity" in html
+    assert "complex" in html
+    assert "Call count" in html
+    assert "Check timeline risk" in html
+    assert "Budget is constrained" in html
+    assert "Clarifying questions" in html
+    assert "What is the main outcome you want from this request?" in html
+    assert "Details" in html
+
+    assert len(fake.requests) == 3
+    assert fake.requests[0].metadata["route"] == "tot"
+    assert fake.requests[1].metadata["route"] == "expert"
+    assert fake.requests[2].metadata["route"] == "expert"
+    assert len({request.model for request in fake.requests}) == 1
+
+    assert raw_secret not in html
+    assert "provider-hidden" not in html
+    assert "raw_metadata" not in html
+    assert "Authorization" not in html
+    assert "Bearer" not in html
+    assert "raw request" not in html.lower()
+    assert "raw response" not in html.lower()
+
+
+def test_preview_copy_keeps_claim_boundaries(client: TestClient) -> None:
+    _login(client)
+
+    response = client.get("/dashboard/expert-preview")
+
+    assert response.status_code == 200
+    body = response.text.lower()
+    assert "better answer" not in body
+    assert "benchmarked superiority" not in body
+    assert "validated mvp" not in body
+    assert "production-ready" not in body
+    assert "runtime-ready" not in body
+    assert "provider reasoning orchestration" not in body
+    assert "autonomous reasoning system" not in body
+    assert "live eval success" not in body


### PR DESCRIPTION
### Motivation

- Provide a narrow, authenticated supervised preview that lets an operator compare same-provider plain output with the Alpha Solver expert-framed output for the same prompt without implying superiority, MVP validation, or production readiness.
- Reuse existing dashboard auth/session/CSRF patterns and existing `/v1/solve` logic to keep the change minimal and testable with fake provider clients.

### Description

- Added a compact authenticated preview route at `/dashboard/expert-preview` implemented in `alpha/webapp/routes/expert_preview.py` that renders a prompt form, displays two panes (Plain provider output and Alpha Solver expert preview), shows the required supervised-preview disclaimer, surfaces expert-friendly fields (mode, confidence, complexity, call count, considerations, assumptions, clarifying questions), and hides raw engineering telemetry behind a `Details` disclosure.
- Reused the existing solve path by invoking `service.app.solve` internally: the plain pane calls the non-expert path and the expert pane calls with `context.route == "expert"` so provider expert-pass behavior is preserved.
- Reused the existing dashboard session/CSRF middleware by adding `/dashboard` to `_PROTECTED_PREFIXES` in `alpha/webapp/routes/auth.py` and added a small client-side form submit helper that includes the `X-Alpha-CSRF` header from the session cookie.
- Added the implementation contract `.specs/UI-PREVIEW-001.md`, registered it in `.specs/INDEX.md`, updated `docs/DASHBOARD_AUTH.md` with the expert preview route and claim boundaries, and added no-network route-level tests in `tests/ui/test_expert_preview.py` that use `FakeProviderClient`.

### Testing

- Ran `git diff --check` which passed.
- Focused UI/auth tests: `python -m pytest tests/ui/test_expert_preview.py -q` passed and verifies auth gating, disclaimer presence, both panes render, plain vs expert routing, surfacing of expert fields, and that raw provider metadata/secrets are not shown.
- Additional focused runs: `python -m pytest tests/ui/test_auth.py tests/test_api_endpoints.py -q` passed.
- Full test suite: `python -m pytest -q` produced an existing/intermittent failure in `tests/test_jwt_auth.py::test_rotation` (logged as `unknown_kid`) while the focused jwt test passes when run directly; this appears unrelated to the UI-PREVIEW-001 changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ce510c6608329b5e40e637df9de8d)