### PR TITLE
Handle unstructured expert preview confidence and surface parse status

### DIFF
--- a/alpha/webapp/routes/expert_preview.py
+++ b/alpha/webapp/routes/expert_preview.py
@@ -40,7 +40,16 @@ def _public_meta(payload: Mapping[str, Any]) -> Dict[str, Any]:
     meta = payload.get("meta")
     if not isinstance(meta, Mapping):
         return {}
-    allowed = ("route", "complexity", "provider", "model", "model_set", "call_count")
+    allowed = (
+        "route",
+        "complexity",
+        "provider",
+        "model",
+        "model_set",
+        "call_count",
+        "preview_parse_status",
+        "confidence_available",
+    )
     return {key: meta[key] for key in allowed if key in meta}
 
 
@@ -69,9 +78,14 @@ def _render_expert_payload(payload: Mapping[str, Any] | None) -> str:
     if payload is None:
         return '<p class="empty">Submit a prompt to render the Alpha Solver expert preview.</p>'
     meta = _public_meta(payload)
+    confidence = (
+        "unavailable"
+        if meta.get("confidence_available") is False
+        else payload.get("confidence", "—")
+    )
     rows = [
         ("Mode", payload.get("mode", "—")),
-        ("Confidence", payload.get("confidence", "—")),
+        ("Confidence", confidence),
         ("Complexity", meta.get("complexity", "—")),
         ("Call count", meta.get("call_count", "—")),
     ]

--- a/service/app.py
+++ b/service/app.py
@@ -441,6 +441,7 @@ _MULTI_PART_MARKERS = (
 
 
 _CONFIDENCE_RE = re.compile(r"(?i)confidence[^0-9%]*(\d+(?:\.\d+)?)\s*(%)?")
+_PERCENT_RE = re.compile(r"(\d+(?:\.\d+)?)\s*%")
 
 
 def _is_expert_route(params: Dict[str, Any]) -> bool:
@@ -473,12 +474,12 @@ def _as_string_list(value: Any) -> list[str]:
     return []
 
 
-def _confidence_value(value: Any) -> float:
+def _parse_confidence_value(value: Any) -> float | None:
     raw: float | None = None
     if isinstance(value, (int, float)) and not isinstance(value, bool):
         raw = float(value)
     elif isinstance(value, str):
-        match = _CONFIDENCE_RE.search(value) or re.search(r"(\d+(?:\.\d+)?)\s*%", value)
+        match = _CONFIDENCE_RE.search(value) or _PERCENT_RE.search(value)
         if match:
             raw = float(match.group(1))
             if match.lastindex and match.group(match.lastindex) == "%":
@@ -489,31 +490,51 @@ def _confidence_value(value: Any) -> float:
             except ValueError:
                 raw = None
     if raw is None:
-        return 0.0
+        return None
     if raw > 1.0:
         raw /= 100.0
     return max(0.0, min(1.0, raw))
 
 
+def _confidence_value(value: Any) -> float:
+    parsed = _parse_confidence_value(value)
+    return 0.0 if parsed is None else parsed
+
+
 def _parse_expert_preview(text: str) -> dict[str, Any]:
     data: dict[str, Any] = {}
+    parse_status = "unstructured"
     try:
         parsed = json.loads(text)
     except json.JSONDecodeError:
         parsed = None
     if isinstance(parsed, dict):
         data = parsed
-    confidence_source = data.get("confidence", text)
+        parse_status = "json"
+
+    confidence_source = data.get("confidence") if "confidence" in data else text
+    parsed_confidence = _parse_confidence_value(confidence_source)
+    confidence_available = parsed_confidence is not None
+
     considerations = _as_string_list(data.get("considerations"))
     assumptions = _as_string_list(data.get("assumptions"))
     if not considerations:
         considerations = _extract_section_list(text, "considerations")
+        if considerations and parse_status == "unstructured":
+            parse_status = "sections"
     if not assumptions:
         assumptions = _extract_section_list(text, "assumptions")
+        if assumptions and parse_status == "unstructured":
+            parse_status = "sections"
+    if confidence_available and parse_status == "unstructured":
+        parse_status = "sections"
+
     return {
         "considerations": considerations,
         "assumptions": assumptions,
-        "confidence": _confidence_value(confidence_source),
+        "confidence": 0.0 if parsed_confidence is None else parsed_confidence,
+        "confidence_available": confidence_available,
+        "preview_parse_status": parse_status,
     }
 
 
@@ -564,6 +585,9 @@ def _expert_step_two_prompt(query: str, preview: dict[str, Any]) -> str:
 
 
 _CLARIFY_MESSAGE = "I need a few details before I can answer this well."
+_BLOCK_MESSAGE = (
+    "I cannot safely provide a final answer for this request in the supervised preview."
+)
 
 
 def _clarifying_questions_for_expert_request(
@@ -606,7 +630,21 @@ def _expert_response(
     model: str,
     call_count: int,
     clarifying_questions: list[str] | None = None,
+    preview_parse_status: str | None = None,
+    confidence_available: bool | None = None,
 ) -> Dict[str, Any]:
+    meta = {
+        "route": "expert",
+        "complexity": complexity,
+        "provider": provider,
+        "model": model,
+        "call_count": call_count,
+    }
+    if preview_parse_status is not None:
+        meta["preview_parse_status"] = preview_parse_status
+    if confidence_available is not None:
+        meta["confidence_available"] = confidence_available
+
     response = {
         "final_answer": answer,
         "answer": answer,
@@ -614,13 +652,7 @@ def _expert_response(
         "assumptions": assumptions,
         "confidence": confidence,
         "mode": mode,
-        "meta": {
-            "route": "expert",
-            "complexity": complexity,
-            "provider": provider,
-            "model": model,
-            "call_count": call_count,
-        },
+        "meta": meta,
     }
     if mode == "clarify" and clarifying_questions is not None:
         response["clarifying_questions"] = clarifying_questions
@@ -786,9 +818,12 @@ async def solve(req: SolveRequest, request: Request) -> JSONResponse:
                     provider_client=provider_client,
                     provider_request=answer_request,
                 )
-                mode = _mode_from_confidence(
-                    preview["confidence"], preview["assumptions"], model_set
-                )
+                if preview.get("confidence_available") is False:
+                    mode = "clarify"
+                else:
+                    mode = _mode_from_confidence(
+                        preview["confidence"], preview["assumptions"], model_set
+                    )
                 expert_answer = answer_result.text
                 clarifying_questions = None
                 if mode == "clarify":
@@ -796,6 +831,8 @@ async def solve(req: SolveRequest, request: Request) -> JSONResponse:
                     clarifying_questions = _clarifying_questions_for_expert_request(
                         query, preview["considerations"], preview["assumptions"]
                     )
+                elif mode == "block":
+                    expert_answer = _BLOCK_MESSAGE
                 return JSONResponse(
                     _expert_response(
                         answer=expert_answer,
@@ -808,6 +845,14 @@ async def solve(req: SolveRequest, request: Request) -> JSONResponse:
                         model=answer_result.model,
                         call_count=2,
                         clarifying_questions=clarifying_questions,
+                        preview_parse_status=(
+                            preview["preview_parse_status"]
+                            if preview.get("confidence_available") is False
+                            else None
+                        ),
+                        confidence_available=(
+                            False if preview.get("confidence_available") is False else None
+                        ),
                     )
                 )
 

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -626,6 +626,53 @@ def test_solve_openai_expert_clarify_mode_surfaces_questions_without_extra_call(
     _clear_provider_factory()
 
 
+def test_solve_openai_expert_unstructured_preview_confidence_falls_back_to_clarify(monkeypatch):
+    monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    raw_answer = (
+        "This long provider answer should not be visible when preview confidence is unavailable."
+    )
+    fake = FakeProviderClient(
+        [
+            _provider_result(
+                "Here is a prose review with some risks and assumptions, but no compact "
+                "JSON object, no section headings, and no numeric confidence value."
+            ),
+            _provider_result(raw_answer),
+        ]
+    )
+    app.state.provider_client_factory = lambda _model_set: fake
+    client, key = _client()
+
+    resp = client.post(
+        "/v1/solve",
+        json={
+            "query": (
+                "Plan a security review and architecture migration where goals, timeline, "
+                "owners, risk tolerance, and compliance constraints are uncertain."
+            ),
+            "context": {"route": "expert"},
+        },
+        headers={"X-API-Key": key},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["mode"] == "clarify"
+    assert body["confidence"] == 0.0
+    assert body["answer"] == "I need a few details before I can answer this well."
+    assert body["final_answer"] == body["answer"]
+    assert body["considerations"] == []
+    assert body["assumptions"] == []
+    assert 2 <= len(body["clarifying_questions"]) <= 4
+    assert body["clarifying_questions"][0] == "What is the main outcome you want from this request?"
+    assert body["meta"]["preview_parse_status"] == "unstructured"
+    assert body["meta"]["confidence_available"] is False
+    assert body["meta"]["call_count"] == 2
+    assert raw_answer not in resp.text
+    assert len(fake.requests) == 2
+    _clear_provider_factory()
+
+
 def test_solve_openai_expert_trivial_route_does_not_add_clarifying_questions(monkeypatch):
     monkeypatch.setenv("MODEL_PROVIDER", "openai")
     fake = FakeProviderClient([_provider_result("Short direct answer.")])
@@ -649,13 +696,14 @@ def test_solve_openai_expert_trivial_route_does_not_add_clarifying_questions(mon
 
 def test_solve_openai_expert_block_mode_remains_distinct_from_clarify(monkeypatch):
     monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    raw_answer = "This long provider answer should not be visible for true block mode."
     fake = FakeProviderClient(
         [
             _provider_result(
                 '{"considerations":["The request may be unsafe"],'
                 '"assumptions":[],"confidence":0.05}'
             ),
-            _provider_result("Cannot safely answer as requested."),
+            _provider_result(raw_answer),
         ]
     )
     app.state.provider_client_factory = lambda _model_set: fake
@@ -676,9 +724,16 @@ def test_solve_openai_expert_block_mode_remains_distinct_from_clarify(monkeypatc
     assert resp.status_code == 200
     body = resp.json()
     assert body["mode"] == "block"
-    assert body["answer"] == "Cannot safely answer as requested."
+    assert body["confidence"] == 0.05
+    assert body["answer"] == (
+        "I cannot safely provide a final answer for this request in the supervised preview."
+    )
+    assert body["final_answer"] == body["answer"]
+    assert body["considerations"] == ["The request may be unsafe"]
     assert "clarifying_questions" not in body
     assert body["meta"]["call_count"] == 2
+    assert "confidence_available" not in body["meta"]
+    assert raw_answer not in resp.text
     assert len(fake.requests) == 2
     _clear_provider_factory()
 

--- a/tests/ui/test_expert_preview.py
+++ b/tests/ui/test_expert_preview.py
@@ -136,6 +136,61 @@ def test_preview_submission_renders_plain_and_expert_outputs(client: TestClient)
     assert "raw response" not in html.lower()
 
 
+def test_preview_submission_handles_unstructured_expert_preview_coherently(
+    client: TestClient,
+) -> None:
+    csrf_token = _login(client)
+    raw_secret = "sk-preview-should-not-render"
+    raw_answer = "This long expert answer should be hidden when confidence is unavailable."
+    fake = FakeProviderClient(
+        [
+            _provider_result("plain same-provider answer", raw_secret=raw_secret),
+            _provider_result(
+                "Here is a prose review with risks and assumptions, but no compact JSON, "
+                "no section headings, and no numeric confidence value.",
+                raw_secret=raw_secret,
+            ),
+            _provider_result(raw_answer, raw_secret=raw_secret),
+        ]
+    )
+    client.app.state.provider_client_factory = lambda _model_set: fake
+
+    response = client.post(
+        "/dashboard/expert-preview",
+        data={
+            "prompt": (
+                "Plan a security review and architecture migration where goals, timeline, "
+                "owners, risk tolerance, and compliance constraints are uncertain."
+            )
+        },
+        headers={auth.CSRF_HEADER_NAME: csrf_token},
+    )
+
+    assert response.status_code == 200
+    html = response.text
+    assert "plain same-provider answer" in html
+    assert "I need a few details before I can answer this well." in html
+    assert "clarify" in html
+    assert "unavailable" in html
+    assert "What is the main outcome you want from this request?" in html
+    assert "preview_parse_status" in html
+    assert "unstructured" in html
+    assert raw_answer not in html
+
+    assert len(fake.requests) == 3
+    assert fake.requests[0].metadata["route"] == "tot"
+    assert fake.requests[1].metadata["route"] == "expert"
+    assert fake.requests[2].metadata["route"] == "expert"
+
+    assert raw_secret not in html
+    assert "provider-hidden" not in html
+    assert "raw_metadata" not in html
+    assert "Authorization" not in html
+    assert "Bearer" not in html
+    assert "raw request" not in html.lower()
+    assert "raw response" not in html.lower()
+
+
 def test_preview_copy_keeps_claim_boundaries(client: TestClient) -> None:
     _login(client)
 


### PR DESCRIPTION
### Motivation
- Improve handling of expert-route preview outputs that are unstructured or lack a numeric confidence by detecting parse status and avoiding inadvertent exposure of long provider answers.
- Surface whether a preview-provided confidence is actually available and represent unavailable confidences in the UI and response metadata.
- Ensure block/clarify decision logic and preview metadata remain consistent and safe for supervised previews.

### Description
- Add robust confidence parsing with ` _PERCENT_RE`, introduce `_parse_confidence_value` to return `None` when confidence cannot be parsed, and keep `_confidence_value` as a compatibility wrapper that returns `0.0` on missing values.
- Update `_parse_expert_preview` to compute `preview_parse_status` (`json`, `sections`, or `unstructured`) and `confidence_available`, and to populate parsed `confidence` accordingly.
- Adjust decision logic in `solve` so that previews with `confidence_available == False` fall back to `clarify`, and add a distinct `_BLOCK_MESSAGE` for true `block` mode while preventing raw provider answers from being shown.
- Expand response metadata in `_expert_response` to include `preview_parse_status` and `confidence_available` when present, and update preview UI rendering in `expert_preview.py` to display `unavailable` when confidence is explicitly unavailable.

### Testing
- Ran unit tests including `test_solve_openai_expert_unstructured_preview_confidence_falls_back_to_clarify` and `test_solve_openai_expert_block_mode_remains_distinct_from_clarify`, which passed.
- Ran UI tests including `test_preview_submission_handles_unstructured_expert_preview_coherently` and `test_preview_submission_renders_plain_and_expert_outputs`, which passed.
- Ran the full test suite for modified endpoint behavior and metadata assertions, and all relevant tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d13411df883299a74657ef806ad45)