### PR TITLE
UI-PREVIEW-BROWSER-SUBMIT-001: fix expert preview browser form submission

### DIFF
--- a/alpha/webapp/routes/expert_preview.py
+++ b/alpha/webapp/routes/expert_preview.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import html
 import json
+from email import policy
+from email.parser import BytesParser
 from typing import Any, Dict, Iterable, Mapping
 from urllib.parse import parse_qs
 
@@ -153,7 +155,7 @@ def _render_page(
       <h1>Supervised preview only</h1>
       <p class="disclaimer">{_escape(DISCLAIMER)}</p>
       {error_html}
-      <form method="post" action="{_ROUTE}">
+      <form method="post" action="{_ROUTE}" id="expert-preview-form">
         <label for="prompt">Prompt</label>
         <textarea id="prompt" name="prompt" required>{_escape(prompt)}</textarea>
         <button type="submit">Compare same-provider outputs</button>
@@ -170,7 +172,6 @@ def _render_page(
       </section>
     </main>
     <script>
-      const form = document.querySelector("form");
       function cookieValue(name) {{
         return document.cookie
           .split(";")
@@ -178,33 +179,85 @@ def _render_page(
           .find((part) => part.startsWith(name + "="))
           ?.slice(name.length + 1) || "";
       }}
-      form.addEventListener("submit", async (event) => {{
-        event.preventDefault();
-        const response = await fetch(form.action, {{
-          method: "POST",
-          headers: {{ "X-Alpha-CSRF": cookieValue("alpha_dashboard_csrf") }},
-          body: new FormData(form),
+      function initExpertPreviewForm() {{
+        const form = document.querySelector("#expert-preview-form");
+        if (!form || form.dataset.alphaSubmitBound === "true") {{
+          return;
+        }}
+        form.dataset.alphaSubmitBound = "true";
+        form.addEventListener("submit", async (event) => {{
+          event.preventDefault();
+          const response = await fetch(form.action, {{
+            method: "POST",
+            headers: {{
+              "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+              "X-Alpha-CSRF": cookieValue("alpha_dashboard_csrf"),
+            }},
+            body: new URLSearchParams(new FormData(form)),
+          }});
+          const html = await response.text();
+          const nextDocument = new DOMParser().parseFromString(html, "text/html");
+          document.title = nextDocument.title;
+          document.body.innerHTML = nextDocument.body.innerHTML;
+          initExpertPreviewForm();
         }});
-        const html = await response.text();
-        document.open();
-        document.write(html);
-        document.close();
-      }});
+      }}
+      initExpertPreviewForm();
     </script>
   </body>
 </html>"""
 
 
+def _prompt_from_multipart_body(content_type: str, body: bytes) -> str:
+    message = BytesParser(policy=policy.default).parsebytes(
+        b"Content-Type: "
+        + content_type.encode("latin-1", errors="ignore")
+        + b"\r\nMIME-Version: 1.0\r\n\r\n"
+        + body
+    )
+    if not message.is_multipart():
+        return ""
+    for part in message.iter_parts():
+        params = dict(part.get_params(header="content-disposition", failobj=[]))
+        if params.get("name") != "prompt":
+            continue
+        payload = part.get_payload(decode=True)
+        if payload is None:
+            return str(part.get_payload()).strip()
+        charset = part.get_content_charset() or "utf-8"
+        return payload.decode(charset, errors="replace").strip()
+    return ""
+
+
+async def _prompt_from_form(request: Request) -> str:
+    form = await request.form()
+    value = form.get("prompt", "")
+    return str(value).strip()
+
+
 async def _extract_prompt(request: Request) -> str:
-    content_type = request.headers.get("content-type", "").lower()
+    content_type_header = request.headers.get("content-type", "")
+    content_type = content_type_header.lower()
     if "application/json" in content_type:
         payload = await request.json()
         if isinstance(payload, Mapping):
             return str(payload.get("prompt", "")).strip()
         return ""
+
+    if "application/x-www-form-urlencoded" in content_type or "multipart/form-data" in content_type:
+        try:
+            return await _prompt_from_form(request)
+        except AssertionError:
+            # Starlette requires the optional python-multipart package even for
+            # URL-encoded form parsing. Keep the preview route compatible with
+            # minimal no-network installs by falling back to the raw body parser.
+            pass
+
     body = await request.body()
     if not body:
         return ""
+    if "multipart/form-data" in content_type:
+        return _prompt_from_multipart_body(content_type_header, body)
     parsed = parse_qs(body.decode())
     return (parsed.get("prompt") or [""])[0].strip()
 

--- a/tests/ui/test_expert_preview.py
+++ b/tests/ui/test_expert_preview.py
@@ -58,6 +58,27 @@ def _login(client: TestClient) -> str:
     return csrf_token
 
 
+def _assert_successful_preview_response(html: str, prompt: str) -> None:
+    assert "plain same-provider answer" in html
+    assert "Alpha Solver expert preview" in html
+    assert f'<textarea id="prompt" name="prompt" required>{prompt}</textarea>' in html
+
+
+def _install_successful_fake(client: TestClient) -> FakeProviderClient:
+    fake = FakeProviderClient(
+        [
+            _provider_result("plain same-provider answer"),
+            _provider_result(
+                '{"considerations":["Check timeline risk"],'
+                '"assumptions":["Budget is constrained"],"confidence":0.35}'
+            ),
+            _provider_result("draft expert answer that clarify mode replaces"),
+        ]
+    )
+    client.app.state.provider_client_factory = lambda _model_set: fake
+    return fake
+
+
 def test_expert_preview_requires_authentication(client: TestClient) -> None:
     response = client.get("/dashboard/expert-preview", follow_redirects=False)
 
@@ -189,6 +210,119 @@ def test_preview_submission_handles_unstructured_expert_preview_coherently(
     assert "Bearer" not in html
     assert "raw request" not in html.lower()
     assert "raw response" not in html.lower()
+
+
+def test_browser_like_multipart_submission_extracts_prompt_and_preserves_it(
+    client: TestClient,
+) -> None:
+    csrf_token = _login(client)
+    fake = _install_successful_fake(client)
+    prompt = "Define alpha in one sentence."
+
+    response = client.post(
+        "/dashboard/expert-preview",
+        files={"prompt": (None, prompt)},
+        headers={auth.CSRF_HEADER_NAME: csrf_token},
+    )
+
+    assert response.status_code == 200
+    _assert_successful_preview_response(response.text, prompt)
+    assert len(fake.requests) == 2
+
+
+def test_urlencoded_submission_extracts_prompt_and_preserves_it(client: TestClient) -> None:
+    csrf_token = _login(client)
+    fake = _install_successful_fake(client)
+    prompt = "Summarize alpha briefly."
+
+    response = client.post(
+        "/dashboard/expert-preview",
+        data={"prompt": prompt},
+        headers={auth.CSRF_HEADER_NAME: csrf_token},
+    )
+
+    assert response.status_code == 200
+    _assert_successful_preview_response(response.text, prompt)
+    assert len(fake.requests) == 2
+
+
+def test_json_submission_still_extracts_prompt(client: TestClient) -> None:
+    csrf_token = _login(client)
+    fake = _install_successful_fake(client)
+    prompt = "Explain alpha as JSON-compatible input."
+
+    response = client.post(
+        "/dashboard/expert-preview",
+        json={"prompt": prompt},
+        headers={auth.CSRF_HEADER_NAME: csrf_token},
+    )
+
+    assert response.status_code == 200
+    _assert_successful_preview_response(response.text, prompt)
+    assert len(fake.requests) == 2
+
+
+def test_empty_prompt_returns_user_facing_error(client: TestClient) -> None:
+    csrf_token = _login(client)
+
+    response = client.post(
+        "/dashboard/expert-preview",
+        data={"prompt": "   "},
+        headers={auth.CSRF_HEADER_NAME: csrf_token},
+    )
+
+    assert response.status_code == 400
+    assert "Prompt is required." in response.text
+    assert "Plain provider output" in response.text
+    assert "Alpha Solver expert preview" in response.text
+
+
+def test_preview_failure_preserves_prompt_in_textarea(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    csrf_token = _login(client)
+    prompt = "Keep this prompt visible after a provider failure."
+
+    async def fail_preview(*args: object, **kwargs: object) -> dict[str, object]:
+        raise RuntimeError("forced preview failure")
+
+    monkeypatch.setattr(expert_preview, "_solve_preview", fail_preview)
+
+    response = client.post(
+        "/dashboard/expert-preview",
+        data={"prompt": prompt},
+        headers={auth.CSRF_HEADER_NAME: csrf_token},
+    )
+
+    assert response.status_code == 502
+    assert "Preview request failed." in response.text
+    assert f'<textarea id="prompt" name="prompt" required>{prompt}</textarea>' in response.text
+
+
+def test_second_browser_style_submit_after_error_keeps_csrf_behavior(client: TestClient) -> None:
+    csrf_token = _login(client)
+    error_response = client.post(
+        "/dashboard/expert-preview",
+        files={"prompt": (None, "")},
+        headers={auth.CSRF_HEADER_NAME: csrf_token},
+    )
+    assert error_response.status_code == 400
+    assert "Prompt is required." in error_response.text
+    assert "document.write" not in error_response.text
+    assert "initExpertPreviewForm" in error_response.text
+    assert "X-Alpha-CSRF" in error_response.text
+
+    fake = _install_successful_fake(client)
+    prompt = "Define alpha in one sentence."
+    response = client.post(
+        "/dashboard/expert-preview",
+        files={"prompt": (None, prompt)},
+        headers={auth.CSRF_HEADER_NAME: csrf_token},
+    )
+
+    assert response.status_code == 200
+    _assert_successful_preview_response(response.text, prompt)
+    assert len(fake.requests) == 2
 
 
 def test_preview_copy_keeps_claim_boundaries(client: TestClient) -> None:


### PR DESCRIPTION
### Motivation
- Browser submissions from `/dashboard/expert-preview` could clear the textarea and fail with `Prompt is required.`, and a subsequent submit could navigate to a raw `{"detail":"missing CSRF token"}` response, breaking the Cloud Run local-provider smoke flow.
- Root cause was twofold: backend `_extract_prompt()` only parsed raw URL-encoded bodies (not `multipart/form-data`), and the frontend used `document.write()` which broke re-binding of the async submit handler so later submits fell back to native POST without the `X-Alpha-CSRF` header.\
- This change is the minimal safe fix to restore reliable browser submits for the supervised expert preview and closes `UI-PREVIEW-BROWSER-SUBMIT-001` when merged without changing provider or auth semantics.

### Description
- Fix prompt extraction by updating `_extract_prompt()` in `alpha/webapp/routes/expert_preview.py` to keep JSON handling, prefer `await request.form()` for `application/x-www-form-urlencoded` and `multipart/form-data`, and fall back to a raw `parse_qs` or a minimal multipart-body parser when optional multipart parsing is unavailable.
- Harden the browser submit path by changing the page form to `id="expert-preview-form"`, sending URL-encoded body via `URLSearchParams(new FormData(form))` and always including the `X-Alpha-CSRF` header on async submits, and replacing `document.write()` with a DOM swap that reinitializes the submit handler (`initExpertPreviewForm()`).
- Preserve UI behavior: the textarea retains the submitted prompt on success or error, empty prompt still returns a user-facing `Prompt is required.` error, and CSRF enforcement is unchanged (requests without `X-Alpha-CSRF` still fail). 
- Files changed: `alpha/webapp/routes/expert_preview.py` (backend + frontend HTML/JS tweaks) and `tests/ui/test_expert_preview.py` (added/updated no-network tests covering multipart, urlencoded, JSON, empty prompt, failure-preserve, and resubmit-with-CSRF scenarios).

### Testing
- Ran `git diff --check` and it reported no whitespace errors. (success)
- Ran `python -m pytest tests/ui/test_expert_preview.py -q` and all tests passed. (success)
- Ran `python -m pytest tests/ui/test_expert_preview_real_app.py -q` and all tests passed. (success)
- Ran `python -m pytest tests/test_api_endpoints.py -q` and the suite passed. (success)
- Ran the full test suite with `python -m pytest -q` and it completed successfully for the local environment (noting existing unrelated JWT rotation flakes are out-of-scope for this PR). (success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dbfdc023083298356c80c5a568445)