### PR TITLE
Add Cloud Run preview Dockerfile, .dockerignore, and deployment docs/spec

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+# VCS and local developer state
+.git
+.gitignore
+.gitattributes
+.venv
+venv
+.env
+.env.*
+!.env.example
+
+# Python caches and test/build outputs
+__pycache__/
+*.py[cod]
+*$py.class
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.coverage
+htmlcov/
+build/
+dist/
+*.egg-info/
+
+# Local/generated runtime artifacts that should not be baked into preview images
+artifacts/
+logs/
+telemetry/
+*.log
+
+# OS/editor noise
+.DS_Store
+Thumbs.db
+.idea/
+.vscode/
+*.swp
+*.swo

--- a/.specs/DEPLOY-CLOUDRUN-CONFIG-001.md
+++ b/.specs/DEPLOY-CLOUDRUN-CONFIG-001.md
@@ -1,0 +1,51 @@
+# DEPLOY-CLOUDRUN-CONFIG-001 · Cloud Run MVP Preview Deployment Config
+
+## Objective
+
+Add minimal Google Cloud Run deployment configuration and operator documentation
+for a controlled Alpha Solver MVP preview deployment of `/dashboard/expert-preview`.
+
+## Scope
+
+- Add a root Cloud Run-specific `Dockerfile`.
+- Add a root `.dockerignore` for container build hygiene.
+- Add `docs/deployment/CLOUD_RUN_MVP_PREVIEW.md` with settings, environment variables, deploy examples, and smoke checks.
+- Keep first deployment mode on `MODEL_PROVIDER=local`.
+- Keep live OpenAI testing held until local-provider Cloud Run smoke testing succeeds and spend is explicitly approved.
+
+## Acceptance criteria
+
+- The root `Dockerfile` uses Python 3.12, installs `requirements.txt`, copies the repo, and starts `service.app:app` with Uvicorn on `0.0.0.0` using Cloud Run `PORT` with an `8080` fallback.
+- `.dockerignore` excludes local caches, artifacts, logs, virtualenvs, VCS state, and local env files without excluding required app files.
+- The Cloud Run MVP preview doc covers purpose, scope boundaries, required settings, required env vars, local build/run, deploy examples, smoke tests, fail-closed dashboard behavior, the `/requests` redirect limitation, local-provider first workflow, held live OpenAI workflow, security notes, claim boundaries, troubleshooting, and backlog impact.
+- No runtime behavior changes are made.
+- No secrets are committed.
+- No Cloud Run deployment is performed from Codex.
+
+## Backlog impact
+
+`DEPLOY-CLOUDRUN-CONFIG-001` should be marked Done only after the PR implementing
+this spec is merged. It remains a deployment-config/docs lane under
+`DEPLOY-CLOUDRUN-EPIC-001` and does not validate the MVP, claim production
+readiness, or enable live OpenAI testing.
+
+## Non-goals
+
+- No Alpha Solver runtime behavior changes.
+- No provider expert-pass behavior changes.
+- No clarify behavior changes.
+- No eval artifact behavior changes.
+- No behavioral demo checklist behavior changes.
+- No preview behavior changes.
+- No dashboard auth behavior changes.
+- No live OpenAI default.
+- No Firebase Hosting.
+- No custom domain setup.
+- No Google Sheets or backlog workbook edits.
+- No MVP validation claim.
+- No Alpha Solver superiority claim.
+- No answer-quality superiority claim.
+- No production-readiness claim.
+- No broad runtime-readiness claim.
+- No answer-quality benchmark success claim.
+- No provider reasoning orchestration claim.

--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -8,6 +8,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `AS-148.md` | CODE SPEC — AS-148 · Policy & PII Gateway (DR_TRACK_A) |
 | `AUTH-SESSION-001.md` | AUTH-SESSION-001 · Dashboard Login + Session |
 | `CLARIFY-SURFACE-001.md` | CLARIFY-SURFACE-001 · Expert Route Clarify Surface |
+| `DEPLOY-CLOUDRUN-CONFIG-001.md` | DEPLOY-CLOUDRUN-CONFIG-001 · Cloud Run MVP Preview Deployment Config |
 | `EPIC_RAG_001.md` | EPIC_RAG_001 · RAG & Semantic Cache Pack |
 | `EVAL-ARTIFACT-PRESERVE-001.md` | EVAL-ARTIFACT-PRESERVE-001 · Preserve Eval Summary Artifacts |
 | `EVAL-BEHAVIORAL-DEMO-001.md` | EVAL-BEHAVIORAL-DEMO-001 · Expert Pass Behavioral Demo Checklist |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Cloud Run-specific image for the controlled Alpha Solver MVP preview.
+# The legacy infrastructure/Dockerfile is a generic placeholder image; this
+# root Dockerfile starts the FastAPI app and honors Cloud Run's PORT contract.
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN python -m pip install --no-cache-dir --upgrade pip \
+    && python -m pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["sh", "-c", "exec python -m uvicorn service.app:app --host 0.0.0.0 --port \"${PORT:-8080}\""]

--- a/docs/deployment/CLOUD_RUN_MVP_PREVIEW.md
+++ b/docs/deployment/CLOUD_RUN_MVP_PREVIEW.md
@@ -1,0 +1,329 @@
+# DEPLOY-CLOUDRUN-CONFIG-001 · Cloud Run MVP Preview Deployment
+
+## 1. Purpose
+
+This document describes the minimal Google Cloud Run setup for a controlled
+operator-test deployment of the Alpha Solver MVP preview route:
+
+```text
+/dashboard/expert-preview
+```
+
+The first deployment is intended to make the already-implemented supervised
+preview reachable behind the existing dashboard password gate. It is a deployment
+configuration and operator-smoke lane only.
+
+## 2. Scope boundaries
+
+This lane adds Cloud Run deployment config and documentation only. It does not:
+
+- deploy the service from Codex;
+- change Alpha Solver runtime behavior;
+- change provider expert-pass behavior;
+- change clarify behavior;
+- change eval artifact behavior;
+- change behavioral demo checklist behavior;
+- change preview behavior;
+- change dashboard auth behavior;
+- enable live OpenAI calls by default;
+- add Firebase Hosting;
+- add custom domain setup;
+- update Google Sheets or backlog workbooks.
+
+The root `Dockerfile` is Cloud Run-specific. The existing
+`infrastructure/Dockerfile` is a generic placeholder image and does not start the
+FastAPI app, so it should not be used as-is for this preview service.
+
+## 3. Required Cloud Run settings
+
+Suggested first service settings:
+
+| Setting | Recommendation |
+| --- | --- |
+| Service name | `alpha-solver-mvp-preview` |
+| Region | Choose a nearby region such as `us-central1` or `us-east1` |
+| Runtime | Container from the root `Dockerfile` |
+| CPU / memory | Start with 1 CPU / 512 MiB, or Cloud Run defaults if sufficient |
+| Min instances | `0` |
+| Max instances | `1` or `2` for controlled testing |
+| Ingress | Cloud Run HTTPS service URL only for this phase |
+| Cloud Run auth | `--allow-unauthenticated` is acceptable for controlled testing only because `/dashboard/*` is password-gated by the app; this is not a production-readiness claim |
+| Provider mode | `MODEL_PROVIDER=local` |
+
+Do not configure Firebase Hosting, a custom domain, or production traffic routing
+for this phase.
+
+## 4. Required environment variables
+
+### Local-provider first deployment
+
+Configure these variables before enabling dashboard access:
+
+```text
+MODEL_PROVIDER=local
+ALPHA_DASHBOARD_PASSWORD=<strong non-default password>
+ALPHA_DASHBOARD_SECRET_KEY=<long random secret>
+```
+
+`ALPHA_DASHBOARD_PASSWORD` must not be `alpha-dashboard`. If the password is
+missing or left at the default, the bundled app fails closed and does not mount
+`/dashboard/*` routes.
+
+If the Cloud Run service is reachable without Cloud Run IAM, also set a strong
+API key for the JSON API surface instead of relying on development defaults:
+
+```text
+SERVICE_AUTH_KEYS=<strong random API key>
+```
+
+or:
+
+```text
+API_KEY=<strong random API key>
+```
+
+### Held live-provider variables
+
+These variables are held until after local-provider Cloud Run smoke testing
+succeeds and live-provider spend is explicitly approved:
+
+```text
+MODEL_PROVIDER=openai
+OPENAI_API_KEY=<test-project-key>
+```
+
+Do not configure `OPENAI_API_KEY` for the first local-provider preview.
+
+## 5. Secret handling
+
+For quick local-only container testing, placeholders may be passed as environment
+variables. Do not reuse those placeholders for a real Cloud Run preview.
+
+For controlled Cloud Run testing, prefer Secret Manager for sensitive values:
+
+- `ALPHA_DASHBOARD_PASSWORD`
+- `ALPHA_DASHBOARD_SECRET_KEY`
+- any future `OPENAI_API_KEY`
+
+Non-sensitive values such as `MODEL_PROVIDER=local` can be plain Cloud Run
+environment variables.
+
+Never commit secrets, paste real secrets into this document, or put real secrets
+in deployment commands checked into git.
+
+## 6. Local build and run commands
+
+Build the Cloud Run image locally:
+
+```bash
+docker build -t alpha-solver-cloudrun-preview .
+```
+
+Run it locally with placeholder preview values:
+
+```bash
+docker run --rm -p 8080:8080 \
+  -e PORT=8080 \
+  -e MODEL_PROVIDER=local \
+  -e ALPHA_DASHBOARD_PASSWORD=local-non-default-password \
+  -e ALPHA_DASHBOARD_SECRET_KEY=local-dashboard-secret \
+  alpha-solver-cloudrun-preview
+```
+
+Then smoke-check the local container:
+
+```bash
+curl -i http://127.0.0.1:8080/healthz
+curl -i http://127.0.0.1:8080/dashboard/expert-preview
+```
+
+The second command should redirect unauthenticated users to `/login` when a
+non-default dashboard password is configured.
+
+## 7. Cloud Run deploy command examples
+
+These commands are examples only. Replace project, region, image, and secret
+names with operator-owned values. Do not paste real secrets into committed docs.
+
+### Build and deploy from the root Dockerfile
+
+```bash
+PROJECT_ID=<google-cloud-project-id>
+REGION=us-central1
+SERVICE=alpha-solver-mvp-preview
+IMAGE="gcr.io/${PROJECT_ID}/${SERVICE}:preview"
+
+gcloud builds submit --project "${PROJECT_ID}" --tag "${IMAGE}" .
+
+gcloud run deploy "${SERVICE}" \
+  --project "${PROJECT_ID}" \
+  --region "${REGION}" \
+  --image "${IMAGE}" \
+  --allow-unauthenticated \
+  --cpu 1 \
+  --memory 512Mi \
+  --min-instances 0 \
+  --max-instances 2 \
+  --set-env-vars MODEL_PROVIDER=local \
+  --set-secrets ALPHA_DASHBOARD_PASSWORD=alpha-dashboard-password:latest,ALPHA_DASHBOARD_SECRET_KEY=alpha-dashboard-secret-key:latest
+```
+
+If Secret Manager is not being used for an initial disposable test, set only
+non-sensitive placeholders in commands and configure real sensitive values in the
+Cloud Run console or through an operator-controlled secret process.
+
+### Temporary fail-closed mount verification
+
+To verify fail-closed behavior, deploy or revise a temporary test revision with
+`ALPHA_DASHBOARD_PASSWORD` unset or set to `alpha-dashboard`, then request:
+
+```bash
+curl -i "${SERVICE_URL}/dashboard/expert-preview"
+```
+
+Expected result: dashboard routes should not mount, so the route should return
+404 rather than exposing the preview behind a default password.
+
+## 8. Post-deploy smoke-test checklist
+
+Use the Cloud Run service URL as `SERVICE_URL`.
+
+### Service health
+
+- [ ] Cloud Run revision becomes ready.
+- [ ] `GET /healthz` returns 200.
+- [ ] `GET /readyz` returns 200, if readiness is expected.
+
+```bash
+curl -i "${SERVICE_URL}/healthz"
+curl -i "${SERVICE_URL}/readyz"
+```
+
+### Dashboard fail-closed behavior
+
+- [ ] With `ALPHA_DASHBOARD_PASSWORD` unset, `/dashboard/expert-preview` does not mount.
+- [ ] With `ALPHA_DASHBOARD_PASSWORD=alpha-dashboard`, `/dashboard/expert-preview` does not mount.
+- [ ] With a non-default password and `ALPHA_DASHBOARD_SECRET_KEY`, `/dashboard/expert-preview` mounts and is protected by auth.
+
+### Route and auth checks
+
+- [ ] Logged-out `GET /dashboard/expert-preview` redirects or blocks according to dashboard auth convention.
+- [ ] Login works with the configured dashboard password.
+- [ ] The known `/requests` post-login redirect limitation is understood and is not treated as a blocker.
+- [ ] After login, direct navigation to `/dashboard/expert-preview` works.
+- [ ] Authenticated `GET /dashboard/expert-preview` returns 200.
+
+Example cookie-jar flow:
+
+```bash
+curl -i -c /tmp/alpha-cookies.txt \
+  -d "password=${ALPHA_DASHBOARD_PASSWORD}" \
+  "${SERVICE_URL}/login"
+
+curl -i -b /tmp/alpha-cookies.txt \
+  "${SERVICE_URL}/dashboard/expert-preview"
+```
+
+### CSRF checks
+
+- [ ] Authenticated `POST /dashboard/expert-preview` without `X-Alpha-CSRF` is rejected.
+- [ ] Authenticated `POST /dashboard/expert-preview` with the `alpha_dashboard_csrf` cookie value in `X-Alpha-CSRF` succeeds.
+
+```bash
+curl -i -b /tmp/alpha-cookies.txt \
+  -d "prompt=hello" \
+  "${SERVICE_URL}/dashboard/expert-preview"
+
+CSRF_TOKEN=$(awk '$6 == "alpha_dashboard_csrf" {print $7}' /tmp/alpha-cookies.txt | tail -n 1)
+
+curl -i -b /tmp/alpha-cookies.txt \
+  -H "X-Alpha-CSRF: ${CSRF_TOKEN}" \
+  -d "prompt=Draft a short rollout checklist for a small internal preview." \
+  "${SERVICE_URL}/dashboard/expert-preview"
+```
+
+### Preview and safety checks
+
+- [ ] Preview page renders in `MODEL_PROVIDER=local` mode.
+- [ ] The supervised preview disclaimer is visible.
+- [ ] No secrets, API keys, bearer tokens, auth headers, raw request bodies, raw response bodies, raw provider payloads, or raw provider metadata are displayed.
+
+## 9. Fail-closed dashboard behavior
+
+The bundled FastAPI app mounts dashboard auth plus `/dashboard/expert-preview`
+only when `ALPHA_DASHBOARD_PASSWORD` is configured and is not the documented
+default `alpha-dashboard`. Otherwise dashboard routes return 404 and the JSON API
+continues serving. Preserve this behavior for Cloud Run.
+
+## 10. Known `/requests` post-login redirect limitation
+
+Successful dashboard login currently redirects to `/requests`. The Cloud Run
+preview service mounts `/login` and `/dashboard/expert-preview`, but not the full
+legacy dashboard request page. A post-login `/requests` 404 is a known deferred
+limitation and is not a deployment blocker. After login, open
+`/dashboard/expert-preview` directly.
+
+## 11. Local-provider first workflow
+
+1. Build the root Dockerfile.
+2. Run locally with `MODEL_PROVIDER=local` and placeholder dashboard values.
+3. Confirm health, auth redirect, login, CSRF rejection, CSRF success, preview render, and safety checks.
+4. Deploy to Cloud Run with `MODEL_PROVIDER=local`.
+5. Repeat the Cloud Run smoke checklist.
+6. Record results in the PR/release notes or operator handoff notes without adding MVP validation or production-readiness claims.
+
+## 12. Held live OpenAI workflow
+
+Live OpenAI preview is explicitly held until all of the following are true:
+
+- local-provider Cloud Run smoke testing has succeeded;
+- an operator explicitly approves live-provider spend;
+- an operator provides a test-project OpenAI key through Secret Manager;
+- bounded live smoke steps and rollback are documented.
+
+Do not enable `MODEL_PROVIDER=openai` or configure `OPENAI_API_KEY` in the first
+preview deployment.
+
+## 13. Security notes
+
+- Do not commit secrets.
+- Do not paste real secrets into documentation or shell history that will be shared.
+- Do not use `alpha-dashboard` as the dashboard password.
+- Prefer Secret Manager for dashboard and provider secrets.
+- Use a strong `SERVICE_AUTH_KEYS` or `API_KEY` if the Cloud Run service allows unauthenticated HTTP access.
+- Keep max instances low during controlled testing.
+- Treat Cloud Run unauthenticated access as a controlled-preview convenience only, not as production security posture.
+- Keep live OpenAI held until explicitly approved.
+
+## 14. Claim boundaries
+
+This deployment config does not claim:
+
+- MVP validation;
+- Alpha Solver superiority;
+- answer-quality superiority;
+- production readiness;
+- broad runtime readiness;
+- answer-quality benchmark success;
+- provider reasoning orchestration.
+
+It only prepares the repo for a controlled Cloud Run MVP preview deployment.
+
+## 15. Troubleshooting
+
+| Symptom | Likely cause | Mitigation |
+| --- | --- | --- |
+| Cloud Run revision never becomes ready | Container is not listening on Cloud Run `PORT` or dependencies failed to install | Use the root `Dockerfile`; confirm the command starts Uvicorn with `--host 0.0.0.0 --port "${PORT:-8080}"` |
+| `/dashboard/expert-preview` returns 404 | Dashboard password is unset or set to `alpha-dashboard` | Configure a strong non-default `ALPHA_DASHBOARD_PASSWORD` and redeploy a new revision |
+| Login succeeds then `/requests` returns 404 | Known login redirect limitation | Navigate directly to `/dashboard/expert-preview` after login |
+| POST to preview returns 403 | Missing or invalid CSRF header | Send `X-Alpha-CSRF` with the value from the `alpha_dashboard_csrf` cookie |
+| Preview attempts live provider calls | `MODEL_PROVIDER` is set to `openai` | Revert to `MODEL_PROVIDER=local`; remove `OPENAI_API_KEY` from the first preview revision |
+| Secrets appear in output | Regression or unsafe manual logging | Stop testing, capture minimal evidence without secrets, rotate affected secrets, and fix before continuing |
+| Cold starts are slow | `min-instances=0` | Accept for first testing or temporarily set `min-instances=1` for scheduled operator sessions |
+
+## 16. Backlog impact
+
+`DEPLOY-CLOUDRUN-CONFIG-001` should be marked Done only if the PR adding this
+configuration is merged. This is a deployment-config/docs lane under
+`DEPLOY-CLOUDRUN-EPIC-001`; it does not deploy the service, validate the MVP,
+claim production readiness, or enable live OpenAI testing.


### PR DESCRIPTION
### Motivation

- Prepare the repository for a controlled Cloud Run Alpha Solver MVP preview by adding build and operator deployment configuration without changing runtime behavior.
- Ensure the preview container image starts the FastAPI app with Uvicorn and that local artifacts and secrets are excluded from image builds.
- Document an operator-safe, local-provider-first deployment workflow and explicitly hold live OpenAI provider configuration until testing and approvals are complete.

### Description

- Add a root `Dockerfile` based on `python:3.12-slim` that installs `requirements.txt`, copies the repo, and runs `service.app:app` with Uvicorn honoring the Cloud Run `PORT` environment variable.
- Add a `.dockerignore` that excludes VCS, virtualenvs, Python caches, test/build outputs, logs, artifacts, and common editor/OS files.
- Add `.specs/DEPLOY-CLOUDRUN-CONFIG-001.md` and `docs/deployment/CLOUD_RUN_MVP_PREVIEW.md` containing deployment intent, required env vars, deploy examples, smoke-test checklists, security notes, and operational boundaries.
- Update `.specs/INDEX.md` to register the new spec entry.

### Testing

- No automated tests were added or run as part of this change and existing CI/test suites were not modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d30acfb4c8329ac21e963dffa8e98)