### PR TITLE
ALPHA-FORMAT-PRESERVATION-001: preserve requested output structure in expert answers

### DIFF
--- a/.specs/ALPHA-FORMAT-PRESERVATION-001.md
+++ b/.specs/ALPHA-FORMAT-PRESERVATION-001.md
@@ -1,0 +1,101 @@
+# ALPHA-FORMAT-PRESERVATION-001 · Expert Answer Format Preservation
+
+## Purpose
+
+Improve the expert-route final answer behavior so Alpha Solver preserves a
+user's requested output format, structure, headings, sectioning, and time boxes
+while still surfacing assumptions, considerations, and conservative claim
+boundaries.
+
+## Context
+
+During the first controlled 3-prompt operator demo, Prompt 3 asked:
+
+> Create a two-hour operator test plan for /dashboard/expert-preview that
+> separates setup, prompt runs, evidence capture, and rollback.
+
+The plain provider output produced a direct time-boxed operator test plan. The
+Alpha Solver expert preview surfaced useful considerations and assumptions, but
+its final answer did not preserve the requested two-hour plan structure as
+clearly. Investigation indicates the likely root cause is the backend expert
+Step 2 prompt: it uses Step 1 considerations and assumptions, but did not
+strongly require the final answer to preserve the requested output shape.
+
+## Scope
+
+In scope:
+
+- Update expert-route final-answer prompt construction so requested output shape
+  is preserved first.
+- Preserve requested section names when present, including setup, prompt runs,
+  evidence capture, and rollback.
+- Preserve requested time boxes when present, including two-hour plan requests.
+- Preserve requested deliverable type when present, including checklist, table,
+  plan, release note, email, rubric, and runbook.
+- Keep assumptions and considerations available without letting them replace the
+  requested deliverable.
+- Preserve safety and claim-boundary language.
+- Add no-network tests using fake provider clients.
+
+Out of scope:
+
+- Provider selection changes.
+- Preview UI changes.
+- Dashboard auth/session/CSRF changes.
+- Enabling OpenAI.
+- Cloud Run deployment.
+- Google Sheets or backlog workbook updates.
+- Claims of MVP validation, Alpha Solver superiority, production readiness,
+  broad runtime readiness, answer-quality benchmark success, or provider
+  reasoning orchestration.
+
+## Requirements
+
+1. If the user asks for a specific format, the expert final answer should
+   preserve it unless unsafe or impossible.
+2. Requested section names should be preserved when present.
+3. Requested time boxes should be preserved when present.
+4. Requested output type should be preserved when present.
+5. Assumptions and considerations should remain useful, but they must not
+   replace the requested deliverable.
+6. Expert final answers should be answer-first: the requested deliverable comes
+   first, and assumptions or considerations can follow or remain in structured
+   detail fields.
+7. Safety and claim-boundary behavior must not be reduced.
+8. Provider selection behavior must not change.
+9. Preview UI behavior must not change unless required by the backend contract.
+
+## Acceptance criteria
+
+- Expert Step 2 prompt construction explicitly instructs the provider to preserve
+  requested output format, section names, order, time boxes, bullets, tables, and
+  named parts unless unsafe or impossible.
+- A no-network API test proves the two-hour operator test plan prompt returns a
+  final answer with setup, prompt runs, evidence capture, rollback, and time-box
+  structure while considerations and assumptions remain available separately.
+- A no-network UI preview test proves the same requested plan structure renders
+  as the primary expert answer and considerations/assumptions remain visible.
+- A no-network API test proves claim-boundary instructions remain present for an
+  overclaim-sensitive release-note prompt.
+- Existing expert-preview and local-provider tests continue to pass.
+- No live provider calls are required or made by the tests.
+
+## Validation expectations
+
+```bash
+git diff --check
+python -m pytest tests/test_api_endpoints.py -q
+python -m pytest tests/ui/test_expert_preview.py -q
+python -m pytest -q
+```
+
+If the full suite cannot complete, report the exact failure or environment
+limitation and still report the focused checks.
+
+## Backlog impact
+
+`ALPHA-FORMAT-PRESERVATION-001` should be marked Done only if this PR is merged.
+This was discovered during the first controlled operator demo. It supports MVP
+operator testing but does not validate the MVP, prove Alpha Solver superiority,
+prove production readiness, prove broad runtime readiness, prove answer-quality
+benchmark success, or prove provider reasoning orchestration.

--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -4,6 +4,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 
 | File | Title |
 | --- | --- |
+| `ALPHA-FORMAT-PRESERVATION-001.md` | ALPHA-FORMAT-PRESERVATION-001 · Expert Answer Format Preservation |
 | `AS-145.md` | CODE SPEC — AS-145 · Tool Adapters: Playwright + GSheets (MVP hardening) (RES_05) |
 | `AS-148.md` | CODE SPEC — AS-148 · Policy & PII Gateway (DR_TRACK_A) |
 | `AUTH-SESSION-001.md` | AUTH-SESSION-001 · Dashboard Login + Session |

--- a/service/app.py
+++ b/service/app.py
@@ -602,7 +602,16 @@ def _expert_step_one_prompt(query: str) -> str:
 def _expert_step_two_prompt(query: str, preview: dict[str, Any]) -> str:
     return (
         "Answer the request below using the provided considerations and assumptions. "
-        "Do not include raw provider metadata.\n\n"
+        "Preserve the user's requested output format first: if they ask for a "
+        "plan, checklist, table, release note, email, rubric, runbook, or other "
+        "specific deliverable, make the final answer that deliverable. Preserve "
+        "requested headings, section names, order, time boxes, bullets, tables, "
+        "and named parts unless unsafe or impossible. Keep useful assumptions, "
+        "considerations, caveats, and claim boundaries, but do not let them replace "
+        "the requested deliverable; place them after the deliverable or weave them "
+        "into it briefly. Do not overclaim certainty, validation, production "
+        "readiness, benchmark success, superiority, or provider reasoning "
+        "orchestration. Do not include raw provider metadata.\n\n"
         f"Considerations: {json.dumps(preview['considerations'], ensure_ascii=False)}\n"
         f"Assumptions: {json.dumps(preview['assumptions'], ensure_ascii=False)}\n"
         f"Self-rated confidence: {preview['confidence']}\n\nRequest:\n{query}"

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -505,6 +505,114 @@ def test_solve_openai_expert_complex_route_makes_two_calls_and_returns_envelope(
     _clear_provider_factory()
 
 
+def test_solve_openai_expert_complex_route_preserves_requested_plan_shape(monkeypatch):
+    monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    prompt = (
+        "Create a two-hour operator test plan for /dashboard/expert-preview "
+        "that separates setup, prompt runs, evidence capture, and rollback."
+    )
+    structured_answer = (
+        "# Two-hour operator test plan for /dashboard/expert-preview\n\n"
+        "| Time box | Section | Tasks | Evidence |\n"
+        "| --- | --- | --- | --- |\n"
+        "| 0:00-0:20 | Setup | Confirm local-provider config and login. | Smoke notes. |\n"
+        "| 0:20-1:15 | Prompt runs | Run the controlled prompts. | Prompt/result summaries. |\n"
+        "| 1:15-1:45 | Evidence capture | Save sanitized observations. | Evidence packet. |\n"
+        "| 1:45-2:00 | Rollback | Return MODEL_PROVIDER=local and record status. | Rollback note. |\n\n"
+        "Assumptions: supervised operator demo only; no production-readiness claim."
+    )
+    fake = FakeProviderClient(
+        [
+            _provider_result(
+                '{"considerations":["Keep the requested two-hour test-plan deliverable first",'
+                '"Preserve section separation for setup, prompt runs, evidence capture, and rollback"],'
+                '"assumptions":["The run is a supervised operator preview, not MVP validation"],'
+                '"confidence":0.82}'
+            ),
+            _provider_result(structured_answer),
+        ]
+    )
+    app.state.provider_client_factory = lambda _model_set: fake
+    client, key = _client()
+
+    resp = client.post(
+        "/v1/solve",
+        json={"query": prompt, "context": {"route": "expert"}},
+        headers={"X-API-Key": key, "X-Request-ID": "req-format"},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["final_answer"] == structured_answer
+    assert body["answer"] == structured_answer
+    assert "Two-hour operator test plan" in body["final_answer"]
+    for section in ("Setup", "Prompt runs", "Evidence capture", "Rollback"):
+        assert section in body["final_answer"]
+    for time_box in ("0:00-0:20", "0:20-1:15", "1:15-1:45", "1:45-2:00"):
+        assert time_box in body["final_answer"]
+    assert body["considerations"] == [
+        "Keep the requested two-hour test-plan deliverable first",
+        "Preserve section separation for setup, prompt runs, evidence capture, and rollback",
+    ]
+    assert body["assumptions"] == [
+        "The run is a supervised operator preview, not MVP validation"
+    ]
+    assert body["mode"] == "direct"
+    assert len(fake.requests) == 2
+    answer_prompt = fake.requests[1].prompt
+    assert "Preserve the user's requested output format first" in answer_prompt
+    assert "plan, checklist, table, release note, email, rubric, runbook" in answer_prompt
+    assert "headings, section names, order, time boxes, bullets, tables" in answer_prompt
+    assert "do not let them replace the requested deliverable" in answer_prompt
+    assert prompt in answer_prompt
+    _clear_provider_factory()
+
+
+def test_solve_openai_expert_prompt_preserves_claim_boundaries(monkeypatch):
+    monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    fake = FakeProviderClient(
+        [
+            _provider_result(
+                '{"considerations":["Avoid broad conclusions from one demo"],'
+                '"assumptions":["Evidence is limited"],"confidence":0.9}'
+            ),
+            _provider_result(
+                "Release note: this supports follow-up testing but does not validate the MVP."
+            ),
+        ]
+    )
+    app.state.provider_client_factory = lambda _model_set: fake
+    client, key = _client()
+
+    resp = client.post(
+        "/v1/solve",
+        json={
+            "query": (
+                "Write a release note for one operator demo, include scope boundaries and "
+                "next-step caveats, and avoid claiming MVP validation, Alpha Solver "
+                "superiority, production readiness, broad runtime readiness, answer-quality "
+                "benchmark success, or provider reasoning orchestration."
+            ),
+            "context": {"route": "expert"},
+        },
+        headers={"X-API-Key": key, "X-Request-ID": "req-claims"},
+    )
+
+    assert resp.status_code == 200
+    assert len(fake.requests) == 2
+    answer_prompt = fake.requests[1].prompt
+    assert "Do not overclaim certainty" in answer_prompt
+    assert "validation" in answer_prompt
+    assert "production readiness" in answer_prompt
+    assert "superiority" in answer_prompt
+    assert "provider reasoning orchestration" in answer_prompt
+    body = resp.json()
+    assert "does not validate the MVP" in body["final_answer"]
+    assert body["considerations"] == ["Avoid broad conclusions from one demo"]
+    assert body["assumptions"] == ["Evidence is limited"]
+    _clear_provider_factory()
+
+
 def test_solve_openai_expert_complex_route_preserves_system_prompt(monkeypatch):
     monkeypatch.setenv("MODEL_PROVIDER", "openai")
     fake = FakeProviderClient(

--- a/tests/ui/test_expert_preview.py
+++ b/tests/ui/test_expert_preview.py
@@ -198,6 +198,59 @@ def test_preview_submission_renders_plain_and_expert_outputs(client: TestClient)
     assert "raw response" not in html.lower()
 
 
+def test_preview_submission_preserves_requested_operator_plan_structure(
+    client: TestClient,
+) -> None:
+    csrf_token = _login(client)
+    prompt = (
+        "Create a two-hour operator test plan for /dashboard/expert-preview "
+        "that separates setup, prompt runs, evidence capture, and rollback."
+    )
+    expert_answer = (
+        "# Two-hour operator test plan\n\n"
+        "## Setup (0:00-0:20)\n"
+        "- Confirm local-provider baseline and dashboard login.\n\n"
+        "## Prompt runs (0:20-1:15)\n"
+        "- Run the controlled prompts and compare panes.\n\n"
+        "## Evidence capture (1:15-1:45)\n"
+        "- Record sanitized summaries only.\n\n"
+        "## Rollback (1:45-2:00)\n"
+        "- Return MODEL_PROVIDER=local and document status.\n\n"
+        "Assumptions: supervised operator test only; no MVP validation claim."
+    )
+    fake = FakeProviderClient(
+        [
+            _provider_result("plain same-provider answer"),
+            _provider_result(
+                '{"considerations":["Preserve the requested plan first"],'
+                '"assumptions":["Operator preview only"],"confidence":0.82}'
+            ),
+            _provider_result(expert_answer),
+        ]
+    )
+    client.app.state.provider_client_factory = lambda _model_set: fake
+
+    response = client.post(
+        "/dashboard/expert-preview",
+        data={"prompt": prompt},
+        headers={auth.CSRF_HEADER_NAME: csrf_token},
+    )
+
+    assert response.status_code == 200
+    html = response.text
+    assert "Two-hour operator test plan" in html
+    for section in ("Setup", "Prompt runs", "Evidence capture", "Rollback"):
+        assert section in html
+    for time_box in ("0:00-0:20", "0:20-1:15", "1:15-1:45", "1:45-2:00"):
+        assert time_box in html
+    assert "Preserve the requested plan first" in html
+    assert "Operator preview only" in html
+    assert len(fake.requests) == 3
+    answer_prompt = fake.requests[2].prompt
+    assert "Preserve the user's requested output format first" in answer_prompt
+    assert "do not let them replace the requested deliverable" in answer_prompt
+
+
 def test_openai_preview_submit_blocks_when_live_preview_flag_absent(
     client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
### Motivation

- During an operator demo the expert preview surfaced useful considerations but did not reliably preserve a user-requested deliverable shape (for example a two-hour operator test plan with named sections and time boxes). 
- Root cause: the expert-route Step 2 prompt used previewed considerations/assumptions but did not explicitly require the final answer to preserve the user's requested format, headings, order, time boxes, or named sections. 
- Goal: make the smallest safe backend change so expert final answers are "answer-first" and preserve requested format while keeping safety and claim-boundary behavior intact.

### Description

- Tightened the expert final-answer prompt in `service/app.py::_expert_step_two_prompt` to explicitly instruct the provider to preserve requested output type, headings, section names, order, time boxes, bullets, tables, and named parts first, and to keep assumptions/considerations and conservative claim boundaries secondary. 
- Added a tracking/spec artifact `.specs/ALPHA-FORMAT-PRESERVATION-001.md` and registered it in `.specs/INDEX.md` documenting scope, acceptance criteria, and non-goals. 
- Added no-network tests that exercise the operator plan prompt and claim-boundary behavior by using `FakeProviderClient` in `tests/test_api_endpoints.py` and `tests/ui/test_expert_preview.py` (new tests: `test_solve_openai_expert_complex_route_preserves_requested_plan_shape`, `test_solve_openai_expert_prompt_preserves_claim_boundaries`, and `test_preview_submission_preserves_requested_operator_plan_structure`). 
- Kept changes narrowly scoped: no provider selection, preview UI, auth/session/CSRF, Cloud Run, or Google Sheets changes were made and safety/claim-boundary logic was preserved.

### Testing

- Ran `git diff --check` and it produced no issues. 
- Ran `python -m pytest tests/test_api_endpoints.py -q` and the updated expert-route API tests passed using `FakeProviderClient` (no network calls). 
- Ran `python -m pytest tests/ui/test_expert_preview.py -q` and the expert-preview UI tests passed with fake providers. 
- Ran the full suite with `python -m pytest -q` and the test run completed successfully; all modified and existing tests remain green and no live provider calls were made.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e272b20f88329a5dd56e162903e11)