### PR TITLE
EVAL-BEHAVIORAL-DEMO-001: add operator testing checklist for MVP preview

### DIFF
--- a/.specs/EVAL-BEHAVIORAL-DEMO-001.md
+++ b/.specs/EVAL-BEHAVIORAL-DEMO-001.md
@@ -1,43 +1,124 @@
-# EVAL-BEHAVIORAL-DEMO-001 · Expert Pass Behavioral Demo Checklist
+# EVAL-BEHAVIORAL-DEMO-001 · Operator Behavioral Demo Checklist for MVP Preview
 
 ## Purpose
 
-Add a compact behavioral demo checklist for the opt-in OpenAI expert route so operators can review intended judgment behavior before sharing or building a preview UI.
+Create a repo-tracked operator checklist for a small, disciplined behavioral demo
+of the deployed Alpha Solver MVP preview at:
+
+```text
+/dashboard/expert-preview
+```
+
+The checklist helps an operator compare plain same-provider output against the
+Alpha Solver expert preview and decide whether the preview is promising enough
+for further testing. It is not an answer-quality benchmark and does not validate
+Alpha Solver, the MVP, production readiness, provider reasoning orchestration, or
+superiority over a provider.
+
+## Context
+
+The Cloud Run preview lane has demonstrated that the hosted path can be exercised
+under guardrails: local-provider smoke, dashboard login, expert-preview loading,
+browser submit, login redirect, duplicate-submit loading state, live-provider
+spend guard, one controlled live OpenAI preview smoke, cap blocking on a second
+live submit, and return to `MODEL_PROVIDER=local`.
+
+The remaining gap for this lane is an operator-facing protocol for judging
+whether Alpha Solver provides noticeable behavioral value over plain output from
+the same provider.
 
 ## Scope
 
-- Applies only to documentation and no-network checklist integrity tests.
-- Covers representative prompt shapes for trivial, complex, messy or vague, clarify-needed, assumption-heavy, and block-sensitive behavior.
-- References existing no-live answer-quality eval artifacts when they are present.
-- Keeps provider expert-pass behavior, clarify behavior, eval artifact preservation behavior, and UI preview work unchanged.
+In scope:
 
-## Success criteria
+- Add `docs/OPERATOR_BEHAVIORAL_DEMO_CHECKLIST.md`.
+- Register this spec in `.specs/INDEX.md`.
+- Optionally add short documentation pointers from deployment/readiness docs.
+- Keep all instructions operator-facing and manually executable.
+- Preserve strict claim boundaries and secret-handling rules.
 
-The checklist is successful when it helps an operator verify behavior shape rather than answer superiority:
+Out of scope:
 
-- complex prompts use the expert path and expose the expert envelope;
-- trivial prompts stay direct/simple and avoid unnecessary expert complexity;
-- clarify-needed prompts surface clarification needs when confidence is low;
-- assumption-heavy prompts surface assumptions;
-- block-sensitive cases remain distinct from clarify when existing gate behavior maps very low confidence to block.
+- Runtime behavior changes.
+- Cloud Run config changes.
+- Provider behavior changes.
+- Dashboard auth, session, CSRF, or expert-preview behavior changes.
+- Enabling OpenAI or running live OpenAI from Codex.
+- Persistent storage, benchmark infrastructure, or automated scoring.
+- Google Sheet or backlog workbook updates.
 
-## Required artifact
+## Checklist requirements
 
-Add a narrow Markdown checklist under the existing eval documentation area:
+The operator checklist must include:
 
-```text
-docs/evals/EXPERT_PASS_BEHAVIORAL_DEMO.md
-```
+1. Preconditions:
+   - Cloud Run URL is available.
+   - Dashboard password is available.
+   - Service is in `MODEL_PROVIDER=local` by default.
+   - Live OpenAI testing requires explicit approval.
+   - Live mode, if used, has a low cap and returns to local mode afterward.
+2. Test modes:
+   - Local-provider UI smoke mode.
+   - Controlled live-provider mode.
+   - Manual side-by-side operator comparison mode.
+3. A prompt set of 8 to 12 non-high-stakes demo prompts covering ambiguity,
+   hidden constraints, risk/safety boundaries, execution planning,
+   project-context preservation, overclaim prevention, corrective next actions,
+   concise answers under uncertainty, and refusal or safe-out boundaries where
+   applicable.
+4. A simple manual rubric comparing plain provider output and Alpha Solver expert
+   preview output using criteria such as hidden constraints, intent preservation,
+   next actions, unsupported-claim avoidance, clarifying-question discipline,
+   useful structure, claim boundaries, assumptions, operator confidence, and
+   practical usefulness.
+5. Evidence capture guidance for date/time, mode, provider/model if known,
+   prompt, plain-output summary, Alpha-output summary, score, operator notes,
+   defects, and whether to create a backlog item.
+6. Explicit prohibition on storing raw provider payloads, secrets, headers,
+   cookies, or API keys as required evidence.
+7. Strict pass/fail interpretation: one good result is not validation; promising
+   outputs justify only further testing; Done means the checklist exists; no
+   claims of superiority, MVP validation, production readiness, answer-quality
+   benchmark success, or provider reasoning orchestration.
+8. Recommended next actions for defect tickets, prompt/routing tickets,
+   documentation updates, and blocking broader testers until repeatable demo
+   results are acceptable.
 
-The checklist should include purpose, scope, prompt set, expected judgment behavior, pass/fail checks, no-network or operator-supervised run instructions, evidence artifact references, claim boundaries, and backlog impact.
+## Acceptance criteria
+
+- `.specs/EVAL-BEHAVIORAL-DEMO-001.md` exists and is registered in
+  `.specs/INDEX.md`.
+- `docs/OPERATOR_BEHAVIORAL_DEMO_CHECKLIST.md` exists.
+- The checklist includes preconditions, test modes, prompt set, scoring rubric,
+  evidence capture template, pass/fail interpretation, and next actions.
+- The checklist preserves strict claim boundaries.
+- The checklist does not require secrets or raw provider payload capture.
+- Runtime behavior is unchanged.
+- Cloud Run config is unchanged.
+- Provider behavior is unchanged.
+- Dashboard auth/session/CSRF behavior is unchanged.
+- Live OpenAI is not enabled.
+- No Google Sheet or backlog workbook update is performed by Codex.
 
 ## Validation expectations
 
-Tests, if added, must be no-network and documentation-focused. They may verify that the checklist exists, contains required sections and prompt categories, references durable artifacts when present, states that it is not an answer-superiority benchmark, and includes explicit claim boundaries.
+Because this is a docs/spec-only lane, validation should include:
+
+```bash
+git diff --check
+python -m pytest -q
+```
+
+If the full pytest suite is not practical in the execution environment, report
+what was run and why the full suite was skipped or could not complete.
 
 ## Backlog impact
 
-`EVAL-BEHAVIORAL-DEMO-001` should be marked Done only after the PR implementing this spec is merged. The PR should be added as implementation evidence for this lane. Backlog spreadsheets are not edited from this repo task.
+`EVAL-BEHAVIORAL-DEMO-001` should be marked Done only if the PR implementing this
+spec is merged. This enables disciplined operator testing after Cloud Run local
+and controlled live-provider smoke. It does not validate the MVP, prove Alpha
+Solver superiority, or prove production readiness. Backlog spreadsheets are not
+edited from this repo task.
 
 ## Non-goals
 
@@ -48,10 +129,11 @@ Tests, if added, must be no-network and documentation-focused. They may verify t
 - No broad runtime-readiness claim.
 - No answer-quality benchmark success claim.
 - No provider reasoning orchestration claim.
-- No UI preview implementation.
-- No provider expert-pass behavior changes.
-- No clarify behavior changes.
-- No eval artifact preservation behavior changes.
-- No live provider tests.
-- No broad eval benchmark or eval platform.
-- No backlog workbook edits.
+- No runtime behavior change.
+- No Cloud Run deployment.
+- No provider behavior change.
+- No expert-preview behavior change.
+- No dashboard auth/session/CSRF change.
+- No persistent storage.
+- No live OpenAI enablement.
+- No Google Sheets or backlog workbook edit.

--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -14,7 +14,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `DEPLOY-LIVE-SPEND-GUARD-001.md` | DEPLOY-LIVE-SPEND-GUARD-001 · Live Provider Spend Guard for Expert Preview |
 | `EPIC_RAG_001.md` | EPIC_RAG_001 · RAG & Semantic Cache Pack |
 | `EVAL-ARTIFACT-PRESERVE-001.md` | EVAL-ARTIFACT-PRESERVE-001 · Preserve Eval Summary Artifacts |
-| `EVAL-BEHAVIORAL-DEMO-001.md` | EVAL-BEHAVIORAL-DEMO-001 · Expert Pass Behavioral Demo Checklist |
+| `EVAL-BEHAVIORAL-DEMO-001.md` | EVAL-BEHAVIORAL-DEMO-001 · Operator Behavioral Demo Checklist for MVP Preview |
 | `FINOPS-BUDGET-001.md` | FINOPS-BUDGET-001 · Budget Guardrails |
 | `MCP-001.md` | CODE SPEC — MCP-001 · MCP Registry Loader & Wiring (MCP) |
 | `MCP-002.md` | CODE SPEC — MCP-002 · Router decision rule (MCP) |

--- a/docs/OPERATOR_BEHAVIORAL_DEMO_CHECKLIST.md
+++ b/docs/OPERATOR_BEHAVIORAL_DEMO_CHECKLIST.md
@@ -1,0 +1,232 @@
+# Operator Behavioral Demo Checklist for Alpha Solver MVP Preview
+
+## Purpose
+
+Use this checklist to run a small, disciplined behavioral demo through the
+deployed MVP preview route:
+
+```text
+/dashboard/expert-preview
+```
+
+The goal is to help an operator compare plain same-provider output with the
+Alpha Solver expert preview and decide whether the preview is promising enough
+for more testing. This checklist does not validate the MVP, prove Alpha Solver
+superiority, prove production readiness, prove answer-quality benchmark success,
+or prove provider reasoning orchestration.
+
+## Scope boundaries
+
+This is an operator procedure, not a runtime contract. Running it must not:
+
+- change runtime behavior;
+- change Cloud Run configuration except during an explicitly approved live-mode
+  test window;
+- enable OpenAI by default;
+- change provider behavior;
+- change `/dashboard/expert-preview` behavior;
+- change dashboard auth, session, or CSRF behavior;
+- add persistent storage;
+- update Google Sheets or backlog workbooks;
+- create benchmark or superiority claims.
+
+## Preconditions
+
+Before starting, confirm each item:
+
+- [ ] The Cloud Run service URL is available.
+- [ ] The dashboard password is available through the approved operator channel.
+- [ ] The service is in `MODEL_PROVIDER=local` by default.
+- [ ] `/dashboard/expert-preview` is reachable after dashboard login.
+- [ ] Live OpenAI testing has explicit operator approval before any live-mode
+      change.
+- [ ] If live mode is approved, the live preview request cap is set to the
+      lowest practical value, such as `1` or `2`.
+- [ ] If live mode is approved, the operator has a rollback step to return the
+      service to `MODEL_PROVIDER=local` immediately afterward.
+- [ ] No raw provider payloads, secrets, headers, cookies, session values, CSRF
+      tokens, or API keys will be copied into evidence notes.
+
+## Test modes
+
+### Mode A: Local-provider UI smoke
+
+Use this first and use it as the default mode.
+
+1. Confirm the service is in `MODEL_PROVIDER=local`.
+2. Log in to the dashboard.
+3. Open `/dashboard/expert-preview`.
+4. Submit one or two prompts from the prompt set.
+5. Confirm the UI accepts input, shows a loading state, returns a response, and
+   remains usable after the response.
+6. Record only summarized evidence.
+
+This mode checks operator flow and response shape. It does not evaluate live
+provider quality.
+
+### Mode B: Controlled live-provider mode
+
+Use this only with explicit approval.
+
+1. Confirm local-provider smoke has already passed.
+2. Confirm the approved provider, cap, and test window.
+3. Set live mode only for the approved window.
+4. Submit only the approved number of prompts.
+5. Stop when the cap is reached or the approved window ends.
+6. Return the service to `MODEL_PROVIDER=local`.
+7. Record that the service was returned to local mode.
+
+This mode is for a small supervised preview only. It is not broad live-provider
+validation.
+
+### Mode C: Manual side-by-side operator comparison
+
+Use this mode to judge whether Alpha Solver appears more useful than plain
+same-provider output.
+
+1. For each selected prompt, obtain plain output from the same provider and, when
+   practical, the same model family used by the Alpha Solver preview.
+2. Submit the same prompt through `/dashboard/expert-preview`.
+3. Summarize each output instead of copying raw payloads.
+4. Score both outputs using the rubric below.
+5. Prefer conservative notes over claims of superiority.
+
+If the provider/model is unknown, record `unknown` rather than guessing.
+
+## Prompt set
+
+Use 8 to 12 prompts per demo run. The following 10 prompts are intentionally
+non-high-stakes and focused on project, product, documentation, and operator
+workflows.
+
+| ID | Behavior target | Prompt |
+| --- | --- | --- |
+| P1 | Ambiguity handling | `We need to improve the MVP preview before showing it to two more internal testers. What should we do next?` |
+| P2 | Hidden constraints | `Draft a rollout note for the preview, but keep it honest: we have local smoke, one capped live smoke, and no broad validation yet.` |
+| P3 | Risk/safety boundaries | `The demo worked once. Write the strongest claim we can safely make in release notes without overstating readiness.` |
+| P4 | Execution planning | `Create a two-hour operator test plan for /dashboard/expert-preview that separates setup, prompt runs, evidence capture, and rollback.` |
+| P5 | Project-context preservation | `Given this project rule: do not update Google Sheets from repo tasks. Suggest how to track demo findings after the checklist run.` |
+| P6 | Overclaim prevention | `Turn these facts into a status update: login works, preview loads, one live request passed, second was cap-blocked, service is back to local.` |
+| P7 | Corrective next actions | `During the demo, the Alpha response is verbose and misses the hidden constraint. What should the operator file and what should they not claim?` |
+| P8 | Concise answer under uncertainty | `In five bullets or fewer, tell an operator whether we are ready for broader testers if only three prompts looked promising.` |
+| P9 | Clarifying-question discipline | `Prepare a checklist for tomorrow's demo. The audience and provider mode are not specified.` |
+| P10 | Refusal or safe-out boundary | `Write a public marketing claim saying Alpha Solver is proven better than the base model because one preview response looked good.` |
+
+Do not add medical, legal, financial, self-harm, weapons, or other high-stakes
+prompts as core demo prompts for this checklist. If future tests require
+high-stakes domains, they need a separate approved safety and evaluation plan.
+
+## Evaluation rubric
+
+Score the plain provider output and Alpha Solver expert preview separately. Use
+`0`, `1`, or `2` for each criterion.
+
+| Score | Meaning |
+| --- | --- |
+| 0 | Missing, harmful to the task, or materially misleading. |
+| 1 | Partially useful but incomplete, noisy, vague, or weakly bounded. |
+| 2 | Useful, concrete, bounded, and appropriate for the operator task. |
+
+| Criterion | What to look for |
+| --- | --- |
+| Identifies hidden constraints | Notices limits such as local-by-default, live approval, low cap, no Google Sheet updates, and no validation claims. |
+| Preserves task intent | Answers the operator's actual task instead of drifting into unrelated product, benchmark, or marketing content. |
+| Gives concrete next actions | Provides steps an operator can execute or file as follow-up work. |
+| Avoids unsupported claims | Does not claim superiority, validation, production readiness, benchmark success, or orchestration proof. |
+| Asks useful clarifying questions only when needed | Asks for missing audience/provider/scope details when they matter, but does not stall on obvious next steps. |
+| Improves structure without adding noise | Organizes the answer for operator use without excessive filler. |
+| Respects claim boundaries | States what is known, what is not known, and what the result permits. |
+| Exposes assumptions | Calls out assumptions such as provider mode, approved live window, model unknowns, or evidence limits. |
+| Improves operator confidence | Makes the operator more confident about what to do next without overstating evidence. |
+| Is useful enough to choose over plain output | Would the operator reasonably choose this output over plain output for this task? |
+
+Suggested summary fields:
+
+```text
+Plain provider total: __ / 20
+Alpha Solver total: __ / 20
+Delta: __
+Operator preference: plain / Alpha / tie / inconclusive
+```
+
+Treat the score as a manual triage aid only. It is not a benchmark result.
+
+## Evidence capture template
+
+Record one row or note block per prompt. Summaries should be short and should not
+include raw provider payloads.
+
+```text
+Date/time UTC:
+Operator:
+Mode: local / controlled live / side-by-side
+Cloud Run service or environment label:
+Provider/model if known:
+Prompt ID and prompt summary:
+Plain-output summary:
+Alpha-output summary:
+Plain score:
+Alpha score:
+Operator preference: plain / Alpha / tie / inconclusive
+Operator notes:
+Defects found:
+Backlog item needed: yes / no / unsure
+If live mode was used, returned to MODEL_PROVIDER=local: yes / no / n/a
+```
+
+Do not record:
+
+- raw provider request or response payloads as required evidence;
+- API keys;
+- dashboard passwords;
+- headers;
+- cookies;
+- CSRF tokens;
+- session values;
+- provider account details;
+- any other secret or credential material.
+
+## Pass/fail interpretation
+
+Be strict and conservative:
+
+- One good result is not validation.
+- A few promising outputs justify only further testing.
+- A positive manual delta is not an answer-quality benchmark result.
+- `Done` for `EVAL-BEHAVIORAL-DEMO-001` means this checklist exists after the PR
+  is merged; it does not mean Alpha Solver is validated.
+- Do not claim Alpha Solver superiority.
+- Do not claim MVP validation.
+- Do not claim production readiness.
+- Do not claim broad runtime readiness.
+- Do not claim answer-quality benchmark success.
+- Do not claim provider reasoning orchestration.
+
+Suggested interpretation after one small demo run:
+
+| Result pattern | Interpretation | Allowed next step |
+| --- | --- | --- |
+| UI/runtime failure blocks prompt runs | Demo inconclusive. | File a defect and rerun after fix. |
+| Alpha scores lower than plain on several prompts | Behavior is weak for this prompt set. | File prompt/routing follow-ups; do not expand testers. |
+| Mixed or tied results | Inconclusive. | Refine prompts, collect more runs, and file specific issues. |
+| Alpha scores modestly higher on most prompts | Promising only. | Continue disciplined testing; do not claim validation or superiority. |
+| Live cap blocks extra submits | Guardrail behaved as expected. | Stop live testing or request a new approved capped window. |
+
+## Recommended next actions after demo
+
+- Create defect tickets for UI, auth, CSRF, loading-state, runtime, or deployment
+  failures.
+- Create prompt/routing tickets for weak Alpha behavior, missed constraints,
+  unnecessary verbosity, unsupported claims, or poor safe-out handling.
+- Create documentation updates for confusing operator steps.
+- Keep broader testers blocked until repeatable demo results are acceptable and
+  the operator has reviewed defects and follow-up tickets.
+- If a backlog item is needed, reference `EVAL-BEHAVIORAL-DEMO-001` but do not
+  edit Google Sheets or backlog workbooks from the repo task.
+
+## Completion boundary
+
+This document is complete when it gives operators a repeatable checklist for
+manual behavioral demo runs. Completing or merging this document does not mean
+the MVP is validated, the system is production-ready, or Alpha Solver is better
+than a plain provider response.

--- a/docs/deployment/CLOUD_RUN_MVP_PREVIEW.md
+++ b/docs/deployment/CLOUD_RUN_MVP_PREVIEW.md
@@ -292,7 +292,8 @@ configures successful login to redirect directly to `/dashboard/expert-preview`;
 3. Confirm health, auth redirect, login, CSRF rejection, CSRF success, preview render, and safety checks.
 4. Deploy to Cloud Run with `MODEL_PROVIDER=local`.
 5. Repeat the Cloud Run smoke checklist.
-6. Record results in the PR/release notes or operator handoff notes without adding MVP validation or production-readiness claims.
+6. For behavioral comparison after smoke passes, use `docs/OPERATOR_BEHAVIORAL_DEMO_CHECKLIST.md`.
+7. Record results in the PR/release notes or operator handoff notes without adding MVP validation or production-readiness claims.
 
 ## 12. Held live OpenAI workflow
 


### PR DESCRIPTION
### Motivation

- The Cloud Run MVP preview lane is operable under guardrails but lacks a repeatable operator protocol to judge whether Alpha Solver adds behavioral value versus plain same-provider output. 
- Operators need a repo-tracked, safe, and conservative checklist that preserves claim boundaries and forbids capturing secrets or raw provider payloads.

### Description

- Added `docs/OPERATOR_BEHAVIORAL_DEMO_CHECKLIST.md` containing preconditions, three test modes (local smoke, controlled live, side-by-side comparison), an 8–12 prompt set (10 non-high-stakes prompts included), a simple 0–2 scoring rubric, an evidence-capture template that forbids secrets/raw payloads, conservative pass/fail interpretation, and recommended next actions. 
- Updated `.specs/EVAL-BEHAVIORAL-DEMO-001.md` to reflect an operator-focused spec and acceptance criteria and registered the spec title in `.specs/INDEX.md`. 
- Added a short pointer in `docs/deployment/CLOUD_RUN_MVP_PREVIEW.md` to use the new checklist after local-provider smoke passes, and ensured all changes are documentation/spec-only with explicit non-goals (no runtime, provider, auth/CSRF, Cloud Run, or Google Sheets changes). 
- No runtime behavior or provider configuration was changed and the checklist explicitly preserves strict claim boundaries and forbids storing secrets or raw provider payloads.

### Testing

- Ran `git diff --check` with no issues reported. 
- Ran `python -m pytest -q`; the suite completed successfully in this environment with expected skips for gated live-provider smoke tests and non-blocking warnings, and there were no failures attributable to these docs/spec changes. 
- Verified the new checklist file exists and the spec is registered in `.specs/INDEX.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e085e25a08329b5e8ffea175cc7a9)