### PR TITLE
DEPLOY-LIVE-SPEND-GUARD-001: add guardrails before live OpenAI preview testing

### DIFF
--- a/.specs/DEPLOY-LIVE-SPEND-GUARD-001.md
+++ b/.specs/DEPLOY-LIVE-SPEND-GUARD-001.md
@@ -1,0 +1,81 @@
+# DEPLOY-LIVE-SPEND-GUARD-001 · Live Provider Spend Guard for Expert Preview
+
+## Purpose
+
+Add a narrow fail-closed spend guard before any live OpenAI-backed operator
+testing of `/dashboard/expert-preview` on Cloud Run. The guard applies only to
+the authenticated dashboard preview route and does not enable live OpenAI.
+
+## Scope
+
+In scope:
+
+- keep `MODEL_PROVIDER=local` preview behavior unchanged;
+- require an explicit `ALPHA_LIVE_PREVIEW_ENABLED=true` opt-in before preview
+  submissions may use `MODEL_PROVIDER=openai`;
+- enforce a per-process preview request cap via
+  `ALPHA_LIVE_PREVIEW_MAX_REQUESTS`;
+- block before provider client construction or provider calls when the opt-in is
+  absent/false or the cap has been reached;
+- render safe user-facing block messages that preserve the submitted prompt;
+- log server-side allow/block decisions without secrets, prompts, raw headers,
+  raw request bodies, or provider payloads;
+- document the environment variables required for approved live-provider preview
+  testing.
+
+Out of scope:
+
+- enabling live OpenAI in Cloud Run;
+- deploying to Cloud Run;
+- making real OpenAI calls in tests;
+- persistent quota storage or billing dashboards;
+- changes to dashboard auth/session/CSRF behavior;
+- changes to provider expert-pass behavior after a request is allowed;
+- Google Sheets/backlog workbook updates.
+
+## Guard design
+
+The guard lives in the `/dashboard/expert-preview` POST route because that route
+is the immediate Cloud Run live-testing surface. It checks `MODEL_PROVIDER` after
+CSRF/session middleware has accepted the request and before the route calls the
+shared solve path.
+
+When `MODEL_PROVIDER` is not `openai`, the guard is bypassed so local-provider
+smoke testing remains unchanged. When `MODEL_PROVIDER=openai`, submissions are
+blocked unless `ALPHA_LIVE_PREVIEW_ENABLED` is truthy (`1`, `true`, `yes`, or
+`on`). Allowed live-preview submissions consume one per-process cap slot. The
+cap comes from `ALPHA_LIVE_PREVIEW_MAX_REQUESTS`; if unset, the default is `1`
+allowed preview submission per service instance. Invalid, zero, or negative caps
+fail closed.
+
+## Environment variables
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `MODEL_PROVIDER` | `local` | `openai` selects the live provider path guarded by this spec. |
+| `ALPHA_LIVE_PREVIEW_ENABLED` | unset/false | Must be truthy before `/dashboard/expert-preview` may call the OpenAI provider path. |
+| `ALPHA_LIVE_PREVIEW_MAX_REQUESTS` | `1` | Per-process cap for allowed live preview submissions. |
+| `OPENAI_API_KEY` | unset | Required only for explicitly approved live-provider testing; never committed. |
+
+## Acceptance criteria
+
+- Local-provider preview submit still returns `200` and renders both panes.
+- OpenAI-provider preview submit is blocked before provider calls when
+  `ALPHA_LIVE_PREVIEW_ENABLED` is absent or false.
+- OpenAI-provider preview submit is allowed when live preview is enabled and the
+  cap permits, using fake-provider tests only.
+- Further preview submits are blocked before provider calls once the configured
+  cap is reached.
+- Blocked responses preserve the submitted prompt and do not render secrets, raw
+  headers, bearer tokens, API keys, raw request bodies, or raw provider payloads.
+- CSRF rejection and dashboard login/session behavior remain unchanged.
+- Provider expert-pass behavior remains unchanged when the guard allows a
+  request.
+
+## Backlog impact
+
+`DEPLOY-LIVE-SPEND-GUARD-001` should be marked Done only if the PR implementing
+this spec is merged. `DEPLOY-CLOUDRUN-LIVE-OPENAI-001` remains Held until the
+operator explicitly approves live-provider testing after this guard is merged and
+deployed. This spec does not validate the MVP, claim production readiness, or
+claim provider reasoning orchestration.

--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -11,6 +11,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `DASHBOARD-LOGIN-REDIRECT-001.md` | DASHBOARD-LOGIN-REDIRECT-001 · Configurable Dashboard Login Redirect |
 | `DEPLOY-CLOUDRUN-CONFIG-001.md` | DEPLOY-CLOUDRUN-CONFIG-001 · Cloud Run MVP Preview Deployment Config |
 | `DEPLOY-CLOUDRUN-DASHBOARD-SECRET-GUARD-001.md` | DEPLOY-CLOUDRUN-DASHBOARD-SECRET-GUARD-001 · Require Dashboard Secret for Bundled Cloud Run Preview Mount |
+| `DEPLOY-LIVE-SPEND-GUARD-001.md` | DEPLOY-LIVE-SPEND-GUARD-001 · Live Provider Spend Guard for Expert Preview |
 | `EPIC_RAG_001.md` | EPIC_RAG_001 · RAG & Semantic Cache Pack |
 | `EVAL-ARTIFACT-PRESERVE-001.md` | EVAL-ARTIFACT-PRESERVE-001 · Preserve Eval Summary Artifacts |
 | `EVAL-BEHAVIORAL-DEMO-001.md` | EVAL-BEHAVIORAL-DEMO-001 · Expert Pass Behavioral Demo Checklist |

--- a/alpha/webapp/routes/expert_preview.py
+++ b/alpha/webapp/routes/expert_preview.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
-import html
-import json
 from email import policy
 from email.parser import BytesParser
+import html
+import json
+import logging
+import os
+from threading import Lock
 from typing import Any, Dict, Iterable, Mapping
 from urllib.parse import parse_qs
 
@@ -13,6 +16,7 @@ from fastapi import APIRouter, Request, status
 from fastapi.responses import HTMLResponse
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 DISCLAIMER = (
     "This preview is for supervised operator review. It does not prove Alpha Solver "
@@ -22,6 +26,88 @@ DISCLAIMER = (
 
 ROUTE = "/dashboard/expert-preview"
 _ROUTE = ROUTE
+LIVE_PREVIEW_ENABLED_ENV = "ALPHA_LIVE_PREVIEW_ENABLED"
+LIVE_PREVIEW_MAX_REQUESTS_ENV = "ALPHA_LIVE_PREVIEW_MAX_REQUESTS"
+_DEFAULT_LIVE_PREVIEW_MAX_REQUESTS = 1
+_LIVE_PREVIEW_DISABLED_MESSAGE = (
+    "Live OpenAI preview testing is disabled. Set "
+    f"{LIVE_PREVIEW_ENABLED_ENV}=true and configure a low "
+    f"{LIVE_PREVIEW_MAX_REQUESTS_ENV} only for explicitly approved operator testing."
+)
+_LIVE_PREVIEW_CAP_MESSAGE = (
+    "Live OpenAI preview request cap reached for this service instance. "
+    f"Raise {LIVE_PREVIEW_MAX_REQUESTS_ENV} only with explicit operator approval."
+)
+
+
+def _truthy_env(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _model_provider() -> str:
+    return os.getenv("MODEL_PROVIDER", "local").strip().lower()
+
+
+def _live_preview_max_requests() -> int:
+    raw = os.getenv(LIVE_PREVIEW_MAX_REQUESTS_ENV, "").strip()
+    if not raw:
+        return _DEFAULT_LIVE_PREVIEW_MAX_REQUESTS
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning(
+            "live_preview_guard blocked reason=invalid_cap provider=openai env=%s",
+            LIVE_PREVIEW_MAX_REQUESTS_ENV,
+        )
+        return 0
+
+
+def _live_preview_lock(request: Request) -> Lock:
+    lock = getattr(request.app.state, "live_preview_guard_lock", None)
+    if lock is None:
+        lock = Lock()
+        request.app.state.live_preview_guard_lock = lock
+    return lock
+
+
+def _check_live_preview_guard(request: Request) -> str | None:
+    """Return a safe user-facing error when the live preview must fail closed."""
+
+    provider = _model_provider()
+    if provider != "openai":
+        return None
+
+    if not _truthy_env(LIVE_PREVIEW_ENABLED_ENV):
+        logger.warning(
+            "live_preview_guard blocked reason=disabled provider=openai env=%s",
+            LIVE_PREVIEW_ENABLED_ENV,
+        )
+        return _LIVE_PREVIEW_DISABLED_MESSAGE
+
+    max_requests = _live_preview_max_requests()
+    if max_requests <= 0:
+        logger.warning(
+            "live_preview_guard blocked reason=cap_not_positive provider=openai max_requests=%s",
+            max_requests,
+        )
+        return _LIVE_PREVIEW_CAP_MESSAGE
+
+    with _live_preview_lock(request):
+        count = int(getattr(request.app.state, "live_preview_request_count", 0))
+        if count >= max_requests:
+            logger.warning(
+                "live_preview_guard blocked reason=cap_reached provider=openai count=%s max_requests=%s",
+                count,
+                max_requests,
+            )
+            return _LIVE_PREVIEW_CAP_MESSAGE
+        request.app.state.live_preview_request_count = count + 1
+        logger.warning(
+            "live_preview_guard allowed provider=openai count=%s max_requests=%s",
+            count + 1,
+            max_requests,
+        )
+    return None
 
 
 def _escape(value: Any) -> str:
@@ -293,6 +379,12 @@ async def expert_preview_submit(request: Request) -> HTMLResponse:
         return HTMLResponse(
             content=_render_page(error="Prompt is required."),
             status_code=status.HTTP_400_BAD_REQUEST,
+        )
+    guard_error = _check_live_preview_guard(request)
+    if guard_error:
+        return HTMLResponse(
+            content=_render_page(prompt=prompt, error=guard_error),
+            status_code=status.HTTP_403_FORBIDDEN,
         )
     try:
         plain = await _solve_preview(request, prompt, expert=False)

--- a/docs/deployment/CLOUD_RUN_MVP_PREVIEW.md
+++ b/docs/deployment/CLOUD_RUN_MVP_PREVIEW.md
@@ -91,9 +91,22 @@ succeeds and live-provider spend is explicitly approved:
 ```text
 MODEL_PROVIDER=openai
 OPENAI_API_KEY=<test-project-key>
+ALPHA_LIVE_PREVIEW_ENABLED=true
+ALPHA_LIVE_PREVIEW_MAX_REQUESTS=<low integer cap, for example 1 or 2>
 ```
 
-Do not configure `OPENAI_API_KEY` for the first local-provider preview.
+Do not configure `OPENAI_API_KEY` for the first local-provider preview. Do not
+switch `MODEL_PROVIDER` from `local` to `openai` until the operator explicitly
+approves live-provider testing after the live-preview spend guard is merged and
+deployed.
+
+`ALPHA_LIVE_PREVIEW_ENABLED` defaults to fail-closed behavior. When
+`MODEL_PROVIDER=openai` but `ALPHA_LIVE_PREVIEW_ENABLED` is unset or false,
+`/dashboard/expert-preview` blocks preview submissions before constructing or
+calling the provider client. `ALPHA_LIVE_PREVIEW_MAX_REQUESTS` is a per-process
+request cap for the preview form; when unset, the app uses a very low default of
+`1` allowed preview submission per service instance. Set it explicitly to the
+lowest number needed for the approved operator test window.
 
 ## 5. Secret handling
 
@@ -326,7 +339,9 @@ It only prepares the repo for a controlled Cloud Run MVP preview deployment.
 | `/dashboard/expert-preview` returns 404 | Dashboard password is unset/default or dashboard secret key is missing/empty | Configure a strong non-default `ALPHA_DASHBOARD_PASSWORD` and non-empty `ALPHA_DASHBOARD_SECRET_KEY`, then redeploy a new revision |
 | Login redirects somewhere other than `/dashboard/expert-preview` | Bundled dashboard login redirect was not configured or regressed | Check `service.app:app` dashboard mounting and rerun the no-network UI tests |
 | POST to preview returns 403 | Missing or invalid CSRF header | Send `X-Alpha-CSRF` with the value from the `alpha_dashboard_csrf` cookie |
-| Preview attempts live provider calls | `MODEL_PROVIDER` is set to `openai` | Revert to `MODEL_PROVIDER=local`; remove `OPENAI_API_KEY` from the first preview revision |
+| Preview attempts live provider calls | `MODEL_PROVIDER` is set to `openai` and live-preview opt-in/cap allowed the request | Revert to `MODEL_PROVIDER=local`; remove `OPENAI_API_KEY` from the first preview revision |
+| Preview submit returns 403 with live preview disabled | `MODEL_PROVIDER=openai` without `ALPHA_LIVE_PREVIEW_ENABLED=true` | This is expected fail-closed behavior; keep held unless live-provider testing is explicitly approved |
+| Preview submit returns 403 after one or a few live tests | `ALPHA_LIVE_PREVIEW_MAX_REQUESTS` cap reached for the Cloud Run instance | Stop testing or deploy a new approved revision with a low explicit cap |
 | Secrets appear in output | Regression or unsafe manual logging | Stop testing, capture minimal evidence without secrets, rotate affected secrets, and fix before continuing |
 | Cold starts are slow | `min-instances=0` | Accept for first testing or temporarily set `min-instances=1` for scheduled operator sessions |
 

--- a/tests/ui/test_expert_preview.py
+++ b/tests/ui/test_expert_preview.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import sys
 from pathlib import Path
 
@@ -35,6 +34,8 @@ def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
     monkeypatch.setenv("ALPHA_DASHBOARD_PASSWORD", "testing-secret")
     monkeypatch.setenv("ALPHA_DASHBOARD_SECRET_KEY", "unit-test-secret")
     monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    monkeypatch.setenv("ALPHA_LIVE_PREVIEW_ENABLED", "true")
+    monkeypatch.setenv("ALPHA_LIVE_PREVIEW_MAX_REQUESTS", "20")
     auth.reset_state()
 
     app = FastAPI()
@@ -47,7 +48,6 @@ def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
         yield test_client
     finally:
         test_client.close()
-        os.environ.pop("MODEL_PROVIDER", None)
 
 
 def _login(client: TestClient) -> str:
@@ -62,6 +62,20 @@ def _assert_successful_preview_response(html: str, prompt: str) -> None:
     assert "plain same-provider answer" in html
     assert "Alpha Solver expert preview" in html
     assert f'<textarea id="prompt" name="prompt" required>{prompt}</textarea>' in html
+
+
+def _assert_no_sensitive_preview_leak(html: str, *secrets: str) -> None:
+    for secret in secrets:
+        assert secret not in html
+    assert "provider-hidden" not in html
+    assert "raw_metadata" not in html
+    assert "Authorization" not in html
+    assert "Bearer" not in html
+    assert "OPENAI_API_KEY" not in html
+    assert "sk-" not in html
+    assert "raw request" not in html.lower()
+    assert "raw response" not in html.lower()
+    assert "raw provider" not in html.lower()
 
 
 def _install_successful_fake(client: TestClient) -> FakeProviderClient:
@@ -155,6 +169,97 @@ def test_preview_submission_renders_plain_and_expert_outputs(client: TestClient)
     assert "Bearer" not in html
     assert "raw request" not in html.lower()
     assert "raw response" not in html.lower()
+
+
+def test_openai_preview_submit_blocks_when_live_preview_flag_absent(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    csrf_token = _login(client)
+    prompt = "Keep this blocked prompt visible."
+    monkeypatch.delenv("ALPHA_LIVE_PREVIEW_ENABLED", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-guard-test-should-not-render")
+
+    def fail_factory(_model_set: object) -> FakeProviderClient:
+        raise AssertionError("provider factory must not be invoked when guard blocks")
+
+    client.app.state.provider_client_factory = fail_factory
+
+    response = client.post(
+        "/dashboard/expert-preview",
+        data={"prompt": prompt},
+        headers={
+            auth.CSRF_HEADER_NAME: csrf_token,
+            "Authorization": "Bearer should-not-render",
+        },
+    )
+
+    assert response.status_code == 403
+    html = response.text
+    assert "Live OpenAI preview testing is disabled." in html
+    assert f'<textarea id="prompt" name="prompt" required>{prompt}</textarea>' in html
+    _assert_no_sensitive_preview_leak(
+        html,
+        "sk-guard-test-should-not-render",
+        "should-not-render",
+    )
+
+
+def test_openai_preview_submit_blocks_when_live_preview_flag_false(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    csrf_token = _login(client)
+    prompt = "Keep this false-flag prompt visible."
+    monkeypatch.setenv("ALPHA_LIVE_PREVIEW_ENABLED", "false")
+
+    def fail_factory(_model_set: object) -> FakeProviderClient:
+        raise AssertionError("provider factory must not be invoked when guard blocks")
+
+    client.app.state.provider_client_factory = fail_factory
+
+    response = client.post(
+        "/dashboard/expert-preview",
+        data={"prompt": prompt},
+        headers={auth.CSRF_HEADER_NAME: csrf_token},
+    )
+
+    assert response.status_code == 403
+    html = response.text
+    assert "Live OpenAI preview testing is disabled." in html
+    assert f'<textarea id="prompt" name="prompt" required>{prompt}</textarea>' in html
+    assert "Plain provider output" in html
+    assert "Alpha Solver expert preview" in html
+
+
+def test_openai_preview_cap_blocks_after_configured_limit(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    csrf_token = _login(client)
+    monkeypatch.setenv("ALPHA_LIVE_PREVIEW_ENABLED", "true")
+    monkeypatch.setenv("ALPHA_LIVE_PREVIEW_MAX_REQUESTS", "1")
+    fake = _install_successful_fake(client)
+    first_prompt = "Define alpha in one sentence."
+    second_prompt = "This second live preview should be blocked."
+
+    first = client.post(
+        "/dashboard/expert-preview",
+        data={"prompt": first_prompt},
+        headers={auth.CSRF_HEADER_NAME: csrf_token},
+    )
+    second = client.post(
+        "/dashboard/expert-preview",
+        data={"prompt": second_prompt},
+        headers={auth.CSRF_HEADER_NAME: csrf_token},
+    )
+
+    assert first.status_code == 200
+    _assert_successful_preview_response(first.text, first_prompt)
+    assert len(fake.requests) == 2
+    assert second.status_code == 403
+    html = second.text
+    assert "Live OpenAI preview request cap reached" in html
+    assert f'<textarea id="prompt" name="prompt" required>{second_prompt}</textarea>' in html
+    assert len(fake.requests) == 2
+    _assert_no_sensitive_preview_leak(html)
 
 
 def test_preview_submission_handles_unstructured_expert_preview_coherently(

--- a/tests/ui/test_expert_preview_real_app.py
+++ b/tests/ui/test_expert_preview_real_app.py
@@ -46,6 +46,9 @@ def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
     monkeypatch.setenv("ALPHA_DASHBOARD_PASSWORD", "testing-secret")
     monkeypatch.setenv("ALPHA_DASHBOARD_SECRET_KEY", "unit-test-secret")
     monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    monkeypatch.setenv("ALPHA_LIVE_PREVIEW_ENABLED", "true")
+    monkeypatch.setenv("ALPHA_LIVE_PREVIEW_MAX_REQUESTS", "20")
+    app.state.live_preview_request_count = 0
     auth.reset_state()
 
     # ``base_url`` must be https: login sets Secure cookies, which the test client


### PR DESCRIPTION
### Motivation

- Prevent accidental spend and repeated live-provider calls from the operator-facing preview `/dashboard/expert-preview` before any Cloud Run `MODEL_PROVIDER=openai` testing is approved.  
- Provide a minimal, fail-closed opt-in and configurable cap so an operator can explicitly enable a small number of live preview runs.  
- Keep existing local-provider preview behavior, dashboard auth/session/CSRF, and provider expert-pass semantics unchanged except for the new pre-call guard checks.

### Description

- Add a route-level live-preview guard in the preview POST handler that runs after CSRF/session acceptance and before the shared `solve`/provider path, returning a safe 403 block message when disabled or capped.  
- Introduce `ALPHA_LIVE_PREVIEW_ENABLED` and `ALPHA_LIVE_PREVIEW_MAX_REQUESTS` environment flags, use a per-process counter on `app.state` with a `threading.Lock`, and log allow/block decisions without exposing secrets or raw payloads.  
- Preserve local-provider behavior by bypassing the guard unless `MODEL_PROVIDER=openai`, and ensure the provider factory/client is not constructed when the guard blocks.  
- Add docs and a spec: `.specs/DEPLOY-LIVE-SPEND-GUARD-001.md`, register it in `.specs/INDEX.md`, and update `docs/deployment/CLOUD_RUN_MVP_PREVIEW.md` with the held env var guidance, fail-closed behavior, and troubleshooting notes; also add no-network unit tests exercising block/allow/cap behavior and sensitive-output assertions.

### Testing

- Ran `git diff --check` with no problems and executed `python -m pytest tests/ui/test_expert_preview.py -q`, which passed.  
- Ran `python -m pytest tests/ui/test_expert_preview_real_app.py -q`, which passed.  
- Ran `python -m pytest tests/test_api_endpoints.py -q`, which passed.  
- Ran full `python -m pytest -q`; all test suites passed except a known JWT rotation flake (`tests/test_jwt_auth.py::test_rotation` returned 401 vs 200), which is reported separately and was not changed or fixed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1de294d20483299ff3bf994dacf2cc)