### PR TITLE
EVAL-DEMO-EVIDENCE-001: add operator demo evidence template

### DIFF
--- a/.specs/EVAL-DEMO-EVIDENCE-001.md
+++ b/.specs/EVAL-DEMO-EVIDENCE-001.md
@@ -1,0 +1,161 @@
+# EVAL-DEMO-EVIDENCE-001 · Operator Demo Evidence Template
+
+## Purpose
+
+Add a lightweight, repo-tracked evidence template for manual Alpha Solver
+operator behavioral demo runs. The template supports the existing
+`EVAL-BEHAVIORAL-DEMO-001` checklist by giving operators a consistent way to
+record summarized findings without storing raw provider payloads or secrets.
+
+## Background
+
+`docs/OPERATOR_BEHAVIORAL_DEMO_CHECKLIST.md` defines a safe manual protocol for
+comparing plain same-provider output against the Alpha Solver expert preview.
+Operators need a copyable note format for each run so findings are consistent,
+bounded, and safe to share without creating benchmark or validation claims.
+
+## Scope
+
+This spec is documentation-only. It adds:
+
+- `docs/OPERATOR_BEHAVIORAL_DEMO_EVIDENCE_TEMPLATE.md`;
+- this spec file;
+- registration in `.specs/INDEX.md`;
+- a short pointer from the operator behavioral demo checklist to the evidence
+  template.
+
+## Requirements
+
+The evidence template must include the following sections.
+
+### Run metadata
+
+- Run ID.
+- Date/time.
+- Operator.
+- Environment.
+- Cloud Run URL or service label, summarized or redacted if needed.
+- Mode: local-provider smoke, controlled live-provider, or side-by-side
+  comparison.
+- Provider/model if known, otherwise `unknown`.
+- Confirmation that the service was returned to `MODEL_PROVIDER=local` if live
+  mode was used.
+
+### Prompt record
+
+- Prompt ID from the checklist.
+- Prompt text or short prompt summary.
+- Reason the prompt was selected.
+- Expected behavior target.
+
+### Output summaries
+
+- Plain provider output summary.
+- Alpha Solver expert preview summary.
+- The template must not require or encourage raw full-output capture.
+- The template must explicitly forbid raw provider payloads, headers, cookies,
+  session values, CSRF tokens, API keys, dashboard passwords, and secrets.
+
+### Scoring
+
+Use the same checklist rubric categories and a simple `0` to `2` score for both
+plain provider output and Alpha Solver output:
+
+- hidden constraints;
+- intent preservation;
+- concrete next actions;
+- unsupported-claim avoidance;
+- clarifying-question discipline;
+- useful structure;
+- claim-boundary respect;
+- assumption visibility;
+- operator confidence;
+- practical usefulness.
+
+### Defects and follow-up
+
+Capture:
+
+- UI defect found;
+- runtime defect found;
+- prompt/routing weakness found;
+- documentation confusion found;
+- suggested backlog item;
+- severity;
+- evidence summary;
+- owner or next reviewer, if known.
+
+### Interpretation
+
+Include conservative outcome options:
+
+- Inconclusive.
+- Promising, needs more runs.
+- Weak, needs prompt/routing improvement.
+- Defect found, create ticket.
+- Do not use for claims.
+
+### Claim boundaries
+
+The template must explicitly state:
+
+- One run is not validation.
+- This evidence does not prove Alpha Solver superiority.
+- This evidence does not prove MVP validation.
+- This evidence does not prove production readiness.
+- This evidence does not prove answer-quality benchmark success.
+- This evidence does not prove provider reasoning orchestration.
+
+## Acceptance criteria
+
+- Evidence template file exists.
+- Spec file exists and is registered in `.specs/INDEX.md`.
+- Checklist links to the evidence template.
+- Template includes metadata, prompt record, output summaries, scoring, defect
+  capture, interpretation, and claim boundaries.
+- Template forbids storing secrets, raw provider payloads, headers, cookies,
+  CSRF tokens, session values, or API keys.
+- Runtime behavior is unchanged.
+- Cloud Run config is unchanged.
+- Provider behavior is unchanged.
+- Dashboard auth/session/CSRF behavior is unchanged.
+- Live OpenAI is not enabled.
+- No Google Sheet update is performed by Codex.
+
+## Validation
+
+Because this is documentation/spec-only work, validation should include:
+
+```bash
+git diff --check
+python -m pytest -q
+```
+
+If the full pytest suite is skipped or cannot complete, report why and include
+any focused checks that were run.
+
+## Backlog impact
+
+`EVAL-DEMO-EVIDENCE-001` should be marked Done only if the PR implementing this
+spec is merged. This supports `EVAL-BEHAVIORAL-DEMO-001`. This does not validate
+the MVP, prove Alpha Solver superiority, or prove production readiness. Backlog
+spreadsheets and Google Sheets are not edited from this repo task.
+
+## Non-goals
+
+- No runtime behavior change.
+- No Cloud Run configuration change.
+- No Cloud Run deployment.
+- No provider behavior change.
+- No expert-preview behavior change.
+- No dashboard auth/session/CSRF change.
+- No live OpenAI enablement.
+- No persistent storage.
+- No automated benchmark claims.
+- No Google Sheets or backlog workbook update.
+- No MVP validation claim.
+- No Alpha Solver superiority claim.
+- No production-readiness claim.
+- No broad runtime-readiness claim.
+- No answer-quality benchmark success claim.
+- No provider reasoning orchestration claim.

--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -15,6 +15,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `EPIC_RAG_001.md` | EPIC_RAG_001 · RAG & Semantic Cache Pack |
 | `EVAL-ARTIFACT-PRESERVE-001.md` | EVAL-ARTIFACT-PRESERVE-001 · Preserve Eval Summary Artifacts |
 | `EVAL-BEHAVIORAL-DEMO-001.md` | EVAL-BEHAVIORAL-DEMO-001 · Operator Behavioral Demo Checklist for MVP Preview |
+| `EVAL-DEMO-EVIDENCE-001.md` | EVAL-DEMO-EVIDENCE-001 · Operator Demo Evidence Template |
 | `FINOPS-BUDGET-001.md` | FINOPS-BUDGET-001 · Budget Guardrails |
 | `MCP-001.md` | CODE SPEC — MCP-001 · MCP Registry Loader & Wiring (MCP) |
 | `MCP-002.md` | CODE SPEC — MCP-002 · Router decision rule (MCP) |

--- a/docs/OPERATOR_BEHAVIORAL_DEMO_CHECKLIST.md
+++ b/docs/OPERATOR_BEHAVIORAL_DEMO_CHECKLIST.md
@@ -15,6 +15,10 @@ for more testing. This checklist does not validate the MVP, prove Alpha Solver
 superiority, prove production readiness, prove answer-quality benchmark success,
 or prove provider reasoning orchestration.
 
+Use the [Operator Behavioral Demo Evidence Template](OPERATOR_BEHAVIORAL_DEMO_EVIDENCE_TEMPLATE.md)
+to record summarized findings for each run without storing raw provider
+payloads, secrets, headers, cookies, session values, CSRF tokens, or API keys.
+
 ## Scope boundaries
 
 This is an operator procedure, not a runtime contract. Running it must not:

--- a/docs/OPERATOR_BEHAVIORAL_DEMO_EVIDENCE_TEMPLATE.md
+++ b/docs/OPERATOR_BEHAVIORAL_DEMO_EVIDENCE_TEMPLATE.md
@@ -1,0 +1,132 @@
+# Operator Behavioral Demo Evidence Template
+
+## Purpose
+
+Use this copyable template to record summarized evidence from the
+[Operator Behavioral Demo Checklist](OPERATOR_BEHAVIORAL_DEMO_CHECKLIST.md) for
+Alpha Solver MVP preview runs. The template is for manual operator notes only.
+It does not create storage, run automated evaluations, validate the MVP, prove
+Alpha Solver superiority, prove production readiness, prove answer-quality
+benchmark success, or prove provider reasoning orchestration.
+
+## Safety and secret-handling rules
+
+Do not store or paste any of the following in this template or in repo-tracked
+evidence:
+
+- raw provider request payloads;
+- raw provider response payloads;
+- full raw model outputs as required evidence;
+- headers;
+- cookies;
+- session values;
+- CSRF tokens;
+- API keys;
+- dashboard passwords;
+- provider account identifiers;
+- secrets, credentials, or token values of any kind.
+
+Summarize behavior in your own words. Redact or summarize Cloud Run URLs when
+needed, for example `https://alpha-solver-preview-...run.app` or
+`preview service, project redacted`.
+
+## Copyable evidence block
+
+Copy one block per prompt or per prompt pair. Keep notes short and conservative.
+
+```text
+# Alpha Solver operator behavioral demo evidence
+
+## 1. Run metadata
+
+Run ID:
+Date/time UTC:
+Operator:
+Environment:
+Cloud Run URL or environment label, summarized/redacted if needed:
+Mode: local-provider smoke / controlled live-provider / side-by-side comparison
+Provider/model if known, otherwise unknown:
+If live mode was used, service returned to MODEL_PROVIDER=local: yes / no / n/a
+
+## 2. Prompt record
+
+Prompt ID from checklist:
+Prompt text or short prompt summary:
+Reason this prompt was selected:
+Expected behavior target:
+
+## 3. Output summaries only
+
+Plain provider output summary:
+Alpha Solver expert preview summary:
+
+Do not paste raw provider payloads, raw full outputs, headers, cookies, session
+values, CSRF tokens, API keys, dashboard passwords, or secrets here.
+
+## 4. Manual scoring table
+
+Score each criterion from 0 to 2.
+0 = missing, harmful, or materially misleading.
+1 = partially useful but incomplete, noisy, vague, or weakly bounded.
+2 = useful, concrete, bounded, and appropriate for the operator task.
+
+| Criterion | Plain output score (0-2) | Alpha Solver score (0-2) | Notes |
+| --- | --- | --- | --- |
+| Hidden constraints |  |  |  |
+| Intent preservation |  |  |  |
+| Concrete next actions |  |  |  |
+| Unsupported-claim avoidance |  |  |  |
+| Clarifying-question discipline |  |  |  |
+| Useful structure |  |  |  |
+| Claim-boundary respect |  |  |  |
+| Assumption visibility |  |  |  |
+| Operator confidence |  |  |  |
+| Practical usefulness |  |  |  |
+
+Plain provider total: __ / 20
+Alpha Solver total: __ / 20
+Delta: __
+Operator preference: plain / Alpha Solver / tie / inconclusive
+
+## 5. Defects and follow-up
+
+UI defect found? yes / no / unsure
+Runtime defect found? yes / no / unsure
+Prompt/routing weakness found? yes / no / unsure
+Documentation confusion found? yes / no / unsure
+Suggested backlog item:
+Severity: low / medium / high / blocking / n/a
+Evidence summary:
+Owner or next reviewer, if known:
+
+## 6. Conservative interpretation
+
+Select one:
+[ ] Inconclusive
+[ ] Promising, needs more runs
+[ ] Weak, needs prompt/routing improvement
+[ ] Defect found, create ticket
+[ ] Do not use for claims
+
+Interpretation notes:
+
+## 7. Claim boundaries
+
+Confirm each statement remains true for this evidence:
+[ ] One run is not validation.
+[ ] This evidence does not prove Alpha Solver superiority.
+[ ] This evidence does not prove MVP validation.
+[ ] This evidence does not prove production readiness.
+[ ] This evidence does not prove answer-quality benchmark success.
+[ ] This evidence does not prove provider reasoning orchestration.
+```
+
+## Operator reminders
+
+- Use this as a manual triage aid, not a benchmark result.
+- Prefer short behavior summaries over copied output.
+- If the run exposes a defect, create a ticket or backlog item outside this
+  template and include only a safe summary.
+- If live provider mode was used, confirm rollback to `MODEL_PROVIDER=local`
+  before ending the run.
+- Do not update Google Sheets or backlog workbooks from this repo task.


### PR DESCRIPTION
### Motivation

- Operators need a consistent, copyable, and repo-tracked evidence template to record manual results from the existing behavioral demo checklist without storing raw provider payloads, secrets, headers, cookies, session values, CSRF tokens, or API keys.
- This fills a documentation gap created by the checklist while preserving strict claim and safety boundaries and avoiding any runtime/config changes.

### Description

- Add `docs/OPERATOR_BEHAVIORAL_DEMO_EVIDENCE_TEMPLATE.md`, a copyable evidence block that captures run metadata, prompt record, plain/Alpha output summaries, a 0–2 scoring table (same rubric as the checklist), defect/follow-up fields, conservative interpretation options, and explicit claim boundaries.
- Add `.specs/EVAL-DEMO-EVIDENCE-001.md`, a spec describing purpose, scope (documentation-only), template requirements, acceptance criteria, validation expectations, backlog impact, and non-goals.
- Register the new spec in `.specs/INDEX.md` and add a short pointer from `docs/OPERATOR_BEHAVIORAL_DEMO_CHECKLIST.md` to the new evidence template so operators know where to record runs.
- No runtime, Cloud Run, provider, dashboard auth/session/CSRF, or storage behavior was changed and nothing enabling OpenAI or automated benchmarks was added.

### Testing

- Ran `git diff --check` with no outstanding whitespace or diff-check issues reported.
- Ran `python -m pytest -q`; the test suite executed and completed successfully with standard warnings and a few expected skips (for live-OpenAI and environment-dependent smoke tests), and no new failures were introduced.
- Confirmed the new files are staged and committed and the spec index and checklist pointer updates are present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e0c33531c83298ee411a3b6d40f1c)