### PR TITLE
Add expert-preview dashboard page behind authentication

### DIFF
--- a/alpha/webapp/routes/auth.py
+++ b/alpha/webapp/routes/auth.py
@@ -22,6 +22,8 @@ __all__ = [
     "SESSION_COOKIE_NAME",
     "CSRF_COOKIE_NAME",
     "CSRF_HEADER_NAME",
+    "PASSWORD_ENV_VAR",
+    "DEFAULT_DASHBOARD_PASSWORD",
 ]
 
 
@@ -32,6 +34,10 @@ CSRF_HEADER_NAME = "x-alpha-csrf"
 
 PASSWORD_ENV_VAR = "ALPHA_DASHBOARD_PASSWORD"
 SECRET_ENV_VAR = "ALPHA_DASHBOARD_SECRET_KEY"
+
+# Fallback password used only when PASSWORD_ENV_VAR is unset. Callers that mount
+# the dashboard on a public app should treat this value as "not configured".
+DEFAULT_DASHBOARD_PASSWORD = "alpha-dashboard"
 
 SESSION_TTL_SECONDS = 60 * 60  # one hour
 LOCKOUT_THRESHOLD = 5
@@ -220,7 +226,7 @@ async def _extract_login_payload(request: Request) -> Dict[str, str]:
 def _expected_password() -> str:
     password = os.getenv(PASSWORD_ENV_VAR)
     if password is None:
-        return "alpha-dashboard"
+        return DEFAULT_DASHBOARD_PASSWORD
     return password
 
 

--- a/docs/DASHBOARD_AUTH.md
+++ b/docs/DASHBOARD_AUTH.md
@@ -65,6 +65,21 @@ validation, production readiness, broad runtime readiness, or answer-quality
 benchmark success. The behavioral demo checklist remains the review aid for
 behavior shape, and this UI does not replace eval evidence.
 
+### Mounting in the bundled API app
+
+In the bundled API application (`service.app:app`), the dashboard — the login
+routes plus `/dashboard/expert-preview` — is mounted **only when a non-default
+`ALPHA_DASHBOARD_PASSWORD` is configured**. If the password is unset or left at
+the documented default, the dashboard is not mounted (its routes return 404), a
+warning is logged, and the JSON API keeps serving normally. This fails closed so
+a misconfigured deployment never exposes the provider-backed preview behind the
+well-known default password.
+
+**Known limitation (deferred):** a successful login redirects to `/requests`,
+which the bundled API app does not mount, so the post-login landing returns 404.
+After logging in, open `/dashboard/expert-preview` directly. A follow-up will
+make the post-login destination configurable.
+
 ## Obtaining the CSRF Token
 
 The CSRF token for the current session is exposed via the

--- a/docs/evals/EXPERT_PASS_BEHAVIORAL_DEMO.md
+++ b/docs/evals/EXPERT_PASS_BEHAVIORAL_DEMO.md
@@ -84,7 +84,7 @@ This checklist explicitly states:
 - `PROVIDER-EXPERT-PASS-001` remains Done from PR #199.
 - `CLARIFY-SURFACE-001` remains separate and should only be marked Done if PR #200 was merged.
 - `EVAL-ARTIFACT-PRESERVE-001` remains separate and should only be marked Done if PR #201 was merged.
-- UI-PREVIEW-001 remains held and not implemented.
+- UI-PREVIEW-001 is implemented and operator-accessible at `/dashboard/expert-preview` (behind dashboard authentication).
 - Do not edit the Google Sheet from Codex.
 - Do not update uncertain legacy concept rows.
 - Do not touch Review Queue concept rows unless the human operator specifically requests it.

--- a/service/app.py
+++ b/service/app.py
@@ -169,9 +169,36 @@ app.add_middleware(
 # Dashboard UI: login/session plus the supervised expert-preview page. This
 # reuses the shared dashboard auth/CSRF middleware (see alpha/webapp/routes/auth.py)
 # so /dashboard/* is protected; we intentionally mount only auth + expert-preview.
-dashboard_auth.install_dashboard_security(app)
-app.include_router(dashboard_auth.router)
-app.include_router(expert_preview.router)
+#
+# Fail closed: mount the dashboard only when a non-default ALPHA_DASHBOARD_PASSWORD
+# is configured. Otherwise /login and the provider-backed preview would sit behind
+# the well-known default password on any deployment that forgot to set one, so we
+# skip mounting (routes 404), log a warning, and leave the JSON API fully working.
+#
+# Known limitation (tracked, deferred): a successful login redirects to /requests
+# (alpha.webapp.routes.auth.login), which this app does not mount, so the post-login
+# landing 404s. Operators should open /dashboard/expert-preview directly. A follow-up
+# should make the post-login destination configurable; we do not change the shared
+# auth redirect here.
+def _dashboard_enabled() -> bool:
+    password = os.getenv(dashboard_auth.PASSWORD_ENV_VAR)
+    return bool(password) and password != dashboard_auth.DEFAULT_DASHBOARD_PASSWORD
+
+
+def _mount_dashboard(target: FastAPI) -> None:
+    dashboard_auth.install_dashboard_security(target)
+    target.include_router(dashboard_auth.router)
+    target.include_router(expert_preview.router)
+
+
+if _dashboard_enabled():
+    _mount_dashboard(app)
+else:
+    logger.warning(
+        "Dashboard UI disabled: set a non-default %s to enable /dashboard/* "
+        "(login + supervised expert-preview).",
+        dashboard_auth.PASSWORD_ENV_VAR,
+    )
 
 
 def _is_openai_provider_enabled() -> bool:

--- a/service/app.py
+++ b/service/app.py
@@ -70,6 +70,7 @@ from .security import validate_api_key, sanitize_query
 from .otel import init_tracer
 from .health import healthcheck
 from .gating.gates import evaluate_gates
+from alpha.webapp.routes import auth as dashboard_auth, expert_preview
 
 
 class JsonFormatter(logging.Formatter):
@@ -164,6 +165,13 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Dashboard UI: login/session plus the supervised expert-preview page. This
+# reuses the shared dashboard auth/CSRF middleware (see alpha/webapp/routes/auth.py)
+# so /dashboard/* is protected; we intentionally mount only auth + expert-preview.
+dashboard_auth.install_dashboard_security(app)
+app.include_router(dashboard_auth.router)
+app.include_router(expert_preview.router)
 
 
 def _is_openai_provider_enabled() -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+"""Session-wide test configuration.
+
+The bundled API app (``service.app:app``) only mounts the dashboard UI when a
+non-default ``ALPHA_DASHBOARD_PASSWORD`` is configured (fail-closed). That
+decision is made at import time, so the password must already be present before
+any test module imports ``service.app``. pytest imports this rootdir conftest
+before collecting test modules, so setting the values here keeps the real-app
+dashboard tests exercising a configured deployment. Individual tests still
+override these via ``monkeypatch`` as needed.
+"""
+
+import os
+
+os.environ.setdefault("ALPHA_DASHBOARD_PASSWORD", "ci-dashboard-secret")
+os.environ.setdefault("ALPHA_DASHBOARD_SECRET_KEY", "ci-dashboard-signing-key")

--- a/tests/test_answer_quality_eval.py
+++ b/tests/test_answer_quality_eval.py
@@ -305,7 +305,7 @@ def test_expert_pass_behavioral_demo_checklist_documents_scope_and_boundaries():
 
     assert "docs/evals/runs/answer_quality_no_live_summary.json" in text
     assert "must not require live OpenAI calls" in text
-    assert "UI-PREVIEW-001 remains held and not implemented" in text
+    assert "UI-PREVIEW-001 is implemented and operator-accessible" in text
 
 
 def test_live_requires_explicit_env_gate_even_with_client_and_key(monkeypatch, tmp_path):

--- a/tests/ui/test_expert_preview_real_app.py
+++ b/tests/ui/test_expert_preview_real_app.py
@@ -13,6 +13,7 @@ import sys
 from pathlib import Path
 
 import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
@@ -21,7 +22,7 @@ if str(PROJECT_ROOT) not in sys.path:
 
 from alpha.providers import FakeProviderClient, ProviderCost, ProviderResult, ProviderUsage  # noqa: E402
 from alpha.webapp.routes import auth, expert_preview  # noqa: E402
-from service.app import app  # noqa: E402
+from service.app import app, _dashboard_enabled, _mount_dashboard  # noqa: E402
 
 ROUTE = "/dashboard/expert-preview"
 
@@ -136,3 +137,35 @@ def test_preview_post_without_csrf_is_rejected(client: TestClient) -> None:
     response = client.post(ROUTE, data={"prompt": "hello"}, follow_redirects=False)
 
     assert response.status_code == 403
+
+
+def test_dashboard_disabled_when_password_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ALPHA_DASHBOARD_PASSWORD", raising=False)
+    assert _dashboard_enabled() is False
+
+
+def test_dashboard_disabled_when_password_is_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ALPHA_DASHBOARD_PASSWORD", auth.DEFAULT_DASHBOARD_PASSWORD)
+    assert _dashboard_enabled() is False
+
+
+def test_dashboard_enabled_when_password_non_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ALPHA_DASHBOARD_PASSWORD", "a-strong-operator-secret")
+    assert _dashboard_enabled() is True
+
+
+def test_mount_dashboard_adds_protected_routes() -> None:
+    fresh = FastAPI()
+    _mount_dashboard(fresh)
+
+    paths = {getattr(route, "path", None) for route in fresh.routes}
+    assert ROUTE in paths
+    assert "/login" in paths
+
+    fresh_client = TestClient(fresh, base_url="https://testserver")
+    try:
+        response = fresh_client.get(ROUTE, follow_redirects=False)
+    finally:
+        fresh_client.close()
+    assert response.status_code == 303
+    assert response.headers["location"] == "/login"

--- a/tests/ui/test_expert_preview_real_app.py
+++ b/tests/ui/test_expert_preview_real_app.py
@@ -1,0 +1,138 @@
+"""Wiring/auth tests for the expert-preview page against the REAL application.
+
+These complement ``tests/ui/test_expert_preview.py`` (which exercises the router
+inside a throwaway fixture app). They assert that ``/dashboard/expert-preview`` is
+actually mounted on ``service.app:app`` and protected by the shared dashboard
+auth/CSRF middleware. ``test_route_registered_in_real_app`` is the regression test
+that would have caught the route being absent from the runnable app.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from alpha.providers import FakeProviderClient, ProviderCost, ProviderResult, ProviderUsage  # noqa: E402
+from alpha.webapp.routes import auth, expert_preview  # noqa: E402
+from service.app import app  # noqa: E402
+
+ROUTE = "/dashboard/expert-preview"
+
+
+def _provider_result(text: str, *, raw_secret: str | None = None) -> ProviderResult:
+    return ProviderResult(
+        provider="openai",
+        model="gpt-test",
+        text=text,
+        finish_reason="stop",
+        usage=ProviderUsage(input_tokens=1, output_tokens=1, total_tokens=2),
+        cost=ProviderCost(estimated_usd=0.0, source="price_hint"),
+        latency_ms=1,
+        request_id="req-preview",
+        raw_metadata={"raw": raw_secret or "hidden", "provider_request_id": "provider-hidden"},
+    )
+
+
+@pytest.fixture()
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setenv("ALPHA_DASHBOARD_PASSWORD", "testing-secret")
+    monkeypatch.setenv("ALPHA_DASHBOARD_SECRET_KEY", "unit-test-secret")
+    monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    auth.reset_state()
+
+    # ``base_url`` must be https: login sets Secure cookies, which the test client
+    # only stores (and resends) over https.
+    test_client = TestClient(app, base_url="https://testserver")
+    try:
+        yield test_client
+    finally:
+        test_client.close()
+        auth.reset_state()
+
+
+def _login(client: TestClient) -> str:
+    response = client.post("/login", data={"password": "testing-secret"}, follow_redirects=False)
+    assert response.status_code == 303
+    csrf_token = client.cookies.get(auth.CSRF_COOKIE_NAME)
+    assert csrf_token
+    return csrf_token
+
+
+def test_route_registered_in_real_app() -> None:
+    """Regression test: the page must be mounted on the runnable app."""
+
+    paths = {getattr(route, "path", None) for route in app.routes}
+    assert ROUTE in paths
+
+
+def test_logged_out_request_redirects_to_login(client: TestClient) -> None:
+    response = client.get(ROUTE, follow_redirects=False)
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/login"
+
+
+def test_authenticated_request_renders_page(client: TestClient) -> None:
+    _login(client)
+
+    response = client.get(ROUTE)
+
+    assert response.status_code == 200
+    assert expert_preview.DISCLAIMER in response.text
+
+
+def test_preview_post_uses_fake_provider_without_network(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    csrf_token = _login(client)
+    raw_secret = "sk-preview-should-not-render"
+    fake = FakeProviderClient(
+        [
+            _provider_result("plain same-provider answer", raw_secret=raw_secret),
+            _provider_result(
+                '{"considerations":["Check timeline risk"],'
+                '"assumptions":["Budget is constrained"],"confidence":0.35}',
+                raw_secret=raw_secret,
+            ),
+            _provider_result("draft expert answer that clarify mode replaces", raw_secret=raw_secret),
+        ]
+    )
+    # Inject the fake on the shared app singleton via monkeypatch so it is restored
+    # afterwards and never leaks into other tests that import the real app.
+    monkeypatch.setattr(app.state, "provider_client_factory", lambda _model_set: fake, raising=False)
+
+    response = client.post(
+        ROUTE,
+        data={
+            "prompt": (
+                "Review this uncertain security migration plan with budget and timeline "
+                "risk, then decide the safest next step."
+            )
+        },
+        headers={auth.CSRF_HEADER_NAME: csrf_token},
+    )
+
+    assert response.status_code == 200
+    html = response.text
+    assert "plain same-provider answer" in html
+    # Three deterministic fake calls (plain tot pass + two expert passes) prove the
+    # preview ran end-to-end with no live provider/network dependency.
+    assert len(fake.requests) == 3
+    # Provider secrets must never reach the rendered page.
+    assert raw_secret not in html
+    assert "provider-hidden" not in html
+
+
+def test_preview_post_without_csrf_is_rejected(client: TestClient) -> None:
+    _login(client)
+
+    response = client.post(ROUTE, data={"prompt": "hello"}, follow_redirects=False)
+
+    assert response.status_code == 403


### PR DESCRIPTION
## Summary

Implements the expert-preview dashboard UI page (`/dashboard/expert-preview`) by:
1. Mounting the expert-preview router on the main application
2. Installing shared dashboard authentication and CSRF middleware
3. Adding comprehensive integration tests against the real app

This makes the expert-preview feature operator-accessible behind dashboard authentication, completing `UI-PREVIEW-001` from the behavioral demo checklist.

## Changes

### `service/app.py`
- Import dashboard auth and expert-preview routers from `alpha.webapp.routes`
- Install dashboard security middleware via `dashboard_auth.install_dashboard_security(app)`
- Register both `dashboard_auth.router` and `expert_preview.router` on the main app
- Routes are now protected by shared auth/CSRF middleware

### `tests/ui/test_expert_preview_real_app.py` (new)
Added integration tests that verify:
- Route is registered on the real application (regression test)
- Unauthenticated requests redirect to login
- Authenticated requests render the page with disclaimer
- POST requests use the fake provider without network calls
- CSRF protection is enforced on POST requests

Tests use environment variable injection and monkeypatching to avoid network dependencies while validating the full auth/CSRF flow.

### `docs/evals/EXPERT_PASS_BEHAVIORAL_DEMO.md`
- Updated `UI-PREVIEW-001` status: now implemented and operator-accessible at `/dashboard/expert-preview`

## Checklist

- [ ] Spec linked: `.specs/<file>.md`
- [ ] Spec sections present/updated (Goal / Motivation / Acceptance Criteria / Definition of Done / Code Targets / Test Plan)
- [x] Tests run: `python -m pytest -q` (new integration tests added and pass)

## Notes for reviewers

The new test file complements existing `tests/ui/test_expert_preview.py` by testing the router in isolation. `test_expert_preview_real_app.py` validates that the route is actually mounted on the runnable application and protected by the shared dashboard middleware—catching regressions where the route might be absent or improperly secured.

The `test_route_registered_in_real_app()` test is the key regression check that would have caught the route being missing from the real app.

https://claude.ai/code/session_01Jrn4BsdoyMvahhWvcEsnNR