### PR TITLE
UI-PREVIEW-RESPONSE-LAYOUT-001: improve long response rendering

### DIFF
--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -56,6 +56,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `UI-PREVIEW-001.md` | UI-PREVIEW-001 · Authenticated Expert Preview UI |
 | `UI-PREVIEW-LOADING-STATE-001.md` | UI-PREVIEW-LOADING-STATE-001 · Expert Preview Loading State |
 | `UI-PREVIEW-LOCAL-SMOKE-001.md` | UI-PREVIEW-LOCAL-SMOKE-001 · Local-provider Expert Preview Smoke Fix |
+| `UI-PREVIEW-RESPONSE-LAYOUT-001.md` | UI-PREVIEW-RESPONSE-LAYOUT-001 · Expert Preview Long Response Layout |
 | `UI-KEYS-001.md` | UI-KEYS-001 · Dashboard: API Keys Management |
 | `UI-REQ-001.md` | UI-REQ-001 · Dashboard Request Submission UI |
 | `UI-RUN-001.md` | UI-RUN-001 · Dashboard One-click Demo Run |

--- a/.specs/UI-PREVIEW-RESPONSE-LAYOUT-001.md
+++ b/.specs/UI-PREVIEW-RESPONSE-LAYOUT-001.md
@@ -1,0 +1,50 @@
+# UI-PREVIEW-RESPONSE-LAYOUT-001 · Expert Preview Long Response Layout
+
+## Purpose
+
+Improve `/dashboard/expert-preview` readability when the plain same-provider pane or Alpha Solver expert-preview pane renders long primary answer text.
+
+This defect was discovered during the first controlled operator demo run. It does not validate the MVP, prove Alpha Solver superiority, or prove production readiness.
+
+## Scope
+
+In scope:
+
+- keep the existing authenticated expert-preview route and form behavior;
+- keep prompt preservation unchanged;
+- keep loading-state and duplicate-submit behavior unchanged;
+- keep dashboard auth/session/CSRF behavior unchanged;
+- keep live spend guard behavior unchanged;
+- keep provider/runtime behavior unchanged;
+- make both primary answer boxes wrap long text and expand vertically without clipping;
+- keep details sections accessible below the primary answer content.
+
+Out of scope:
+
+- enabling OpenAI;
+- Cloud Run deployment;
+- Google Sheet or backlog workbook updates;
+- provider behavior changes;
+- dashboard auth/session/CSRF changes;
+- live spend guard semantic changes;
+- MVP validation claims;
+- Alpha Solver superiority claims;
+- production-readiness claims;
+- answer-quality benchmark claims;
+- provider reasoning orchestration claims.
+
+## Acceptance criteria
+
+No-network UI tests should prove:
+
+- long plain provider output renders inside the primary answer element;
+- long Alpha Solver expert-preview output renders inside the primary answer element;
+- both answer elements use layout CSS that wraps long text, allows panes to shrink inside the grid, and avoids fixed-height clipping;
+- existing loading-state script behavior remains present;
+- existing CSRF behavior remains covered by existing tests.
+
+## Backlog impact
+
+`UI-PREVIEW-RESPONSE-LAYOUT-001` should be marked Done only after the PR implementing this spec is merged.
+
+This defect was discovered during the first controlled operator demo run. This does not validate the MVP, prove Alpha Solver superiority, or prove production readiness. Backlog spreadsheets and Google Sheets are not edited from this repo task.

--- a/alpha/webapp/routes/expert_preview.py
+++ b/alpha/webapp/routes/expert_preview.py
@@ -157,7 +157,7 @@ def _render_plain_payload(payload: Mapping[str, Any] | None) -> str:
     meta = _public_meta(payload)
     details = json.dumps(meta, indent=2, sort_keys=True) if meta else "{}"
     return f"""
-      <p class="answer">{_escape(_answer(payload))}</p>
+      <div class="answer response-text" aria-label="Primary response">{_escape(_answer(payload))}</div>
       <details>
         <summary>Details</summary>
         <pre>{_escape(details)}</pre>
@@ -185,7 +185,7 @@ def _render_expert_payload(payload: Mapping[str, Any] | None) -> str:
         f"<div><dt>{_escape(label)}</dt><dd>{_escape(value)}</dd></div>" for label, value in rows
     )
     return f"""
-      <p class="answer">{_escape(_answer(payload))}</p>
+      <div class="answer response-text" aria-label="Primary response">{_escape(_answer(payload))}</div>
       <dl class="metadata">{rows_html}</dl>
       <h3>Considerations</h3>
       {_render_list(_as_list(payload.get('considerations')))}
@@ -225,10 +225,11 @@ def _render_page(
       textarea {{ min-height: 130px; resize: vertical; border: 1px solid #cdd5ef; border-radius: 12px; padding: 0.85rem 1rem; font: inherit; color: inherit; background: rgba(255,255,255,0.78); }}
       button {{ justify-self: start; border: 0; border-radius: 999px; padding: 0.7rem 1.25rem; font: inherit; font-weight: 700; color: white; background: linear-gradient(135deg, #5661f6, #7b5ff4); cursor: pointer; }}
       button:disabled {{ cursor: wait; opacity: 0.72; }}
-      .panes {{ display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 1rem; }}
+      .panes {{ display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); align-items: start; gap: 1rem; }}
+      .pane {{ min-width: 0; }}
       .pane h2 {{ margin-top: 0; }}
-      .answer, pre {{ white-space: pre-wrap; overflow-wrap: anywhere; }}
-      .answer {{ border: 1px solid rgba(86, 97, 246, 0.16); background: rgba(237, 240, 255, 0.65); border-radius: 12px; padding: 1rem; }}
+      .answer, pre {{ white-space: pre-wrap; overflow-wrap: anywhere; word-break: break-word; }}
+      .answer {{ display: block; margin: 0 0 1rem; max-height: none; overflow: visible; border: 1px solid rgba(86, 97, 246, 0.16); background: rgba(237, 240, 255, 0.65); border-radius: 12px; padding: 1rem; }}
       .metadata {{ display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.75rem; }}
       dt {{ color: #565b8f; font-size: 0.8rem; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; }}
       dd {{ margin: 0; font-weight: 600; }}

--- a/tests/ui/test_expert_preview.py
+++ b/tests/ui/test_expert_preview.py
@@ -80,6 +80,14 @@ def _assert_loading_state_script(html: str) -> None:
     assert "initExpertPreviewForm();" in html
 
 
+def _assert_long_response_layout(html: str) -> None:
+    assert '.panes { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); align-items: start;' in html
+    assert '.pane { min-width: 0; }' in html
+    assert '.answer, pre { white-space: pre-wrap; overflow-wrap: anywhere; word-break: break-word; }' in html
+    assert '.answer { display: block; margin: 0 0 1rem; max-height: none; overflow: visible;' in html
+    assert 'class="answer response-text" aria-label="Primary response"' in html
+
+
 def _assert_no_sensitive_preview_leak(html: str, *secrets: str) -> None:
     for secret in secrets:
         assert secret not in html
@@ -334,6 +342,39 @@ def test_preview_submission_handles_unstructured_expert_preview_coherently(
     assert "Bearer" not in html
     assert "raw request" not in html.lower()
     assert "raw response" not in html.lower()
+
+
+def test_long_plain_and_expert_responses_use_expanding_wrapping_answer_boxes(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    csrf_token = _login(client)
+    long_plain = "Plain provider output " + ("wraps cleanly with a very long segment " * 80)
+    long_expert = "Alpha Solver expert preview output " + ("expands vertically for operator review " * 80)
+
+    async def fake_solve_preview(*args: object, expert: bool) -> dict[str, object]:
+        if expert:
+            return {
+                "final_answer": long_expert,
+                "confidence": 0.62,
+                "considerations": ["Review long output layout"],
+                "meta": {"route": "expert", "call_count": 1},
+            }
+        return {"final_answer": long_plain, "meta": {"route": "tot", "call_count": 1}}
+
+    monkeypatch.setattr(expert_preview, "_solve_preview", fake_solve_preview)
+
+    response = client.post(
+        "/dashboard/expert-preview",
+        data={"prompt": "Render long responses without clipping."},
+        headers={auth.CSRF_HEADER_NAME: csrf_token},
+    )
+
+    assert response.status_code == 200
+    html = response.text
+    assert long_plain in html
+    assert long_expert in html
+    assert html.count('class="answer response-text" aria-label="Primary response"') == 2
+    _assert_long_response_layout(html)
 
 
 def test_browser_like_multipart_submission_extracts_prompt_and_preserves_it(

--- a/tests/ui/test_expert_preview_real_app.py
+++ b/tests/ui/test_expert_preview_real_app.py
@@ -75,6 +75,13 @@ def _assert_loading_state_script(html: str) -> None:
     assert "initExpertPreviewForm();" in html
 
 
+def _assert_long_response_layout(html: str) -> None:
+    assert '.panes { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); align-items: start;' in html
+    assert '.pane { min-width: 0; }' in html
+    assert '.answer, pre { white-space: pre-wrap; overflow-wrap: anywhere; word-break: break-word; }' in html
+    assert '.answer { display: block; margin: 0 0 1rem; max-height: none; overflow: visible;' in html
+
+
 def _login(client: TestClient) -> str:
     response = client.post("/login", data={"password": "testing-secret"}, follow_redirects=False)
     assert response.status_code == 303
@@ -134,6 +141,7 @@ def test_authenticated_request_renders_page(client: TestClient) -> None:
     assert response.status_code == 200
     assert expert_preview.DISCLAIMER in response.text
     _assert_loading_state_script(response.text)
+    _assert_long_response_layout(response.text)
 
 
 def test_preview_post_uses_fake_provider_without_network(


### PR DESCRIPTION
### Motivation
- Long plain-provider and Alpha Solver expert-preview outputs produced during an operator demo were cramped and hard to review because the primary answer region did not expand or wrap cleanly. 
- Root cause: the primary answer was rendered with minimal inline/paragraph styling and the panes' grid/CSS did not allow children to shrink and expand without clipping, causing long text to appear constrained.

### Description
- Replace the inline paragraph answer with a block-level primary response element by rendering both panes' main answer as `<div class="answer response-text" aria-label="Primary response">…</div>` so both panes are consistent. 
- Tighten CSS for the preview panes by setting `.panes` to `align-items: start`, adding `.pane { min-width: 0; }`, and updating `.answer` rules to include `word-break: break-word`, `display: block`, `max-height: none`, and `overflow: visible` so long text wraps and the card expands vertically with Details accessible below. 
- Add an implementation spec `UI-PREVIEW-RESPONSE-LAYOUT-001.md` and register it in `.specs/INDEX.md`. 
- Add no-network UI assertions and a focused test that submits long plain and expert results to verify the new markup and CSS are present and both panes render long primary answers without clipping.
- Scope boundaries: this is a UI-only change and makes no provider/runtime/auth/CSRF/live-spend changes, does not enable OpenAI, and does not touch Cloud Run or Google Sheets.

### Testing
- Ran `git diff --check` which produced no warnings. 
- Ran `python -m pytest tests/ui/test_expert_preview.py -q` and `python -m pytest tests/ui/test_expert_preview_real_app.py -q`, both of which passed. 
- Ran the full test suite with `python -m pytest -q` which completed with all tests passing (UI tests included).
- Backlog impact: merge of this PR implements `UI-PREVIEW-RESPONSE-LAYOUT-001` and that ticket should be marked Done only once this change is merged; this fix was discovered during an operator demo and does not validate MVP or production readiness.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e231a747c83298a2c3cad7cdf707f)