### PR TITLE
UI-PREVIEW-LOCAL-SMOKE-001: fix local-provider expert preview execution

### DIFF
--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -50,6 +50,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `REVIEW-P0P1.md` | CODE SPEC — REVIEW-P0P1 · P0 + P1 Bulk Review (MVP Readiness) (RES_06) |
 | `UI-JOBS-001.md` | UI-JOBS-001 · Dashboard Job History & Metrics (RES_Dash) |
 | `UI-PREVIEW-001.md` | UI-PREVIEW-001 · Authenticated Expert Preview UI |
+| `UI-PREVIEW-LOCAL-SMOKE-001.md` | UI-PREVIEW-LOCAL-SMOKE-001 · Local-provider Expert Preview Smoke Fix |
 | `UI-KEYS-001.md` | UI-KEYS-001 · Dashboard: API Keys Management |
 | `UI-REQ-001.md` | UI-REQ-001 · Dashboard Request Submission UI |
 | `UI-RUN-001.md` | UI-RUN-001 · Dashboard One-click Demo Run |

--- a/.specs/UI-PREVIEW-LOCAL-SMOKE-001.md
+++ b/.specs/UI-PREVIEW-LOCAL-SMOKE-001.md
@@ -1,0 +1,30 @@
+# UI-PREVIEW-LOCAL-SMOKE-001 · Local-provider Expert Preview Smoke Fix
+
+## Purpose
+
+Fix the Cloud Run smoke failure where `/dashboard/expert-preview` returns `Preview request failed.` when the deployment is intentionally configured with `MODEL_PROVIDER=local`.
+
+## Scope
+
+- Preserve the authenticated expert-preview flow from `UI-PREVIEW-001`.
+- Keep OpenAI disabled for the smoke path; the fix must pass with `MODEL_PROVIDER=local`.
+- Keep the preview route submitting a plain request and an expert request through the shared `/v1/solve` logic.
+- Treat `context.route` as a service/provider routing seam, not as a local solver runtime kwarg.
+- Preserve deterministic local/offline solver execution for local provider mode.
+
+## Non-goals
+
+- No OpenAI enablement.
+- No live provider smoke test.
+- No answer-quality or superiority claim.
+- No dashboard redesign.
+- No broad solver refactor.
+
+## Validation expectations
+
+No-network tests should prove:
+
+- `/v1/solve` in `MODEL_PROVIDER=local` accepts `context.route == "expert"` without invoking a provider.
+- `/dashboard/expert-preview` in `MODEL_PROVIDER=local` can render both panes for `Define alpha in one sentence.`.
+- The prompt remains preserved after submit.
+- Existing OpenAI/fake-provider expert preview behavior remains covered by existing tests.

--- a/service/app.py
+++ b/service/app.py
@@ -452,6 +452,24 @@ _CONFIDENCE_RE = re.compile(r"(?i)confidence[^0-9%]*(\d+(?:\.\d+)?)\s*(%)?")
 _PERCENT_RE = re.compile(r"(\d+(?:\.\d+)?)\s*%")
 
 
+_LOCAL_SOLVER_CONTEXT_CONTROL_KEYS = frozenset({"route"})
+
+
+def _local_solver_params(params: Dict[str, Any]) -> Dict[str, Any]:
+    """Return context kwargs safe for the deterministic local solver.
+
+    ``context.route`` is a service/provider routing seam.  The local solver does
+    not accept it as a runtime knob, so strip it before forwarding request
+    context into the local/offline implementation.
+    """
+
+    return {
+        key: value
+        for key, value in params.items()
+        if key not in _LOCAL_SOLVER_CONTEXT_CONTROL_KEYS
+    }
+
+
 def _is_expert_route(params: Dict[str, Any]) -> bool:
     return str(params.get("route", "")).strip().lower() == "expert"
 
@@ -898,7 +916,7 @@ async def solve(req: SolveRequest, request: Request) -> JSONResponse:
         max_steps = params.get("max_steps", 2)
         result = run_react_lite(query, seed=seed, max_steps=max_steps)
     else:
-        result = _tree_of_thought(query, **params)
+        result = _tree_of_thought(query, **_local_solver_params(params))
     duration_ms = (time.time() - start) * 1000
     cost = duration_ms * cfg.cost_per_ms
     _record_cost(duration_ms, cost)

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -766,7 +766,7 @@ def test_solve_expert_route_local_mode_preserves_local_response(monkeypatch):
         AssertionError("provider should not be used in local mode")
     )
 
-    def fake_solver(query: str, **kwargs):
+    def fake_solver(query: str):
         return {"final_answer": f"local:{query}"}
 
     monkeypatch.setattr("service.app._tree_of_thought", fake_solver)

--- a/tests/ui/test_expert_preview.py
+++ b/tests/ui/test_expert_preview.py
@@ -246,6 +246,38 @@ def test_urlencoded_submission_extracts_prompt_and_preserves_it(client: TestClie
     assert len(fake.requests) == 2
 
 
+def test_local_provider_expert_preview_ignores_route_context(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    csrf_token = _login(client)
+    monkeypatch.setenv("MODEL_PROVIDER", "local")
+    client.app.state.provider_client_factory = lambda _model_set: (_ for _ in ()).throw(
+        AssertionError("provider should not be used in local mode")
+    )
+    calls: list[str] = []
+
+    def fake_solver(query: str) -> dict[str, str]:
+        calls.append(query)
+        label = "plain" if len(calls) == 1 else "expert"
+        return {"final_answer": f"local {label}: {query}"}
+
+    monkeypatch.setattr("service.app._tree_of_thought", fake_solver)
+    prompt = "Define alpha in one sentence."
+
+    response = client.post(
+        "/dashboard/expert-preview",
+        data={"prompt": prompt},
+        headers={auth.CSRF_HEADER_NAME: csrf_token},
+    )
+
+    assert response.status_code == 200
+    html = response.text
+    assert "local plain: Define alpha in one sentence." in html
+    assert "local expert: Define alpha in one sentence." in html
+    assert f'<textarea id="prompt" name="prompt" required>{prompt}</textarea>' in html
+    assert calls == [prompt, prompt]
+
+
 def test_json_submission_still_extracts_prompt(client: TestClient) -> None:
     csrf_token = _login(client)
     fake = _install_successful_fake(client)


### PR DESCRIPTION
### Motivation
- Cloud Run local-provider smoke showed `/dashboard/expert-preview` returning a generic `Preview request failed.` when `MODEL_PROVIDER=local` because the expert `context.route` was forwarded into the deterministic local solver and caused execution errors. 
- The local solver entrypoint (`_tree_of_thought`) expects runtime kwargs for solver behavior, not service/provider routing seams like `route`, so the routing hint must not be forwarded. 
- The change preserves the supervised expert-preview UI behavior while ensuring local/offline deployments run without invoking the provider factory.

### Description
- Added `_LOCAL_SOLVER_CONTEXT_CONTROL_KEYS` and a helper `def _local_solver_params(params: Dict[str, Any]) -> Dict[str, Any]` in `service/app.py` to strip service/provider-only routing keys (currently `route`) from the context forwarded to the local solver. 
- Updated the local execution path to call `_tree_of_thought(query, **_local_solver_params(params))` so `context.route` is not passed into the deterministic local solver. 
- Tightened tests to reflect the local solver call shape: adjusted `tests/test_api_endpoints.py` so the fake local solver has the signature `fake_solver(query: str)`, and added a UI regression `test_local_provider_expert_preview_ignores_route_context` in `tests/ui/test_expert_preview.py` that verifies both panes render with `MODEL_PROVIDER=local` and the prompt is preserved. 
- Added a new spec file `.specs/UI-PREVIEW-LOCAL-SMOKE-001.md` and updated `.specs/INDEX.md` to register the smoke-fix validation scope.

### Testing
- Ran focused pytest on the new/affected tests: `python -m pytest -q tests/test_api_endpoints.py::test_solve_expert_route_local_mode_preserves_local_response tests/ui/test_expert_preview.py::test_local_provider_expert_preview_ignores_route_context tests/ui/test_expert_preview.py::test_urlencoded_submission_extracts_prompt_and_preserves_it`, and these passed. 
- Ran the combined UI + real-app + API subset: `python -m pytest -q tests/ui/test_expert_preview.py tests/ui/test_expert_preview_real_app.py tests/test_api_endpoints.py`, and these passed. 
- Ran a full test run `python -m pytest -q`; the only failing test was an unrelated pre-existing failure `tests/test_jwt_auth.py::test_rotation` (returns `401 unknown_kid`), while the expert-preview/local-provider focused tests in this PR passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dc9be7c588329a3e89c5b1c4e8fb0)