### PR TITLE
ALPHA-LIVE-EXPERT-STEP1-PARSE-001: recover actionable execution prompts when Step 1 metadata is missing

### DIFF
--- a/.specs/ALPHA-LIVE-EXPERT-STEP1-PARSE-001.md
+++ b/.specs/ALPHA-LIVE-EXPERT-STEP1-PARSE-001.md
@@ -1,0 +1,92 @@
+# ALPHA-LIVE-EXPERT-STEP1-PARSE-001 · Recover Actionable Execution Prompts When Step 1 Metadata Is Missing
+
+## Purpose
+
+Fix the live expert-route fallback where an actionable execution-planning prompt
+can enter generic clarify-only behavior when Step 1 provider metadata is empty,
+malformed, non-JSON, or missing confidence.
+
+## Context
+
+After `ALPHA-CLARIFY-THRESHOLD-001` and `ALPHA-PRIMARY-ANSWER-EMPTY-001`, a
+controlled live retest still showed Alpha Solver expert preview clarifying this
+concrete prompt while the plain provider produced a direct plan:
+
+> Create a two-hour operator test plan for /dashboard/expert-preview that
+> separates setup, prompt runs, evidence capture, and rollback.
+
+The live response showed mode `clarify`, confidence `unavailable`, no surfaced
+considerations, and no surfaced assumptions. This indicates Step 1 metadata was
+missing, unavailable, or unparseable, bypassing the existing confidence-band
+fallback for actionable execution-planning prompts.
+
+## Scope
+
+In scope:
+
+- Narrowly recover actionable execution-planning prompts when Step 1 confidence
+  metadata is unavailable.
+- Default to `answer_with_assumptions` only when the prompt is concrete and
+  recognized by the existing actionable execution-planning heuristic.
+- Add safe default assumptions when Step 1 returns none.
+- Preserve the primary-answer fallback so an empty Step 2 answer still returns a
+  direct two-hour operator test plan.
+- Add no-network API and expert-preview UI coverage.
+
+Out of scope:
+
+- Global clarification disablement.
+- Broad routing rewrites.
+- Provider selection changes.
+- Dashboard auth/session/CSRF changes.
+- Request metrics changes.
+- Live OpenAI enablement, Cloud Run deployment, or Google Sheets updates.
+- Claims of MVP validation, Alpha Solver superiority, production readiness,
+  broad runtime readiness, answer-quality benchmark success, exact billing
+  accuracy, or provider reasoning orchestration.
+
+## Requirements
+
+1. The retest prompt must not return generic clarify-only behavior solely
+   because Step 1 confidence metadata is missing or unparseable.
+2. Missing Step 1 confidence for concrete actionable execution-planning prompts
+   should use `answer_with_assumptions`.
+3. The final answer must include a direct two-hour operator test plan.
+4. The answer must preserve setup, prompt runs, evidence capture, and rollback.
+5. If Step 1 returns no assumptions, safe defaults should cover supervised
+   operator preview only, local rollback availability, claim boundaries, and
+   sanitized evidence.
+6. Genuinely underspecified prompts must still clarify.
+7. Unsafe or high-risk prompts must still block or clarify as appropriate.
+8. Existing `ALPHA-CLARIFY-THRESHOLD-001`,
+   `ALPHA-PRIMARY-ANSWER-EMPTY-001`, and `ALPHA-FORMAT-PRESERVATION-001`
+   behavior must remain intact.
+
+## Acceptance criteria
+
+- No-network `/v1/solve` tests simulate empty, malformed, non-JSON, and
+  missing-confidence Step 1 responses for the retest prompt.
+- Those tests return `mode=answer_with_assumptions`, a non-empty primary answer,
+  the requested plan sections, and default safe assumptions.
+- A no-network `/dashboard/expert-preview` test renders the direct deliverable
+  rather than the generic clarify message.
+- Existing clarify, block/safe-out, request metrics, format-preservation, and
+  primary-answer fallback tests continue to pass.
+
+## Validation expectations
+
+```bash
+git diff --check
+python -m pytest tests/test_api_endpoints.py -q
+python -m pytest tests/ui/test_expert_preview.py -q
+python -m pytest -q
+```
+
+## Backlog impact
+
+`ALPHA-LIVE-EXPERT-STEP1-PARSE-001` should be marked Done only if this PR is
+merged. It was discovered during the post-PR #225 controlled live retest and is a
+pre-MVP blocker for the supervised live checkpoint. This does not validate the
+MVP, prove Alpha Solver superiority, prove production readiness, prove broad
+runtime readiness, prove answer-quality benchmark success, prove exact billing
+accuracy, or prove provider reasoning orchestration.

--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -6,6 +6,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | --- | --- |
 | `ALPHA-CLARIFY-THRESHOLD-001.md` | ALPHA-CLARIFY-THRESHOLD-001 · Answer Execution Prompts with Assumptions When Sufficient |
 | `ALPHA-FORMAT-PRESERVATION-001.md` | ALPHA-FORMAT-PRESERVATION-001 · Expert Answer Format Preservation |
+| `ALPHA-LIVE-EXPERT-STEP1-PARSE-001.md` | ALPHA-LIVE-EXPERT-STEP1-PARSE-001 · Recover Actionable Execution Prompts When Step 1 Metadata Is Missing |
 | `ALPHA-PRIMARY-ANSWER-EMPTY-001.md` | ALPHA-PRIMARY-ANSWER-EMPTY-001 · Ensure Answer-with-Assumptions Returns a Primary Deliverable |
 | `AS-145.md` | CODE SPEC — AS-145 · Tool Adapters: Playwright + GSheets (MVP hardening) (RES_05) |
 | `AS-148.md` | CODE SPEC — AS-148 · Policy & PII Gateway (DR_TRACK_A) |

--- a/service/app.py
+++ b/service/app.py
@@ -587,6 +587,15 @@ _UNDERSPECIFIED_OR_HIGH_RISK_RE = re.compile(
     r"unsafe|impossible|legal|medical|financial|compliance|security)\b"
 )
 _LOW_CONFIDENCE_BLOCK_THRESHOLD = 0.10
+_ACTIONABLE_EXECUTION_PLAN_DEFAULT_ASSUMPTIONS = [
+    "Supervised operator preview only.",
+    "Local rollback is available after the controlled run.",
+    (
+        "No MVP validation, production-readiness, Alpha Solver superiority, "
+        "broad benchmark success, or exact billing accuracy claim is made from this run."
+    ),
+    "Evidence must be sanitized before capture or sharing.",
+]
 
 
 def _is_actionable_execution_planning_prompt(query: str) -> bool:
@@ -607,6 +616,28 @@ def _is_actionable_execution_planning_prompt(query: str) -> bool:
         and _EXECUTION_PLANNING_DELIVERABLE_RE.search(text) is not None
         and _CONCRETE_TARGET_RE.search(text) is not None
     )
+
+
+def _default_actionable_execution_plan_assumptions(
+    query: str, assumptions: list[str], *, confidence_available: bool
+) -> list[str]:
+    """Add narrow defaults when unavailable Step 1 metadata gave no assumptions."""
+
+    if (
+        confidence_available
+        or assumptions
+        or not _is_actionable_execution_planning_prompt(query)
+    ):
+        return assumptions
+    return list(_ACTIONABLE_EXECUTION_PLAN_DEFAULT_ASSUMPTIONS)
+
+
+def _mode_for_unavailable_expert_confidence(query: str) -> str:
+    """Choose a safe mode when Step 1 confidence metadata is missing/unparseable."""
+
+    if _is_actionable_execution_planning_prompt(query):
+        return "answer_with_assumptions"
+    return "clarify"
 
 
 def _mode_from_confidence(
@@ -940,6 +971,11 @@ async def solve(req: SolveRequest, request: Request) -> JSONResponse:
                     provider_request=preview_request,
                 )
                 preview = _parse_expert_preview(preview_result.text)
+                preview["assumptions"] = _default_actionable_execution_plan_assumptions(
+                    query,
+                    preview["assumptions"],
+                    confidence_available=bool(preview.get("confidence_available")),
+                )
                 answer_request = replace(
                     provider_request,
                     prompt=_expert_step_two_prompt(query, preview),
@@ -950,7 +986,7 @@ async def solve(req: SolveRequest, request: Request) -> JSONResponse:
                     provider_request=answer_request,
                 )
                 if preview.get("confidence_available") is False:
-                    mode = "clarify"
+                    mode = _mode_for_unavailable_expert_confidence(query)
                 else:
                     mode = _mode_from_confidence(
                         preview["confidence"],

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -619,6 +619,63 @@ def test_solve_openai_expert_answerable_operator_plan_uses_assumptions_not_clari
     _clear_provider_factory()
 
 
+@pytest.mark.parametrize(
+    "step_one_text",
+    [
+        "",
+        "not json and no confidence metadata",
+        "{malformed json",
+        '{"considerations":[],"assumptions":[]}',
+    ],
+)
+def test_solve_openai_expert_actionable_plan_missing_step_one_metadata_answers_with_defaults(
+    monkeypatch, step_one_text
+):
+    monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    prompt = (
+        "Create a two-hour operator test plan for /dashboard/expert-preview "
+        "that separates setup, prompt runs, evidence capture, and rollback."
+    )
+    fake = FakeProviderClient(
+        [
+            _provider_result(step_one_text),
+            _provider_result("   "),
+        ]
+    )
+    app.state.provider_client_factory = lambda _model_set: fake
+    client, key = _client()
+
+    resp = client.post(
+        "/v1/solve",
+        json={"query": prompt, "context": {"route": "expert"}},
+        headers={"X-API-Key": key, "X-Request-ID": "req-live-step1-fallback"},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["mode"] == "answer_with_assumptions"
+    assert body["answer"].strip()
+    assert body["final_answer"] == body["answer"]
+    assert body["answer"] != "I need a few details before I can answer this well."
+    assert "Two-hour operator test plan" in body["answer"]
+    for section in ("Setup", "Prompt runs", "Evidence capture", "Rollback"):
+        assert section in body["answer"]
+    assert body["assumptions"] == [
+        "Supervised operator preview only.",
+        "Local rollback is available after the controlled run.",
+        (
+            "No MVP validation, production-readiness, Alpha Solver superiority, "
+            "broad benchmark success, or exact billing accuracy claim is made from this run."
+        ),
+        "Evidence must be sanitized before capture or sharing.",
+    ]
+    assert "clarifying_questions" not in body
+    assert body["meta"]["confidence_available"] is False
+    assert body["meta"]["preview_parse_status"] in {"unstructured", "json"}
+    assert len(fake.requests) == 2
+    _clear_provider_factory()
+
+
 def test_solve_openai_expert_answer_with_assumptions_empty_step_two_uses_plan_fallback(monkeypatch):
     monkeypatch.setenv("MODEL_PROVIDER", "openai")
     prompt = (

--- a/tests/ui/test_expert_preview.py
+++ b/tests/ui/test_expert_preview.py
@@ -377,6 +377,47 @@ def test_preview_submission_renders_operator_plan_when_expert_step_two_is_empty(
     assert len(fake.requests) == 3
 
 
+def test_preview_submission_actionable_operator_plan_recovers_when_step_one_metadata_missing(
+    client: TestClient,
+) -> None:
+    csrf_token = _login(client)
+    prompt = (
+        "Create a two-hour operator test plan for /dashboard/expert-preview "
+        "that separates setup, prompt runs, evidence capture, and rollback."
+    )
+    fake = FakeProviderClient(
+        [
+            _provider_result("plain same-provider answer"),
+            _provider_result("not json and no confidence metadata"),
+            _provider_result(""),
+        ]
+    )
+    client.app.state.provider_client_factory = lambda _model_set: fake
+
+    response = client.post(
+        "/dashboard/expert-preview",
+        data={"prompt": prompt},
+        headers={auth.CSRF_HEADER_NAME: csrf_token},
+    )
+
+    assert response.status_code == 200
+    html = response.text
+    assert "plain same-provider answer" in html
+    assert "answer_with_assumptions" in html
+    assert "Two-hour operator test plan" in html
+    for section in ("Setup", "Prompt runs", "Evidence capture", "Rollback"):
+        assert section in html
+    assert "Supervised operator preview only." in html
+    assert "Local rollback is available after the controlled run." in html
+    assert "Evidence must be sanitized before capture or sharing." in html
+    assert "I need a few details before I can answer this well." not in html
+    assert "Clarifying questions" in html
+    assert "None surfaced." in html
+    assert "unavailable" in html
+    assert "preview_parse_status" in html
+    assert len(fake.requests) == 3
+
+
 def test_expert_preview_answer_uses_final_answer_when_answer_alias_is_blank() -> None:
     html = expert_preview._render_expert_payload(
         {


### PR DESCRIPTION
### Motivation
- After recent clarify/primary-answer fixes, a controlled live retest still produced generic `clarify` for a concrete two-hour operator test-plan prompt because expert Step 1 metadata was missing/unparseable; the expert preview showed `confidence=unavailable` and no assumptions, blocking the actionable fallback.
- The intent is to narrowly recover actionable execution-planning prompts when Step 1 confidence or assumptions are unavailable, while preserving clarify/block behavior for genuinely underspecified or unsafe requests.

### Description
- Added a narrow fallback and safe defaults: introduced `_ACTIONABLE_EXECUTION_PLAN_DEFAULT_ASSUMPTIONS`, `_default_actionable_execution_plan_assumptions(...)`, and `_mode_for_unavailable_expert_confidence(...)` in `service/app.py` and applied them immediately after parsing Step 1 preview so Step 2 sees safe assumptions when Step 1 returned none or confidence was unavailable.
- Changed the unavailable-confidence branch to call `_mode_for_unavailable_expert_confidence(query)` so actionable prompts can map to `answer_with_assumptions` even when preview parsing leaves `confidence_available` false, while preserving clarify for non-actionable or high-risk prompts.
- Kept the existing primary-answer fallback (`_actionable_execution_plan_fallback`) so an empty Step 2 still returns a direct two-hour plan preserving setup, prompt runs, evidence capture, and rollback.
- Added spec and tests: new `.specs/ALPHA-LIVE-EXPERT-STEP1-PARSE-001.md` and index update, API tests in `tests/test_api_endpoints.py` (parametrized cases for empty/malformed/non-JSON/missing-confidence Step 1) and UI test in `tests/ui/test_expert_preview.py` that exercise the expert-preview path and assert `mode=answer_with_assumptions`, presence of the two-hour plan sections, default safe assumptions, and no generic clarify-only output.

### Testing
- Ran focused checks and full test suite: `git diff --check` (clean), `python -m pytest tests/test_api_endpoints.py -q`, `python -m pytest tests/ui/test_expert_preview.py -q`, and `python -m pytest -q`.
- All added and existing automated tests passed in this environment (full suite completed with expected skips for gated live/OpenAI tests), and the new cases assert: `mode == "answer_with_assumptions"`, non-empty `answer`/`final_answer`, presence of setup/prompt runs/evidence capture/rollback sections, default safe assumptions when Step 1 produced none, and UI expert-preview renders the direct deliverable instead of the generic clarify message.
- No live provider calls are required by the tests; behavior is covered by fake provider clients in the no-network test harness.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e4dae6c208329997ceb517df322e6)