### PR TITLE
DEPLOY-CLOUDRUN-DASHBOARD-SECRET-GUARD-001: require dashboard secret for bundled preview mount

### DIFF
--- a/.specs/DEPLOY-CLOUDRUN-DASHBOARD-SECRET-GUARD-001.md
+++ b/.specs/DEPLOY-CLOUDRUN-DASHBOARD-SECRET-GUARD-001.md
@@ -1,0 +1,64 @@
+# DEPLOY-CLOUDRUN-DASHBOARD-SECRET-GUARD-001 · Require Dashboard Secret for Bundled Cloud Run Preview Mount
+
+## Objective
+
+Tighten the bundled `service.app:app` dashboard mount guard so the Cloud Run MVP
+preview dashboard mounts only when both required dashboard deployment values are
+explicitly configured:
+
+- `ALPHA_DASHBOARD_PASSWORD` is set and is not the documented default
+  `alpha-dashboard`; and
+- `ALPHA_DASHBOARD_SECRET_KEY` is set to a non-empty value.
+
+This closes the deployment safety gap where a non-default password alone could
+mount the bundled preview while dashboard auth fell back to a random runtime
+session-signing secret.
+
+## Scope
+
+- Update only the bundled app's dashboard mount guard and warning text.
+- Keep the shared dashboard auth/session/CSRF implementation unchanged after the
+  dashboard is mounted.
+- Document that the bundled Cloud Run preview dashboard fails closed if either
+  required dashboard environment variable is missing or invalid.
+- Add no-network tests for the password and secret-key mount matrix.
+
+## Acceptance criteria
+
+- Dashboard routes do not mount when `ALPHA_DASHBOARD_PASSWORD` is unset.
+- Dashboard routes do not mount when `ALPHA_DASHBOARD_PASSWORD` is
+  `alpha-dashboard`.
+- Dashboard routes do not mount when `ALPHA_DASHBOARD_PASSWORD` is non-default
+  but `ALPHA_DASHBOARD_SECRET_KEY` is unset or empty.
+- Dashboard routes mount when `ALPHA_DASHBOARD_PASSWORD` is non-default and
+  `ALPHA_DASHBOARD_SECRET_KEY` is non-empty.
+- When dashboard routes do not mount, the JSON API remains available.
+- Existing dashboard auth/session/CSRF behavior remains unchanged after mount.
+- Provider behavior, expert-pass behavior, clarify behavior, eval behavior,
+  preview behavior, and Cloud Run Docker behavior do not change.
+
+## Backlog impact
+
+`DEPLOY-CLOUDRUN-DASHBOARD-SECRET-GUARD-001` should be marked Done only after the
+PR implementing this spec is merged. It is a deployment safety follow-up under
+`DEPLOY-CLOUDRUN-EPIC-001`, should be completed before
+`DEPLOY-CLOUDRUN-SMOKE-001`, and does not deploy Cloud Run, enable live OpenAI,
+validate the MVP, or claim production readiness.
+
+## Non-goals
+
+- No Cloud Run deployment.
+- No committed secrets or real secret requests.
+- No Google Sheets or backlog workbook updates.
+- No live OpenAI enablement.
+- No Firebase Hosting.
+- No custom domain support.
+- No login redirect configurability.
+- No JWT flake fixes.
+- No live spend guard changes.
+- No MVP validation claim.
+- No Alpha Solver superiority claim.
+- No production-readiness claim.
+- No broad runtime-readiness claim.
+- No answer-quality benchmark success claim.
+- No provider reasoning orchestration claim.

--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -9,6 +9,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `AUTH-SESSION-001.md` | AUTH-SESSION-001 · Dashboard Login + Session |
 | `CLARIFY-SURFACE-001.md` | CLARIFY-SURFACE-001 · Expert Route Clarify Surface |
 | `DEPLOY-CLOUDRUN-CONFIG-001.md` | DEPLOY-CLOUDRUN-CONFIG-001 · Cloud Run MVP Preview Deployment Config |
+| `DEPLOY-CLOUDRUN-DASHBOARD-SECRET-GUARD-001.md` | DEPLOY-CLOUDRUN-DASHBOARD-SECRET-GUARD-001 · Require Dashboard Secret for Bundled Cloud Run Preview Mount |
 | `EPIC_RAG_001.md` | EPIC_RAG_001 · RAG & Semantic Cache Pack |
 | `EVAL-ARTIFACT-PRESERVE-001.md` | EVAL-ARTIFACT-PRESERVE-001 · Preserve Eval Summary Artifacts |
 | `EVAL-BEHAVIORAL-DEMO-001.md` | EVAL-BEHAVIORAL-DEMO-001 · Expert Pass Behavioral Demo Checklist |

--- a/docs/DASHBOARD_AUTH.md
+++ b/docs/DASHBOARD_AUTH.md
@@ -69,11 +69,15 @@ behavior shape, and this UI does not replace eval evidence.
 
 In the bundled API application (`service.app:app`), the dashboard — the login
 routes plus `/dashboard/expert-preview` — is mounted **only when a non-default
-`ALPHA_DASHBOARD_PASSWORD` is configured**. If the password is unset or left at
-the documented default, the dashboard is not mounted (its routes return 404), a
-warning is logged, and the JSON API keeps serving normally. This fails closed so
-a misconfigured deployment never exposes the provider-backed preview behind the
-well-known default password.
+`ALPHA_DASHBOARD_PASSWORD` and an explicit non-empty
+`ALPHA_DASHBOARD_SECRET_KEY` are configured**. If the password is unset/default
+or the secret key is missing/empty, the dashboard is not mounted (its routes
+return 404), a warning is logged, and the JSON API keeps serving normally. This
+fails closed so a misconfigured deployment never exposes the provider-backed
+preview behind the well-known default password or an ephemeral runtime signing
+secret. The auth module's fallback random secret remains available for custom
+router integrations; the bundled app's Cloud Run/operator mount guard requires
+explicit configuration.
 
 **Known limitation (deferred):** a successful login redirects to `/requests`,
 which the bundled API app does not mount, so the post-login landing returns 404.

--- a/docs/deployment/CLOUD_RUN_MVP_PREVIEW.md
+++ b/docs/deployment/CLOUD_RUN_MVP_PREVIEW.md
@@ -65,9 +65,10 @@ ALPHA_DASHBOARD_PASSWORD=<strong non-default password>
 ALPHA_DASHBOARD_SECRET_KEY=<long random secret>
 ```
 
-`ALPHA_DASHBOARD_PASSWORD` must not be `alpha-dashboard`. If the password is
-missing or left at the default, the bundled app fails closed and does not mount
-`/dashboard/*` routes.
+`ALPHA_DASHBOARD_PASSWORD` must not be `alpha-dashboard`, and
+`ALPHA_DASHBOARD_SECRET_KEY` must be explicitly set to a non-empty value. If the
+password is missing/default or the secret key is missing/empty, the bundled app
+fails closed and does not mount `/dashboard/*` routes.
 
 If the Cloud Run service is reachable without Cloud Run IAM, also set a strong
 API key for the JSON API surface instead of relying on development defaults:
@@ -137,8 +138,8 @@ curl -i http://127.0.0.1:8080/healthz
 curl -i http://127.0.0.1:8080/dashboard/expert-preview
 ```
 
-The second command should redirect unauthenticated users to `/login` when a
-non-default dashboard password is configured.
+The second command should redirect unauthenticated users to `/login` when both a
+non-default dashboard password and dashboard secret key are configured.
 
 ## 7. Cloud Run deploy command examples
 
@@ -175,14 +176,17 @@ Cloud Run console or through an operator-controlled secret process.
 ### Temporary fail-closed mount verification
 
 To verify fail-closed behavior, deploy or revise a temporary test revision with
-`ALPHA_DASHBOARD_PASSWORD` unset or set to `alpha-dashboard`, then request:
+`ALPHA_DASHBOARD_PASSWORD` unset, `ALPHA_DASHBOARD_PASSWORD=alpha-dashboard`, or
+a non-default password but missing/empty `ALPHA_DASHBOARD_SECRET_KEY`, then
+request:
 
 ```bash
 curl -i "${SERVICE_URL}/dashboard/expert-preview"
 ```
 
 Expected result: dashboard routes should not mount, so the route should return
-404 rather than exposing the preview behind a default password.
+404 rather than exposing the preview behind a default password or an ephemeral
+runtime signing secret.
 
 ## 8. Post-deploy smoke-test checklist
 
@@ -203,7 +207,8 @@ curl -i "${SERVICE_URL}/readyz"
 
 - [ ] With `ALPHA_DASHBOARD_PASSWORD` unset, `/dashboard/expert-preview` does not mount.
 - [ ] With `ALPHA_DASHBOARD_PASSWORD=alpha-dashboard`, `/dashboard/expert-preview` does not mount.
-- [ ] With a non-default password and `ALPHA_DASHBOARD_SECRET_KEY`, `/dashboard/expert-preview` mounts and is protected by auth.
+- [ ] With a non-default password but missing/empty `ALPHA_DASHBOARD_SECRET_KEY`, `/dashboard/expert-preview` does not mount.
+- [ ] With a non-default password and non-empty `ALPHA_DASHBOARD_SECRET_KEY`, `/dashboard/expert-preview` mounts and is protected by auth.
 
 ### Route and auth checks
 
@@ -251,9 +256,12 @@ curl -i -b /tmp/alpha-cookies.txt \
 ## 9. Fail-closed dashboard behavior
 
 The bundled FastAPI app mounts dashboard auth plus `/dashboard/expert-preview`
-only when `ALPHA_DASHBOARD_PASSWORD` is configured and is not the documented
-default `alpha-dashboard`. Otherwise dashboard routes return 404 and the JSON API
-continues serving. Preserve this behavior for Cloud Run.
+only when `ALPHA_DASHBOARD_PASSWORD` is configured, is not the documented
+default `alpha-dashboard`, and `ALPHA_DASHBOARD_SECRET_KEY` is explicitly set to
+a non-empty value. Otherwise dashboard routes return 404 and the JSON API
+continues serving. Preserve this behavior for Cloud Run. The auth module's
+standalone random-secret fallback is intentionally unchanged for custom app
+integrations, but the bundled Cloud Run preview mount guard must not rely on it.
 
 ## 10. Known `/requests` post-login redirect limitation
 
@@ -314,7 +322,7 @@ It only prepares the repo for a controlled Cloud Run MVP preview deployment.
 | Symptom | Likely cause | Mitigation |
 | --- | --- | --- |
 | Cloud Run revision never becomes ready | Container is not listening on Cloud Run `PORT` or dependencies failed to install | Use the root `Dockerfile`; confirm the command starts Uvicorn with `--host 0.0.0.0 --port "${PORT:-8080}"` |
-| `/dashboard/expert-preview` returns 404 | Dashboard password is unset or set to `alpha-dashboard` | Configure a strong non-default `ALPHA_DASHBOARD_PASSWORD` and redeploy a new revision |
+| `/dashboard/expert-preview` returns 404 | Dashboard password is unset/default or dashboard secret key is missing/empty | Configure a strong non-default `ALPHA_DASHBOARD_PASSWORD` and non-empty `ALPHA_DASHBOARD_SECRET_KEY`, then redeploy a new revision |
 | Login succeeds then `/requests` returns 404 | Known login redirect limitation | Navigate directly to `/dashboard/expert-preview` after login |
 | POST to preview returns 403 | Missing or invalid CSRF header | Send `X-Alpha-CSRF` with the value from the `alpha_dashboard_csrf` cookie |
 | Preview attempts live provider calls | `MODEL_PROVIDER` is set to `openai` | Revert to `MODEL_PROVIDER=local`; remove `OPENAI_API_KEY` from the first preview revision |

--- a/service/app.py
+++ b/service/app.py
@@ -170,10 +170,12 @@ app.add_middleware(
 # reuses the shared dashboard auth/CSRF middleware (see alpha/webapp/routes/auth.py)
 # so /dashboard/* is protected; we intentionally mount only auth + expert-preview.
 #
-# Fail closed: mount the dashboard only when a non-default ALPHA_DASHBOARD_PASSWORD
-# is configured. Otherwise /login and the provider-backed preview would sit behind
-# the well-known default password on any deployment that forgot to set one, so we
-# skip mounting (routes 404), log a warning, and leave the JSON API fully working.
+# Fail closed: mount the dashboard only when both a non-default
+# ALPHA_DASHBOARD_PASSWORD and an explicit ALPHA_DASHBOARD_SECRET_KEY are
+# configured. Otherwise /login and the provider-backed preview could sit behind
+# the well-known default password or use an ephemeral runtime signing secret on a
+# deployment that forgot to set one, so we skip mounting (routes 404), log a
+# warning, and leave the JSON API fully working.
 #
 # Known limitation (tracked, deferred): a successful login redirects to /requests
 # (alpha.webapp.routes.auth.login), which this app does not mount, so the post-login
@@ -182,7 +184,12 @@ app.add_middleware(
 # auth redirect here.
 def _dashboard_enabled() -> bool:
     password = os.getenv(dashboard_auth.PASSWORD_ENV_VAR)
-    return bool(password) and password != dashboard_auth.DEFAULT_DASHBOARD_PASSWORD
+    secret_key = os.getenv(dashboard_auth.SECRET_ENV_VAR)
+    return (
+        bool(password)
+        and password != dashboard_auth.DEFAULT_DASHBOARD_PASSWORD
+        and bool(secret_key)
+    )
 
 
 def _mount_dashboard(target: FastAPI) -> None:
@@ -195,9 +202,10 @@ if _dashboard_enabled():
     _mount_dashboard(app)
 else:
     logger.warning(
-        "Dashboard UI disabled: set a non-default %s to enable /dashboard/* "
-        "(login + supervised expert-preview).",
+        "Dashboard UI disabled: set a non-default %s and explicit %s "
+        "to enable /dashboard/* (login + supervised expert-preview).",
         dashboard_auth.PASSWORD_ENV_VAR,
+        dashboard_auth.SECRET_ENV_VAR,
     )
 
 

--- a/tests/ui/test_expert_preview_real_app.py
+++ b/tests/ui/test_expert_preview_real_app.py
@@ -140,17 +140,34 @@ def test_preview_post_without_csrf_is_rejected(client: TestClient) -> None:
 
 
 def test_dashboard_disabled_when_password_unset(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("ALPHA_DASHBOARD_PASSWORD", raising=False)
+    monkeypatch.delenv(auth.PASSWORD_ENV_VAR, raising=False)
+    monkeypatch.setenv(auth.SECRET_ENV_VAR, "unit-test-secret")
     assert _dashboard_enabled() is False
 
 
 def test_dashboard_disabled_when_password_is_default(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("ALPHA_DASHBOARD_PASSWORD", auth.DEFAULT_DASHBOARD_PASSWORD)
+    monkeypatch.setenv(auth.PASSWORD_ENV_VAR, auth.DEFAULT_DASHBOARD_PASSWORD)
+    monkeypatch.setenv(auth.SECRET_ENV_VAR, "unit-test-secret")
     assert _dashboard_enabled() is False
 
 
-def test_dashboard_enabled_when_password_non_default(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("ALPHA_DASHBOARD_PASSWORD", "a-strong-operator-secret")
+def test_dashboard_disabled_when_secret_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(auth.PASSWORD_ENV_VAR, "a-strong-operator-secret")
+    monkeypatch.delenv(auth.SECRET_ENV_VAR, raising=False)
+    assert _dashboard_enabled() is False
+
+
+def test_dashboard_disabled_when_secret_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(auth.PASSWORD_ENV_VAR, "a-strong-operator-secret")
+    monkeypatch.setenv(auth.SECRET_ENV_VAR, "")
+    assert _dashboard_enabled() is False
+
+
+def test_dashboard_enabled_when_password_non_default_and_secret_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(auth.PASSWORD_ENV_VAR, "a-strong-operator-secret")
+    monkeypatch.setenv(auth.SECRET_ENV_VAR, "unit-test-secret")
     assert _dashboard_enabled() is True
 
 


### PR DESCRIPTION
### Motivation

- A read-only Cloud Run smoke planning pass found that the bundled `service.app:app` mounted the dashboard when `ALPHA_DASHBOARD_PASSWORD` was non-default even if `ALPHA_DASHBOARD_SECRET_KEY` was missing, allowing the auth layer to fall back to a runtime random secret which is not acceptable for the Cloud Run preview mount guard.  
- The goal is a narrow deployment-safety change so the bundled preview only mounts when both a non-default `ALPHA_DASHBOARD_PASSWORD` and an explicit non-empty `ALPHA_DASHBOARD_SECRET_KEY` are configured.

### Description

- Tighten the mount guard by updating `_dashboard_enabled()` in `service/app.py` so it returns true only when `ALPHA_DASHBOARD_PASSWORD` is set and not equal to `dashboard_auth.DEFAULT_DASHBOARD_PASSWORD` and `ALPHA_DASHBOARD_SECRET_KEY` is explicitly set and non-empty.  
- Update the dashboard-disabled warning text to instruct operators to set both `ALPHA_DASHBOARD_PASSWORD` and `ALPHA_DASHBOARD_SECRET_KEY`.  
- Add/adjust no-network unit tests in `tests/ui/test_expert_preview_real_app.py` to cover the matrix: password unset, password default, password non-default with secret unset, secret empty, and password+secret set, while preserving mounted route/auth assertions.  
- Update operator docs and add a spec: `docs/deployment/CLOUD_RUN_MVP_PREVIEW.md` and `docs/DASHBOARD_AUTH.md` now state that the bundled Cloud Run preview fails closed if either env var is missing/invalid, and a new spec `.specs/DEPLOY-CLOUDRUN-DASHBOARD-SECRET-GUARD-001.md` was added and registered in `.specs/INDEX.md`; scope limited to the bundled mount guard and documentation, and the auth module's internal random-secret fallback remains unchanged for custom integrations.

### Testing

- Ran `git diff --check` (no problems).  
- Ran focused tests and full test suite: `python -m pytest tests/ui/test_expert_preview_real_app.py -q`, `python -m pytest tests/ui/test_auth.py -q`, `python -m pytest tests/ui/test_expert_preview.py -q`, `python -m pytest tests/test_api_endpoints.py -q`, `python -m pytest tests/test_answer_quality_eval.py -q`, and `python -m pytest -q`; all targeted tests passed (some CI skips), with only expected deprecation warnings; no JWT rotation flake was encountered during these runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1daef97a2c8329ac27c77ee9332d8b)