### PR TITLE
MVP-CLOSEOUT-001: add MVP tester handoff and readiness packet

### DIFF
--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -20,6 +20,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `MCP-006.md` | CODE SPEC — MCP-006 · Retry & Backoff (MCP) |
 | `MCP-007.md` | CODE SPEC — MCP-007 · MCP Observability hooks (MCP) |
 | `MCP-008.md` | MCP-008 · Domainless MCP Tool Allowlist Enforcement |
+| `MVP-CLOSEOUT-001.md` | MVP-CLOSEOUT-001 · MVP Tester Handoff and Readiness Packet |
 | `NEW-009.md` | CODE SPEC — NEW-009 · Clarify Templates Pack (RES_02) |
 | `NEW-010.md` | CODE SPEC — NEW-010 · Section-Specific Prompt Decks (RES_01) |
 | `NEW-011.md` | CODE SPEC — NEW-011 · Weight-Tuning Harness (RES-03 scoring) (RES_03) |

--- a/.specs/MVP-CLOSEOUT-001.md
+++ b/.specs/MVP-CLOSEOUT-001.md
@@ -1,0 +1,65 @@
+# MVP-CLOSEOUT-001 · MVP Tester Handoff and Readiness Packet
+
+## Objective
+
+Add a final, operator-facing MVP closeout packet that makes the current MVP lanes testable, explainable, and handoff-ready without adding runtime features or expanding product scope.
+
+## Scope
+
+- Add `docs/MVP_TESTER_HANDOFF.md` as the canonical final MVP tester/operator handoff packet.
+- Document the five completed MVP lanes:
+  - `PROVIDER-EXPERT-PASS-001`
+  - `CLARIFY-SURFACE-001`
+  - `EVAL-ARTIFACT-PRESERVE-001`
+  - `EVAL-BEHAVIORAL-DEMO-001`
+  - `UI-PREVIEW-001`
+- Include local and focused test commands.
+- Explain `/v1/solve` expert-route behavior at an operator level.
+- Explain `/dashboard/expert-preview` authenticated preview usage and claim boundaries.
+- Reference `docs/evals/EXPERT_PASS_BEHAVIORAL_DEMO.md` and `docs/evals/runs/answer_quality_no_live_summary.json`.
+- Add a small no-network docs integrity test for the handoff packet.
+
+## Acceptance criteria
+
+- The final MVP tester handoff document exists.
+- It explains all five implemented MVP lanes.
+- It gives clear local and focused testing commands.
+- It explains authenticated expert preview UI usage.
+- It references the behavioral demo checklist.
+- It references the durable no-live eval summary artifact.
+- It states claim boundaries clearly.
+- It lists known limitations and out-of-scope items.
+- No runtime behavior changes are made.
+- No live provider tests are added.
+
+## Backlog impact
+
+`MVP-CLOSEOUT-001` should be marked Done only after the PR implementing this spec is merged. Add that PR as implementation evidence for final MVP handoff/readiness documentation.
+
+Existing lane rows remain tied to their own implementation PRs:
+
+- `PROVIDER-EXPERT-PASS-001`: PR #199
+- `CLARIFY-SURFACE-001`: PR #200
+- `EVAL-ARTIFACT-PRESERVE-001`: PR #201
+- `EVAL-BEHAVIORAL-DEMO-001`: PR #202
+- `UI-PREVIEW-001`: PR #203
+
+Do not mutate uncertain legacy concept rows. Do not touch Review Queue concept rows unless the human operator specifically requests it.
+
+## Non-goals
+
+- No runtime behavior changes.
+- No provider expert-pass behavior changes.
+- No clarify behavior changes.
+- No eval artifact behavior changes.
+- No behavioral demo behavior changes.
+- No preview UI behavior changes.
+- No MVP validation claim.
+- No Alpha Solver superiority claim.
+- No answer-quality superiority claim.
+- No production-readiness claim.
+- No broad runtime-readiness claim.
+- No answer-quality benchmark success claim.
+- No provider reasoning orchestration claim.
+- No live provider tests.
+- No backlog workbook edits.

--- a/docs/MVP_TESTER_HANDOFF.md
+++ b/docs/MVP_TESTER_HANDOFF.md
@@ -1,0 +1,173 @@
+# MVP-CLOSEOUT-001 · MVP Tester Handoff and Readiness Packet
+
+## 1. Purpose
+
+This packet is a tester/operator handoff for the current Alpha Solver MVP lanes. It collects what landed, how to run no-network checks, how to inspect the supervised expert preview, where evidence artifacts live, and which claims are explicitly outside this closeout lane.
+
+This document is intentionally narrow. It does not add runtime behavior, provider behavior, clarify behavior, eval behavior, preview UI behavior, live-provider tests, or product features.
+
+## 2. MVP contents
+
+The current MVP handoff covers these completed implementation lanes:
+
+- `PROVIDER-EXPERT-PASS-001`: opt-in expert provider pass for complex OpenAI requests on `/v1/solve` when the request context selects `route: "expert"`.
+- `CLARIFY-SURFACE-001`: clarify questions surfaced when the expert route produces clarify mode.
+- `EVAL-ARTIFACT-PRESERVE-001`: no-live eval summary artifacts preserved under `docs/evals/runs/`.
+- `EVAL-BEHAVIORAL-DEMO-001`: expert-pass behavioral demo checklist for operator review.
+- `UI-PREVIEW-001`: authenticated plain-vs-expert preview UI for supervised operator comparison.
+
+## 3. How to run local tests
+
+Use the offline/local test path first. These commands should not require live provider credentials:
+
+```bash
+git diff --check
+python -m pytest -q
+```
+
+Focused checks for this handoff and its underlying MVP lanes:
+
+```bash
+python -m pytest tests/test_api_endpoints.py -q
+python -m pytest tests/test_answer_quality_eval.py -q
+python -m pytest tests/ui/test_expert_preview.py -q
+```
+
+## 4. How to test the provider expert route
+
+The provider expert route is exercised through `/v1/solve` with OpenAI provider mode explicitly enabled and request context containing `route: "expert"`. No live OpenAI call is required for the committed route tests; they use the repository fake provider client.
+
+Expected route behavior to verify with the focused API tests:
+
+- complex prompts use the expert route and return an expert envelope with `answer`, `final_answer`, `considerations`, `assumptions`, `confidence`, `mode`, and `meta`;
+- trivial prompts remain direct/simple and avoid unnecessary expert complexity;
+- non-expert provider requests preserve the ordinary provider pass-through shape;
+- raw provider metadata, request IDs, authorization headers, bearer tokens, request bodies, response bodies, and secrets are not exposed in responses.
+
+Run:
+
+```bash
+python -m pytest tests/test_api_endpoints.py -q
+```
+
+## 5. How to test clarify behavior
+
+Clarify behavior is bounded to the expert-route response shape. When the expert route determines that the request is under-specified, it should return `mode == "clarify"`, a concise clarification-facing `answer`/`final_answer`, and a bounded `clarifying_questions` list.
+
+Expected clarify behavior:
+
+- clarify questions are surfaced only when clarify mode is produced;
+- direct/trivial expert responses do not add clarify questions;
+- block mode remains distinct from clarify mode and does not add clarify questions;
+- clarify output does not expose raw provider metadata or secrets.
+
+Run:
+
+```bash
+python -m pytest tests/test_api_endpoints.py -q
+```
+
+## 6. How to access and use the authenticated expert preview UI
+
+The supervised preview route is:
+
+```text
+/dashboard/expert-preview
+```
+
+Usage expectations:
+
+- Authentication is required before loading `/dashboard/expert-preview`.
+- Logged-out users should be blocked and redirected to login by the dashboard auth flow.
+- The plain pane means same-provider non-expert output.
+- The expert pane means same-provider output with `context.route == "expert"`.
+- The visible supervised-preview disclaimer must remain visible.
+- Raw metadata, raw request bodies, raw response bodies, authorization headers, API keys, bearer tokens, and other secrets must not be exposed.
+- The preview is for supervised comparison and explanation, not an automated quality judgment.
+
+Run:
+
+```bash
+python -m pytest tests/ui/test_expert_preview.py -q
+```
+
+See also `docs/DASHBOARD_AUTH.md` for dashboard authentication setup and expectations.
+
+## 7. How to use the behavioral demo checklist
+
+Use `docs/evals/EXPERT_PASS_BEHAVIORAL_DEMO.md` as the compact behavioral demo checklist for operator review. It describes representative prompt shapes for trivial, complex planning, messy/vague, clarify-needed, assumption-heavy, block-sensitive, and provider pass-through cases.
+
+The checklist is a review aid. It should be used to observe routing and envelope behavior, clarify behavior, assumptions, and block-vs-clarify separation. It is not a substitute for live evaluation or real user testing.
+
+## 8. Where eval summary artifacts live
+
+The durable no-live answer-quality summary artifact lives at:
+
+```text
+docs/evals/runs/answer_quality_no_live_summary.json
+```
+
+Use `docs/evals/ANSWER_QUALITY_EVAL.md` for the broader answer-quality eval procedure, including the distinction between no-live artifacts and gated live evaluation. The committed no-live artifact is preserved as evidence that the no-live eval summary path works; it is not proof of answer-quality performance.
+
+## 9. What evidence exists
+
+Current evidence for this MVP handoff includes:
+
+- route-level `/v1/solve` tests for provider pass-through, expert route behavior, clarify mode, block-vs-clarify separation, and response secret redaction;
+- authenticated preview UI tests for login gating, disclaimer visibility, plain-vs-expert rendering, same-provider routing, public metadata rendering, and secret redaction;
+- answer-quality eval tests for dataset shape, dry-run/no-live behavior, durable summary artifact preservation, repeatability reporting, and claim-boundary language;
+- `docs/evals/EXPERT_PASS_BEHAVIORAL_DEMO.md` as the operator-facing behavioral demo checklist;
+- `docs/evals/runs/answer_quality_no_live_summary.json` as the durable no-live eval summary artifact.
+
+## 10. What is not claimed
+
+This handoff states the following claim boundaries explicitly:
+
+- This is a tester/operator handoff.
+- It does not prove MVP validation.
+- It does not prove Alpha Solver superiority.
+- It does not prove answer-quality superiority.
+- It does not prove production readiness.
+- It does not prove broad runtime readiness.
+- It does not prove answer-quality benchmark success.
+- It does not implement or claim provider reasoning orchestration.
+- It does not replace live evaluation or real user testing.
+
+## 11. Known limitations
+
+- Expert preview is supervised/operator-facing.
+- Confidence is a preview/self-rating or mode signal, not calibrated truth.
+- No answer-quality superiority benchmark has been passed.
+- Live provider use remains gated and should be operator-supervised.
+- MVP behavior is bounded to the implemented lanes listed in this packet.
+- Further hardening may be needed before production deployment.
+
+## 12. Out-of-scope items
+
+This closeout lane does not include:
+
+- runtime behavior changes;
+- provider expert-pass behavior changes;
+- clarify behavior changes;
+- eval artifact behavior changes;
+- behavioral demo behavior changes;
+- preview UI behavior changes;
+- live provider tests;
+- broad provider orchestration, provider loops, fan-out, verify-revise behavior, or re-synthesis;
+- a broad eval platform;
+- backlog workbook edits;
+- edits to uncertain legacy concept rows or Review Queue concept rows.
+
+## 13. Backlog impact
+
+- `MVP-CLOSEOUT-001` should be marked Done only if the PR that adds this packet is merged.
+- Add the PR as implementation evidence for final MVP handoff/readiness documentation.
+- Existing lane rows should remain tied to their own implementation PRs:
+  - `PROVIDER-EXPERT-PASS-001`: PR #199
+  - `CLARIFY-SURFACE-001`: PR #200
+  - `EVAL-ARTIFACT-PRESERVE-001`: PR #201
+  - `EVAL-BEHAVIORAL-DEMO-001`: PR #202
+  - `UI-PREVIEW-001`: PR #203
+- Do not mutate uncertain legacy concept rows.
+- Do not touch Review Queue concept rows unless the human operator specifically requests it.
+- Do not claim MVP validation, Alpha Solver superiority, production readiness, broad runtime readiness, answer-quality benchmark success, or provider reasoning orchestration.

--- a/tests/test_answer_quality_eval.py
+++ b/tests/test_answer_quality_eval.py
@@ -563,3 +563,57 @@ def test_live_repeatability_total_cost_ceiling_refuses_before_provider_call(monk
     assert "estimated cost" in report["stopped_reason"]
     assert client.requests == []
     assert (Path(report["artifact_dir"]) / "repeatability_summary.json").exists()
+
+
+def test_mvp_tester_handoff_doc_covers_closeout_boundaries():
+    doc_path = Path("docs/MVP_TESTER_HANDOFF.md")
+
+    assert doc_path.exists()
+    text = doc_path.read_text(encoding="utf-8")
+    lower = text.lower()
+
+    for lane in (
+        "PROVIDER-EXPERT-PASS-001",
+        "CLARIFY-SURFACE-001",
+        "EVAL-ARTIFACT-PRESERVE-001",
+        "EVAL-BEHAVIORAL-DEMO-001",
+        "UI-PREVIEW-001",
+    ):
+        assert lane in text
+
+    for required_reference in (
+        "/dashboard/expert-preview",
+        "docs/evals/EXPERT_PASS_BEHAVIORAL_DEMO.md",
+        "docs/evals/runs/answer_quality_no_live_summary.json",
+    ):
+        assert required_reference in text
+
+    for required_boundary in (
+        "This is a tester/operator handoff.",
+        "It does not prove MVP validation.",
+        "It does not prove Alpha Solver superiority.",
+        "It does not prove answer-quality superiority.",
+        "It does not prove production readiness.",
+        "It does not prove broad runtime readiness.",
+        "It does not prove answer-quality benchmark success.",
+        "It does not implement or claim provider reasoning orchestration.",
+        "It does not replace live evaluation or real user testing.",
+    ):
+        assert required_boundary in text
+
+    assert "production-ready" not in lower
+    assert "validated superiority" not in lower
+    for positive_claim in (
+        "proves mvp validation",
+        "proves alpha solver superiority",
+        "proves answer-quality superiority",
+        "proves production readiness",
+        "proves broad runtime readiness",
+        "proves answer-quality benchmark success",
+        "claims provider reasoning orchestration",
+    ):
+        assert positive_claim not in lower
+
+    for line in text.splitlines():
+        if "benchmark success" in line.lower() or "provider reasoning orchestration" in line.lower():
+            assert "does not" in line.lower() or "do not" in line.lower()


### PR DESCRIPTION
### Motivation

- Produce a final operator-facing MVP closeout/handoff packet that collects the implemented MVP lanes, testing steps, evidence artifacts, claim boundaries, and known limitations so an operator or evaluator can test and review the MVP without adding runtime behavior. 
- Keep the change narrow and documentation-only so the current MVP is explainable and handoff-ready while avoiding any overclaiming of validation, performance, or production readiness.

### Description

- Add `docs/MVP_TESTER_HANDOFF.md` as the canonical MVP tester handoff/readiness packet containing purpose, MVP contents, how to run local/focused tests, provider expert-route and clarify testing guidance, authenticated preview UI usage (`/dashboard/expert-preview`), behavioral demo checklist reference, durable eval artifact path, claim boundaries, known limitations, out-of-scope items, and backlog impact.
- Add `.specs/MVP-CLOSEOUT-001.md` and register it in `.specs/INDEX.md` to record the docs-only closeout lane and its acceptance criteria.
- Add a small no-network docs integrity test in `tests/test_answer_quality_eval.py` that verifies `docs/MVP_TESTER_HANDOFF.md` exists, references the five MVP lanes, references `/dashboard/expert-preview`, references `docs/evals/EXPERT_PASS_BEHAVIORAL_DEMO.md` and `docs/evals/runs/answer_quality_no_live_summary.json`, includes required claim boundaries, and avoids forbidden positive claims.
- Scope boundaries: this PR is docs/spec/test updates only; it makes no runtime, provider, clarify, eval artifact preservation, behavioral-demo, or preview-UI behavior changes and does not add live provider tests or claim MVP validation, superiority, production readiness, or provider reasoning orchestration.

### Testing

- Ran `git diff --check` and focused pytest commands as recommended: `python -m pytest tests/test_answer_quality_eval.py -q`, `python -m pytest tests/test_api_endpoints.py -q`, and `python -m pytest tests/ui/test_expert_preview.py -q`; these focused test runs passed.
- Ran the full test suite with `python -m pytest -q`; an intermittent/order-dependent failure occurred on `tests/test_jwt_auth.py::test_rotation` in the full-suite run (JWT `unknown_kid`), while the same test passed when run directly; this appears to be an existing ordering/full-suite artifact unrelated to the docs-only changes.
- The added docs integrity test passed in focused runs and validates the required references and claim boundaries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ce8aecbd4832994af508765496ca1)