### PR TITLE
ALPHA-CLARIFY-THRESHOLD-001: answer execution prompts with assumptions when sufficient

### DIFF
--- a/.specs/ALPHA-CLARIFY-THRESHOLD-001.md
+++ b/.specs/ALPHA-CLARIFY-THRESHOLD-001.md
@@ -1,0 +1,106 @@
+# ALPHA-CLARIFY-THRESHOLD-001 · Answer Execution Prompts with Assumptions When Sufficient
+
+## Purpose
+
+Improve expert-route mode selection so Alpha Solver answers actionable
+execution-planning prompts with reasonable assumptions instead of replacing the
+requested deliverable with clarify-only behavior.
+
+## Context
+
+During the post-fix controlled live retest, Prompt A asked:
+
+> Create a two-hour operator test plan for /dashboard/expert-preview that
+> separates setup, prompt runs, evidence capture, and rollback.
+
+Plain provider output produced a direct two-hour operator test plan, but Alpha
+Solver expert preview entered clarify mode with a generic clarification message.
+The request already contained a concrete deliverable, route target, time box, and
+required sections, so a useful answer with explicit assumptions was preferable.
+
+`ALPHA-FORMAT-PRESERVATION-001` strengthened the final-answer prompt after the
+expert route chooses to answer. This spec covers the earlier mode-selection
+threshold so answerable execution-planning prompts are not blocked by unnecessary
+clarification.
+
+## Scope
+
+In scope:
+
+- Narrowly adjust expert-route clarify threshold behavior for actionable
+  execution-planning prompts.
+- Prefer `answer_with_assumptions` over `clarify` when a prompt includes an
+  explicit execution-style deliverable and concrete target/context.
+- Preserve requested sections for the retest prompt: setup, prompt runs,
+  evidence capture, and rollback.
+- Keep clarifying questions available for genuinely underspecified, unsafe,
+  impossible, or high-risk requests.
+- Add no-network API and expert-preview UI coverage using fake provider clients.
+
+Out of scope:
+
+- Global clarification disablement.
+- Broad routing rewrites.
+- Provider selection changes.
+- Preview UI changes unless strictly necessary.
+- Request metrics behavior changes.
+- Dashboard auth/session/CSRF changes.
+- Enabling OpenAI.
+- Cloud Run deployment.
+- Google Sheets or backlog workbook updates.
+- Claims of MVP validation, Alpha Solver superiority, production readiness,
+  broad runtime readiness, answer-quality benchmark success, exact billing
+  accuracy, or provider reasoning orchestration.
+
+## Requirements
+
+1. Actionable execution-planning prompts with enough context should answer with
+   assumptions instead of entering clarify mode.
+2. The retest prompt should produce a direct two-hour plan, not a
+   clarification-only response.
+3. The answer should preserve setup, prompt runs, evidence capture, and rollback.
+4. Assumptions and considerations may appear, but they must not replace the
+   requested deliverable.
+5. Clarifying questions should still be allowed when requests are genuinely
+   underspecified, unsafe, impossible, or high-risk.
+6. SAFE-OUT behavior must be preserved.
+7. Claim-boundary behavior must be preserved.
+8. `ALPHA-FORMAT-PRESERVATION-001` behavior must be preserved.
+9. Provider selection, preview UI, request metrics, dashboard auth/session/CSRF,
+   and deployment behavior must not change.
+
+## Acceptance criteria
+
+- A no-network API test proves the retest prompt does not return clarify-only
+  behavior when the expert preview confidence is in the clarify band.
+- The API response includes setup, prompt runs, evidence capture, and rollback
+  in the primary answer.
+- A no-network expert-preview UI test proves the primary Alpha answer is not the
+  generic clarify message for the retest prompt.
+- Existing control coverage still proves genuinely underspecified expert-route
+  prompts can clarify.
+- Existing format-preservation, claim-boundary, SAFE-OUT, request metrics, and
+  expert-preview tests continue to pass.
+- No live provider calls are required or made by the tests.
+
+## Validation expectations
+
+```bash
+git diff --check
+python -m pytest tests/test_api_endpoints.py -q
+python -m pytest tests/ui/test_expert_preview.py -q
+python -m pytest -q
+```
+
+If the full suite cannot complete, report the exact failure or environment
+limitation and still report the focused checks.
+
+## Backlog impact
+
+`ALPHA-CLARIFY-THRESHOLD-001` should be marked Done only if this PR is merged.
+This was discovered during the post-fix controlled live retest. It supports MVP
+readiness by preventing answerable execution prompts from being blocked by
+unnecessary clarification, but it does not validate the MVP, prove Alpha Solver
+superiority, prove production readiness, prove broad runtime readiness, prove
+answer-quality benchmark success, prove exact billing accuracy, or prove provider
+reasoning orchestration.

--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -4,6 +4,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 
 | File | Title |
 | --- | --- |
+| `ALPHA-CLARIFY-THRESHOLD-001.md` | ALPHA-CLARIFY-THRESHOLD-001 · Answer Execution Prompts with Assumptions When Sufficient |
 | `ALPHA-FORMAT-PRESERVATION-001.md` | ALPHA-FORMAT-PRESERVATION-001 · Expert Answer Format Preservation |
 | `AS-145.md` | CODE SPEC — AS-145 · Tool Adapters: Playwright + GSheets (MVP hardening) (RES_05) |
 | `AS-148.md` | CODE SPEC — AS-148 · Policy & PII Gateway (DR_TRACK_A) |

--- a/service/app.py
+++ b/service/app.py
@@ -573,8 +573,46 @@ def _extract_section_list(text: str, section: str) -> list[str]:
     return _as_string_list(match.group(1))
 
 
-def _mode_from_confidence(confidence: float, assumptions: list[str], model_set: ModelSet) -> str:
-    if confidence <= 0.10:
+_EXECUTION_PLANNING_DELIVERABLE_RE = re.compile(
+    r"(?i)\b(?:test\s+plan|operator\s+test\s+plan|runbook|checklist|plan)\b"
+)
+_EXECUTION_PLANNING_ACTION_RE = re.compile(
+    r"(?i)\b(?:create|draft|write|produce|build|outline|prepare)\b"
+)
+_CONCRETE_TARGET_RE = re.compile(
+    r"(?:/[A-Za-z0-9_.~:/?#\[\]@!$&'()*+,;=%-]+|\bfor\s+[^.?!]+)"
+)
+_UNDERSPECIFIED_OR_HIGH_RISK_RE = re.compile(
+    r"(?i)\b(?:ambiguous|uncertain|unknown|unspecified|not\s+specified|missing|"
+    r"unsafe|impossible|legal|medical|financial|compliance|security)\b"
+)
+_LOW_CONFIDENCE_BLOCK_THRESHOLD = 0.10
+
+
+def _is_actionable_execution_planning_prompt(query: str) -> bool:
+    """Return True when a planning request is actionable enough to answer.
+
+    This deliberately stays narrow: it only recognizes explicit execution-style
+    deliverable requests that include a target/context signal and avoids prompts
+    that state they are underspecified or belong to high-risk domains.
+    """
+
+    text = query.strip()
+    if not text:
+        return False
+    if _UNDERSPECIFIED_OR_HIGH_RISK_RE.search(text):
+        return False
+    return (
+        _EXECUTION_PLANNING_ACTION_RE.search(text) is not None
+        and _EXECUTION_PLANNING_DELIVERABLE_RE.search(text) is not None
+        and _CONCRETE_TARGET_RE.search(text) is not None
+    )
+
+
+def _mode_from_confidence(
+    confidence: float, assumptions: list[str], model_set: ModelSet, *, query: str = ""
+) -> str:
+    if confidence <= _LOW_CONFIDENCE_BLOCK_THRESHOLD:
         return "block"
     decision, _info = evaluate_gates(
         confidence=confidence,
@@ -584,6 +622,8 @@ def _mode_from_confidence(confidence: float, assumptions: list[str], model_set: 
     if decision == "block":
         return "block"
     if decision == "clarify":
+        if _is_actionable_execution_planning_prompt(query):
+            return "answer_with_assumptions"
         return "clarify"
     if assumptions and confidence < 0.75:
         return "answer_with_assumptions"
@@ -856,7 +896,10 @@ async def solve(req: SolveRequest, request: Request) -> JSONResponse:
                     mode = "clarify"
                 else:
                     mode = _mode_from_confidence(
-                        preview["confidence"], preview["assumptions"], model_set
+                        preview["confidence"],
+                        preview["assumptions"],
+                        model_set,
+                        query=query,
                     )
                 expert_answer = answer_result.text
                 clarifying_questions = None

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -568,6 +568,56 @@ def test_solve_openai_expert_complex_route_preserves_requested_plan_shape(monkey
     _clear_provider_factory()
 
 
+def test_solve_openai_expert_answerable_operator_plan_uses_assumptions_not_clarify(monkeypatch):
+    monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    prompt = (
+        "Create a two-hour operator test plan for /dashboard/expert-preview "
+        "that separates setup, prompt runs, evidence capture, and rollback."
+    )
+    structured_answer = (
+        "# Two-hour operator test plan for /dashboard/expert-preview\n\n"
+        "Assumptions: supervised operator test; local rollback is available.\n\n"
+        "## Setup\n"
+        "- 0:00-0:20: Confirm dashboard auth, local-provider defaults, and evidence template.\n\n"
+        "## Prompt runs\n"
+        "- 0:20-1:10: Run the controlled prompts and record plain vs Alpha summaries.\n\n"
+        "## Evidence capture\n"
+        "- 1:10-1:45: Capture sanitized screenshots, request IDs, and observed modes.\n\n"
+        "## Rollback\n"
+        "- 1:45-2:00: Restore MODEL_PROVIDER=local and document unresolved issues."
+    )
+    fake = FakeProviderClient(
+        [
+            _provider_result(
+                '{"considerations":["The request includes a concrete route and named sections"],'
+                '"assumptions":["Run is a supervised operator preview"],"confidence":0.50}'
+            ),
+            _provider_result(structured_answer),
+        ]
+    )
+    app.state.provider_client_factory = lambda _model_set: fake
+    client, key = _client()
+
+    resp = client.post(
+        "/v1/solve",
+        json={"query": prompt, "context": {"route": "expert"}},
+        headers={"X-API-Key": key, "X-Request-ID": "req-clarify-threshold"},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["mode"] == "answer_with_assumptions"
+    assert body["final_answer"] == structured_answer
+    assert body["answer"] == structured_answer
+    assert body["answer"] != "I need a few details before I can answer this well."
+    assert "clarifying_questions" not in body
+    for section in ("Setup", "Prompt runs", "Evidence capture", "Rollback"):
+        assert section in body["final_answer"]
+    assert "Assumptions" in body["final_answer"]
+    assert body["assumptions"] == ["Run is a supervised operator preview"]
+    assert len(fake.requests) == 2
+    _clear_provider_factory()
+
 def test_solve_openai_expert_prompt_preserves_claim_boundaries(monkeypatch):
     monkeypatch.setenv("MODEL_PROVIDER", "openai")
     fake = FakeProviderClient(

--- a/tests/ui/test_expert_preview.py
+++ b/tests/ui/test_expert_preview.py
@@ -287,6 +287,57 @@ def test_preview_submission_preserves_requested_operator_plan_structure(
     assert "do not let them replace the requested deliverable" in answer_prompt
 
 
+def test_preview_submission_answerable_operator_plan_is_not_clarify_only(
+    client: TestClient,
+) -> None:
+    csrf_token = _login(client)
+    prompt = (
+        "Create a two-hour operator test plan for /dashboard/expert-preview "
+        "that separates setup, prompt runs, evidence capture, and rollback."
+    )
+    expert_answer = (
+        "# Two-hour operator test plan\n\n"
+        "Assumptions: supervised preview only; no MVP validation claim.\n\n"
+        "## Setup\n"
+        "- Confirm dashboard auth and local-provider rollback path.\n\n"
+        "## Prompt runs\n"
+        "- Execute controlled prompts and compare primary answers.\n\n"
+        "## Evidence capture\n"
+        "- Save sanitized observations, screenshots, and request IDs.\n\n"
+        "## Rollback\n"
+        "- Restore local mode and record status."
+    )
+    fake = FakeProviderClient(
+        [
+            _provider_result("plain same-provider answer"),
+            _provider_result(
+                '{"considerations":["The prompt already names the deliverable and route"],'
+                '"assumptions":["Operator has approved preview access"],"confidence":0.50}'
+            ),
+            _provider_result(expert_answer),
+        ]
+    )
+    client.app.state.provider_client_factory = lambda _model_set: fake
+
+    response = client.post(
+        "/dashboard/expert-preview",
+        data={"prompt": prompt},
+        headers={auth.CSRF_HEADER_NAME: csrf_token},
+    )
+
+    assert response.status_code == 200
+    html = response.text
+    assert "I need a few details before I can answer this well." not in html
+    assert "Two-hour operator test plan" in html
+    for section in ("Setup", "Prompt runs", "Evidence capture", "Rollback"):
+        assert section in html
+    assert "Assumptions" in html
+    assert "The prompt already names the deliverable and route" in html
+    assert "Operator has approved preview access" in html
+    assert "Mode" in html
+    assert "answer_with_assumptions" in html
+    assert len(fake.requests) == 3
+
 def test_openai_preview_submit_blocks_when_live_preview_flag_absent(
     client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
### Motivation

- During a post-fix operator retest, an actionable execution-planning prompt (two-hour operator test plan) incorrectly triggered expert clarify mode instead of producing the requested plan with explicit assumptions. 
- The change aims to prefer answering with assumptions for concrete execution-style deliverables while preserving safety, claim boundaries, and existing format-preservation behavior. 
- The fix must be narrow and not disable clarification globally or change provider/preview/metrics/auth behavior.

### Description

- Added a new spec `ALPHA-CLARIFY-THRESHOLD-001.md` and registered it in `.specs/INDEX.md` documenting the intent, scope, and acceptance criteria. 
- Implemented a narrow detection heuristic in `service/app.py` (`_is_actionable_execution_planning_prompt`) using regexes that recognize explicit execution-planning requests with a deliverable, an action verb, and a concrete target while excluding underspecified or high-risk prompts. 
- Updated `_mode_from_confidence` to accept the original `query` and convert clarify-band decisions into `answer_with_assumptions` when the prompt matches the actionable execution-planning detector, otherwise preserving existing `clarify` and `block` behavior. 
- Passed the `query` through the expert flow when deciding mode (updated call site in `solve`) so the new heuristic can act on the original prompt. 
- Added no-network tests: an API-level test `test_solve_openai_expert_answerable_operator_plan_uses_assumptions_not_clarify` and a UI-level preview test `test_preview_submission_answerable_operator_plan_is_not_clarify_only` that assert the retest prompt produces an answer-with-assumptions plan preserving `setup`, `prompt runs`, `evidence capture`, and `rollback`; both tests use `FakeProviderClient` and do not invoke live providers.

### Testing

- Ran `git diff --check` and the focused tests: `python -m pytest tests/test_api_endpoints.py -q` and `python -m pytest tests/ui/test_expert_preview.py -q`, and then the full suite with `python -m pytest -q`. 
- All added tests passed and the full test suite completed with existing skipped tests unchanged (no live OpenAI calls); the new API and UI tests exercised the change using `FakeProviderClient` and confirmed the expert route returns `answer_with_assumptions` and preserves the requested plan sections. 
- Safety and fallback behaviors remain intact: genuinely underspecified or high-risk prompts still produce `clarify` or `block` as before, and provider selection, preview UI, request metrics, and auth/CSRF were not changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e380bb6dc8329a8fe632247555237)