### PR TITLE
EVAL-ARTIFACT-PRESERVE-001: preserve evaluation artifacts for future comparison runs

### DIFF
--- a/.specs/EVAL-ARTIFACT-PRESERVE-001.md
+++ b/.specs/EVAL-ARTIFACT-PRESERVE-001.md
@@ -1,62 +1,269 @@
-# EVAL-ARTIFACT-PRESERVE-001 · Preserve Eval Summary Artifacts
+# EVAL-ARTIFACT-PRESERVE-001 · Preserve Evaluation Artifacts for Comparison Runs
+
+## Status
+
+Documentation/spec-first lane for `OUTPUT-DIFFERENTIATION-PHASE-001`.
+
+This spec defines how future Alpha-vs-plain evaluation runs preserve durable,
+citable, sanitized artifacts. It does not change runtime behavior, provider
+behavior, dashboard behavior, Cloud Run configuration, OpenAI enablement, or
+Google Sheet planning ledgers.
 
 ## Purpose
 
-Add a safe committed-documentation path for no-live answer-quality eval summary artifacts so future eval and behavioral-demo review can cite durable repo artifacts rather than ignored local outputs or operator-reported summaries.
+Future higher-headroom evals must be inspectable from the repository instead of
+relying on screenshots, chat memory, temporary local files, or operator notes.
+This lane creates the preservation contract for summarized artifacts so future
+runs can be cited, reviewed, and used for conservative decision-making.
+
+The supervised preview remains operator-test-ready only. This artifact lane does
+not validate the MVP, prove Alpha Solver superiority, prove production
+readiness, prove benchmark success, or prove provider reasoning orchestration.
 
 ## Scope
 
-- Applies only to `scripts/run_answer_quality_eval.py` answer-quality eval summary preservation.
-- Adds an opt-in `--save-summary` CLI path for no-live runs.
-- Writes the safe summary artifact under `docs/evals/runs/` by default.
-- Keeps existing no-live behavior safe and non-live by default.
-- Keeps live provider execution behind the existing `--live`, `ALPHA_LIVE_ANSWER_QUALITY=1`, key, and cost-ceiling gates.
+In scope:
 
-## Artifact path
+- Define the committed documentation lane for future eval run artifacts.
+- Define artifact locations, names, required summary fields, side-by-side fields,
+  redaction rules, acceptable artifact types, evidence strength levels, and claim
+  boundaries.
+- Add a copyable future run-report template under `docs/evals/templates/`.
+- Preserve the existing `docs/evals/runs/` path for sanitized, summarized run
+  artifacts.
 
-The default committed artifact path is:
+Out of scope:
+
+- Runtime behavior changes.
+- Provider behavior changes.
+- Dashboard behavior changes.
+- Cloud Run config changes.
+- Enabling OpenAI or running live provider evals.
+- Deployment.
+- Google Sheets updates.
+- Raw provider payload storage.
+- Broad eval platform implementation.
+
+## Source hierarchy
+
+When interpreting future eval artifacts, source authority is:
+
+1. Repo code and tests.
+2. Repo specs and docs, including this spec and `docs/evals/ARTIFACT_PRESERVATION.md`.
+3. External planning/status ledgers, including Google Sheets.
+4. AI-generated outputs and chat summaries, which are advisory unless preserved
+   with evidence under this artifact lane.
+
+If artifacts conflict with code/tests, code/tests win. If a planning ledger
+conflicts with repo specs/docs, repo specs/docs win until the repo contract is
+changed.
+
+## Artifact location
+
+Future eval preservation artifacts should live under:
 
 ```text
-docs/evals/runs/answer_quality_no_live_summary.json
+docs/evals/runs/
 ```
 
-Tests and local checks may override the destination with `--summary-output PATH` to avoid mutating committed evidence files during automated runs.
+Copyable templates and instructions should live under:
 
-## Artifact safety exclusions
+```text
+docs/evals/templates/
+docs/evals/ARTIFACT_PRESERVATION.md
+```
 
-The no-live summary artifact must include only summary-level fields such as schema version, no-live mode, dataset path/hash, case count, categories, quality-gate reference, pre-registered success criteria, model/settings metadata, estimated pre-flight cost, skipped/no-live status, safety exclusions, and claim boundaries.
+Artifacts under `docs/evals/runs/` must be sanitized, summary-level, and
+appropriate for committing. Large raw traces, raw provider payloads, or local
+archives do not belong in this lane.
 
-The artifact must not include API keys, auth headers, raw provider payloads, raw request/response bodies, raw prompts, generated answer text, environment dumps, broad telemetry dumps, exception dumps, raw secrets, credentials, or provider raw metadata.
+## Naming conventions
+
+Use stable, lowercase, hyphenated run directories or Markdown/JSON filenames.
+Future Alpha-vs-plain comparison runs should use:
+
+```text
+docs/evals/runs/<YYYYMMDD>-<lane-id>-<short-scope>/
+docs/evals/runs/<YYYYMMDD>-<lane-id>-<short-scope>/run-summary.md
+docs/evals/runs/<YYYYMMDD>-<lane-id>-<short-scope>/score-table.csv
+docs/evals/runs/<YYYYMMDD>-<lane-id>-<short-scope>/defects.md
+```
+
+For single-file summarized artifacts, use:
+
+```text
+docs/evals/runs/<YYYYMMDD>-<lane-id>-<short-scope>-summary.md
+```
+
+Examples:
+
+```text
+docs/evals/runs/20260602-higher-headroom-eval-001-smoke/run-summary.md
+docs/evals/runs/20260602-eval-differentiation-run-001-alpha-vs-plain-summary.md
+```
+
+Run IDs should match the artifact path stem and include the lane ID when
+possible. Do not encode secrets, provider account names, private customer names,
+or raw prompt text in file or directory names.
+
+## Required eval run summary fields
+
+Every future run summary must include:
+
+- Run ID.
+- Date.
+- Operator.
+- Branch/commit.
+- Provider/mode.
+- Prompt set.
+- Prompt count.
+- Live mode used: yes/no.
+- Request cap used.
+- Rollback confirmed: yes/no/not applicable.
+- Plain output summary.
+- Alpha output summary.
+- Rubric used.
+- Score table or score-table reference.
+- Alpha advantages observed.
+- Plain advantages observed.
+- Defects or regressions.
+- Metrics summary.
+- Evidence strength.
+- Redactions performed.
+- Conservative interpretation.
+- Follow-up tickets.
+- Non-claims.
+
+## Required side-by-side comparison fields
+
+Every Alpha-vs-plain side-by-side artifact must include:
+
+- Comparison ID.
+- Parent Run ID.
+- Prompt ID or sanitized prompt label.
+- Prompt category or capability being tested.
+- Plain provider/mode and configuration summary.
+- Alpha provider/mode and configuration summary.
+- Plain output summary, not raw provider output.
+- Alpha output summary, not raw provider output.
+- Rubric dimensions used for this comparison.
+- Per-dimension scores for plain output.
+- Per-dimension scores for Alpha output.
+- Winner/tie/no-decision field, if the rubric permits that conclusion.
+- Explanation limited to evidence preserved in the artifact.
+- Defects or regressions for each side.
+- Redactions performed.
+- Evidence strength.
+- Non-claims.
+
+## Redaction and storage rules
+
+Before committing any eval artifact, redact or omit:
+
+- Secrets and credentials.
+- Runtime account metadata that could identify provider accounts or private
+  tenants.
+- Private user data unless explicitly sanitized and necessary for the eval.
+- Raw prompts when they contain private, sensitive, or proprietary material.
+- Raw output text when it contains private, sensitive, or proprietary material.
+- Screenshots unless they are sanitized and referenced with a clear description
+  of what was redacted.
+
+Artifacts must state what redactions were performed. If a safe summary cannot be
+created without preserving sensitive data, do not commit the artifact.
+
+## Material that must never be stored
+
+The following must never be committed or intentionally preserved in this lane:
+
+- API keys.
+- Bearer tokens.
+- Dashboard passwords.
+- Cookies.
+- CSRF tokens.
+- Session values.
+- Raw provider payloads.
+- Provider account identifiers.
+- Full unredacted request/response traces.
+- Private user data unless explicitly sanitized and needed.
+
+## Acceptable artifact types
+
+The preservation lane accepts only sanitized, summary-level artifacts such as:
+
+- Summarized run report.
+- Prompt set manifest.
+- Scoring rubric reference.
+- Summarized plain output.
+- Summarized Alpha output.
+- Score table.
+- Defect list.
+- Conservative interpretation.
+- Screenshot reference if sanitized.
+
+## Evidence strength levels
+
+Future artifacts must label evidence strength using one or more of these levels:
+
+1. `operator-reported-summary` — operator reported the result, but the repo does
+   not preserve supporting artifacts.
+2. `screenshot-backed-summary` — summary is backed by sanitized screenshots or
+   screenshot references.
+3. `repo-preserved-summarized-artifact` — sanitized summary artifacts are
+   preserved in the repo.
+4. `automated-test-backed-artifact` — artifact generation or validation is backed
+   by automated tests.
+5. `live-provider-artifact-with-sanitized-metrics` — live provider run metrics
+   are preserved in sanitized form without raw payloads or sensitive material.
+
+Higher evidence strength improves reviewability, but none of these levels alone
+turns an eval into proof of superiority or production readiness.
+
+## Claim boundaries
+
+Artifact preservation does not prove or imply:
+
+- MVP validation.
+- Alpha Solver superiority.
+- Production readiness.
+- Broad runtime readiness.
+- Benchmark success.
+- Exact billing accuracy.
+- Provider reasoning orchestration.
+
+Future run reports must include a `Non-claims` section carrying these boundaries
+unless a later, explicit spec narrows or extends them with evidence.
+
+## Supported next-phase lanes
+
+This lane supports the next phase by making future evidence durable and citable:
+
+- `HIGHER-HEADROOM-EVAL-001` can preserve sanitized run summaries before more
+  live eval spend.
+- `DISC-MRG-069` and `DISC-MRG-068` can cite preserved artifacts instead of chat
+  memory or temporary operator notes.
+- `ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001` can assemble side-by-side evidence
+  packets from sanitized preserved comparisons.
+- Future `EVAL-DIFFERENTIATION-RUN-001` can record Alpha-vs-plain output
+  summaries, score tables, defects, metrics, redactions, evidence strength, and
+  conservative interpretation in a consistent form.
 
 ## Validation expectations
 
-Tests should prove:
+For this docs/spec-first lane:
 
-- no-live eval can write a summary artifact when `--save-summary` is used;
-- the artifact is written under the intended safe path or an injected test path;
-- the artifact excludes obvious sensitive fields and unsafe dump markers;
-- default no-live behavior does not write the committed summary artifact unless opted in;
-- existing no-live eval behavior still makes no provider calls;
-- live-gated behavior is not enabled or broadened;
-- docs mention the artifact path and safety exclusions.
+- Run `git diff --check`.
+- Run `python -m pytest -q` when practical.
+- If full pytest is skipped for a docs-only change, explain why and still run
+  `git diff --check`.
+
+No live provider calls are required or allowed by this lane.
 
 ## Backlog impact
 
-`EVAL-ARTIFACT-PRESERVE-001` should be marked Done only after the PR implementing this spec is merged. The PR should be added as implementation evidence for this lane. Backlog spreadsheets are not edited from this repo task.
+`EVAL-ARTIFACT-PRESERVE-001` should be marked Done only after the implementing PR
+is merged. This is P0 for `OUTPUT-DIFFERENTIATION-PHASE-001` and enables future
+higher-headroom evals and Alpha-vs-plain evidence packets.
 
-## Non-goals
-
-- No MVP validation claim.
-- No Alpha Solver superiority claim.
-- No answer-superiority claim.
-- No production-readiness claim.
-- No broad runtime-readiness claim.
-- No answer-quality benchmark success claim.
-- No provider reasoning orchestration claim.
-- No UI preview.
-- No behavioral demo checklist.
-- No live provider tests.
-- No broad eval platform.
-- No provider expert-pass behavior changes.
-- No clarify behavior changes.
-- No backlog workbook edits.
+This lane does not prove Alpha Solver superiority, validate the MVP, or prove
+production readiness. Backlog spreadsheets are not edited from this repo task.

--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -17,7 +17,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `DEPLOY-CLOUDRUN-DASHBOARD-SECRET-GUARD-001.md` | DEPLOY-CLOUDRUN-DASHBOARD-SECRET-GUARD-001 · Require Dashboard Secret for Bundled Cloud Run Preview Mount |
 | `DEPLOY-LIVE-SPEND-GUARD-001.md` | DEPLOY-LIVE-SPEND-GUARD-001 · Live Provider Spend Guard for Expert Preview |
 | `EPIC_RAG_001.md` | EPIC_RAG_001 · RAG & Semantic Cache Pack |
-| `EVAL-ARTIFACT-PRESERVE-001.md` | EVAL-ARTIFACT-PRESERVE-001 · Preserve Eval Summary Artifacts |
+| `EVAL-ARTIFACT-PRESERVE-001.md` | EVAL-ARTIFACT-PRESERVE-001 · Preserve Evaluation Artifacts for Comparison Runs |
 | `EVAL-BEHAVIORAL-DEMO-001.md` | EVAL-BEHAVIORAL-DEMO-001 · Operator Behavioral Demo Checklist for MVP Preview |
 | `EVAL-DEMO-EVIDENCE-001.md` | EVAL-DEMO-EVIDENCE-001 · Operator Demo Evidence Template |
 | `EVAL-DEMO-FINDINGS-001.md` | EVAL-DEMO-FINDINGS-001 · First Operator Demo Findings |

--- a/docs/evals/ARTIFACT_PRESERVATION.md
+++ b/docs/evals/ARTIFACT_PRESERVATION.md
@@ -1,0 +1,229 @@
+# Eval Artifact Preservation
+
+## Purpose
+
+This guide defines the durable artifact lane for future Alpha-vs-plain
+evaluation runs. The goal is to preserve sanitized, citable, repo-inspectable
+summaries for decision-making without storing raw provider payloads, secrets,
+private runtime material, or temporary operator notes.
+
+This guide supports `OUTPUT-DIFFERENTIATION-PHASE-001`, whose goal is to move
+from "the preview works" to "we can measure whether Alpha produces visibly
+better outputs than plain provider output on higher-headroom prompts."
+
+## Scope boundaries
+
+This is a documentation/spec preservation lane only. It does not:
+
+- Validate the MVP.
+- Prove Alpha Solver superiority.
+- Prove production readiness.
+- Prove broad runtime readiness.
+- Prove benchmark success.
+- Prove exact billing accuracy.
+- Prove provider reasoning orchestration.
+- Change runtime behavior.
+- Change provider behavior.
+- Change dashboard behavior.
+- Change Cloud Run configuration.
+- Enable OpenAI.
+- Deploy anything.
+- Update Google Sheets.
+
+## Source hierarchy
+
+When interpreting eval evidence, use this hierarchy:
+
+1. Repo code and tests.
+2. Repo specs and docs.
+3. External planning/status ledgers, including Google Sheets.
+4. AI outputs and chat summaries, which are advisory unless recorded with
+   evidence.
+
+Artifact preservation improves the evidence level of future evals, but it does
+not override the code, tests, or implementation contracts.
+
+## Where artifacts live
+
+Committed future eval artifacts should live under:
+
+```text
+docs/evals/runs/
+```
+
+Templates should live under:
+
+```text
+docs/evals/templates/
+```
+
+Use `docs/evals/templates/run_report_template.md` as the copyable starting point
+for future run reports. Keep artifacts sanitized and summary-level before
+committing them.
+
+## Naming conventions
+
+Use lowercase, hyphenated names with an ISO-like date and lane ID:
+
+```text
+docs/evals/runs/<YYYYMMDD>-<lane-id>-<short-scope>/run-summary.md
+docs/evals/runs/<YYYYMMDD>-<lane-id>-<short-scope>/score-table.csv
+docs/evals/runs/<YYYYMMDD>-<lane-id>-<short-scope>/defects.md
+```
+
+For a single summarized artifact, use:
+
+```text
+docs/evals/runs/<YYYYMMDD>-<lane-id>-<short-scope>-summary.md
+```
+
+Examples:
+
+```text
+docs/evals/runs/20260602-higher-headroom-eval-001-smoke/run-summary.md
+docs/evals/runs/20260602-eval-differentiation-run-001-alpha-vs-plain-summary.md
+```
+
+Do not include secrets, provider account names, private customer names, or raw
+prompt text in artifact paths.
+
+## Required run summary fields
+
+Every future eval run summary must include:
+
+- Run ID.
+- Date.
+- Operator.
+- Branch/commit.
+- Provider/mode.
+- Prompt set.
+- Prompt count.
+- Live mode used: yes/no.
+- Request cap used.
+- Rollback confirmed: yes/no/not applicable.
+- Plain output summary.
+- Alpha output summary.
+- Rubric used.
+- Score table.
+- Alpha advantages observed.
+- Plain advantages observed.
+- Defects or regressions.
+- Metrics summary.
+- Evidence strength.
+- Redactions performed.
+- Conservative interpretation.
+- Follow-up tickets.
+- Non-claims.
+
+## Required side-by-side comparison fields
+
+Every side-by-side Alpha-vs-plain artifact must include:
+
+- Comparison ID.
+- Parent Run ID.
+- Prompt ID or sanitized prompt label.
+- Prompt category or capability tested.
+- Plain provider/mode and configuration summary.
+- Alpha provider/mode and configuration summary.
+- Plain output summary.
+- Alpha output summary.
+- Rubric dimensions.
+- Plain per-dimension scores.
+- Alpha per-dimension scores.
+- Winner, tie, or no-decision field when the rubric permits it.
+- Evidence-limited explanation.
+- Defects or regressions for each side.
+- Redactions performed.
+- Evidence strength.
+- Non-claims.
+
+Summaries may cite sanitized excerpts only when safe and necessary. They must not
+store raw provider payloads or full unredacted request/response traces.
+
+## Redaction rules
+
+Before committing artifacts:
+
+- Remove secrets, credentials, bearer tokens, cookies, CSRF tokens, session
+  values, and dashboard passwords.
+- Remove provider account identifiers and private tenant/user identifiers.
+- Summarize outputs instead of committing raw provider payloads.
+- Summarize or sanitize prompt text if it contains private, sensitive, or
+  proprietary material.
+- Sanitize screenshots before referencing them.
+- Record the redactions performed in the run summary.
+
+If a safe summary cannot be produced without sensitive material, do not commit
+that artifact.
+
+## Never store
+
+Never commit or intentionally preserve these items in this eval artifact lane:
+
+- API keys.
+- Bearer tokens.
+- Dashboard passwords.
+- Cookies.
+- CSRF tokens.
+- Session values.
+- Raw provider payloads.
+- Provider account identifiers.
+- Full unredacted request/response traces.
+- Private user data unless explicitly sanitized and needed.
+
+## Acceptable artifact types
+
+Acceptable committed artifacts are sanitized and summary-level:
+
+- Summarized run report.
+- Prompt set manifest.
+- Scoring rubric reference.
+- Summarized plain output.
+- Summarized Alpha output.
+- Score table.
+- Defect list.
+- Conservative interpretation.
+- Screenshot reference if sanitized.
+
+## Evidence strength levels
+
+Use the strongest applicable label and explain it in the run summary:
+
+| Level | Label | Meaning |
+| --- | --- | --- |
+| 1 | `operator-reported-summary` | Operator-reported result without preserved repo artifacts. |
+| 2 | `screenshot-backed-summary` | Summary backed by sanitized screenshots or screenshot references. |
+| 3 | `repo-preserved-summarized-artifact` | Sanitized summary artifacts preserved in the repo. |
+| 4 | `automated-test-backed-artifact` | Artifact generation or validation backed by automated tests. |
+| 5 | `live-provider-artifact-with-sanitized-metrics` | Live provider run metrics preserved in sanitized form without raw payloads. |
+
+Evidence strength improves reviewability. It does not by itself prove MVP
+validation, Alpha superiority, production readiness, benchmark success, billing
+accuracy, or provider reasoning orchestration.
+
+## Claim boundaries for every future report
+
+Every future report must include a `Non-claims` section stating that artifact
+preservation does not prove:
+
+- MVP validation.
+- Alpha Solver superiority.
+- Production readiness.
+- Broad runtime readiness.
+- Benchmark success.
+- Exact billing accuracy.
+- Provider reasoning orchestration.
+
+## Supported future lanes
+
+This preservation guide supports:
+
+- `HIGHER-HEADROOM-EVAL-001` by defining where and how to preserve sanitized run
+  evidence before more live eval spend.
+- `DISC-MRG-069` and `DISC-MRG-068` by providing citable repo artifacts for
+  decisions that should not rely on chat memory or screenshots alone.
+- `ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001` by defining required fields for
+  Alpha-vs-plain comparison packets.
+- Future `EVAL-DIFFERENTIATION-RUN-001` by defining the run report, score table,
+  defects, redactions, evidence strength, and conservative interpretation needed
+  for decision-making.

--- a/docs/evals/runs/README.md
+++ b/docs/evals/runs/README.md
@@ -1,0 +1,11 @@
+# Eval Runs
+
+This directory is the committed home for sanitized, summary-level future eval
+run artifacts. Use `docs/evals/templates/run_report_template.md` for new run
+reports and follow `docs/evals/ARTIFACT_PRESERVATION.md` before committing any
+artifact.
+
+Do not store raw provider payloads, secrets, dashboard credentials, cookies,
+CSRF tokens, session values, provider account identifiers, full unredacted
+request/response traces, or private user data unless explicitly sanitized and
+needed.

--- a/docs/evals/templates/run_report_template.md
+++ b/docs/evals/templates/run_report_template.md
@@ -1,0 +1,100 @@
+# <Run ID> · Eval Run Report
+
+## Run metadata
+
+- Run ID:
+- Date:
+- Operator:
+- Branch/commit:
+- Provider/mode:
+- Prompt set:
+- Prompt count:
+- Live mode used: yes/no
+- Request cap used:
+- Rollback confirmed: yes/no/not applicable
+
+## Plain output summary
+
+Summarize plain provider output. Do not paste raw provider payloads or full
+unredacted request/response traces.
+
+## Alpha output summary
+
+Summarize Alpha output. Do not paste raw provider payloads or full unredacted
+request/response traces.
+
+## Rubric used
+
+- Rubric reference:
+- Rubric version or commit:
+- Scoring dimensions:
+
+## Score table
+
+| Prompt ID | Category | Plain score | Alpha score | Winner/tie/no decision | Notes |
+| --- | --- | ---: | ---: | --- | --- |
+|  |  |  |  |  |  |
+
+## Alpha advantages observed
+
+- TBD.
+
+## Plain advantages observed
+
+- TBD.
+
+## Defects or regressions
+
+| ID | Side | Prompt ID | Defect/regression | Severity | Follow-up |
+| --- | --- | --- | --- | --- | --- |
+|  |  |  |  |  |  |
+
+## Metrics summary
+
+- Latency summary:
+- Token/cost summary, if safely available:
+- Request cap usage:
+- Error/rollback summary:
+
+## Evidence strength
+
+Choose one or more:
+
+- `operator-reported-summary`
+- `screenshot-backed-summary`
+- `repo-preserved-summarized-artifact`
+- `automated-test-backed-artifact`
+- `live-provider-artifact-with-sanitized-metrics`
+
+Explanation:
+
+## Redactions performed
+
+- Secrets removed:
+- Tokens/cookies/session values removed:
+- Provider account identifiers removed:
+- Private user data sanitized or not present:
+- Raw provider payloads omitted:
+- Full unredacted request/response traces omitted:
+- Screenshots sanitized or not applicable:
+
+## Conservative interpretation
+
+State the narrowest interpretation supported by the preserved evidence. Separate
+observations from conclusions and note uncertainty.
+
+## Follow-up tickets
+
+- TBD.
+
+## Non-claims
+
+This artifact does not prove:
+
+- MVP validation.
+- Alpha Solver superiority.
+- Production readiness.
+- Broad runtime readiness.
+- Benchmark success.
+- Exact billing accuracy.
+- Provider reasoning orchestration.


### PR DESCRIPTION
### Motivation

- Future Alpha-vs-plain evaluation runs need durable, citable, sanitized repo artifacts instead of relying on screenshots, chat memory, or ephemeral operator notes. 
- Provide a low-risk, documentation/spec-first lane that defines where and how sanitized summaries are committed so future evidence can be inspected and used for conservative decision-making. 
- Keep this change strictly docs/spec-level to avoid runtime/provider/dashboard/Cloud Run or deployment changes. 

### Description

- Adds a formal spec at `.specs/EVAL-ARTIFACT-PRESERVE-001.md` that defines scope, source hierarchy, artifact locations, naming conventions, required run and side-by-side fields, redaction/storage rules, evidence strength levels, and claim boundaries. 
- Updates `.specs/INDEX.md` to reflect the spec title change. 
- Adds operator-facing guidance in `docs/evals/ARTIFACT_PRESERVATION.md`, a run-directory README at `docs/evals/runs/README.md`, and a copyable run report template at `docs/evals/templates/run_report_template.md`. 
- Defines redaction and safety rules that explicitly forbid committing secrets, raw provider payloads, provider account identifiers, full unredacted request/response traces, session tokens, and other sensitive runtime material. 
- Defines an evidence strength model (`operator-reported-summary`, `screenshot-backed-summary`, `repo-preserved-summarized-artifact`, `automated-test-backed-artifact`, `live-provider-artifact-with-sanitized-metrics`) and explicit claim boundaries that preserve the distinction between preserved evidence and proof (e.g., no MVP validation or Alpha superiority claims). 
- Scope boundaries and backlog impact are recorded: this PR is docs/spec-only, P0 for `OUTPUT-DIFFERENTIATION-PHASE-001`, and `EVAL-ARTIFACT-PRESERVE-001` should be marked Done only after merge. 

### Testing

- Ran `git diff --check` and the pre-commit checks: no staged whitespace or check errors were reported. 
- Ran `python -m pytest -q` as a precaution; the test run completed with the test suite executing and finishing successfully for non-skipped tests, with a small number of environment-gated tests skipped (for example the live OpenAI smoke that requires `ALPHA_LIVE_OPENAI` and an API key). 
- Reason for pytest in a docs/spec PR: validate that repository tests are not unexpectedly broken by documentation changes and to follow repo validation guidance; no runtime or provider behavior was modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e7fb91284832995c0b144d8da9030)