### PR TITLE
EVAL-DEMO-RUN-PACKET-001: add one-page operator demo run packet

### DIFF
--- a/.specs/EVAL-DEMO-RUN-PACKET-001.md
+++ b/.specs/EVAL-DEMO-RUN-PACKET-001.md
@@ -1,0 +1,134 @@
+# EVAL-DEMO-RUN-PACKET-001 · One-Page Operator Demo Run Packet
+
+## Purpose
+
+Add a concise operator-facing run packet for one manual Alpha Solver preview test
+session. The packet bundles the behavioral demo checklist and evidence template
+into a practical step-by-step procedure for comparing plain same-provider output
+against the Alpha Solver expert preview while capturing only summarized evidence.
+
+The packet must not claim MVP validation, Alpha Solver superiority, production
+readiness, answer-quality benchmark success, broad runtime readiness, or provider
+reasoning orchestration.
+
+## Context
+
+The Cloud Run preview lane already has local-provider smoke, controlled one-call
+live OpenAI smoke, live-provider opt-in/cap guard, expert-preview loading state,
+an operator behavioral demo checklist, and an evidence template. Operators still
+need a short run packet that says exactly what to do in one manual session
+without rereading all supporting documents.
+
+## Scope
+
+In scope:
+
+- Add `docs/OPERATOR_DEMO_RUN_PACKET.md`.
+- Register this spec in `.specs/INDEX.md`.
+- Link the run packet to the checklist and evidence template.
+- Link the checklist and evidence template back to the run packet.
+- Optionally add a deployment-doc pointer.
+
+Out of scope:
+
+- Runtime behavior changes.
+- Cloud Run config changes.
+- Provider behavior changes.
+- Expert-preview behavior changes.
+- Dashboard auth, session, or CSRF behavior changes.
+- Enabling OpenAI or running live OpenAI from Codex.
+- Deploying Cloud Run.
+- Persistent storage.
+- Automated benchmark claims.
+- Google Sheet or backlog workbook updates.
+
+## Run packet requirements
+
+The operator run packet must include:
+
+1. Purpose: run one small manual behavioral demo session, compare plain
+   same-provider output against Alpha Solver expert preview, capture summarized
+   evidence only, and avoid validation or superiority claims.
+2. Before-you-start checks for Cloud Run URL, dashboard password,
+   `MODEL_PROVIDER=local` by default unless a live test window is approved, and
+   no copying of secrets or raw provider payloads.
+3. Default local-provider run sequence for opening `/dashboard/expert-preview`,
+   logging in, selecting 3 to 5 checklist prompt IDs, submitting one prompt at a
+   time, confirming loading state and both panes, recording evidence, and filing
+   follow-up tickets only for real defects or clear routing/prompt weaknesses.
+4. Optional controlled live-provider sequence requiring explicit approval,
+   `MODEL_PROVIDER=openai`, `ALPHA_LIVE_PREVIEW_ENABLED=true`, a low
+   `ALPHA_LIVE_PREVIEW_MAX_REQUESTS` such as `1` or `2`, `max-instances=1` for
+   the test window when using the current per-process cap, approved prompt count
+   only, cap confirmation when in scope, immediate return to
+   `MODEL_PROVIDER=local`, and rollback confirmation.
+5. Recommended first-run prompt subset covering overclaim prevention, hidden
+   constraints, execution planning, corrective next actions, and project-context
+   preservation.
+6. Evidence packet instructions linking to the evidence template, copying one
+   block per prompt, summarizing outputs instead of pasting raw full outputs,
+   scoring, and conservative interpretation.
+7. Stop conditions for login failure, CSRF or submit errors,
+   `Preview request failed`, unexpected live cap behavior, secrets or raw
+   payloads appearing in UI/logs/evidence, unsafe or unsupported claims, and
+   inability to return to local mode after live testing.
+8. Interpretation boundaries: one run is not validation, promising results only
+   justify more testing, weak results become prompt/routing tickets, runtime/UI
+   failures become defect tickets, and run results must not be used for public
+   claims.
+
+## Acceptance criteria
+
+- `docs/OPERATOR_DEMO_RUN_PACKET.md` exists.
+- `.specs/EVAL-DEMO-RUN-PACKET-001.md` exists and is registered in
+  `.specs/INDEX.md`.
+- The run packet links to the checklist and evidence template.
+- The checklist and evidence template link back to the run packet.
+- The run packet includes local-provider sequence, optional controlled
+  live-provider sequence, prompt subset guidance, evidence instructions, stop
+  conditions, and claim boundaries.
+- Runtime behavior is unchanged.
+- Cloud Run config is unchanged.
+- Provider behavior is unchanged.
+- Dashboard auth/session/CSRF behavior is unchanged.
+- Live OpenAI is not enabled.
+- No Google Sheet or backlog workbook update is performed by Codex.
+
+## Validation expectations
+
+Because this is docs/spec-only, validation should include:
+
+```bash
+git diff --check
+python -m pytest -q
+```
+
+If the full pytest suite is not practical, report why and still run
+`git diff --check`.
+
+## Backlog impact
+
+`EVAL-DEMO-RUN-PACKET-001` should be marked Done only if this PR is merged. This
+supports `EVAL-BEHAVIORAL-DEMO-001` and `EVAL-DEMO-EVIDENCE-001`. It does not
+validate the MVP, prove Alpha Solver superiority, prove production readiness,
+prove broad runtime readiness, prove answer-quality benchmark success, or prove
+provider reasoning orchestration. Backlog spreadsheets are not edited from this
+repo task.
+
+## Non-goals
+
+- No runtime behavior change.
+- No OpenAI enablement.
+- No Cloud Run deployment.
+- No provider behavior change.
+- No expert-preview behavior change.
+- No dashboard auth/session/CSRF change.
+- No persistent storage.
+- No automated benchmark claims.
+- No Google Sheets or backlog workbook update.
+- No MVP validation claim.
+- No Alpha Solver superiority claim.
+- No production-readiness claim.
+- No broad runtime-readiness claim.
+- No answer-quality benchmark success claim.
+- No provider reasoning orchestration claim.

--- a/.specs/EVAL-DEMO-RUN-PACKET-001.md
+++ b/.specs/EVAL-DEMO-RUN-PACKET-001.md
@@ -58,10 +58,15 @@ The operator run packet must include:
    follow-up tickets only for real defects or clear routing/prompt weaknesses.
 4. Optional controlled live-provider sequence requiring explicit approval,
    `MODEL_PROVIDER=openai`, `ALPHA_LIVE_PREVIEW_ENABLED=true`, a low
-   `ALPHA_LIVE_PREVIEW_MAX_REQUESTS` such as `1` or `2`, `max-instances=1` for
-   the test window when using the current per-process cap, approved prompt count
-   only, cap confirmation when in scope, immediate return to
-   `MODEL_PROVIDER=local`, and rollback confirmation.
+   `ALPHA_LIVE_PREVIEW_MAX_REQUESTS` such as `1` or `2`, and a safe-key
+   prerequisite that `OPENAI_API_KEY` is configured through the approved secret
+   mechanism, preferably Secret Manager. The sequence must warn operators not to
+   paste the API key into the run packet, evidence template, screenshots, logs,
+   Google Sheets, PR comments, or chat, and not to proceed if the live key is
+   missing or cannot be confirmed as mounted safely. It must also include
+   `max-instances=1` for the test window when using the current per-process cap,
+   approved prompt count only, cap confirmation when in scope, immediate return
+   to `MODEL_PROVIDER=local`, and rollback confirmation.
 5. Recommended first-run prompt subset covering overclaim prevention, hidden
    constraints, execution planning, corrective next actions, and project-context
    preservation.

--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -16,6 +16,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `EVAL-ARTIFACT-PRESERVE-001.md` | EVAL-ARTIFACT-PRESERVE-001 · Preserve Eval Summary Artifacts |
 | `EVAL-BEHAVIORAL-DEMO-001.md` | EVAL-BEHAVIORAL-DEMO-001 · Operator Behavioral Demo Checklist for MVP Preview |
 | `EVAL-DEMO-EVIDENCE-001.md` | EVAL-DEMO-EVIDENCE-001 · Operator Demo Evidence Template |
+| `EVAL-DEMO-RUN-PACKET-001.md` | EVAL-DEMO-RUN-PACKET-001 · One-Page Operator Demo Run Packet |
 | `FINOPS-BUDGET-001.md` | FINOPS-BUDGET-001 · Budget Guardrails |
 | `MCP-001.md` | CODE SPEC — MCP-001 · MCP Registry Loader & Wiring (MCP) |
 | `MCP-002.md` | CODE SPEC — MCP-002 · Router decision rule (MCP) |

--- a/docs/OPERATOR_BEHAVIORAL_DEMO_CHECKLIST.md
+++ b/docs/OPERATOR_BEHAVIORAL_DEMO_CHECKLIST.md
@@ -15,7 +15,9 @@ for more testing. This checklist does not validate the MVP, prove Alpha Solver
 superiority, prove production readiness, prove answer-quality benchmark success,
 or prove provider reasoning orchestration.
 
-Use the [Operator Behavioral Demo Evidence Template](OPERATOR_BEHAVIORAL_DEMO_EVIDENCE_TEMPLATE.md)
+For a one-session step-by-step procedure, start with the
+[Operator Demo Run Packet](OPERATOR_DEMO_RUN_PACKET.md). Use the
+[Operator Behavioral Demo Evidence Template](OPERATOR_BEHAVIORAL_DEMO_EVIDENCE_TEMPLATE.md)
 to record summarized findings for each run without storing raw provider
 payloads, secrets, headers, cookies, session values, CSRF tokens, or API keys.
 

--- a/docs/OPERATOR_BEHAVIORAL_DEMO_EVIDENCE_TEMPLATE.md
+++ b/docs/OPERATOR_BEHAVIORAL_DEMO_EVIDENCE_TEMPLATE.md
@@ -3,8 +3,9 @@
 ## Purpose
 
 Use this copyable template to record summarized evidence from the
-[Operator Behavioral Demo Checklist](OPERATOR_BEHAVIORAL_DEMO_CHECKLIST.md) for
-Alpha Solver MVP preview runs. The template is for manual operator notes only.
+[Operator Behavioral Demo Checklist](OPERATOR_BEHAVIORAL_DEMO_CHECKLIST.md) and
+the [Operator Demo Run Packet](OPERATOR_DEMO_RUN_PACKET.md) for Alpha Solver MVP
+preview runs. The template is for manual operator notes only.
 It does not create storage, run automated evaluations, validate the MVP, prove
 Alpha Solver superiority, prove production readiness, prove answer-quality
 benchmark success, or prove provider reasoning orchestration.

--- a/docs/OPERATOR_DEMO_RUN_PACKET.md
+++ b/docs/OPERATOR_DEMO_RUN_PACKET.md
@@ -59,14 +59,19 @@ Use this only with explicit approval for a live-provider test window.
 2. Set `MODEL_PROVIDER=openai` only for the approved window.
 3. Set `ALPHA_LIVE_PREVIEW_ENABLED=true`.
 4. Set `ALPHA_LIVE_PREVIEW_MAX_REQUESTS` to a low value, usually `1` or `2`.
-5. Keep Cloud Run `max-instances=1` for the test window if using the current
+5. Confirm `OPENAI_API_KEY` is configured through the approved secret mechanism,
+   preferably Secret Manager. Do not paste the API key into this run packet, the
+   evidence template, screenshots, logs, Google Sheets, PR comments, or chat. Do
+   not proceed if the live key is missing or the operator cannot confirm it is
+   mounted safely.
+6. Keep Cloud Run `max-instances=1` for the test window if using the current
    per-process cap.
-6. Run only the approved prompt count.
-7. If cap behavior is part of the test, confirm the cap blocks additional live
+7. Run only the approved prompt count.
+8. If cap behavior is part of the test, confirm the cap blocks additional live
    preview submissions as expected.
-8. Immediately return the service to `MODEL_PROVIDER=local` when the approved
+9. Immediately return the service to `MODEL_PROVIDER=local` when the approved
    prompts or window are complete.
-9. Record rollback confirmation in the evidence block.
+10. Record rollback confirmation in the evidence block.
 
 ## Evidence packet
 

--- a/docs/OPERATOR_DEMO_RUN_PACKET.md
+++ b/docs/OPERATOR_DEMO_RUN_PACKET.md
@@ -1,0 +1,103 @@
+# Operator Demo Run Packet
+
+Use this one-page packet to run one small manual Alpha Solver preview session.
+For the full prompt list and rubric, use the
+[Operator Behavioral Demo Checklist](OPERATOR_BEHAVIORAL_DEMO_CHECKLIST.md). For
+notes, use the
+[Operator Behavioral Demo Evidence Template](OPERATOR_BEHAVIORAL_DEMO_EVIDENCE_TEMPLATE.md).
+
+## Purpose
+
+- Run one small manual behavioral demo session through `/dashboard/expert-preview`.
+- Compare plain same-provider output against the Alpha Solver expert preview.
+- Capture only summarized evidence; do not paste raw full outputs or provider
+  payloads.
+- Do not claim MVP validation, Alpha Solver superiority, production readiness,
+  answer-quality benchmark success, or provider reasoning orchestration.
+
+## Before you start
+
+Confirm all of the following before the first prompt:
+
+- Cloud Run URL is known and reachable by the operator.
+- Dashboard password is available through the approved operator channel.
+- Service is in `MODEL_PROVIDER=local` unless an explicit live test window has
+  been approved.
+- No secrets, headers, cookies, session values, CSRF tokens, API keys, raw
+  provider payloads, or raw full model outputs will be copied into evidence.
+
+## Default local-provider run sequence
+
+1. Open `/dashboard/expert-preview` on the Cloud Run preview URL.
+2. Log in with the dashboard password.
+3. Select 3 to 5 prompt IDs from the checklist.
+4. Submit one prompt at a time.
+5. Confirm the loading state appears and duplicate submission is blocked while
+   the request is in flight.
+6. Confirm both comparison panes render before recording evidence.
+7. Record summarized evidence using one evidence-template block per prompt.
+8. Create follow-up tickets only for real defects or clear routing/prompt
+   weaknesses.
+
+## Recommended first-run prompt subset
+
+Choose 3 to 5 prompt IDs from the checklist that cover the widest operator
+signal with the smallest run:
+
+- `P6` for overclaim prevention.
+- `P2` for hidden constraints.
+- `P4` for execution planning.
+- `P7` for corrective next actions.
+- `P5` for project-context preservation.
+
+## Optional controlled live-provider sequence
+
+Use this only with explicit approval for a live-provider test window.
+
+1. Confirm the approved prompt count, operator, provider, cap, and rollback
+   owner.
+2. Set `MODEL_PROVIDER=openai` only for the approved window.
+3. Set `ALPHA_LIVE_PREVIEW_ENABLED=true`.
+4. Set `ALPHA_LIVE_PREVIEW_MAX_REQUESTS` to a low value, usually `1` or `2`.
+5. Keep Cloud Run `max-instances=1` for the test window if using the current
+   per-process cap.
+6. Run only the approved prompt count.
+7. If cap behavior is part of the test, confirm the cap blocks additional live
+   preview submissions as expected.
+8. Immediately return the service to `MODEL_PROVIDER=local` when the approved
+   prompts or window are complete.
+9. Record rollback confirmation in the evidence block.
+
+## Evidence packet
+
+- Use the
+  [Operator Behavioral Demo Evidence Template](OPERATOR_BEHAVIORAL_DEMO_EVIDENCE_TEMPLATE.md).
+- Copy one evidence block per prompt.
+- Summarize plain-provider and Alpha Solver outputs in your own words.
+- Include manual scoring and conservative interpretation.
+- Do not paste raw full outputs, raw provider request/response payloads, secrets,
+  headers, cookies, session values, CSRF tokens, API keys, dashboard passwords,
+  or provider account identifiers.
+
+## Stop conditions
+
+Stop the run and file the appropriate follow-up if any of these occur:
+
+- Login fails.
+- CSRF or submit errors appear.
+- `Preview request failed` appears.
+- Live cap behavior is unexpected.
+- Secrets or raw payloads appear in the UI, logs, or evidence.
+- Output makes unsafe or unsupported claims.
+- The service cannot be returned to `MODEL_PROVIDER=local` after live testing.
+
+## Interpretation and claim boundaries
+
+- One run is not validation.
+- A promising result only justifies more testing.
+- Weak results should become prompt/routing tickets.
+- Runtime or UI failures should become defect tickets.
+- Do not use run results for public claims, MVP validation claims, Alpha Solver
+  superiority claims, production-readiness claims, broad runtime-readiness
+  claims, answer-quality benchmark claims, or provider reasoning orchestration
+  claims.

--- a/docs/deployment/CLOUD_RUN_MVP_PREVIEW.md
+++ b/docs/deployment/CLOUD_RUN_MVP_PREVIEW.md
@@ -11,7 +11,8 @@ operator-test deployment of the Alpha Solver MVP preview route:
 
 The first deployment is intended to make the already-implemented supervised
 preview reachable behind the existing dashboard password gate. It is a deployment
-configuration and operator-smoke lane only.
+configuration and operator-smoke lane only. For one manual preview session, use
+the [Operator Demo Run Packet](../OPERATOR_DEMO_RUN_PACKET.md).
 
 ## 2. Scope boundaries
 


### PR DESCRIPTION
### Motivation

- Operators had an existing behavioral demo checklist and evidence template but lacked a single concise one-page run packet that tells an operator exactly what to do in one manual Alpha Solver preview session.
- The packet closes that documentation gap while preserving strict safety and claim boundaries and avoiding any runtime or provider changes.

### Description

- Add `docs/OPERATOR_DEMO_RUN_PACKET.md` as a one-page operator-facing run packet that includes purpose, before-you-start checks, a default local-provider sequence, an optional controlled live-provider sequence, a recommended 3–5 prompt subset, evidence instructions, stop conditions, and strict interpretation/claim boundaries.
- Add `.specs/EVAL-DEMO-RUN-PACKET-001.md` documenting scope, requirements, acceptance criteria, validation expectations, backlog impact, and non-goals for the run packet, and register it in `.specs/INDEX.md`.
- Update `docs/OPERATOR_BEHAVIORAL_DEMO_CHECKLIST.md` and `docs/OPERATOR_BEHAVIORAL_DEMO_EVIDENCE_TEMPLATE.md` to link to the new run packet, and add a short pointer from `docs/deployment/CLOUD_RUN_MVP_PREVIEW.md` to the packet; no code or runtime behavior was changed.
- Files changed: added `docs/OPERATOR_DEMO_RUN_PACKET.md`, added `.specs/EVAL-DEMO-RUN-PACKET-001.md`, updated `.specs/INDEX.md`, `docs/OPERATOR_BEHAVIORAL_DEMO_CHECKLIST.md`, `docs/OPERATOR_BEHAVIORAL_DEMO_EVIDENCE_TEMPLATE.md`, and `docs/deployment/CLOUD_RUN_MVP_PREVIEW.md`.

### Testing

- Ran `git diff --check` which returned clean results.
- Ran `python -m pytest -q` and the test suite completed successfully with a small number of expected skips for live-OpenAI tests (e.g., `tests/providers/test_openai_live_smoke.py`) that require explicit live credentials; no new test failures were introduced.
- Because this is documentation/spec-only work, no runtime/manual verification was required and no code behavior changes were made.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e11a784f08329b2216b7069dec0e9)