### PR TITLE
OUTPUT-DIFF-A3-OPERATOR-CHECKLIST-DRY-RUN-001: operator checklist and dry-run readiness

### DIFF
--- a/docs/evals/runs/20260602-eval-differentiation-run-001-alpha-vs-plain/artifact-population-guide.md
+++ b/docs/evals/runs/20260602-eval-differentiation-run-001-alpha-vs-plain/artifact-population-guide.md
@@ -1,0 +1,129 @@
+# EVAL-DIFFERENTIATION-RUN-001 · Artifact Population Guide (A3-0)
+
+This companion to `operator-checklist.md` describes how the A3-1 step should
+populate the run artifacts once it is separately approved. It is documentation
+only. A3-0 does not populate any artifact described here.
+
+- Lane: `OUTPUT-DIFF-A3-OPERATOR-CHECKLIST-DRY-RUN-001`
+- Step: A3-0 (readiness only)
+- Run directory: `docs/evals/runs/20260602-eval-differentiation-run-001-alpha-vs-plain/`
+- Operator checklist: `operator-checklist.md`
+
+## Scope of this guide
+
+This guide explains the mechanics of filling each artifact so an operator can
+execute A3-1 consistently and safely. It does not authorize execution. Read the
+stop conditions, redaction rules, and non-claims in `operator-checklist.md`
+first; they govern everything below.
+
+A3-0 adds no outputs, no scores, no provider calls, no populated paired-output
+captures, and no populated evidence packets.
+
+## Population order for A3-1
+
+Follow this order so blinding is preserved:
+
+1. Confirm every Section A pre-run item in `operator-checklist.md` is recorded.
+2. Generate the two outputs per prompt under the approved cap.
+3. Write one sanitized paired-output capture per prompt.
+4. Assign Output A / Output B and record `blinding-map.csv`.
+5. Score the blinded sheet (`blinded-score-sheet.csv`) on all 14 dimensions.
+6. Unblind via the map, then fill `score-table.csv`.
+7. Compute the decision fields and apply the polish-only guard.
+8. Record any defects in `defects.md`.
+9. Write evidence packets only if operator-approved.
+10. Update `run-summary.md` with a conservative interpretation.
+
+## Paired-output captures
+
+Planned files (one per prompt):
+
+```text
+paired-output-captures/cmp-HHE-002-paired-output-capture.md
+paired-output-captures/cmp-HHE-003-paired-output-capture.md
+paired-output-captures/cmp-HHE-007-paired-output-capture.md
+paired-output-captures/cmp-HHE-009-paired-output-capture.md
+```
+
+Each capture must reuse
+`docs/evals/templates/paired_output_capture_template.md` and should record:
+
+- prompt ID and run ID;
+- sanitized plain answer text or summary;
+- sanitized Alpha answer text or summary;
+- word counts for each side;
+- sanitized Alpha expert-envelope fields only if available and allowed;
+- allowed summary-level metadata only;
+- redactions performed;
+- non-claims.
+
+Do not place Alpha/plain identity in any judge-facing field. Save sanitized
+answer text only. Never paste raw provider payloads, response IDs, headers,
+account identifiers, cookies, CSRF or session values, environment dumps, or
+private user data into a capture.
+
+## Blinding map
+
+`blinding-map.csv` records the de-anonymizing mapping and stays separate from the
+judge-facing score sheet. Populate it only at step 4 above, using a recorded
+random method or seed. The scorer must not consult it until blinded scoring is
+complete. Blinding is procedural, not cryptographic.
+
+## Blinded score sheet
+
+`blinded-score-sheet.csv` is the judge-facing sheet. It uses neutral
+`Output A` / `Output B` columns and must contain no Alpha or plain labels. Score
+all 14 rubric dimensions per `docs/evals/RESPONSE_QUALITY_RUBRIC.md` before
+unblinding.
+
+## Score table
+
+After unblinding, transfer scores into `score-table.csv` using the hardened
+comparison schema. Compute the decision fields:
+
+- `plain_total` and `alpha_total`;
+- `total_delta`, `lift_delta`, and `polish_delta`;
+- `lift_qualified` and `material_constraint_verified`;
+- `polish_only_flag`.
+
+Apply the polish-only guard from `docs/evals/LIFT_DECISION_RULE.md`. Do not count
+polish-only wins as expert-interrogation lift. Record plain wins and ties
+honestly.
+
+## Defects
+
+Record defects in `defects.md` with defect ID, prompt ID, side, rubric dimension,
+category, severity, evidence pointer, follow-up ticket, and whether the defect
+affects `lift_qualified`. Use the defect categories listed in
+`operator-checklist.md`.
+
+## Evidence packets
+
+Planned files (one per prompt), created only if operator-approved:
+
+```text
+evidence-packets/cmp-HHE-002-evidence-packet.md
+evidence-packets/cmp-HHE-003-evidence-packet.md
+evidence-packets/cmp-HHE-007-evidence-packet.md
+evidence-packets/cmp-HHE-009-evidence-packet.md
+```
+
+Each evidence packet must reuse
+`docs/evals/templates/side_by_side_evidence_packet_template.md` and should
+reference the paired-output capture and score-table row rather than duplicating
+raw content. Packets must preserve the same redaction and non-claim boundaries.
+
+## Redaction reminder
+
+Never commit API keys, bearer-token credentials, dashboard passwords, cookies,
+CSRF tokens, session values, auth headers, raw provider payloads, provider
+account identifiers, full unredacted request/response traces, environment dumps,
+private user data, or any secret-like string. Only sanitized, summary-level,
+re-scorable artifacts may be committed.
+
+## Non-claims
+
+Artifacts produced by following this guide do not claim MVP validation, Alpha
+Solver superiority, answer-quality superiority, production readiness, broad
+runtime readiness, benchmark success, exact billing accuracy, or provider
+reasoning orchestration.

--- a/docs/evals/runs/20260602-eval-differentiation-run-001-alpha-vs-plain/artifact-population-guide.md
+++ b/docs/evals/runs/20260602-eval-differentiation-run-001-alpha-vs-plain/artifact-population-guide.md
@@ -21,18 +21,31 @@ captures, and no populated evidence packets.
 
 ## Population order for A3-1
 
-Follow this order so blinding is preserved:
+Follow this order so blinding is preserved and the captures stay aligned to the
+`Output A` / `Output B` framing that scoring uses:
 
 1. Confirm every Section A pre-run item in `operator-checklist.md` is recorded.
 2. Generate the two outputs per prompt under the approved cap.
-3. Write one sanitized paired-output capture per prompt.
-4. Assign Output A / Output B and record `blinding-map.csv`.
-5. Score the blinded sheet (`blinded-score-sheet.csv`) on all 14 dimensions.
-6. Unblind via the map, then fill `score-table.csv`.
-7. Compute the decision fields and apply the polish-only guard.
-8. Record any defects in `defects.md`.
-9. Write evidence packets only if operator-approved.
-10. Update `run-summary.md` with a conservative interpretation.
+3. Assign plain and Alpha to `Output A` / `Output B` using a recorded random
+   method or seed.
+4. Record the mapping in `blinding-map.csv`, kept separate from judge-facing
+   scoring.
+5. Write one sanitized paired-output capture per prompt using the `Output A` /
+   `Output B` labels, not judge-facing plain/Alpha labels.
+6. Score `blinded-score-sheet.csv` on all 14 dimensions using `Output A` and
+   `Output B` only.
+7. Unblind via `blinding-map.csv` only after blinded scoring is complete.
+8. Fill `score-table.csv` from the unblinded scores.
+9. Compute the decision fields and apply the polish-only guard from
+   `docs/evals/LIFT_DECISION_RULE.md`.
+10. Record any defects in `defects.md`.
+11. Write evidence packets only if operator-approved.
+12. Update `run-summary.md` with a conservative interpretation.
+
+This order matches `docs/evals/BLIND_SCORING_PROCEDURE.md`: outputs are assigned
+to `Output A` / `Output B` and recorded in the blinding map before any capture or
+scoring, so the captures and the blinded score sheet share the same neutral
+labels and no rewrite is needed after unblinding.
 
 ## Paired-output captures
 
@@ -48,26 +61,32 @@ paired-output-captures/cmp-HHE-009-paired-output-capture.md
 Each capture must reuse
 `docs/evals/templates/paired_output_capture_template.md` and should record:
 
-- prompt ID and run ID;
-- sanitized plain answer text or summary;
-- sanitized Alpha answer text or summary;
-- word counts for each side;
-- sanitized Alpha expert-envelope fields only if available and allowed;
+- comparison ID, prompt ID, and run ID;
+- sanitized `Output A` answer text or summary, with word count;
+- sanitized `Output B` answer text or summary, with word count;
+- sanitized Alpha expert-envelope fields, only if available and allowed, in the
+  template's unblinded-analysis section;
 - allowed summary-level metadata only;
 - redactions performed;
 - non-claims.
 
-Do not place Alpha/plain identity in any judge-facing field. Save sanitized
-answer text only. Never paste raw provider payloads, response IDs, headers,
-account identifiers, cookies, CSRF or session values, environment dumps, or
-private user data into a capture.
+Write captures only after `Output A` / `Output B` are assigned and recorded in
+`blinding-map.csv` (steps 3 and 4 above). Use the `Output A` / `Output B` labels
+in all judge-facing sections and keep plain/Alpha identity out of them. A capture
+may carry the plain/Alpha mapping only if it is not used as a judge-facing scoring
+artifact; otherwise it must preserve the `Output A` / `Output B` framing. The
+Alpha expert-envelope fields are for unblinded material-lift analysis only and
+must not be used to bias blinded scoring. Save sanitized answer text only. Never
+paste raw provider payloads, response IDs, headers, account identifiers, cookies,
+CSRF or session values, environment dumps, or private user data into a capture.
 
 ## Blinding map
 
 `blinding-map.csv` records the de-anonymizing mapping and stays separate from the
-judge-facing score sheet. Populate it only at step 4 above, using a recorded
-random method or seed. The scorer must not consult it until blinded scoring is
-complete. Blinding is procedural, not cryptographic.
+judge-facing score sheet. Populate it at steps 3 and 4 above — immediately after
+assigning `Output A` / `Output B` and before writing any capture or scoring —
+using a recorded random method or seed. The scorer must not consult it until
+blinded scoring is complete. Blinding is procedural, not cryptographic.
 
 ## Blinded score sheet
 

--- a/docs/evals/runs/20260602-eval-differentiation-run-001-alpha-vs-plain/operator-checklist.md
+++ b/docs/evals/runs/20260602-eval-differentiation-run-001-alpha-vs-plain/operator-checklist.md
@@ -1,0 +1,263 @@
+# OUTPUT-DIFF-A3-OPERATOR-CHECKLIST-DRY-RUN-001 · Operator Checklist
+
+## Purpose
+
+This checklist makes the operator workflow for the first scored Alpha-vs-plain
+differentiation run explicit, and defines the dry-run validation rules that must
+hold before any output is captured or scored. It is the readiness step for the
+controlled pilot scaffolded by `EVAL-DIFFERENTIATION-RUN-001`.
+
+- Lane: `OUTPUT-DIFF-A3-OPERATOR-CHECKLIST-DRY-RUN-001`
+- Step: A3-0 (checklist and dry-run readiness only)
+- Phase: `OUTPUT-DIFFERENTIATION-PHASE-001`
+- Run directory: `docs/evals/runs/20260602-eval-differentiation-run-001-alpha-vs-plain/`
+- Rubric reference: `docs/evals/RESPONSE_QUALITY_RUBRIC.md`
+- Lift decision reference: `docs/evals/LIFT_DECISION_RULE.md`
+- Blind scoring reference: `docs/evals/BLIND_SCORING_PROCEDURE.md`
+- Artifact preservation reference: `docs/evals/ARTIFACT_PRESERVATION.md`
+- Companion guide: `artifact-population-guide.md`
+
+## A3-0 versus A3-1 boundary
+
+This document is the A3-0 step. A3-0 prepares the checklist and validation rules.
+It is documentation only.
+
+A3-0 explicitly does not:
+
+- execute the run;
+- call live providers or make any provider request;
+- add outputs;
+- add scores;
+- populate paired-output captures;
+- populate evidence packets;
+- populate `score-table.csv`, `blinded-score-sheet.csv`, or `blinding-map.csv`
+  rows;
+- modify any runtime, provider, clarify, `/v1/solve`, preview-UI, dashboard-auth,
+  or eval-script behavior.
+
+A3-1 is the later, separately approved step that actually captures sanitized
+paired outputs, performs blinded scoring, unblinds, and records a conservative
+result. A3-1 is not performed here.
+
+## How to use this checklist
+
+Work top to bottom. Do not start output generation until every Section A box is
+checked and recorded. If any Section H stop condition is true, halt and escalate
+instead of continuing. Treat every rule in Sections B through G as binding during
+A3-1.
+
+## A. Pre-run setup
+
+Complete and record all of the following before any execution begins:
+
+- [ ] Operator approval to begin A3-1 is recorded.
+- [ ] The approved branch is recorded before execution.
+- [ ] The approved commit SHA is recorded before execution.
+- [ ] The exact run directory is confirmed as
+      `docs/evals/runs/20260602-eval-differentiation-run-001-alpha-vs-plain/`.
+- [ ] The exact prompt subset is confirmed as exactly these four prompts:
+  - `HHE-002`
+  - `HHE-003`
+  - `HHE-007`
+  - `HHE-009`
+- [ ] The expected primary generation cap is confirmed as **8 primary
+      generations**, because 4 prompts x 2 surfaces.
+- [ ] An optional contingency cap of **10 to 12 total requests** is used only if
+      it is explicitly approved in writing; otherwise the cap stays at 8.
+- [ ] The plain surface is identified and recorded before execution.
+- [ ] The Alpha surface is identified and recorded before execution.
+- [ ] It is confirmed that no runtime or provider behavior changes are allowed for
+      this run.
+
+The same prompt text must be sent to both surfaces. Neither surface may receive
+extra instructions that the other did not receive.
+
+## B. Output generation rules for the later A3-1 step
+
+For each of the four prompts:
+
+- Submit the same prompt to the plain surface.
+- Submit the same prompt to the Alpha surface.
+- Save sanitized answer text only.
+- Save word counts for each output.
+- Save only allowed summary-level metadata.
+- Save sanitized Alpha expert-envelope fields only if available and allowed.
+
+Do not, while generating outputs:
+
+- Save raw provider payloads.
+- Save response IDs, headers, account identifiers, cookies, CSRF or session
+  values, environment dumps, or private user data.
+- Score the outputs.
+- Unblind the outputs.
+
+Output generation is a capture step only. Scoring and unblinding happen later and
+separately.
+
+## C. Blinding rules
+
+- Assign plain and Alpha to `Output A` and `Output B` using a recorded random
+  method or seed.
+- Record the mapping in `blinding-map.csv`.
+- Complete blinded scoring before consulting the map.
+- Keep Alpha and plain identity out of all judge-facing fields.
+- Treat blinding as procedural, not cryptographic. The committed map is visible;
+  the protection comes from scoring the blinded sheet before consulting the map.
+  Alpha's expert envelope may remain a structural tell.
+
+## D. Scoring rules for the later A3-1 step
+
+- Score `Output A` and `Output B` on all 14 rubric dimensions.
+- Use `docs/evals/RESPONSE_QUALITY_RUBRIC.md` as the scoring contract.
+- Fill `blinded-score-sheet.csv` first, using neutral Output A / Output B labels.
+- Unblind only after blinded scoring is complete.
+- Transfer scores into `score-table.csv` after unblinding.
+- Compute and record each of the following:
+  - `plain_total`
+  - `alpha_total`
+  - `total_delta`
+  - `lift_delta`
+  - `polish_delta`
+  - `lift_qualified`
+  - `material_constraint_verified`
+  - `polish_only_flag`
+- Apply the polish-only guard from `docs/evals/LIFT_DECISION_RULE.md`.
+- Do not count polish-only wins as expert-interrogation lift. A better-structured,
+  longer, or tidier answer is not lift unless a real constraint was surfaced.
+
+The 14 rubric dimensions are: `d01_intent`, `d02_direct`, `d03_structure`,
+`d04_assumptions`, `d05_hidden_constraints`, `d06_risk_failure`,
+`d07_claim_boundary`, `d08_evidence_uncertainty`, `d09_decision`,
+`d10_next_actions`, `d11_specificity`, `d12_brevity`, `d13_safety`, and
+`d14_comparative_value`.
+
+## E. Planned artifact names for A3-1
+
+These artifacts are planned for the later A3-1 step. They are listed here for
+readiness only and are not created or populated by A3-0.
+
+Planned paired-output captures:
+
+```text
+paired-output-captures/cmp-HHE-002-paired-output-capture.md
+paired-output-captures/cmp-HHE-003-paired-output-capture.md
+paired-output-captures/cmp-HHE-007-paired-output-capture.md
+paired-output-captures/cmp-HHE-009-paired-output-capture.md
+```
+
+Planned evidence packets:
+
+```text
+evidence-packets/cmp-HHE-002-evidence-packet.md
+evidence-packets/cmp-HHE-003-evidence-packet.md
+evidence-packets/cmp-HHE-007-evidence-packet.md
+evidence-packets/cmp-HHE-009-evidence-packet.md
+```
+
+Paired-output captures must reuse
+`docs/evals/templates/paired_output_capture_template.md`. Evidence packets must
+reuse `docs/evals/templates/side_by_side_evidence_packet_template.md`. See
+`artifact-population-guide.md` for field-by-field guidance.
+
+## F. Defect workflow
+
+Record each observed defect during A3-1 in `defects.md` with these fields:
+
+- defect ID;
+- prompt ID;
+- side;
+- rubric dimension;
+- category;
+- severity;
+- evidence pointer;
+- follow-up ticket;
+- whether it affects `lift_qualified`.
+
+Use these defect categories (or a narrowly named new category):
+
+- missed requested deliverable;
+- unsupported claim;
+- treating backlog as repo proof;
+- unsafe secret/cookie/session handling;
+- raw payload preservation suggestion;
+- over-interrogation;
+- excessive caveats;
+- invented constraints;
+- plain output more direct/useful.
+
+## G. Redaction rules
+
+It is explicitly prohibited to commit any of the following:
+
+- API keys;
+- bearer-token credentials;
+- dashboard passwords;
+- cookies;
+- CSRF tokens;
+- session values;
+- auth headers;
+- raw provider payloads;
+- provider account identifiers;
+- full unredacted request/response traces;
+- environment dumps;
+- private user data;
+- credentials or any secret-like strings.
+
+Only sanitized, summary-level, re-scorable artifacts may be committed. When in
+doubt, redact and note the redaction.
+
+## H. Stop conditions
+
+A3 execution must stop if any of the following is true:
+
+- operator approval is missing;
+- the branch or commit is not recorded;
+- the request cap is missing or has been exceeded;
+- the prompt text differs between the plain and Alpha surfaces;
+- either surface receives extra instructions not given to the other;
+- outputs contain sensitive data that cannot be redacted;
+- artifacts would require raw provider payloads;
+- runtime or provider changes would be needed to proceed;
+- blinding cannot be performed before scoring;
+- the scorer sees the Alpha/plain mapping before scoring;
+- the artifact format cannot be validated;
+- any result would be used to claim validation, superiority, production readiness,
+  benchmark success, exact billing accuracy, or provider reasoning orchestration.
+
+If a stop condition triggers, halt, record why, and escalate before continuing.
+
+## I. Non-claims
+
+A3 artifacts do not claim:
+
+- MVP validation;
+- Alpha Solver superiority;
+- answer-quality superiority;
+- production readiness;
+- broad runtime readiness;
+- benchmark success;
+- exact billing accuracy;
+- provider reasoning orchestration.
+
+A single small, supervised, blinded comparison cannot establish broad conclusions.
+Plain wins and ties must be recorded honestly.
+
+## A3-0 completion confirmation
+
+This A3-0 step confirms that, in this PR:
+
+- the run is not executed;
+- no outputs are captured;
+- no scores are recorded;
+- no provider calls are made;
+- no paired-output captures are populated;
+- no evidence packets are populated;
+- `score-table.csv`, `blinded-score-sheet.csv`, and `blinding-map.csv` remain
+  header-only;
+- `paired-output-captures/` and `evidence-packets/` remain placeholder
+  directories;
+- no runtime, provider, clarify, `/v1/solve`, preview-UI, dashboard-auth, or
+  eval-script behavior is changed.
+
+A3-0 prepares readiness only. A3-1 is the later approved step that performs the
+scored run.

--- a/docs/evals/runs/20260602-eval-differentiation-run-001-alpha-vs-plain/operator-checklist.md
+++ b/docs/evals/runs/20260602-eval-differentiation-run-001-alpha-vs-plain/operator-checklist.md
@@ -99,6 +99,9 @@ separately.
 - Assign plain and Alpha to `Output A` and `Output B` using a recorded random
   method or seed.
 - Record the mapping in `blinding-map.csv`.
+- Assign `Output A` / `Output B` and record the map before writing any
+  judge-facing paired-output capture, so captures and scoring share the same
+  neutral labels (see `artifact-population-guide.md`).
 - Complete blinded scoring before consulting the map.
 - Keep Alpha and plain identity out of all judge-facing fields.
 - Treat blinding as procedural, not cryptographic. The committed map is visible;

--- a/docs/evals/runs/20260602-eval-differentiation-run-001-alpha-vs-plain/run-plan.md
+++ b/docs/evals/runs/20260602-eval-differentiation-run-001-alpha-vs-plain/run-plan.md
@@ -11,12 +11,20 @@
 - Lift decision reference: `docs/evals/LIFT_DECISION_RULE.md`
 - Blind scoring reference: `docs/evals/BLIND_SCORING_PROCEDURE.md`
 - Artifact preservation reference: `docs/evals/ARTIFACT_PRESERVATION.md`
+- Operator checklist reference: `operator-checklist.md`
+- Artifact population guide reference: `artifact-population-guide.md`
 
 ## Explicit execution boundary
 
 This PR does not execute the run. It does not capture outputs, score outputs,
 call live providers, unblind results, populate paired-output captures, populate
 evidence packets, or record an Alpha-vs-plain result.
+
+Before the first scored run, follow `operator-checklist.md`
+(`OUTPUT-DIFF-A3-OPERATOR-CHECKLIST-DRY-RUN-001`, the A3-0 readiness step) for
+pre-run setup, output-generation, blinding, scoring, defect, redaction, stop, and
+non-claim rules. That checklist also is documentation only and does not execute
+the run.
 
 ## Selected prompt subset
 

--- a/docs/evals/runs/20260602-eval-differentiation-run-001-alpha-vs-plain/run-summary.md
+++ b/docs/evals/runs/20260602-eval-differentiation-run-001-alpha-vs-plain/run-summary.md
@@ -21,6 +21,15 @@ This run is not executed. No outputs are captured, no scores are recorded, no
 blinded judging has occurred, no unblinding has occurred, and there is no
 Alpha-vs-plain result yet.
 
+### A3-0 checklist and dry-run readiness
+
+The `OUTPUT-DIFF-A3-OPERATOR-CHECKLIST-DRY-RUN-001` step (A3-0) has prepared the
+operator checklist (`operator-checklist.md`) and the dry-run validation rules
+(`artifact-population-guide.md`). This is readiness only: the run is still not
+executed, no outputs are captured, no scores are recorded, there is no
+Alpha-vs-plain result yet, and no validation or superiority claim is made. A3-0
+made no provider calls and changed no runtime behavior.
+
 ## Plain output summary
 
 Not executed. No plain output has been captured.

--- a/tests/test_output_diff_a3_operator_checklist.py
+++ b/tests/test_output_diff_a3_operator_checklist.py
@@ -329,13 +329,45 @@ def test_no_secret_like_strings_in_a3_docs():
             assert marker.lower() not in lowered, f"{path} contains {marker}"
 
 
+# Minimum physical line counts guard against line-collapsed files: a file that
+# was serialized onto a few long lines fails loudly here instead of merely
+# looking short. Thresholds are deliberately well above the real content size.
+MIN_PHYSICAL_LINES = {
+    "operator-checklist.md": 100,
+    "artifact-population-guide.md": 50,
+    "test_output_diff_a3_operator_checklist.py": 100,
+}
+
+REQUIRED_CHECKLIST_HEADINGS = (
+    "## A. Pre-run setup",
+    "## B. Output generation rules for the later A3-1 step",
+    "## C. Blinding rules",
+    "## D. Scoring rules for the later A3-1 step",
+    "## E. Planned artifact names for A3-1",
+    "## F. Defect workflow",
+    "## G. Redaction rules",
+    "## H. Stop conditions",
+    "## I. Non-claims",
+)
+
+REQUIRED_GUIDE_HEADINGS = (
+    "## Population order for A3-1",
+    "## Paired-output captures",
+    "## Blinding map",
+    "## Blinded score sheet",
+    "## Score table",
+    "## Non-claims",
+)
+
+
 def test_markdown_and_python_files_have_reviewable_physical_formatting():
     targets = [CHECKLIST, POPULATION_GUIDE, Path(__file__)]
     for path in targets:
         text = _read(path)
         assert "\r" not in text, f"{path} contains carriage returns"
         lines = text.splitlines()
-        assert len(lines) > 50, f"{path} appears collapsed or too short"
+        minimum = MIN_PHYSICAL_LINES[path.name]
+        assert len(lines) > minimum, f"{path} appears line-collapsed (<= {minimum} lines)"
         assert len(lines) < 500, f"{path} has an unreasonable line count"
         assert max(len(line) for line in lines) < 500, f"{path} has an overly long line"
         for character in text:
@@ -343,3 +375,56 @@ def test_markdown_and_python_files_have_reviewable_physical_formatting():
             category = unicodedata.category(character)
             assert bidi not in BIDI_CONTROL_CATEGORIES, f"{path} has bidi control"
             assert category != "Cf", f"{path} contains hidden format character"
+
+
+def test_required_markdown_headings_are_standalone_lines():
+    checklist_lines = _read(CHECKLIST).splitlines()
+    for heading in REQUIRED_CHECKLIST_HEADINGS:
+        assert heading in checklist_lines, f"checklist missing standalone heading {heading!r}"
+    guide_lines = _read(POPULATION_GUIDE).splitlines()
+    for heading in REQUIRED_GUIDE_HEADINGS:
+        assert heading in guide_lines, f"guide missing standalone heading {heading!r}"
+
+
+def _population_order_section() -> str:
+    """Return the lowercased 'Population order for A3-1' section of the guide."""
+    heading = "## Population order for A3-1"
+    text = _read(POPULATION_GUIDE)
+    start = text.index(heading)
+    rest = text[start + len(heading):]
+    end = rest.find("\n## ")
+    section = rest if end == -1 else rest[:end]
+    return section.lower()
+
+
+def test_population_guide_assigns_blinded_labels_before_writing_captures():
+    section = _population_order_section()
+    positions = {
+        "assign output a/b": section.find("assign plain and alpha to"),
+        "record blinding map": section.find("record the mapping in"),
+        "write paired-output capture": section.find(
+            "write one sanitized paired-output capture"
+        ),
+        "score blinded sheet": section.find("blinded-score-sheet.csv"),
+        "unblind": section.find("unblind via"),
+        "fill score table": section.find("score-table.csv"),
+    }
+    for label, pos in positions.items():
+        assert pos != -1, f"population order missing step: {label}"
+    ordered = [
+        positions["assign output a/b"],
+        positions["record blinding map"],
+        positions["write paired-output capture"],
+        positions["score blinded sheet"],
+        positions["unblind"],
+        positions["fill score table"],
+    ]
+    assert ordered == sorted(ordered), f"population order is wrong: {positions}"
+
+
+def test_population_guide_capture_uses_blinded_labels_and_envelope_caveat():
+    normalized = _normalized(POPULATION_GUIDE)
+    assert "write captures only after" in normalized
+    assert "output a` / `output b` labels" in normalized
+    assert "for unblinded material-lift analysis only" in normalized
+    assert "must not be used to bias blinded scoring" in normalized

--- a/tests/test_output_diff_a3_operator_checklist.py
+++ b/tests/test_output_diff_a3_operator_checklist.py
@@ -1,0 +1,345 @@
+"""Docs-integrity tests for OUTPUT-DIFF-A3-OPERATOR-CHECKLIST-DRY-RUN-001.
+
+This lane (A3-0) prepares the operator checklist and dry-run validation rules for
+the later first scored Alpha-vs-plain differentiation run. These tests validate
+only the committed docs/checklist scaffold. They do not run providers, capture
+outputs, score outputs, or inspect runtime behavior.
+
+A3-0 is explicitly not A3-1: it does not execute the run, call providers, add
+outputs, add scores, populate paired-output captures, or populate evidence
+packets. The tests below assert those boundaries hold.
+
+Natural-language phrase checks use a whitespace-normalized, lowercased view of the
+text so that ordinary Markdown line wrapping does not cause spurious failures.
+Case-sensitive paths, planned artifact filenames, and exact decision-field tokens
+are matched against the raw text instead.
+"""
+from __future__ import annotations
+
+import csv
+import re
+import unicodedata
+from pathlib import Path
+
+RUN_DIR = Path(
+    "docs/evals/runs/"
+    "20260602-eval-differentiation-run-001-alpha-vs-plain"
+)
+RUN_DIR_REFERENCE = (
+    "docs/evals/runs/"
+    "20260602-eval-differentiation-run-001-alpha-vs-plain/"
+)
+
+CHECKLIST = RUN_DIR / "operator-checklist.md"
+POPULATION_GUIDE = RUN_DIR / "artifact-population-guide.md"
+
+PILOT_PROMPTS = ("HHE-002", "HHE-003", "HHE-007", "HHE-009")
+
+DECISION_FIELDS = (
+    "plain_total",
+    "alpha_total",
+    "total_delta",
+    "lift_delta",
+    "polish_delta",
+    "lift_qualified",
+    "material_constraint_verified",
+    "polish_only_flag",
+)
+
+PLANNED_PAIRED_CAPTURES = tuple(
+    f"paired-output-captures/cmp-{prompt}-paired-output-capture.md"
+    for prompt in PILOT_PROMPTS
+)
+PLANNED_EVIDENCE_PACKETS = tuple(
+    f"evidence-packets/cmp-{prompt}-evidence-packet.md"
+    for prompt in PILOT_PROMPTS
+)
+
+DEFECT_FIELDS = (
+    "defect id",
+    "prompt id",
+    "side",
+    "rubric dimension",
+    "category",
+    "severity",
+    "evidence pointer",
+    "follow-up ticket",
+    "lift_qualified",
+)
+
+DEFECT_CATEGORIES = (
+    "missed requested deliverable",
+    "unsupported claim",
+    "treating backlog as repo proof",
+    "unsafe secret/cookie/session handling",
+    "raw payload preservation suggestion",
+    "over-interrogation",
+    "excessive caveats",
+    "invented constraints",
+    "plain output more direct/useful",
+)
+
+REDACTION_PROHIBITIONS = (
+    "api keys",
+    "bearer-token",
+    "dashboard passwords",
+    "cookies",
+    "csrf tokens",
+    "session values",
+    "auth headers",
+    "raw provider payloads",
+    "provider account identifiers",
+    "full unredacted request/response traces",
+    "environment dumps",
+    "private user data",
+    "secret-like strings",
+)
+
+STOP_CONDITIONS = (
+    "operator approval is missing",
+    "branch or commit is not recorded",
+    "request cap is missing or has been exceeded",
+    "prompt text differs between the plain and alpha surfaces",
+    "extra instructions not given to the other",
+    "sensitive data that cannot be redacted",
+    "runtime or provider changes would be needed",
+    "blinding cannot be performed before scoring",
+    "the scorer sees the alpha/plain mapping before scoring",
+    "the artifact format cannot be validated",
+)
+
+NON_CLAIMS = (
+    "mvp validation",
+    "alpha solver superiority",
+    "answer-quality superiority",
+    "production readiness",
+    "broad runtime readiness",
+    "benchmark success",
+    "exact billing accuracy",
+    "provider reasoning orchestration",
+)
+
+SECRET_MARKERS = ("sk-", "xoxb-", "-----BEGIN", "bearer ")
+BIDI_CONTROL_CATEGORIES = {
+    "RLO",
+    "LRO",
+    "RLE",
+    "LRE",
+    "PDF",
+    "RLI",
+    "LRI",
+    "FSI",
+    "PDI",
+}
+
+
+def _read(path: Path) -> str:
+    assert path.exists(), f"missing required file: {path}"
+    return path.read_text(encoding="utf-8")
+
+
+def _normalized(path: Path) -> str:
+    """Lowercased text with whitespace runs collapsed to single spaces.
+
+    This lets phrase assertions ignore Markdown line wrapping.
+    """
+    return re.sub(r"\s+", " ", _read(path)).lower()
+
+
+def _csv_rows(path: Path) -> list[list[str]]:
+    assert path.exists(), f"missing required CSV: {path}"
+    with path.open(newline="", encoding="utf-8") as handle:
+        return list(csv.reader(handle))
+
+
+def test_operator_checklist_exists():
+    assert CHECKLIST.exists(), "operator-checklist.md must exist"
+    assert CHECKLIST.is_file()
+
+
+def test_references_exact_run_directory():
+    text = _read(CHECKLIST)
+    assert RUN_DIR_REFERENCE in text
+
+
+def test_references_exactly_the_four_prompts():
+    text = _read(CHECKLIST)
+    found = sorted(set(re.findall(r"HHE-\d{3}", text)))
+    assert found == sorted(PILOT_PROMPTS), found
+
+
+def test_includes_request_cap_guidance():
+    normalized = _normalized(CHECKLIST)
+    assert "8 primary generations" in normalized
+    assert "4 prompts" in normalized
+    assert "2 surfaces" in normalized
+    assert "10 to 12" in normalized
+
+
+def test_includes_plain_and_alpha_surface_rules():
+    normalized = _normalized(CHECKLIST)
+    assert "plain surface" in normalized
+    assert "alpha surface" in normalized
+    assert "identified" in normalized
+    assert "before execution" in normalized
+
+
+def test_includes_output_generation_rules():
+    normalized = _normalized(CHECKLIST)
+    assert "submit the same prompt to the plain surface" in normalized
+    assert "submit the same prompt to the alpha surface" in normalized
+    assert "sanitized answer text only" in normalized
+    assert "word counts" in normalized
+    assert "expert-envelope" in normalized
+    assert "raw provider payloads" in normalized
+    assert "response ids" in normalized
+    assert "score the outputs" in normalized
+    assert "unblind the outputs" in normalized
+
+
+def test_includes_blinding_rules():
+    normalized = _normalized(CHECKLIST)
+    assert "output a" in normalized
+    assert "output b" in normalized
+    assert "blinding-map.csv" in normalized
+    assert "random method or seed" in normalized
+    assert "before consulting the map" in normalized
+    assert "procedural, not cryptographic" in normalized
+
+
+def test_includes_scoring_rules():
+    text = _read(CHECKLIST)
+    normalized = _normalized(CHECKLIST)
+    assert "14 rubric dimensions" in normalized
+    assert "polish-only" in normalized
+    assert "docs/evals/RESPONSE_QUALITY_RUBRIC.md" in text
+    assert "docs/evals/LIFT_DECISION_RULE.md" in text
+    assert "blinded-score-sheet.csv" in text
+    assert "score-table.csv" in text
+    for field in DECISION_FIELDS:
+        assert field in text, f"checklist missing decision field {field}"
+
+
+def test_includes_planned_paired_output_capture_filenames():
+    text = _read(CHECKLIST)
+    for name in PLANNED_PAIRED_CAPTURES:
+        assert name in text, f"checklist missing planned capture {name}"
+
+
+def test_includes_planned_evidence_packet_filenames():
+    text = _read(CHECKLIST)
+    for name in PLANNED_EVIDENCE_PACKETS:
+        assert name in text, f"checklist missing planned packet {name}"
+
+
+def test_includes_defect_workflow_and_categories():
+    normalized = _normalized(CHECKLIST)
+    for field in DEFECT_FIELDS:
+        assert field in normalized, f"checklist missing defect field {field}"
+    for category in DEFECT_CATEGORIES:
+        assert category in normalized, f"checklist missing defect category {category}"
+
+
+def test_includes_redaction_rules():
+    normalized = _normalized(CHECKLIST)
+    assert "prohibited" in normalized
+    for item in REDACTION_PROHIBITIONS:
+        assert item in normalized, f"checklist missing redaction item {item}"
+
+
+def test_includes_stop_conditions():
+    normalized = _normalized(CHECKLIST)
+    assert "stop condition" in normalized
+    assert "must stop" in normalized
+    for condition in STOP_CONDITIONS:
+        assert condition in normalized, f"checklist missing stop condition {condition}"
+
+
+def test_includes_strict_non_claims():
+    normalized = _normalized(CHECKLIST)
+    assert "non-claims" in normalized
+    for claim in NON_CLAIMS:
+        assert claim in normalized, f"checklist missing non-claim {claim}"
+
+
+def test_confirms_a3_0_does_not_execute_the_run():
+    normalized = _normalized(CHECKLIST)
+    assert "a3-0" in normalized
+    assert "execute the run" in normalized
+    assert "the run is not executed" in normalized
+
+
+def test_confirms_a3_0_adds_no_outputs_scores_providers_or_artifacts():
+    normalized = _normalized(CHECKLIST)
+    assert "no outputs are captured" in normalized
+    assert "no scores are recorded" in normalized
+    assert "no provider calls are made" in normalized
+    assert "no paired-output captures are populated" in normalized
+    assert "no evidence packets are populated" in normalized
+
+
+def test_population_guide_exists_and_is_consistent():
+    text = _read(POPULATION_GUIDE)
+    normalized = _normalized(POPULATION_GUIDE)
+    assert RUN_DIR_REFERENCE in text
+    found = sorted(set(re.findall(r"HHE-\d{3}", text)))
+    assert found == sorted(PILOT_PROMPTS), found
+    assert "non-claims" in normalized
+    assert "bearer-token" in normalized
+    assert "raw provider payloads" in normalized
+    for name in PLANNED_PAIRED_CAPTURES:
+        assert name in text
+    for name in PLANNED_EVIDENCE_PACKETS:
+        assert name in text
+
+
+def test_run_plan_and_summary_reference_checklist_and_stay_unexecuted():
+    plan = _read(RUN_DIR / "run-plan.md")
+    summary = _read(RUN_DIR / "run-summary.md")
+    assert "operator-checklist.md" in plan
+    assert "operator-checklist.md" in summary
+    for normalized in (
+        _normalized(RUN_DIR / "run-plan.md"),
+        _normalized(RUN_DIR / "run-summary.md"),
+    ):
+        assert "not executed" in normalized
+        assert "no outputs" in normalized
+        assert "no scores" in normalized
+
+
+def test_scaffold_files_remain_header_only_and_placeholders():
+    for csv_name in (
+        "blinded-score-sheet.csv",
+        "blinding-map.csv",
+        "score-table.csv",
+    ):
+        rows = _csv_rows(RUN_DIR / csv_name)
+        assert len(rows) == 1, f"{csv_name} must remain header-only in A3-0"
+
+    paired_files = sorted(p.name for p in (RUN_DIR / "paired-output-captures").iterdir())
+    packet_files = sorted(p.name for p in (RUN_DIR / "evidence-packets").iterdir())
+    assert paired_files == [".gitkeep"], paired_files
+    assert packet_files == [".gitkeep"], packet_files
+
+
+def test_no_secret_like_strings_in_a3_docs():
+    for path in (CHECKLIST, POPULATION_GUIDE):
+        lowered = _read(path).lower()
+        for marker in SECRET_MARKERS:
+            assert marker.lower() not in lowered, f"{path} contains {marker}"
+
+
+def test_markdown_and_python_files_have_reviewable_physical_formatting():
+    targets = [CHECKLIST, POPULATION_GUIDE, Path(__file__)]
+    for path in targets:
+        text = _read(path)
+        assert "\r" not in text, f"{path} contains carriage returns"
+        lines = text.splitlines()
+        assert len(lines) > 50, f"{path} appears collapsed or too short"
+        assert len(lines) < 500, f"{path} has an unreasonable line count"
+        assert max(len(line) for line in lines) < 500, f"{path} has an overly long line"
+        for character in text:
+            bidi = unicodedata.bidirectional(character)
+            category = unicodedata.category(character)
+            assert bidi not in BIDI_CONTROL_CATEGORIES, f"{path} has bidi control"
+            assert category != "Cf", f"{path} contains hidden format character"


### PR DESCRIPTION
## Summary

Implements `OUTPUT-DIFF-A3-OPERATOR-CHECKLIST-DRY-RUN-001` (the A3-0 step): a narrow docs/tests-only readiness change that makes the operator workflow explicit and defines the dry-run validation rules before the first scored Alpha-vs-plain differentiation run in `OUTPUT-DIFFERENTIATION-PHASE-001`.

This is **A3-0, not A3-1**. It does not execute the run, call providers, add outputs, add scores, populate paired-output captures, or populate evidence packets. The repo stays scaffold-only after PR #234; this PR adds the checklist/dry-run validation layer that reduces risk before committing the first scored run artifacts.

## Changes

- **Add `operator-checklist.md`** in `docs/evals/runs/20260602-eval-differentiation-run-001-alpha-vs-plain/`:
  - A. Pre-run setup — approved branch and commit recorded before execution; exact run directory; the exact four prompts (`HHE-002`, `HHE-003`, `HHE-007`, `HHE-009`); expected primary generation cap of **8** (4 prompts × 2 surfaces); optional **10–12** contingency cap only if explicitly approved; plain/Alpha surface identification before execution; no runtime/provider changes.
  - B. A3-1 output-generation rules (same prompt to both surfaces; sanitized answer text + word counts + allowed summary metadata + sanitized Alpha envelope only; no raw payloads, response IDs, headers, cookies, CSRF/session values, env dumps, or private data; no scoring/unblinding while generating).
  - C. Blinding rules (Output A/B via recorded random method/seed; mapping in `blinding-map.csv`; blinded scoring before consulting the map; procedural, not cryptographic).
  - D. Scoring rules (all 14 rubric dimensions; `RESPONSE_QUALITY_RUBRIC.md`; blinded sheet first; unblind then transfer to `score-table.csv`; compute `plain_total`/`alpha_total`/`total_delta`/`lift_delta`/`polish_delta`/`lift_qualified`/`material_constraint_verified`/`polish_only_flag`; polish-only guard from `LIFT_DECISION_RULE.md`).
  - E. Planned A3-1 paired-output-capture and evidence-packet filenames.
  - F. Defect workflow fields and categories.
  - G. Redaction prohibitions.
  - H. Stop conditions.
  - I. Strict non-claims.
  - A3-0 completion confirmation (run not executed; CSVs header-only; capture/packet dirs are placeholders; no runtime change).
- **Add `artifact-population-guide.md`**: companion guide for how A3-1 should populate each artifact, with the same redaction and non-claim boundaries.
- **Update `run-plan.md`** (minimal): reference the operator checklist and population guide.
- **Update `run-summary.md`** (minimal): note A3-0 checklist/dry-run readiness while preserving the not-executed / no-outputs / no-scores / no-result / no-claim language.
- **Add `tests/test_output_diff_a3_operator_checklist.py`**: 21 docs-integrity tests covering checklist content, planned artifact names, scaffold-still-empty invariants, no secret-like strings, and physical formatting.

## Tests run

- `git diff --check` — clean
- `python -m py_compile tests/test_output_diff_a3_operator_checklist.py` — OK
- `python -m pytest -q tests/test_output_diff_a3_operator_checklist.py` — **21 passed**
- `python -m pytest -q tests/test_eval_differentiation_run_001.py` — **11 passed**
- `python -m pytest -q tests/test_alpha_side_by_side_evidence_packet.py` — **15 passed**
- `python -m pytest -q tests/test_output_diff_measurement_hardening.py` — **13 passed**
- `python -m pytest -q` (full suite) — **695 passed, 3 skipped, 2 failed**

The 2 full-suite failures (`test_smoke_quickstart.py::test_release_script`, `test_tag_release.py::test_tag_release`) are pre-existing and unrelated to this change: they shell out to `git commit` in temporary repos, which fails on the CI environment's commit-signing wrapper. Baseline before this change had the identical 2 failures; this PR added exactly +21 passing tests (674 → 695).

Line-format verification (operator-checklist.md 263 lines / artifact-population-guide.md 129 lines / test file 345 lines): all > 50 and < 500 lines, max line length < 90, zero bidirectional/hidden-format characters.

## Backlog impact

`OUTPUT-DIFF-A3-OPERATOR-CHECKLIST-DRY-RUN-001` should be marked Done only after this PR merges. It prepares the operator checklist and dry-run validation rules for the later first scored run artifact PR. It does not execute or score the first differentiation run.

## Non-goals / non-claims

Does not execute the first scored differentiation run, make live provider calls, score actual Alpha-vs-plain outputs, add populated paired-output captures or evidence packets, or populate score-table / blinded-score-sheet / blinding-map rows. Does not modify provider expert-pass behavior, clarify behavior, `/v1/solve`, preview UI rendering, dashboard auth, `scripts/run_answer_quality_eval.py`, MCQ answer-quality eval behavior, tool routing, effort toggle, persistent quota, Google Sheets, or backlog workbook files.

This PR claims nothing about: MVP validation; Alpha Solver superiority; answer-quality superiority; production readiness; broad runtime readiness; benchmark success; exact billing accuracy; provider reasoning orchestration.

https://claude.ai/code/session_017MhEbD8S2or2JHmLGLowym

---
_Generated by [Claude Code](https://claude.ai/code/session_017MhEbD8S2or2JHmLGLowym)_