### PR TITLE
DASHBOARD-LOGIN-REDIRECT-001: make dashboard login redirect configurable

### DIFF
--- a/.specs/DASHBOARD-LOGIN-REDIRECT-001.md
+++ b/.specs/DASHBOARD-LOGIN-REDIRECT-001.md
@@ -1,0 +1,59 @@
+# DASHBOARD-LOGIN-REDIRECT-001 · Configurable Dashboard Login Redirect
+
+## Objective
+
+Fix the bundled `service.app:app` Cloud Run/operator preview login landing so a
+successful dashboard login redirects to `/dashboard/expert-preview` instead of
+`/requests`, while preserving the shared dashboard auth router's default landing
+behavior for existing/custom consumers.
+
+## Scope
+
+- Add app-local configurability for the dashboard post-login redirect in
+  `alpha.webapp.routes.auth`.
+- Configure only the bundled `service.app:app` dashboard mount to use
+  `/dashboard/expert-preview` after successful login.
+- Keep the bundled app mounted only for login/auth and expert preview; do not
+  mount `/requests`, `/settings`, `/run`, or `/jobs`.
+- Keep dashboard session cookies, CSRF checks, lockout behavior, and fail-closed
+  mount guard semantics unchanged.
+- Update operator documentation that previously described the `/requests`
+  post-login redirect as a known limitation.
+
+## Acceptance criteria
+
+- Successful login in bundled `service.app:app` redirects to
+  `/dashboard/expert-preview`.
+- Successful login still sets the dashboard session and CSRF cookies.
+- Incorrect passwords still render the login page with `Invalid credentials`.
+- Logged-out requests to `/dashboard/expert-preview` still redirect to `/login`.
+- Logged-in requests to `/dashboard/expert-preview` render successfully.
+- `/requests`, `/settings`, `/run`, and `/jobs` remain unmounted in the bundled
+  Cloud Run/operator preview app unless independently mounted by future approved
+  work.
+- The default shared auth router login redirect remains `/requests` unless an
+  application explicitly configures a different redirect target.
+- No provider, OpenAI, expert-pass, clarify/eval, or Cloud Run Docker behavior
+  changes.
+
+## Backlog impact
+
+`DASHBOARD-LOGIN-REDIRECT-001` should be marked Done only after the implementing
+PR is merged. This is a UX cleanup after `DEPLOY-CLOUDRUN-SMOKE-001`; it does
+not change Cloud Run deployment status, enable live OpenAI, validate the MVP, or
+claim production readiness.
+
+## Non-goals
+
+- No mounting `/requests`, `/settings`, `/run`, or `/jobs` in the bundled app.
+- No dashboard redesign.
+- No auth/session/CSRF weakening.
+- No dashboard fail-closed behavior changes.
+- No OpenAI or provider behavior changes.
+- No expert-pass, clarify, or eval behavior changes.
+- No JWT flake fixes.
+- No live spend guard changes.
+- No Google Sheets or backlog workbook updates.
+- No MVP-validation, Alpha Solver superiority, production-readiness, broad
+  runtime-readiness, answer-quality benchmark success, or provider reasoning
+  orchestration claims.

--- a/.specs/DEPLOY-CLOUDRUN-CONFIG-001.md
+++ b/.specs/DEPLOY-CLOUDRUN-CONFIG-001.md
@@ -17,7 +17,7 @@ for a controlled Alpha Solver MVP preview deployment of `/dashboard/expert-previ
 
 - The root `Dockerfile` uses Python 3.12, installs `requirements.txt`, copies the repo, and starts `service.app:app` with Uvicorn on `0.0.0.0` using Cloud Run `PORT` with an `8080` fallback.
 - `.dockerignore` excludes local caches, artifacts, logs, virtualenvs, VCS state, and local env files without excluding required app files.
-- The Cloud Run MVP preview doc covers purpose, scope boundaries, required settings, required env vars, local build/run, deploy examples, smoke tests, fail-closed dashboard behavior, the `/requests` redirect limitation, local-provider first workflow, held live OpenAI workflow, security notes, claim boundaries, troubleshooting, and backlog impact.
+- The Cloud Run MVP preview doc covers purpose, scope boundaries, required settings, required env vars, local build/run, deploy examples, smoke tests, fail-closed dashboard behavior, the bundled preview login redirect behavior, local-provider first workflow, held live OpenAI workflow, security notes, claim boundaries, troubleshooting, and backlog impact.
 - No runtime behavior changes are made.
 - No secrets are committed.
 - No Cloud Run deployment is performed from Codex.

--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -8,6 +8,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `AS-148.md` | CODE SPEC — AS-148 · Policy & PII Gateway (DR_TRACK_A) |
 | `AUTH-SESSION-001.md` | AUTH-SESSION-001 · Dashboard Login + Session |
 | `CLARIFY-SURFACE-001.md` | CLARIFY-SURFACE-001 · Expert Route Clarify Surface |
+| `DASHBOARD-LOGIN-REDIRECT-001.md` | DASHBOARD-LOGIN-REDIRECT-001 · Configurable Dashboard Login Redirect |
 | `DEPLOY-CLOUDRUN-CONFIG-001.md` | DEPLOY-CLOUDRUN-CONFIG-001 · Cloud Run MVP Preview Deployment Config |
 | `DEPLOY-CLOUDRUN-DASHBOARD-SECRET-GUARD-001.md` | DEPLOY-CLOUDRUN-DASHBOARD-SECRET-GUARD-001 · Require Dashboard Secret for Bundled Cloud Run Preview Mount |
 | `EPIC_RAG_001.md` | EPIC_RAG_001 · RAG & Semantic Cache Pack |

--- a/alpha/webapp/routes/auth.py
+++ b/alpha/webapp/routes/auth.py
@@ -24,6 +24,8 @@ __all__ = [
     "CSRF_HEADER_NAME",
     "PASSWORD_ENV_VAR",
     "DEFAULT_DASHBOARD_PASSWORD",
+    "DEFAULT_LOGIN_REDIRECT",
+    "configure_login_redirect",
 ]
 
 
@@ -38,6 +40,12 @@ SECRET_ENV_VAR = "ALPHA_DASHBOARD_SECRET_KEY"
 # Fallback password used only when PASSWORD_ENV_VAR is unset. Callers that mount
 # the dashboard on a public app should treat this value as "not configured".
 DEFAULT_DASHBOARD_PASSWORD = "alpha-dashboard"
+
+# Default dashboard landing page after a successful login. Bundled or custom
+# applications can override this on their FastAPI app state without changing the
+# shared router's default behavior.
+DEFAULT_LOGIN_REDIRECT = "/requests"
+_LOGIN_REDIRECT_STATE_ATTR = "alpha_dashboard_login_redirect"
 
 SESSION_TTL_SECONDS = 60 * 60  # one hour
 LOCKOUT_THRESHOLD = 5
@@ -235,6 +243,28 @@ def _build_lockout_response() -> HTMLResponse:
     return HTMLResponse(content=html, status_code=status.HTTP_429_TOO_MANY_REQUESTS)
 
 
+def _validate_login_redirect(target: str) -> str:
+    if not target.startswith("/") or target.startswith("//"):
+        raise ValueError("dashboard login redirect must be a root-relative path")
+    return target
+
+
+def configure_login_redirect(app: FastAPI, target: str) -> None:
+    """Configure the app-local dashboard landing path after successful login."""
+
+    setattr(app.state, _LOGIN_REDIRECT_STATE_ATTR, _validate_login_redirect(target))
+
+
+def _login_redirect_for(request: Request) -> str:
+    target = getattr(request.app.state, _LOGIN_REDIRECT_STATE_ATTR, DEFAULT_LOGIN_REDIRECT)
+    if not isinstance(target, str):
+        return DEFAULT_LOGIN_REDIRECT
+    try:
+        return _validate_login_redirect(target)
+    except ValueError:
+        return DEFAULT_LOGIN_REDIRECT
+
+
 @router.get("/login", response_class=HTMLResponse)
 async def login_form() -> HTMLResponse:
     return HTMLResponse(content=_render_login_template())
@@ -251,7 +281,9 @@ async def login(request: Request) -> Response:
     if secrets.compare_digest(supplied_password, _expected_password()):
         _record_success(identifier)
         session = _create_session()
-        response = RedirectResponse("/requests", status_code=status.HTTP_303_SEE_OTHER)
+        response = RedirectResponse(
+            _login_redirect_for(request), status_code=status.HTTP_303_SEE_OTHER
+        )
         response.set_cookie(
             CSRF_COOKIE_NAME,
             session.csrf_token,

--- a/alpha/webapp/routes/expert_preview.py
+++ b/alpha/webapp/routes/expert_preview.py
@@ -20,7 +20,10 @@ DISCLAIMER = (
     "answer-quality benchmark success."
 )
 
-_ROUTE = "/dashboard/expert-preview"
+ROUTE = "/dashboard/expert-preview"
+_ROUTE = ROUTE
+
+
 def _escape(value: Any) -> str:
     return html.escape("" if value is None else str(value), quote=True)
 

--- a/docs/DASHBOARD_AUTH.md
+++ b/docs/DASHBOARD_AUTH.md
@@ -79,10 +79,10 @@ secret. The auth module's fallback random secret remains available for custom
 router integrations; the bundled app's Cloud Run/operator mount guard requires
 explicit configuration.
 
-**Known limitation (deferred):** a successful login redirects to `/requests`,
-which the bundled API app does not mount, so the post-login landing returns 404.
-After logging in, open `/dashboard/expert-preview` directly. A follow-up will
-make the post-login destination configurable.
+The shared auth router still defaults successful login to `/requests` for
+custom/full-dashboard consumers. The bundled API app configures its app-local
+post-login redirect to `/dashboard/expert-preview` because it intentionally
+mounts only auth plus the supervised expert-preview route.
 
 ## Obtaining the CSRF Token
 

--- a/docs/deployment/CLOUD_RUN_MVP_PREVIEW.md
+++ b/docs/deployment/CLOUD_RUN_MVP_PREVIEW.md
@@ -214,8 +214,8 @@ curl -i "${SERVICE_URL}/readyz"
 
 - [ ] Logged-out `GET /dashboard/expert-preview` redirects or blocks according to dashboard auth convention.
 - [ ] Login works with the configured dashboard password.
-- [ ] The known `/requests` post-login redirect limitation is understood and is not treated as a blocker.
-- [ ] After login, direct navigation to `/dashboard/expert-preview` works.
+- [ ] Login redirects to `/dashboard/expert-preview`, not `/requests`.
+- [ ] `/requests` remains unmounted in the bundled preview app.
 - [ ] Authenticated `GET /dashboard/expert-preview` returns 200.
 
 Example cookie-jar flow:
@@ -263,13 +263,14 @@ continues serving. Preserve this behavior for Cloud Run. The auth module's
 standalone random-secret fallback is intentionally unchanged for custom app
 integrations, but the bundled Cloud Run preview mount guard must not rely on it.
 
-## 10. Known `/requests` post-login redirect limitation
+## 10. Bundled preview login landing
 
-Successful dashboard login currently redirects to `/requests`. The Cloud Run
-preview service mounts `/login` and `/dashboard/expert-preview`, but not the full
-legacy dashboard request page. A post-login `/requests` 404 is a known deferred
-limitation and is not a deployment blocker. After login, open
-`/dashboard/expert-preview` directly.
+The shared dashboard auth router defaults successful login to `/requests` for
+custom/full-dashboard consumers. The Cloud Run preview service intentionally
+mounts `/login` and `/dashboard/expert-preview`, but not the full legacy
+dashboard request page. The bundled `service.app:app` integration therefore
+configures successful login to redirect directly to `/dashboard/expert-preview`;
+`/requests` remains unmounted in this preview app.
 
 ## 11. Local-provider first workflow
 
@@ -323,7 +324,7 @@ It only prepares the repo for a controlled Cloud Run MVP preview deployment.
 | --- | --- | --- |
 | Cloud Run revision never becomes ready | Container is not listening on Cloud Run `PORT` or dependencies failed to install | Use the root `Dockerfile`; confirm the command starts Uvicorn with `--host 0.0.0.0 --port "${PORT:-8080}"` |
 | `/dashboard/expert-preview` returns 404 | Dashboard password is unset/default or dashboard secret key is missing/empty | Configure a strong non-default `ALPHA_DASHBOARD_PASSWORD` and non-empty `ALPHA_DASHBOARD_SECRET_KEY`, then redeploy a new revision |
-| Login succeeds then `/requests` returns 404 | Known login redirect limitation | Navigate directly to `/dashboard/expert-preview` after login |
+| Login redirects somewhere other than `/dashboard/expert-preview` | Bundled dashboard login redirect was not configured or regressed | Check `service.app:app` dashboard mounting and rerun the no-network UI tests |
 | POST to preview returns 403 | Missing or invalid CSRF header | Send `X-Alpha-CSRF` with the value from the `alpha_dashboard_csrf` cookie |
 | Preview attempts live provider calls | `MODEL_PROVIDER` is set to `openai` | Revert to `MODEL_PROVIDER=local`; remove `OPENAI_API_KEY` from the first preview revision |
 | Secrets appear in output | Regression or unsafe manual logging | Stop testing, capture minimal evidence without secrets, rotate affected secrets, and fix before continuing |

--- a/service/app.py
+++ b/service/app.py
@@ -177,11 +177,9 @@ app.add_middleware(
 # deployment that forgot to set one, so we skip mounting (routes 404), log a
 # warning, and leave the JSON API fully working.
 #
-# Known limitation (tracked, deferred): a successful login redirects to /requests
-# (alpha.webapp.routes.auth.login), which this app does not mount, so the post-login
-# landing 404s. Operators should open /dashboard/expert-preview directly. A follow-up
-# should make the post-login destination configurable; we do not change the shared
-# auth redirect here.
+# The bundled preview app intentionally does not mount the full dashboard request,
+# settings, run, or jobs routes. Successful login therefore lands on the mounted
+# expert-preview page instead of the shared dashboard default.
 def _dashboard_enabled() -> bool:
     password = os.getenv(dashboard_auth.PASSWORD_ENV_VAR)
     secret_key = os.getenv(dashboard_auth.SECRET_ENV_VAR)
@@ -194,6 +192,7 @@ def _dashboard_enabled() -> bool:
 
 def _mount_dashboard(target: FastAPI) -> None:
     dashboard_auth.install_dashboard_security(target)
+    dashboard_auth.configure_login_redirect(target, expert_preview.ROUTE)
     target.include_router(dashboard_auth.router)
     target.include_router(expert_preview.router)
 

--- a/tests/ui/test_auth.py
+++ b/tests/ui/test_auth.py
@@ -53,6 +53,7 @@ def test_login_sets_secure_cookie_and_allows_access(client: TestClient) -> None:
 
     response = client.post("/login", data={"password": "testing-secret"}, follow_redirects=False)
     assert response.status_code == 303
+    assert response.headers["location"] == auth.DEFAULT_LOGIN_REDIRECT
 
     session_cookie = client.cookies.get(auth.SESSION_COOKIE_NAME)
     csrf_cookie = client.cookies.get(auth.CSRF_COOKIE_NAME)
@@ -68,6 +69,37 @@ def test_login_sets_secure_cookie_and_allows_access(client: TestClient) -> None:
     page = client.get("/requests")
     assert page.status_code == 200
     assert "<form" in page.text
+
+
+def test_configured_login_redirect_preserves_session_cookies(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ALPHA_DASHBOARD_PASSWORD", "testing-secret")
+    monkeypatch.setenv("ALPHA_DASHBOARD_SECRET_KEY", "unit-test-secret")
+    monkeypatch.setenv("ALPHA_DASHBOARD_SECRETS_PATH", str(tmp_path / "secrets.json"))
+    monkeypatch.setenv("ALPHA_DASHBOARD_AUDIT_LOG", str(tmp_path / "audit.log"))
+
+    auth.reset_state()
+    request_routes.reset_state()
+
+    app = FastAPI()
+    auth.install_dashboard_security(app)
+    auth.configure_login_redirect(app, "/dashboard/expert-preview")
+    app.include_router(auth.router)
+    app.include_router(request_routes.router)
+
+    configured_client = TestClient(app, base_url="https://testserver")
+    try:
+        response = configured_client.post(
+            "/login", data={"password": "testing-secret"}, follow_redirects=False
+        )
+        assert response.status_code == 303
+        assert response.headers["location"] == "/dashboard/expert-preview"
+        assert configured_client.cookies.get(auth.SESSION_COOKIE_NAME)
+        assert configured_client.cookies.get(auth.CSRF_COOKIE_NAME)
+    finally:
+        configured_client.close()
+        auth.reset_state()
 
 
 def test_failed_logins_trigger_lockout(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/ui/test_expert_preview_real_app.py
+++ b/tests/ui/test_expert_preview_real_app.py
@@ -61,9 +61,38 @@ def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
 def _login(client: TestClient) -> str:
     response = client.post("/login", data={"password": "testing-secret"}, follow_redirects=False)
     assert response.status_code == 303
+    assert response.headers["location"] == ROUTE
     csrf_token = client.cookies.get(auth.CSRF_COOKIE_NAME)
     assert csrf_token
     return csrf_token
+
+
+def test_successful_login_redirects_to_expert_preview_and_sets_cookies(
+    client: TestClient,
+) -> None:
+    response = client.post("/login", data={"password": "testing-secret"}, follow_redirects=False)
+
+    assert response.status_code == 303
+    assert response.headers["location"] == ROUTE
+    assert client.cookies.get(auth.SESSION_COOKIE_NAME)
+    assert client.cookies.get(auth.CSRF_COOKIE_NAME)
+
+
+def test_incorrect_password_returns_login_page(client: TestClient) -> None:
+    response = client.post("/login", data={"password": "wrong"}, follow_redirects=False)
+
+    assert response.status_code == 401
+    assert "Invalid credentials" in response.text
+    assert not client.cookies.get(auth.SESSION_COOKIE_NAME)
+
+
+def test_requests_route_remains_unmounted_in_bundled_app(client: TestClient) -> None:
+    _login(client)
+
+    response = client.get("/requests")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Not Found"}
 
 
 def test_route_registered_in_real_app() -> None:


### PR DESCRIPTION
### Motivation

- Fix the bundled Cloud Run/operator preview UX where a successful dashboard login redirected to `/requests` (not mounted in the bundled preview) and landed operators on a 404. 
- Provide the smallest safe change to make the post-login landing configurable while preserving the shared router's existing default behavior. 
- Keep dashboard fail-closed mounting, session/CSRF semantics, and the decision to not mount `/requests`, `/settings`, `/run`, or `/jobs` in the bundled preview unchanged.

### Description

- Add app-local configurability to the shared auth router by introducing `DEFAULT_LOGIN_REDIRECT`, `configure_login_redirect(app, target)`, and `_login_redirect_for(request)` in `alpha/webapp/routes/auth.py`, and use that value from the `login` handler. 
- Validate configured redirect targets to be root-relative to avoid unsafe redirects. 
- Expose the expert-preview route as `ROUTE` in `alpha/webapp/routes/expert_preview.py` and configure the bundled app to call `dashboard_auth.configure_login_redirect(target, expert_preview.ROUTE)` in `service/app.py` when mounting the dashboard. 
- Add the implementation contract `.specs/DASHBOARD-LOGIN-REDIRECT-001.md`, update docs in `docs/DASHBOARD_AUTH.md` and `docs/deployment/CLOUD_RUN_MVP_PREVIEW.md` to reflect the new bundled landing, and add/adjust no-network tests in `tests/ui/test_auth.py` and `tests/ui/test_expert_preview_real_app.py` to cover the configurable redirect and cookie/CSRF behavior.

### Testing

- Ran `pytest tests/ui/test_expert_preview_real_app.py` and `pytest tests/ui/test_expert_preview.py` and they passed (updated assertions verify bundled app login redirects to `/dashboard/expert-preview`). 
- Ran `pytest tests/ui/test_auth.py` and `pytest tests/test_api_endpoints.py` and they passed (tests confirm default `/requests` redirect remains for unconfigured apps and cookies/CSRF behavior unchanged). 
- Ran the full test suite (`python -m pytest -q`) and it completed successfully with unrelated deprecation warnings and expected skipped live-smoke tests. 
- Targeted auth + real-app assertions now cover: successful bundled-app login redirect, session and CSRF cookies set, invalid-password response, preview protection when logged out, and that `/requests` remains unmounted in the bundled preview app.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dd7b16b648329a91b84454695cb2a)