### PR TITLE
UI-PREVIEW-LOADING-STATE-001: prevent duplicate preview submits

### DIFF
--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -52,6 +52,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `REVIEW-P0P1.md` | CODE SPEC — REVIEW-P0P1 · P0 + P1 Bulk Review (MVP Readiness) (RES_06) |
 | `UI-JOBS-001.md` | UI-JOBS-001 · Dashboard Job History & Metrics (RES_Dash) |
 | `UI-PREVIEW-001.md` | UI-PREVIEW-001 · Authenticated Expert Preview UI |
+| `UI-PREVIEW-LOADING-STATE-001.md` | UI-PREVIEW-LOADING-STATE-001 · Expert Preview Loading State |
 | `UI-PREVIEW-LOCAL-SMOKE-001.md` | UI-PREVIEW-LOCAL-SMOKE-001 · Local-provider Expert Preview Smoke Fix |
 | `UI-KEYS-001.md` | UI-KEYS-001 · Dashboard: API Keys Management |
 | `UI-REQ-001.md` | UI-REQ-001 · Dashboard Request Submission UI |

--- a/.specs/UI-PREVIEW-LOADING-STATE-001.md
+++ b/.specs/UI-PREVIEW-LOADING-STATE-001.md
@@ -1,0 +1,47 @@
+# UI-PREVIEW-LOADING-STATE-001 · Expert Preview Loading State
+
+## Purpose
+
+Add a narrow UI-only loading state and duplicate-submit guard for `/dashboard/expert-preview` so a controlled operator preview request cannot be accidentally submitted twice while the first request is still in flight.
+
+This cleanup was discovered during controlled live OpenAI preview testing with a one-request cap. It does not validate the MVP, claim production readiness, or change provider behavior.
+
+## Scope
+
+In scope:
+
+- keep the existing expert-preview form, prompt extraction, prompt preservation, CSRF header behavior, async fetch path, and DOM replacement flow;
+- immediately disable the compare submit button after a submit starts;
+- change the button label to a running/loading message while the request is in flight;
+- ignore duplicate submit events for the currently rendered form while its request is in flight;
+- keep the prompt textarea visible and readable while a request is running;
+- reinitialize the submit handler after the returned page body is rendered.
+
+Out of scope:
+
+- enabling OpenAI;
+- Cloud Run deployment;
+- provider behavior changes;
+- expert-pass behavior changes;
+- dashboard auth/session/CSRF changes;
+- live spend guard semantic changes;
+- local-provider behavior changes;
+- persistent quota storage;
+- backlog workbook or Google Sheets updates.
+
+## Acceptance criteria
+
+No-network tests should prove:
+
+- the rendered page includes loading-state and duplicate-submit protection for the preview submit script;
+- local-provider preview submit still returns `200` and renders both panes;
+- existing browser-style form submits still pass;
+- CSRF rejection remains unchanged;
+- successful responses preserve the submitted prompt;
+- blocked/error responses preserve the submitted prompt;
+- live preview cap behavior remains unchanged;
+- rendered pages do not expose secrets, raw headers, bearer tokens, API keys, raw request bodies, or provider payloads.
+
+## Backlog impact
+
+`UI-PREVIEW-LOADING-STATE-001` should be marked Done only after the PR implementing this spec is merged. `DEPLOY-CLOUDRUN-LIVE-OPENAI-001` remains inconclusive/held until this fix is merged, deployed, and the one-request live test is repeated. This spec does not validate the MVP and does not claim production readiness.

--- a/alpha/webapp/routes/expert_preview.py
+++ b/alpha/webapp/routes/expert_preview.py
@@ -224,6 +224,7 @@ def _render_page(
       label {{ font-weight: 700; }}
       textarea {{ min-height: 130px; resize: vertical; border: 1px solid #cdd5ef; border-radius: 12px; padding: 0.85rem 1rem; font: inherit; color: inherit; background: rgba(255,255,255,0.78); }}
       button {{ justify-self: start; border: 0; border-radius: 999px; padding: 0.7rem 1.25rem; font: inherit; font-weight: 700; color: white; background: linear-gradient(135deg, #5661f6, #7b5ff4); cursor: pointer; }}
+      button:disabled {{ cursor: wait; opacity: 0.72; }}
       .panes {{ display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 1rem; }}
       .pane h2 {{ margin-top: 0; }}
       .answer, pre {{ white-space: pre-wrap; overflow-wrap: anywhere; }}
@@ -274,21 +275,44 @@ def _render_page(
           return;
         }}
         form.dataset.alphaSubmitBound = "true";
+        let previewInFlight = false;
         form.addEventListener("submit", async (event) => {{
           event.preventDefault();
-          const response = await fetch(form.action, {{
-            method: "POST",
-            headers: {{
-              "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
-              "X-Alpha-CSRF": cookieValue("alpha_dashboard_csrf"),
-            }},
-            body: new URLSearchParams(new FormData(form)),
-          }});
-          const html = await response.text();
-          const nextDocument = new DOMParser().parseFromString(html, "text/html");
-          document.title = nextDocument.title;
-          document.body.innerHTML = nextDocument.body.innerHTML;
-          initExpertPreviewForm();
+          if (previewInFlight) {{
+            return;
+          }}
+          previewInFlight = true;
+          const submitButton = form.querySelector('button[type="submit"]');
+          const originalButtonText = submitButton?.textContent || "Compare same-provider outputs";
+          if (submitButton) {{
+            submitButton.disabled = true;
+            submitButton.textContent = "Running preview...";
+          }}
+          form.setAttribute("aria-busy", "true");
+          try {{
+            const response = await fetch(form.action, {{
+              method: "POST",
+              headers: {{
+                "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+                "X-Alpha-CSRF": cookieValue("alpha_dashboard_csrf"),
+              }},
+              body: new URLSearchParams(new FormData(form)),
+            }});
+            const html = await response.text();
+            const nextDocument = new DOMParser().parseFromString(html, "text/html");
+            document.title = nextDocument.title;
+            document.body.innerHTML = nextDocument.body.innerHTML;
+            initExpertPreviewForm();
+          }} finally {{
+            previewInFlight = false;
+            if (document.body.contains(form)) {{
+              form.removeAttribute("aria-busy");
+              if (submitButton) {{
+                submitButton.disabled = false;
+                submitButton.textContent = originalButtonText;
+              }}
+            }}
+          }}
         }});
       }}
       initExpertPreviewForm();

--- a/tests/ui/test_expert_preview.py
+++ b/tests/ui/test_expert_preview.py
@@ -11,7 +11,12 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from alpha.providers import FakeProviderClient, ProviderCost, ProviderResult, ProviderUsage  # noqa: E402
+from alpha.providers import (
+    FakeProviderClient,
+    ProviderCost,
+    ProviderResult,
+    ProviderUsage,
+)  # noqa: E402
 from alpha.webapp.routes import auth, expert_preview  # noqa: E402
 
 
@@ -64,6 +69,17 @@ def _assert_successful_preview_response(html: str, prompt: str) -> None:
     assert f'<textarea id="prompt" name="prompt" required>{prompt}</textarea>' in html
 
 
+def _assert_loading_state_script(html: str) -> None:
+    assert "let previewInFlight = false;" in html
+    assert "if (previewInFlight)" in html
+    assert "submitButton.disabled = true;" in html
+    assert "Running preview..." in html
+    assert 'form.setAttribute("aria-busy", "true");' in html
+    assert '"X-Alpha-CSRF": cookieValue("alpha_dashboard_csrf")' in html
+    assert "document.body.innerHTML = nextDocument.body.innerHTML;" in html
+    assert "initExpertPreviewForm();" in html
+
+
 def _assert_no_sensitive_preview_leak(html: str, *secrets: str) -> None:
     for secret in secrets:
         assert secret not in html
@@ -110,6 +126,7 @@ def test_authenticated_user_can_access_preview_page(client: TestClient) -> None:
     assert expert_preview.DISCLAIMER in response.text
     assert "Plain provider output" in response.text
     assert "Alpha Solver expert preview" in response.text
+    _assert_loading_state_script(response.text)
 
 
 def test_preview_submission_renders_plain_and_expert_outputs(client: TestClient) -> None:
@@ -123,7 +140,9 @@ def test_preview_submission_renders_plain_and_expert_outputs(client: TestClient)
                 '"assumptions":["Budget is constrained"],"confidence":0.35}',
                 raw_secret=raw_secret,
             ),
-            _provider_result("draft expert answer that clarify mode replaces", raw_secret=raw_secret),
+            _provider_result(
+                "draft expert answer that clarify mode replaces", raw_secret=raw_secret
+            ),
         ]
     )
     client.app.state.provider_client_factory = lambda _model_set: fake
@@ -446,8 +465,7 @@ def test_second_browser_style_submit_after_error_keeps_csrf_behavior(client: Tes
     assert error_response.status_code == 400
     assert "Prompt is required." in error_response.text
     assert "document.write" not in error_response.text
-    assert "initExpertPreviewForm" in error_response.text
-    assert "X-Alpha-CSRF" in error_response.text
+    _assert_loading_state_script(error_response.text)
 
     fake = _install_successful_fake(client)
     prompt = "Define alpha in one sentence."

--- a/tests/ui/test_expert_preview_real_app.py
+++ b/tests/ui/test_expert_preview_real_app.py
@@ -20,7 +20,12 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from alpha.providers import FakeProviderClient, ProviderCost, ProviderResult, ProviderUsage  # noqa: E402
+from alpha.providers import (
+    FakeProviderClient,
+    ProviderCost,
+    ProviderResult,
+    ProviderUsage,
+)  # noqa: E402
 from alpha.webapp.routes import auth, expert_preview  # noqa: E402
 from service.app import app, _dashboard_enabled, _mount_dashboard  # noqa: E402
 
@@ -59,6 +64,15 @@ def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
     finally:
         test_client.close()
         auth.reset_state()
+
+
+def _assert_loading_state_script(html: str) -> None:
+    assert "let previewInFlight = false;" in html
+    assert "submitButton.disabled = true;" in html
+    assert "Running preview..." in html
+    assert '"X-Alpha-CSRF": cookieValue("alpha_dashboard_csrf")' in html
+    assert "document.body.innerHTML = nextDocument.body.innerHTML;" in html
+    assert "initExpertPreviewForm();" in html
 
 
 def _login(client: TestClient) -> str:
@@ -119,6 +133,7 @@ def test_authenticated_request_renders_page(client: TestClient) -> None:
 
     assert response.status_code == 200
     assert expert_preview.DISCLAIMER in response.text
+    _assert_loading_state_script(response.text)
 
 
 def test_preview_post_uses_fake_provider_without_network(
@@ -134,12 +149,16 @@ def test_preview_post_uses_fake_provider_without_network(
                 '"assumptions":["Budget is constrained"],"confidence":0.35}',
                 raw_secret=raw_secret,
             ),
-            _provider_result("draft expert answer that clarify mode replaces", raw_secret=raw_secret),
+            _provider_result(
+                "draft expert answer that clarify mode replaces", raw_secret=raw_secret
+            ),
         ]
     )
     # Inject the fake on the shared app singleton via monkeypatch so it is restored
     # afterwards and never leaks into other tests that import the real app.
-    monkeypatch.setattr(app.state, "provider_client_factory", lambda _model_set: fake, raising=False)
+    monkeypatch.setattr(
+        app.state, "provider_client_factory", lambda _model_set: fake, raising=False
+    )
 
     response = client.post(
         ROUTE,


### PR DESCRIPTION
### Motivation
- Prevent accidental duplicate preview submissions and provide a visible in-flight state after the operator clicks `Compare same-provider outputs`, which caused inconclusive live OpenAI preview results when a one-request cap was hit. 
- The immediate goal is a minimal UI-only safety/UX fix that preserves existing prompt preservation, CSRF behavior, local-provider behavior, and the live spend guard semantics.

### Description
- Added the `UI-PREVIEW-LOADING-STATE-001` spec and registered it in `.specs/INDEX.md` to document the narrow UX/safety change. 
- Updated the expert preview page inline script in `alpha/webapp/routes/expert_preview.py` to add an in-flight guard (`previewInFlight`), immediately disable the submit button and change its label to `Running preview...`, set `aria-busy` while the fetch is running, ignore duplicate submits during the in-flight window, and reinitialize the submit handler after the returned page body is rendered. 
- Added disabled-button styling so a disabled submit shows a wait cursor and reduced opacity, and kept the prompt textarea visible/readable while requests are running. 
- Updated no-network UI tests in `tests/ui/test_expert_preview.py` and `tests/ui/test_expert_preview_real_app.py` to assert the presence of the loading/duplicate-submit protection script and preserved the existing CSRF, DOM-replacement, prompt-preservation, local-provider, and live-cap behaviors; scope intentionally excludes provider/Cloud Run/auth/guard semantics changes.

### Testing
- Ran `git diff --check` with no issues. 
- Ran `python -m pytest tests/ui/test_expert_preview.py -q` and the test suite passed. 
- Ran `python -m pytest tests/ui/test_expert_preview_real_app.py -q` and the test suite passed. 
- Ran `python -m pytest tests/test_api_endpoints.py -q` and full endpoint tests passed. 
- Ran `python -m pytest -q` for the full test matrix and all tests completed successfully (some deprecation warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dfb4f4da88329b69f60c71b0eac33)