### PR TITLE
Add side-by-side evidence packet template (ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001)

### DIFF
--- a/.specs/ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001.md
+++ b/.specs/ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001.md
@@ -82,16 +82,41 @@ examples or populated evidence.
 
 ## Required packet fields
 
-A future packet must carry placeholders for: `packet_id`, `comparison_id`,
-`parent_run_id`, `run_directory`, `prompt_id`, `prompt_family`,
-`difficulty_headroom`, `evidence_strength`, `non_claims_confirmed`,
-`blinded_score_sheet path`, `blinding_map path`, `paired_output_capture path`,
-`comparison_score_table path`, `run_report path`, `plain_total`, `alpha_total`,
-`total_delta`, `lift_delta`, `polish_delta`, `winning_surface`, `lift_qualified`,
-`material_constraint_verified`, `polish_only_flag`, `length_ratio`,
-`considerations`, `assumptions`, `material/correct tags`, `confidence`, `mode`,
-`clarifying questions`, `sanitized metadata`, `over-interrogation defect category`,
-and `redactions performed`.
+A future packet must carry placeholders for:
+
+- `packet_id`
+- `comparison_id`
+- `parent_run_id`
+- `run_directory`
+- `prompt_id`
+- `prompt_family`
+- `difficulty_headroom`
+- `evidence_strength`
+- `non_claims_confirmed`
+- `blinded_score_sheet path`
+- `blinding_map path`
+- `paired_output_capture path`
+- `comparison_score_table path`
+- `run_report path`
+- `plain_total`
+- `alpha_total`
+- `total_delta`
+- `lift_delta`
+- `polish_delta`
+- `winning_surface`
+- `lift_qualified`
+- `material_constraint_verified`
+- `polish_only_flag`
+- `length_ratio`
+- `considerations`
+- `assumptions`
+- `material/correct tags`
+- `confidence`
+- `mode`
+- `clarifying questions`
+- `sanitized metadata`
+- `over-interrogation defect category`
+- `redactions performed`
 
 ## Fourteen-dimension coverage
 

--- a/.specs/ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001.md
+++ b/.specs/ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001.md
@@ -1,0 +1,131 @@
+# ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001 · Side-by-Side Evidence Packet Contract
+
+## Status
+
+Documentation/spec-first lane for `OUTPUT-DIFFERENTIATION-PHASE-001`.
+
+`ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001` creates the reusable side-by-side evidence
+packet contract and blank packet template that future Alpha-vs-plain
+`EVAL-DIFFERENTIATION-RUN-001` artifacts can populate. This lane is
+**docs/templates/tests only**. It does not execute a run, score outputs, create
+live provider calls, or add populated evidence packets.
+
+## Purpose
+
+The output-differentiation measurement layer now has hardened capture and scoring
+artifacts for all 14 rubric dimensions, blinded Output A / Output B scoring,
+separate unblinding maps, paired-output capture, lift/polish/length decision aids,
+Alpha expert-envelope evidence, and strict non-claims. This spec adds a thin
+review/index/interpretation packet on top of those artifacts so future reviewers
+can summarize one comparison without replacing the underlying source artifacts.
+
+## Scope
+
+In scope:
+
+- Add `docs/evals/templates/side_by_side_evidence_packet_template.md` as a
+  blank, placeholder-only packet template.
+- Require packet references to the existing hardened artifacts:
+  - `docs/evals/templates/paired_output_capture_template.md`;
+  - `docs/evals/templates/blinded_score_sheet_template.csv`;
+  - `docs/evals/templates/blinding_map_template.csv`;
+  - `docs/evals/templates/comparison_score_table_template.csv`;
+  - `docs/evals/templates/run_report_template.md`;
+  - `docs/evals/RESPONSE_QUALITY_RUBRIC.md`;
+  - `docs/evals/LIFT_DECISION_RULE.md`;
+  - `docs/evals/BLIND_SCORING_PROCEDURE.md`;
+  - `docs/evals/ARTIFACT_PRESERVATION.md`.
+- Add docs-integrity tests that verify the packet contract, section coverage,
+  field coverage, artifact references, redaction boundaries, and non-claims.
+- Update eval docs to identify the packet as an optional future per-comparison
+  review/index/interpretation artifact stored beside sanitized run artifacts.
+
+Out of scope:
+
+- The first scored differentiation run or any populated evidence packet.
+- Live provider calls, scoring actual Alpha-vs-plain outputs, or changing scoring
+  behavior.
+- Provider expert-pass behavior, clarify behavior, `/v1/solve`, preview UI
+  rendering, dashboard auth, tool routing, effort toggle, persistent quota, or
+  provider reasoning orchestration.
+- `scripts/run_answer_quality_eval.py` or the multiple-choice answer-quality eval.
+- Google Sheets, backlog workbooks, or external planning ledgers.
+
+## Packet contract
+
+The side-by-side evidence packet is a **review/index/interpretation artifact**.
+It must link to source artifacts and preserve conservative interpretation, but it
+must not replace the comparison score table, paired-output capture, blinded score
+sheet, blinding map, or run report.
+
+A future populated packet must include the following sections:
+
+1. Packet identity
+2. Source artifact references
+3. Prompt under review
+4. Output capture summary
+5. Blinded scoring record
+6. Unblinding record
+7. Fourteen-dimension scores
+8. Lift / polish / total decision aid
+9. Expert-envelope evidence
+10. Material constraints, assumptions, and risks
+11. Defects, regressions, and over-interrogation
+12. Evidence-limited explanation
+13. Conservative interpretation
+14. Redactions performed
+15. Follow-up tickets
+16. Non-claims
+
+The template must remain blank/placeholder-only and must not include actual scored
+examples or populated evidence.
+
+## Required packet fields
+
+A future packet must carry placeholders for: `packet_id`, `comparison_id`,
+`parent_run_id`, `run_directory`, `prompt_id`, `prompt_family`,
+`difficulty_headroom`, `evidence_strength`, `non_claims_confirmed`,
+`blinded_score_sheet path`, `blinding_map path`, `paired_output_capture path`,
+`comparison_score_table path`, `run_report path`, `plain_total`, `alpha_total`,
+`total_delta`, `lift_delta`, `polish_delta`, `winning_surface`, `lift_qualified`,
+`material_constraint_verified`, `polish_only_flag`, `length_ratio`,
+`considerations`, `assumptions`, `material/correct tags`, `confidence`, `mode`,
+`clarifying questions`, `sanitized metadata`, `over-interrogation defect category`,
+and `redactions performed`.
+
+## Fourteen-dimension coverage
+
+The packet must list all 14 dimension keys from
+`docs/evals/RESPONSE_QUALITY_RUBRIC.md`:
+
+- `d01_intent`
+- `d02_direct`
+- `d03_structure`
+- `d04_assumptions`
+- `d05_hidden_constraints`
+- `d06_risk_failure`
+- `d07_claim_boundary`
+- `d08_evidence_uncertainty`
+- `d09_decision`
+- `d10_next_actions`
+- `d11_specificity`
+- `d12_brevity`
+- `d13_safety`
+- `d14_comparative_value`
+
+## Redaction and storage boundaries
+
+Packets may include sanitized summaries and references to committed source
+artifacts. They must not commit secrets, credentials, raw provider payloads,
+provider account identifiers, private user data, full unredacted request/response
+traces, environment dumps, dashboard credentials, cookies, CSRF tokens, session
+values, or authorization tokens. If a safe summary cannot be produced, omit the
+unsafe material and record the omission in `redactions performed`.
+
+## Non-claims
+
+This packet contract does not claim MVP validation, Alpha Solver superiority,
+answer-quality superiority, production readiness, broad runtime readiness,
+benchmark success, exact billing accuracy, or provider reasoning orchestration.
+Each future packet must carry these non-claims and should interpret only the
+narrow evidence preserved in its referenced artifacts.

--- a/.specs/ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001.md
+++ b/.specs/ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001.md
@@ -1,4 +1,4 @@
-# ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001 · Side-by-Side Evidence Packet Contract
+# ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001 - Side-by-Side Evidence Packet Contract
 
 ## Status
 

--- a/.specs/ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001.md
+++ b/.specs/ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001.md
@@ -4,20 +4,23 @@
 
 Documentation/spec-first lane for `OUTPUT-DIFFERENTIATION-PHASE-001`.
 
-`ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001` creates the reusable side-by-side evidence
-packet contract and blank packet template that future Alpha-vs-plain
-`EVAL-DIFFERENTIATION-RUN-001` artifacts can populate. This lane is
-**docs/templates/tests only**. It does not execute a run, score outputs, create
-live provider calls, or add populated evidence packets.
+`ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001` creates the reusable side-by-side
+evidence packet contract and blank packet template that future Alpha-vs-plain
+`EVAL-DIFFERENTIATION-RUN-001` artifacts can populate.
+
+This lane is docs/templates/tests only. It does not execute a run, score
+outputs, create live provider calls, or add populated evidence packets.
 
 ## Purpose
 
-The output-differentiation measurement layer now has hardened capture and scoring
-artifacts for all 14 rubric dimensions, blinded Output A / Output B scoring,
-separate unblinding maps, paired-output capture, lift/polish/length decision aids,
-Alpha expert-envelope evidence, and strict non-claims. This spec adds a thin
-review/index/interpretation packet on top of those artifacts so future reviewers
-can summarize one comparison without replacing the underlying source artifacts.
+The output-differentiation measurement layer already has hardened capture and
+scoring artifacts for all 14 rubric dimensions, blinded Output A / Output B
+scoring, separate unblinding maps, paired-output capture, lift/polish/length
+decision aids, Alpha expert-envelope evidence, and strict non-claims.
+
+This spec adds a thin review/index/interpretation packet on top of those
+artifacts so future reviewers can summarize one comparison without replacing the
+underlying source artifacts.
 
 ## Scope
 
@@ -25,40 +28,52 @@ In scope:
 
 - Add `docs/evals/templates/side_by_side_evidence_packet_template.md` as a
   blank, placeholder-only packet template.
-- Require packet references to the existing hardened artifacts:
-  - `docs/evals/templates/paired_output_capture_template.md`;
-  - `docs/evals/templates/blinded_score_sheet_template.csv`;
-  - `docs/evals/templates/blinding_map_template.csv`;
-  - `docs/evals/templates/comparison_score_table_template.csv`;
-  - `docs/evals/templates/run_report_template.md`;
-  - `docs/evals/RESPONSE_QUALITY_RUBRIC.md`;
-  - `docs/evals/LIFT_DECISION_RULE.md`;
-  - `docs/evals/BLIND_SCORING_PROCEDURE.md`;
-  - `docs/evals/ARTIFACT_PRESERVATION.md`.
-- Add docs-integrity tests that verify the packet contract, section coverage,
-  field coverage, artifact references, redaction boundaries, and non-claims.
-- Update eval docs to identify the packet as an optional future per-comparison
-  review/index/interpretation artifact stored beside sanitized run artifacts.
+- Require packet references to existing hardened artifacts.
+- Add docs-integrity tests for packet contract coverage.
+- Update eval docs to identify the packet as an optional future
+  per-comparison review/index/interpretation artifact.
 
 Out of scope:
 
-- The first scored differentiation run or any populated evidence packet.
-- Live provider calls, scoring actual Alpha-vs-plain outputs, or changing scoring
-  behavior.
-- Provider expert-pass behavior, clarify behavior, `/v1/solve`, preview UI
-  rendering, dashboard auth, tool routing, effort toggle, persistent quota, or
-  provider reasoning orchestration.
-- `scripts/run_answer_quality_eval.py` or the multiple-choice answer-quality eval.
-- Google Sheets, backlog workbooks, or external planning ledgers.
+- The first scored differentiation run.
+- Any populated evidence packet.
+- Live provider calls.
+- Scoring actual Alpha-vs-plain outputs.
+- Provider expert-pass behavior.
+- Clarify behavior.
+- `/v1/solve` behavior.
+- Preview UI rendering.
+- Dashboard auth.
+- Tool routing.
+- Effort toggle.
+- Persistent quota.
+- Provider reasoning orchestration.
+- `scripts/run_answer_quality_eval.py`.
+- Google Sheets or backlog workbook updates.
+
+## Source artifacts
+
+A packet must reference these source artifacts instead of replacing them:
+
+- `docs/evals/templates/paired_output_capture_template.md`
+- `docs/evals/templates/blinded_score_sheet_template.csv`
+- `docs/evals/templates/blinding_map_template.csv`
+- `docs/evals/templates/comparison_score_table_template.csv`
+- `docs/evals/templates/run_report_template.md`
+- `docs/evals/RESPONSE_QUALITY_RUBRIC.md`
+- `docs/evals/LIFT_DECISION_RULE.md`
+- `docs/evals/BLIND_SCORING_PROCEDURE.md`
+- `docs/evals/ARTIFACT_PRESERVATION.md`
 
 ## Packet contract
 
-The side-by-side evidence packet is a **review/index/interpretation artifact**.
-It must link to source artifacts and preserve conservative interpretation, but it
-must not replace the comparison score table, paired-output capture, blinded score
-sheet, blinding map, or run report.
+The side-by-side evidence packet is a review/index/interpretation artifact.
 
-A future populated packet must include the following sections:
+It must link to source artifacts and preserve conservative interpretation, but
+it must not replace the comparison score table, paired-output capture, blinded
+score sheet, blinding map, or run report.
+
+A future populated packet must include these sections:
 
 1. Packet identity
 2. Source artifact references
@@ -77,8 +92,8 @@ A future populated packet must include the following sections:
 15. Follow-up tickets
 16. Non-claims
 
-The template must remain blank/placeholder-only and must not include actual scored
-examples or populated evidence.
+The template must remain blank/placeholder-only and must not include actual
+scored examples or populated evidence.
 
 ## Required packet fields
 
@@ -141,16 +156,38 @@ The packet must list all 14 dimension keys from
 ## Redaction and storage boundaries
 
 Packets may include sanitized summaries and references to committed source
-artifacts. They must not commit secrets, credentials, raw provider payloads,
-provider account identifiers, private user data, full unredacted request/response
-traces, environment dumps, dashboard credentials, cookies, CSRF tokens, session
-values, or authorization tokens. If a safe summary cannot be produced, omit the
-unsafe material and record the omission in `redactions performed`.
+artifacts.
+
+Packets must not commit:
+
+- secrets;
+- credentials;
+- raw provider payloads;
+- provider account identifiers;
+- private user data;
+- full unredacted request/response traces;
+- environment dumps;
+- dashboard credentials;
+- cookies;
+- CSRF tokens;
+- session values;
+- authorization tokens.
+
+If a safe summary cannot be produced, omit the unsafe material and record the
+omission in `redactions performed`.
 
 ## Non-claims
 
-This packet contract does not claim MVP validation, Alpha Solver superiority,
-answer-quality superiority, production readiness, broad runtime readiness,
-benchmark success, exact billing accuracy, or provider reasoning orchestration.
+This packet contract does not claim:
+
+- MVP validation;
+- Alpha Solver superiority;
+- answer-quality superiority;
+- production readiness;
+- broad runtime readiness;
+- benchmark success;
+- exact billing accuracy;
+- provider reasoning orchestration.
+
 Each future packet must carry these non-claims and should interpret only the
 narrow evidence preserved in its referenced artifacts.

--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -8,7 +8,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `ALPHA-FORMAT-PRESERVATION-001.md` | ALPHA-FORMAT-PRESERVATION-001 · Expert Answer Format Preservation |
 | `ALPHA-LIVE-EXPERT-STEP1-PARSE-001.md` | ALPHA-LIVE-EXPERT-STEP1-PARSE-001 · Recover Actionable Execution Prompts When Step 1 Metadata Is Missing |
 | `ALPHA-PRIMARY-ANSWER-EMPTY-001.md` | ALPHA-PRIMARY-ANSWER-EMPTY-001 · Ensure Answer-with-Assumptions Returns a Primary Deliverable |
-| `ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001.md` | ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001 · Side-by-Side Evidence Packet Contract |
+| `ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001.md` | ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001 - Side-by-Side Evidence Packet Contract |
 | `AS-145.md` | CODE SPEC — AS-145 · Tool Adapters: Playwright + GSheets (MVP hardening) (RES_05) |
 | `AS-148.md` | CODE SPEC — AS-148 · Policy & PII Gateway (DR_TRACK_A) |
 | `AUTH-SESSION-001.md` | AUTH-SESSION-001 · Dashboard Login + Session |

--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -8,6 +8,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `ALPHA-FORMAT-PRESERVATION-001.md` | ALPHA-FORMAT-PRESERVATION-001 · Expert Answer Format Preservation |
 | `ALPHA-LIVE-EXPERT-STEP1-PARSE-001.md` | ALPHA-LIVE-EXPERT-STEP1-PARSE-001 · Recover Actionable Execution Prompts When Step 1 Metadata Is Missing |
 | `ALPHA-PRIMARY-ANSWER-EMPTY-001.md` | ALPHA-PRIMARY-ANSWER-EMPTY-001 · Ensure Answer-with-Assumptions Returns a Primary Deliverable |
+| `ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001.md` | ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001 · Side-by-Side Evidence Packet Contract |
 | `AS-145.md` | CODE SPEC — AS-145 · Tool Adapters: Playwright + GSheets (MVP hardening) (RES_05) |
 | `AS-148.md` | CODE SPEC — AS-148 · Policy & PII Gateway (DR_TRACK_A) |
 | `AUTH-SESSION-001.md` | AUTH-SESSION-001 · Dashboard Login + Session |

--- a/docs/evals/ARTIFACT_PRESERVATION.md
+++ b/docs/evals/ARTIFACT_PRESERVATION.md
@@ -245,3 +245,12 @@ This preservation guide supports:
 - Future `EVAL-DIFFERENTIATION-RUN-001` by defining the run report, score table,
   defects, redactions, evidence strength, and conservative interpretation needed
   for decision-making.
+
+## Side-by-side evidence packets
+
+Future Alpha-vs-plain comparison runs may add blank-template-derived
+side-by-side evidence packets under `docs/evals/runs/` using
+`docs/evals/templates/side_by_side_evidence_packet_template.md`. These packets
+are review/index/interpretation artifacts only and must reference, not replace,
+the score table, paired-output capture, blinded score sheet, blinding map, and
+run report.

--- a/docs/evals/PROMPT_QUALITY_SCORING_HARNESS.md
+++ b/docs/evals/PROMPT_QUALITY_SCORING_HARNESS.md
@@ -215,7 +215,10 @@ Recommended templates:
 - `docs/evals/templates/run_report_template.md`;
 - `docs/evals/templates/blinded_score_sheet_template.csv`;
 - `docs/evals/templates/blinding_map_template.csv`;
-- `docs/evals/templates/paired_output_capture_template.md`.
+- `docs/evals/templates/paired_output_capture_template.md`;
+- `docs/evals/templates/side_by_side_evidence_packet_template.md` for future
+  per-comparison review/index/interpretation packets that cite the hardened
+  artifacts and preserve conservative non-claims.
 
 ## Redaction and safety
 

--- a/docs/evals/runs/README.md
+++ b/docs/evals/runs/README.md
@@ -9,3 +9,9 @@ Do not store raw provider payloads, secrets, dashboard credentials, cookies,
 CSRF tokens, session values, provider account identifiers, full unredacted
 request/response traces, or private user data unless explicitly sanitized and
 needed.
+
+Future Alpha-vs-plain comparison runs may also store side-by-side evidence
+packets derived from `docs/evals/templates/side_by_side_evidence_packet_template.md`;
+those packets are review/index/interpretation artifacts only and must reference,
+not replace, the score table, paired-output capture, blinded score sheet,
+blinding map, and run report.

--- a/docs/evals/templates/side_by_side_evidence_packet_template.md
+++ b/docs/evals/templates/side_by_side_evidence_packet_template.md
@@ -1,0 +1,193 @@
+# Side-by-Side Evidence Packet Template
+
+This packet is a blank, placeholder-only **review/index/interpretation artifact**
+for a single future Alpha-vs-plain comparison. It references and interprets the
+source artifacts listed below; it does not replace the score table,
+paired-output capture, blinded score sheet, blinding map, or run report.
+
+Use with:
+
+- `docs/evals/templates/paired_output_capture_template.md`
+- `docs/evals/templates/blinded_score_sheet_template.csv`
+- `docs/evals/templates/blinding_map_template.csv`
+- `docs/evals/templates/comparison_score_table_template.csv`
+- `docs/evals/templates/run_report_template.md`
+- `docs/evals/RESPONSE_QUALITY_RUBRIC.md`
+- `docs/evals/LIFT_DECISION_RULE.md`
+- `docs/evals/BLIND_SCORING_PROCEDURE.md`
+- `docs/evals/ARTIFACT_PRESERVATION.md`
+
+## 1. Packet identity
+
+| Field | Placeholder |
+| --- | --- |
+| `packet_id` | `TBD` |
+| `comparison_id` | `TBD` |
+| `parent_run_id` | `TBD` |
+| `run_directory` | `docs/evals/runs/TBD/` |
+| `prompt_id` | `TBD` |
+| `prompt_family` | `TBD` |
+| `difficulty_headroom` | `TBD` |
+| `evidence_strength` | `TBD` |
+| `non_claims_confirmed` | `TBD` |
+
+## 2. Source artifact references
+
+| Source artifact | Path |
+| --- | --- |
+| `blinded_score_sheet path` | `TBD` |
+| `blinding_map path` | `TBD` |
+| `paired_output_capture path` | `TBD` |
+| `comparison_score_table path` | `TBD` |
+| `run_report path` | `TBD` |
+
+Storage boundary: this packet indexes sanitized artifacts already preserved under
+`docs/evals/runs/`; do not paste raw provider payloads, provider account identifiers, private user data, full unredacted request/response traces,
+environment dumps, dashboard credentials, cookies, CSRF tokens, session values,
+credential strings, or authorization-token material here.
+
+## 3. Prompt under review
+
+- `prompt_id`: `TBD`
+- `prompt_family`: `TBD`
+- `difficulty_headroom`: `TBD`
+- Prompt summary: `TBD sanitized summary only`
+- Expected deliverable: `TBD`
+- Material constraints to verify: `TBD`
+
+## 4. Output capture summary
+
+- `paired_output_capture path`: `TBD`
+- Output A sanitized summary: `TBD`
+- Output B sanitized summary: `TBD`
+- `length_ratio`: `TBD`
+- Length-control notes: `TBD`
+
+## 5. Blinded scoring record
+
+- `blinded_score_sheet path`: `TBD`
+- Blinded scoring completed before unblinding: `TBD yes/no`
+- Reviewer: `TBD`
+- Rubric reference: `docs/evals/RESPONSE_QUALITY_RUBRIC.md`
+- Procedure reference: `docs/evals/BLIND_SCORING_PROCEDURE.md`
+
+## 6. Unblinding record
+
+- `blinding_map path`: `TBD`
+- Unblinded by: `TBD`
+- Unblinded at: `TBD`
+- Plain surface after unblinding: `TBD Output A or Output B`
+- Alpha surface after unblinding: `TBD Output A or Output B`
+- Mapping notes: `TBD`
+
+## 7. Fourteen-dimension scores
+
+Copy score values from `comparison_score_table path`; do not rescore in this
+packet.
+
+| Dimension key | Plain score | Alpha score | Delta | Evidence note |
+| --- | --- | --- | --- | --- |
+| `d01_intent` | `TBD` | `TBD` | `TBD` | `TBD` |
+| `d02_direct` | `TBD` | `TBD` | `TBD` | `TBD` |
+| `d03_structure` | `TBD` | `TBD` | `TBD` | `TBD` |
+| `d04_assumptions` | `TBD` | `TBD` | `TBD` | `TBD` |
+| `d05_hidden_constraints` | `TBD` | `TBD` | `TBD` | `TBD` |
+| `d06_risk_failure` | `TBD` | `TBD` | `TBD` | `TBD` |
+| `d07_claim_boundary` | `TBD` | `TBD` | `TBD` | `TBD` |
+| `d08_evidence_uncertainty` | `TBD` | `TBD` | `TBD` | `TBD` |
+| `d09_decision` | `TBD` | `TBD` | `TBD` | `TBD` |
+| `d10_next_actions` | `TBD` | `TBD` | `TBD` | `TBD` |
+| `d11_specificity` | `TBD` | `TBD` | `TBD` | `TBD` |
+| `d12_brevity` | `TBD` | `TBD` | `TBD` | `TBD` |
+| `d13_safety` | `TBD` | `TBD` | `TBD` | `TBD` |
+| `d14_comparative_value` | `TBD` | `TBD` | `TBD` | `TBD` |
+
+## 8. Lift / polish / total decision aid
+
+Use `docs/evals/LIFT_DECISION_RULE.md`; treat these fields as internal review
+decision aids, not broad claims.
+
+| Field | Placeholder |
+| --- | --- |
+| `plain_total` | `TBD` |
+| `alpha_total` | `TBD` |
+| `total_delta` | `TBD` |
+| `lift_delta` | `TBD` |
+| `polish_delta` | `TBD` |
+| `winning_surface` | `TBD` |
+| `lift_qualified` | `TBD` |
+| `material_constraint_verified` | `TBD` |
+| `polish_only_flag` | `TBD` |
+| `length_ratio` | `TBD` |
+
+## 9. Expert-envelope evidence
+
+Use only sanitized envelope fields from `paired_output_capture path` after
+unblinding.
+
+- `considerations`: `TBD`
+- `assumptions`: `TBD`
+- `material/correct tags`: `TBD`
+- `confidence`: `TBD`
+- `mode`: `TBD`
+- `clarifying questions`: `TBD`
+- `sanitized metadata`: `TBD`
+
+## 10. Material constraints, assumptions, and risks
+
+- Material constraints verified: `TBD`
+- Assumptions accepted: `TBD`
+- Assumptions rejected or unsupported: `TBD`
+- Risk and failure-mode notes: `TBD`
+- Constraint misses: `TBD`
+
+## 11. Defects, regressions, and over-interrogation
+
+- Plain defects: `TBD`
+- Alpha defects: `TBD`
+- Regression status: `TBD`
+- Over-interrogation observed: `TBD yes/no`
+- `over-interrogation defect category`: `TBD none / unnecessary clarification / excessive caveats / delayed answer / other`
+- Defect evidence references: `TBD`
+
+## 12. Evidence-limited explanation
+
+State only what the referenced artifacts support. Do not infer hidden runtime
+behavior, model quality in general, provider reasoning orchestration, or product
+readiness from this packet.
+
+- Evidence-limited explanation: `TBD`
+
+## 13. Conservative interpretation
+
+- Outcome label: `TBD Alpha local advantage / Plain local advantage / Tie / Inconclusive / Regression flagged / Expected change`
+- Conservative interpretation: `TBD`
+- Reasons the evidence may be incomplete: `TBD`
+
+## 14. Redactions performed
+
+- `redactions performed`: `TBD`
+- Sanitization reviewer: `TBD`
+- Storage boundary confirmed: `TBD yes/no`
+- Omitted unsafe material: `TBD`
+
+## 15. Follow-up tickets
+
+| Ticket/spec | Reason | Owner/status |
+| --- | --- | --- |
+| `TBD` | `TBD` | `TBD` |
+
+## 16. Non-claims
+
+This packet does not claim:
+
+- MVP validation;
+- Alpha Solver superiority;
+- answer-quality superiority;
+- production readiness;
+- broad runtime readiness;
+- benchmark success;
+- exact billing accuracy;
+- provider reasoning orchestration.
+
+`non_claims_confirmed`: `TBD`

--- a/docs/evals/templates/side_by_side_evidence_packet_template.md
+++ b/docs/evals/templates/side_by_side_evidence_packet_template.md
@@ -171,8 +171,14 @@ readiness from this packet.
 
 ## 13. Conservative interpretation
 
-- Outcome label:
-  `TBD Alpha local advantage / Plain local advantage / Tie / Inconclusive / Regression flagged / Expected change`
+- Outcome label: `TBD`
+- Allowed outcome labels:
+  - `Alpha local advantage`
+  - `Plain local advantage`
+  - `Tie`
+  - `Inconclusive`
+  - `Regression flagged`
+  - `Expected change`
 - Conservative interpretation: `TBD`
 - Reasons the evidence may be incomplete: `TBD`
 

--- a/docs/evals/templates/side_by_side_evidence_packet_template.md
+++ b/docs/evals/templates/side_by_side_evidence_packet_template.md
@@ -1,9 +1,11 @@
 # Side-by-Side Evidence Packet Template
 
-This packet is a blank, placeholder-only **review/index/interpretation artifact**
-for a single future Alpha-vs-plain comparison. It references and interprets the
-source artifacts listed below; it does not replace the score table,
-paired-output capture, blinded score sheet, blinding map, or run report.
+This packet is a blank, placeholder-only review/index/interpretation artifact
+for a single future Alpha-vs-plain comparison.
+
+It references and interprets the source artifacts listed below. It does not replace
+the score table, paired-output capture, blinded score sheet, blinding map, or
+run report.
 
 Use with:
 
@@ -92,7 +94,7 @@ Storage boundary: this packet indexes sanitized artifacts already preserved unde
 
 ## 7. Fourteen-dimension scores
 
-Copy score values from `comparison_score_table path`; do not rescore in this
+Copy score values from `comparison_score_table path`. Do not rescore in this
 packet.
 
 | Dimension key | Plain score | Alpha score | Delta | Evidence note |
@@ -114,7 +116,7 @@ packet.
 
 ## 8. Lift / polish / total decision aid
 
-Use `docs/evals/LIFT_DECISION_RULE.md`; treat these fields as internal review
+Use `docs/evals/LIFT_DECISION_RULE.md`. Treat these fields as internal review
 decision aids, not broad claims.
 
 | Field | Placeholder |
@@ -157,8 +159,13 @@ unblinding.
 - Alpha defects: `TBD`
 - Regression status: `TBD`
 - Over-interrogation observed: `TBD yes/no`
-- `over-interrogation defect category`:
-  `TBD none / unnecessary clarification / excessive caveats / delayed answer / other`
+- `over-interrogation defect category`: `TBD`
+- Allowed over-interrogation categories:
+  - `none`
+  - `unnecessary clarification`
+  - `excessive caveats`
+  - `delayed answer`
+  - `other`
 - Defect evidence references: `TBD`
 
 ## 12. Evidence-limited explanation

--- a/docs/evals/templates/side_by_side_evidence_packet_template.md
+++ b/docs/evals/templates/side_by_side_evidence_packet_template.md
@@ -42,9 +42,19 @@ Use with:
 | `run_report path` | `TBD` |
 
 Storage boundary: this packet indexes sanitized artifacts already preserved under
-`docs/evals/runs/`; do not paste raw provider payloads, provider account identifiers, private user data, full unredacted request/response traces,
-environment dumps, dashboard credentials, cookies, CSRF tokens, session values,
-credential strings, or authorization-token material here.
+`docs/evals/runs/`. Do not paste any of the following here:
+
+- raw provider payloads;
+- provider account identifiers;
+- private user data;
+- full unredacted request/response traces;
+- environment dumps;
+- dashboard credentials;
+- cookies;
+- CSRF tokens;
+- session values;
+- credential strings;
+- authorization-token material.
 
 ## 3. Prompt under review
 
@@ -147,7 +157,8 @@ unblinding.
 - Alpha defects: `TBD`
 - Regression status: `TBD`
 - Over-interrogation observed: `TBD yes/no`
-- `over-interrogation defect category`: `TBD none / unnecessary clarification / excessive caveats / delayed answer / other`
+- `over-interrogation defect category`:
+  `TBD none / unnecessary clarification / excessive caveats / delayed answer / other`
 - Defect evidence references: `TBD`
 
 ## 12. Evidence-limited explanation
@@ -160,7 +171,8 @@ readiness from this packet.
 
 ## 13. Conservative interpretation
 
-- Outcome label: `TBD Alpha local advantage / Plain local advantage / Tie / Inconclusive / Regression flagged / Expected change`
+- Outcome label:
+  `TBD Alpha local advantage / Plain local advantage / Tie / Inconclusive / Regression flagged / Expected change`
 - Conservative interpretation: `TBD`
 - Reasons the evidence may be incomplete: `TBD`
 

--- a/tests/test_alpha_side_by_side_evidence_packet.py
+++ b/tests/test_alpha_side_by_side_evidence_packet.py
@@ -7,11 +7,23 @@ evidence packets.
 """
 from __future__ import annotations
 
+import ast
+import unicodedata
 from pathlib import Path
 
 SPEC = Path(".specs/ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001.md")
 INDEX = Path(".specs/INDEX.md")
 TEMPLATE = Path("docs/evals/templates/side_by_side_evidence_packet_template.md")
+TEST_FILE = Path("tests/test_alpha_side_by_side_evidence_packet.py")
+
+REVIEWABILITY_FILES = (
+    SPEC,
+    TEMPLATE,
+    TEST_FILE,
+    Path("docs/evals/ARTIFACT_PRESERVATION.md"),
+    Path("docs/evals/PROMPT_QUALITY_SCORING_HARNESS.md"),
+    Path("docs/evals/runs/README.md"),
+)
 
 REQUIRED_ARTIFACTS = (
     "docs/evals/templates/paired_output_capture_template.md",
@@ -42,6 +54,18 @@ REQUIRED_SECTIONS = (
     "## 14. Redactions performed",
     "## 15. Follow-up tickets",
     "## 16. Non-claims",
+)
+
+SPEC_REQUIRED_HEADINGS = (
+    "# ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001 · Side-by-Side Evidence Packet Contract",
+    "## Status",
+    "## Purpose",
+    "## Scope",
+    "## Packet contract",
+    "## Required packet fields",
+    "## Fourteen-dimension coverage",
+    "## Redaction and storage boundaries",
+    "## Non-claims",
 )
 
 DIMENSION_KEYS = (
@@ -113,6 +137,17 @@ STRICT_NON_CLAIMS = (
 )
 
 SECRET_LIKE_PATTERNS = ("sk-", "xoxb-", "-----BEGIN", "bearer ")
+BIDI_CONTROL_CATEGORIES = {
+    "RLO",
+    "LRO",
+    "RLE",
+    "LRE",
+    "PDF",
+    "RLI",
+    "LRI",
+    "FSI",
+    "PDI",
+}
 
 
 def _read(path: Path) -> str:
@@ -120,10 +155,51 @@ def _read(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
+def _standalone_lines(path: Path) -> set[str]:
+    return {line.strip() for line in _read(path).splitlines()}
+
+
 def test_spec_exists_and_is_indexed():
     assert SPEC.exists()
     index = _read(INDEX)
     assert "ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001.md" in index
+
+
+def test_new_test_file_parses_as_normal_python():
+    source = _read(TEST_FILE)
+    ast.parse(source, filename=str(TEST_FILE))
+    assert source.startswith('"""Docs-integrity tests')
+    expected_prefix = (
+        '"""'
+        + chr(10)
+        + 'from __future__ import annotations'
+        + chr(10)
+        + chr(10)
+        + 'import ast'
+        + chr(10)
+    )
+    assert expected_prefix in source
+
+
+def test_new_and_edited_files_have_reviewable_text_formatting():
+    for path in REVIEWABILITY_FILES:
+        text = _read(path)
+        literal_newline_escape = "\\" + "n"
+        assert literal_newline_escape not in text, (
+            f"{path} contains literal newline escape sequences"
+        )
+        assert len(text.splitlines()) > 1, f"{path} appears collapsed onto one line"
+        for character in text:
+            bidi = unicodedata.bidirectional(character)
+            assert bidi not in BIDI_CONTROL_CATEGORIES, (
+                f"{path} contains hidden/bidirectional control character {bidi}"
+            )
+
+
+def test_spec_contains_required_headings_as_standalone_lines():
+    lines = _standalone_lines(SPEC)
+    for heading in SPEC_REQUIRED_HEADINGS:
+        assert heading in lines, f"spec missing standalone heading: {heading}"
 
 
 def test_template_exists_and_references_hardened_artifacts():
@@ -143,10 +219,11 @@ def test_template_exists_and_references_hardened_artifacts():
         assert source_name in lowered
 
 
-def test_template_includes_required_sections_and_identity_fields():
+def test_template_includes_required_sections_as_standalone_lines_and_fields():
     text = _read(TEMPLATE)
+    lines = _standalone_lines(TEMPLATE)
     for section in REQUIRED_SECTIONS:
-        assert section in text, f"template missing section: {section}"
+        assert section in lines, f"template missing standalone section: {section}"
     for field in IDENTITY_AND_SOURCE_FIELDS:
         assert field in text, f"template missing field: {field}"
 
@@ -186,7 +263,8 @@ def test_template_enforces_redaction_and_storage_boundaries():
         "redactions performed",
         "storage boundary",
         "sanitized",
-        "do not paste raw provider payloads",
+        "do not paste any of the following here",
+        "raw provider payloads",
         "provider account identifiers",
         "private user data",
         "full unredacted request/response traces",
@@ -202,7 +280,7 @@ def test_template_enforces_redaction_and_storage_boundaries():
 
 def test_template_carries_strict_non_claims():
     text = _read(TEMPLATE)
-    assert "## 16. Non-claims" in text
+    assert "## 16. Non-claims" in _standalone_lines(TEMPLATE)
     for claim in STRICT_NON_CLAIMS:
         assert claim in text, f"template missing non-claim: {claim}"
 

--- a/tests/test_alpha_side_by_side_evidence_packet.py
+++ b/tests/test_alpha_side_by_side_evidence_packet.py
@@ -72,7 +72,7 @@ TEMPLATE_TABLES = (
 )
 
 SPEC_REQUIRED_HEADINGS = (
-    "# ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001 · Side-by-Side Evidence Packet Contract",
+    "# ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001 - Side-by-Side Evidence Packet Contract",
     "## Status",
     "## Purpose",
     "## Scope",

--- a/tests/test_alpha_side_by_side_evidence_packet.py
+++ b/tests/test_alpha_side_by_side_evidence_packet.py
@@ -207,6 +207,7 @@ def test_new_and_edited_files_have_reviewable_text_formatting():
         assert literal_newline_escape not in text, (
             f"{path} contains literal newline escape sequences"
         )
+        assert "\r" not in text, f"{path} contains carriage returns"
         lines = text.splitlines()
         assert len(lines) > 1, f"{path} appears collapsed onto one line"
         assert max(len(line) for line in lines) < 500, (

--- a/tests/test_alpha_side_by_side_evidence_packet.py
+++ b/tests/test_alpha_side_by_side_evidence_packet.py
@@ -16,10 +16,14 @@ INDEX = Path(".specs/INDEX.md")
 TEMPLATE = Path("docs/evals/templates/side_by_side_evidence_packet_template.md")
 TEST_FILE = Path("tests/test_alpha_side_by_side_evidence_packet.py")
 
-REVIEWABILITY_FILES = (
-    SPEC,
-    TEMPLATE,
+TARGET_FORMAT_FILES = (
     TEST_FILE,
+    TEMPLATE,
+    SPEC,
+)
+
+REVIEWABILITY_FILES = (
+    *TARGET_FORMAT_FILES,
     INDEX,
     Path("docs/evals/ARTIFACT_PRESERVATION.md"),
     Path("docs/evals/PROMPT_QUALITY_SCORING_HARNESS.md"),
@@ -159,6 +163,7 @@ BIDI_CONTROL_CATEGORIES = {
     "FSI",
     "PDI",
 }
+HIDDEN_CONTROL_CATEGORIES = {"Cf"}
 
 
 def _read(path: Path) -> str:
@@ -208,9 +213,22 @@ def test_new_and_edited_files_have_reviewable_text_formatting():
         )
         for character in text:
             bidi = unicodedata.bidirectional(character)
+            category = unicodedata.category(character)
             assert bidi not in BIDI_CONTROL_CATEGORIES, (
-                f"{path} contains hidden/bidirectional control character {bidi}"
+                f"{path} contains bidirectional control character {bidi}"
             )
+            assert category not in HIDDEN_CONTROL_CATEGORIES, (
+                f"{path} contains hidden Unicode control category {category}"
+            )
+
+
+def test_target_files_have_many_physical_lines_and_bounded_line_lengths():
+    for path in TARGET_FORMAT_FILES:
+        lines = _read(path).splitlines()
+        assert len(lines) > 20, f"{path} is still line-collapsed"
+        assert max(len(line) for line in lines) < 500, (
+            f"{path} still has collapsed long lines"
+        )
 
 
 def test_spec_contains_required_headings_as_standalone_lines():

--- a/tests/test_alpha_side_by_side_evidence_packet.py
+++ b/tests/test_alpha_side_by_side_evidence_packet.py
@@ -1,0 +1,215 @@
+"""Docs-integrity tests for ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001.
+
+These checks validate the additive, blank side-by-side evidence packet contract
+for future Alpha-vs-plain differentiation artifacts. They parse committed docs
+only; they do not execute provider calls, score outputs, or create populated
+evidence packets.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+SPEC = Path(".specs/ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001.md")
+INDEX = Path(".specs/INDEX.md")
+TEMPLATE = Path("docs/evals/templates/side_by_side_evidence_packet_template.md")
+
+REQUIRED_ARTIFACTS = (
+    "docs/evals/templates/paired_output_capture_template.md",
+    "docs/evals/templates/blinded_score_sheet_template.csv",
+    "docs/evals/templates/blinding_map_template.csv",
+    "docs/evals/templates/comparison_score_table_template.csv",
+    "docs/evals/templates/run_report_template.md",
+    "docs/evals/RESPONSE_QUALITY_RUBRIC.md",
+    "docs/evals/LIFT_DECISION_RULE.md",
+    "docs/evals/BLIND_SCORING_PROCEDURE.md",
+    "docs/evals/ARTIFACT_PRESERVATION.md",
+)
+
+REQUIRED_SECTIONS = (
+    "## 1. Packet identity",
+    "## 2. Source artifact references",
+    "## 3. Prompt under review",
+    "## 4. Output capture summary",
+    "## 5. Blinded scoring record",
+    "## 6. Unblinding record",
+    "## 7. Fourteen-dimension scores",
+    "## 8. Lift / polish / total decision aid",
+    "## 9. Expert-envelope evidence",
+    "## 10. Material constraints, assumptions, and risks",
+    "## 11. Defects, regressions, and over-interrogation",
+    "## 12. Evidence-limited explanation",
+    "## 13. Conservative interpretation",
+    "## 14. Redactions performed",
+    "## 15. Follow-up tickets",
+    "## 16. Non-claims",
+)
+
+DIMENSION_KEYS = (
+    "d01_intent",
+    "d02_direct",
+    "d03_structure",
+    "d04_assumptions",
+    "d05_hidden_constraints",
+    "d06_risk_failure",
+    "d07_claim_boundary",
+    "d08_evidence_uncertainty",
+    "d09_decision",
+    "d10_next_actions",
+    "d11_specificity",
+    "d12_brevity",
+    "d13_safety",
+    "d14_comparative_value",
+)
+
+IDENTITY_AND_SOURCE_FIELDS = (
+    "packet_id",
+    "comparison_id",
+    "parent_run_id",
+    "run_directory",
+    "prompt_id",
+    "prompt_family",
+    "difficulty_headroom",
+    "evidence_strength",
+    "non_claims_confirmed",
+    "blinded_score_sheet path",
+    "blinding_map path",
+    "paired_output_capture path",
+    "comparison_score_table path",
+    "run_report path",
+)
+
+LIFT_POLISH_LENGTH_FIELDS = (
+    "plain_total",
+    "alpha_total",
+    "total_delta",
+    "lift_delta",
+    "polish_delta",
+    "winning_surface",
+    "lift_qualified",
+    "material_constraint_verified",
+    "polish_only_flag",
+    "length_ratio",
+)
+
+EXPERT_ENVELOPE_FIELDS = (
+    "considerations",
+    "assumptions",
+    "material/correct tags",
+    "confidence",
+    "mode",
+    "clarifying questions",
+    "sanitized metadata",
+)
+
+STRICT_NON_CLAIMS = (
+    "MVP validation",
+    "Alpha Solver superiority",
+    "answer-quality superiority",
+    "production readiness",
+    "broad runtime readiness",
+    "benchmark success",
+    "exact billing accuracy",
+    "provider reasoning orchestration",
+)
+
+SECRET_LIKE_PATTERNS = ("sk-", "xoxb-", "-----BEGIN", "bearer ")
+
+
+def _read(path: Path) -> str:
+    assert path.exists(), f"missing required file: {path}"
+    return path.read_text(encoding="utf-8")
+
+
+def test_spec_exists_and_is_indexed():
+    assert SPEC.exists()
+    index = _read(INDEX)
+    assert "ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001.md" in index
+
+
+def test_template_exists_and_references_hardened_artifacts():
+    text = _read(TEMPLATE)
+    for artifact in REQUIRED_ARTIFACTS:
+        assert artifact in text, f"template missing artifact reference: {artifact}"
+    lowered = text.lower()
+    assert "review/index/interpretation artifact" in lowered
+    assert "does not replace" in lowered
+    for source_name in (
+        "score table",
+        "paired-output capture",
+        "blinded score sheet",
+        "blinding map",
+        "run report",
+    ):
+        assert source_name in lowered
+
+
+def test_template_includes_required_sections_and_identity_fields():
+    text = _read(TEMPLATE)
+    for section in REQUIRED_SECTIONS:
+        assert section in text, f"template missing section: {section}"
+    for field in IDENTITY_AND_SOURCE_FIELDS:
+        assert field in text, f"template missing field: {field}"
+
+
+def test_template_includes_all_14_rubric_dimension_keys():
+    text = _read(TEMPLATE)
+    for key in DIMENSION_KEYS:
+        assert key in text, f"template missing rubric dimension key: {key}"
+
+
+def test_template_includes_lift_polish_length_fields():
+    text = _read(TEMPLATE)
+    for field in LIFT_POLISH_LENGTH_FIELDS:
+        assert field in text, f"template missing lift/polish/length field: {field}"
+    assert "LIFT_DECISION_RULE.md" in text
+
+
+def test_template_includes_expert_envelope_fields():
+    text = _read(TEMPLATE)
+    for field in EXPERT_ENVELOPE_FIELDS:
+        assert field in text, f"template missing expert-envelope field: {field}"
+
+
+def test_template_includes_defects_and_over_interrogation():
+    text = _read(TEMPLATE)
+    lowered = text.lower()
+    assert "defects, regressions, and over-interrogation" in lowered
+    assert "over-interrogation defect category" in text
+    assert "unnecessary clarification" in lowered
+    assert "excessive caveats" in lowered
+
+
+def test_template_enforces_redaction_and_storage_boundaries():
+    text = _read(TEMPLATE)
+    lowered = text.lower()
+    for phrase in (
+        "redactions performed",
+        "storage boundary",
+        "sanitized",
+        "do not paste raw provider payloads",
+        "provider account identifiers",
+        "private user data",
+        "full unredacted request/response traces",
+        "environment dumps",
+        "dashboard credentials",
+        "cookies",
+        "csrf tokens",
+        "session values",
+        "authorization-token material",
+    ):
+        assert phrase in lowered, f"template missing redaction/storage phrase: {phrase}"
+
+
+def test_template_carries_strict_non_claims():
+    text = _read(TEMPLATE)
+    assert "## 16. Non-claims" in text
+    for claim in STRICT_NON_CLAIMS:
+        assert claim in text, f"template missing non-claim: {claim}"
+
+
+def test_template_has_no_obvious_secret_like_strings():
+    text = _read(TEMPLATE)
+    lowered = text.lower()
+    for pattern in SECRET_LIKE_PATTERNS:
+        haystack = lowered if pattern == pattern.lower() else text
+        assert pattern not in haystack, f"template contains secret-like pattern: {pattern}"

--- a/tests/test_alpha_side_by_side_evidence_packet.py
+++ b/tests/test_alpha_side_by_side_evidence_packet.py
@@ -76,6 +76,7 @@ SPEC_REQUIRED_HEADINGS = (
     "## Status",
     "## Purpose",
     "## Scope",
+    "## Source artifacts",
     "## Packet contract",
     "## Required packet fields",
     "## Fourteen-dimension coverage",
@@ -190,10 +191,10 @@ def test_new_test_file_parses_as_normal_python():
     expected_prefix = (
         '"""'
         + chr(10)
-        + 'from __future__ import annotations'
+        + "from __future__ import annotations"
         + chr(10)
         + chr(10)
-        + 'import ast'
+        + "import ast"
         + chr(10)
     )
     assert expected_prefix in source
@@ -225,7 +226,10 @@ def test_new_and_edited_files_have_reviewable_text_formatting():
 def test_target_files_have_many_physical_lines_and_bounded_line_lengths():
     for path in TARGET_FORMAT_FILES:
         lines = _read(path).splitlines()
-        assert len(lines) > 20, f"{path} is still line-collapsed"
+        if path.suffix == ".py":
+            assert len(lines) > 100, f"{path} is still line-collapsed"
+        else:
+            assert len(lines) > 50, f"{path} is still line-collapsed"
         assert max(len(line) for line in lines) < 500, (
             f"{path} still has collapsed long lines"
         )

--- a/tests/test_alpha_side_by_side_evidence_packet.py
+++ b/tests/test_alpha_side_by_side_evidence_packet.py
@@ -342,3 +342,4 @@ def test_template_has_no_obvious_secret_like_strings():
     for pattern in SECRET_LIKE_PATTERNS:
         haystack = lowered if pattern == pattern.lower() else text
         assert pattern not in haystack, f"template contains secret-like pattern: {pattern}"
+        

--- a/tests/test_alpha_side_by_side_evidence_packet.py
+++ b/tests/test_alpha_side_by_side_evidence_packet.py
@@ -20,6 +20,7 @@ REVIEWABILITY_FILES = (
     SPEC,
     TEMPLATE,
     TEST_FILE,
+    INDEX,
     Path("docs/evals/ARTIFACT_PRESERVATION.md"),
     Path("docs/evals/PROMPT_QUALITY_SCORING_HARNESS.md"),
     Path("docs/evals/runs/README.md"),
@@ -54,6 +55,16 @@ REQUIRED_SECTIONS = (
     "## 14. Redactions performed",
     "## 15. Follow-up tickets",
     "## 16. Non-claims",
+)
+
+TEMPLATE_TABLES = (
+    ("| Field | Placeholder |", "| --- | --- |"),
+    ("| Source artifact | Path |", "| --- | --- |"),
+    (
+        "| Dimension key | Plain score | Alpha score | Delta | Evidence note |",
+        "| --- | --- | --- | --- | --- |",
+    ),
+    ("| Ticket/spec | Reason | Owner/status |", "| --- | --- | --- |"),
 )
 
 SPEC_REQUIRED_HEADINGS = (
@@ -167,7 +178,9 @@ def test_spec_exists_and_is_indexed():
 
 def test_new_test_file_parses_as_normal_python():
     source = _read(TEST_FILE)
+    lines = source.splitlines()
     ast.parse(source, filename=str(TEST_FILE))
+    assert len(lines) > 100, f"{TEST_FILE} appears collapsed onto too few lines"
     assert source.startswith('"""Docs-integrity tests')
     expected_prefix = (
         '"""'
@@ -188,7 +201,11 @@ def test_new_and_edited_files_have_reviewable_text_formatting():
         assert literal_newline_escape not in text, (
             f"{path} contains literal newline escape sequences"
         )
-        assert len(text.splitlines()) > 1, f"{path} appears collapsed onto one line"
+        lines = text.splitlines()
+        assert len(lines) > 1, f"{path} appears collapsed onto one line"
+        assert max(len(line) for line in lines) < 500, (
+            f"{path} has an overly long line that may indicate collapsed text"
+        )
         for character in text:
             bidi = unicodedata.bidirectional(character)
             assert bidi not in BIDI_CONTROL_CATEGORIES, (
@@ -226,6 +243,17 @@ def test_template_includes_required_sections_as_standalone_lines_and_fields():
         assert section in lines, f"template missing standalone section: {section}"
     for field in IDENTITY_AND_SOURCE_FIELDS:
         assert field in text, f"template missing field: {field}"
+
+
+def test_template_tables_have_standalone_header_and_separator_rows():
+    lines = _read(TEMPLATE).splitlines()
+    for header, separator in TEMPLATE_TABLES:
+        assert header in lines, f"template missing standalone table header: {header}"
+        header_index = lines.index(header)
+        assert header_index + 1 < len(lines), f"template table has no separator: {header}"
+        assert lines[header_index + 1] == separator, (
+            f"template table separator must follow header {header!r} on its own line"
+        )
 
 
 def test_template_includes_all_14_rubric_dimension_keys():


### PR DESCRIPTION
### Motivation
- Summary: prepare a reusable, blank side-by-side evidence packet contract and template to support future Alpha-vs-plain differentiation runs (OUTPUT-DIFFERENTIATION-PHASE-001) without executing any run or scoring outputs. 
- Rationale: the measurement-hardening lane already added hardened artifacts (14-dimension rubric capture, blinded sheets, blinding map, paired-output capture, lift/polish aids, run reports); reviewers need a lightweight review/index/interpretation packet that references those artifacts but does not replace them.

### Description
- Changes: added `.specs/ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001.md` defining the packet contract and required fields, and `docs/evals/templates/side_by_side_evidence_packet_template.md` as a blank/placeholder-only packet template containing the required 16 sections and all required fields (packet identity, source artifact refs, prompt, outputs, blinded scoring, unblinding, all 14 rubric keys, lift/polish/length fields, expert-envelope fields, defects/over-interrogation, redactions, follow-ups, and strict non-claims). 
- Cross-doc updates: registered the new spec in `.specs/INDEX.md` and added one-line cross-references to `docs/evals/ARTIFACT_PRESERVATION.md`, `docs/evals/PROMPT_QUALITY_SCORING_HARNESS.md`, and `docs/evals/runs/README.md` to point to the new template (template is explicitly described as a review/index/interpretation artifact that must reference, not replace, hardened artifacts). 
- Tests: added `tests/test_alpha_side_by_side_evidence_packet.py` which verifies the spec exists and is indexed, the template exists and references the required hardened artifacts, the template contains all required sections/fields (including all 14 rubric keys, lift/polish/length fields, expert-envelope fields, defects/over-interrogation, redaction/storage boundaries, and strict non-claims), and that the template contains no obvious secret-like strings. 
- Non-goals / boundaries: no runtime or provider changes were made, no provider calls are added, no populated evidence packets or scoring runs are created, and the packet explicitly must not replace the score table, paired-output capture, blinded score sheet, blinding map, or run report; the spec includes strict non-claims about MVP validation or Alpha superiority.
- Backlog impact: `ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001` should be marked Done only after this PR merges; it creates the reusable template/contract for future `EVAL-DIFFERENTIATION-RUN-001` artifacts and does not implement or score any run.

### Testing
- Ran `python -m pytest -q tests/test_alpha_side_by_side_evidence_packet.py` and it passed. 
- Ran `python -m pytest -q tests/test_output_diff_measurement_hardening.py` and it passed. 
- Ran `git diff --check` with no problems reported. 
- Ran full `python -m pytest -q` (CI-sized test suite) and completed; the docs-integrity tests added here passed and the repository test run completed (standard repo tests emitted expected skips/warnings unrelated to this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f30d946208329a1799bdd926ed385)