### PR TITLE
Guard expert route against empty primary answers

### DIFF
--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -66,6 +66,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `RES-07.md` | CODE SPEC — RES-07 · Observability (route_explain + JSONL replay) (RES) |
 | `RES-08.md` | CODE SPEC — RES-08 · Budget Simulator + Evidence Pack (RES) |
 | `REVIEW-P0P1.md` | CODE SPEC — REVIEW-P0P1 · P0 + P1 Bulk Review (MVP Readiness) (RES_06) |
+| `SOLVE-EXPERT-EMPTY-ANSWER-GUARD-001.md` | SOLVE-EXPERT-EMPTY-ANSWER-GUARD-001 · Expert Route Empty Primary Answer Guard |
 | `SOLVE-SANITIZER-FALSE-POSITIVE-001.md` | SOLVE-SANITIZER-FALSE-POSITIVE-001 · Narrow Import-Substring Sanitizer Fix |
 | `UI-JOBS-001.md` | UI-JOBS-001 · Dashboard Job History & Metrics (RES_Dash) |
 | `UI-PREVIEW-001.md` | UI-PREVIEW-001 · Authenticated Expert Preview UI |

--- a/.specs/SOLVE-EXPERT-EMPTY-ANSWER-GUARD-001.md
+++ b/.specs/SOLVE-EXPERT-EMPTY-ANSWER-GUARD-001.md
@@ -1,0 +1,44 @@
+# SOLVE-EXPERT-EMPTY-ANSWER-GUARD-001 - Expert Route Empty Primary Answer Guard
+
+## Goal
+
+Prevent the expert-route `/v1/solve` response assembly path from returning HTTP 200 with empty `final_answer` / `answer` when the Step 2 provider call succeeds but its extracted answer text is empty or whitespace.
+
+## Root cause
+
+The complex expert route performs a Step 1 preview call, selects a mode, then performs a Step 2 answer call. `_primary_expert_answer` strips the Step 2 text and returns approved deterministic fallbacks only for narrow `answer_with_assumptions` cases. If Step 2 text is empty or unextractable and no approved deterministic fallback applies, the empty provider text can continue into `_expert_response`, which serializes the empty string into both `final_answer` and `answer` under HTTP 200.
+
+## Scope
+
+- Add a minimal runtime guard in the complex expert-route `/v1/solve` response assembly path.
+- When the assembled primary expert answer is empty after existing clarify, block, and approved fallback handling, return a typed provider SAFE-OUT-style response instead of a successful empty expert envelope.
+- Preserve existing expert clarify behavior.
+- Preserve existing expert block behavior.
+- Preserve existing trivial expert-route behavior.
+- Preserve non-empty direct expert-route pass-through behavior.
+- Preserve plain `/v1/solve` behavior outside the focused empty-output guard.
+- Add focused fake-provider tests for the empty Step 2 path, no-secret/no-raw-payload response safety, and non-empty expert pass-through preservation.
+
+## Non-goals
+
+- No A3-1 capture execution.
+- No reuse of partial failed-capture outputs.
+- No scoring or unblinding.
+- No eval artifact population.
+- No Google Sheets updates.
+- No Batch B work.
+- No provider prompt refactor.
+- No broad routing, SAFE-OUT, budget, telemetry, replay, or SolverEnvelope refactor.
+- No claims of MVP validation, Alpha Solver superiority, answer-quality superiority, production readiness, broad runtime readiness, benchmark success, exact billing accuracy, or provider reasoning orchestration.
+
+## Safety requirements
+
+The empty-answer guard response must not leak API keys, authorization headers, bearer tokens, raw provider payloads, raw provider metadata, raw prompts, raw system prompts, raw user query dumps, exception strings, tracebacks, environment dumps, config dumps, or unsafe internal metadata.
+
+## Acceptance criteria
+
+- A complex expert-route request whose Step 1 preview yields high-confidence direct mode and whose Step 2 answer text is empty or whitespace does not return HTTP 200 with empty `final_answer` / `answer`.
+- The empty Step 2 case returns a safe non-empty SAFE-OUT-style response or typed safe failure response.
+- The empty Step 2 response is allowlist-shaped and redacted.
+- Non-empty complex expert-route direct answers still pass through.
+- Existing clarify, block, trivial expert-route, and sanitizer false-positive behavior remains covered by tests.

--- a/service/app.py
+++ b/service/app.py
@@ -1008,6 +1008,18 @@ async def solve(req: SolveRequest, request: Request) -> JSONResponse:
                     )
                 elif mode == "block":
                     expert_answer = _BLOCK_MESSAGE
+                if not expert_answer.strip():
+                    record_safe_out(request.url.path)
+                    return _provider_error_response(
+                        ProviderError(
+                            provider=answer_result.provider,
+                            category="unknown",
+                            retryable=False,
+                            safe_message="Provider returned an empty expert answer.",
+                            request_id=answer_result.request_id,
+                            retry_count=answer_result.retry_count,
+                        )
+                    )
                 return JSONResponse(
                     _expert_response(
                         answer=expert_answer,

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -505,6 +505,115 @@ def test_solve_openai_expert_complex_route_makes_two_calls_and_returns_envelope(
     _clear_provider_factory()
 
 
+def test_solve_openai_expert_direct_mode_empty_step_two_returns_safe_out(monkeypatch):
+    monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    fake = FakeProviderClient(
+        [
+            _provider_result(
+                '{"considerations":["Check the requested decision"],'
+                '"assumptions":[],"confidence":0.95}'
+            ),
+            _provider_result("   ", request_id="req-empty-step-two"),
+        ]
+    )
+    app.state.provider_client_factory = lambda _model_set: fake
+    client, key = _client()
+
+    resp = client.post(
+        "/v1/solve",
+        json={
+            "query": (
+                "Review this database migration plan, compare reliability risks "
+                "and tradeoffs, and decide whether the team should proceed this "
+                "quarter with rollback checkpoints."
+            ),
+            "context": {"route": "expert"},
+        },
+        headers={"X-API-Key": key, "X-Request-ID": "req-empty-step-two"},
+    )
+
+    assert resp.status_code == 502
+    body = resp.json()
+    _assert_provider_safe_out_schema(
+        body,
+        category="unknown",
+        retryable=False,
+        request_id="req-empty-step-two",
+    )
+    assert body["final_answer"] == "SAFE-OUT: Provider returned an empty expert answer."
+    assert "answer" not in body
+    assert body["final_answer"].strip()
+    assert len(fake.requests) == 2
+    _clear_provider_factory()
+
+
+def test_solve_openai_expert_empty_step_two_safe_out_does_not_leak_raw_data(
+    monkeypatch,
+):
+    monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    secret = "sk-test-empty-expert-secret"
+    raw_payload = "raw-provider-payload-secret"
+    prompt_sentinel = "MUST_NOT_LEAK_RAW_PROMPT_SENTINEL"
+    fake = FakeProviderClient(
+        [
+            _provider_result(
+                '{"considerations":["Use safe response assembly"],'
+                '"assumptions":[],"confidence":0.95}',
+                request_id="req-empty-redact-preview",
+            ),
+            ProviderResult(
+                provider="openai",
+                model="gpt-test",
+                text=" \n\t ",
+                finish_reason="stop",
+                usage=ProviderUsage(input_tokens=1, output_tokens=0, total_tokens=1),
+                cost=ProviderCost(estimated_usd=0.0, source="price_hint"),
+                latency_ms=1,
+                request_id="req-empty-redact",
+                raw_metadata={
+                    "raw": raw_payload,
+                    "api_key": secret,
+                    "Authorization": f"Bearer {secret}",
+                    "prompt": prompt_sentinel,
+                    "provider_request_id": "provider-req-empty-redact",
+                },
+            ),
+        ]
+    )
+    app.state.provider_client_factory = lambda _model_set: fake
+    client, key = _client()
+
+    resp = client.post(
+        "/v1/solve",
+        json={
+            "query": (
+                f"Review {prompt_sentinel} migration reliability risks, compare "
+                "tradeoffs, and decide whether this complex plan should proceed."
+            ),
+            "context": {"route": "expert"},
+        },
+        headers={"X-API-Key": key, "X-Request-ID": "req-empty-redact"},
+    )
+
+    assert resp.status_code == 502
+    body = resp.json()
+    _assert_provider_safe_out_schema(
+        body, category="unknown", retryable=False, request_id="req-empty-redact"
+    )
+    serialized = resp.text
+    assert secret not in serialized
+    assert key not in serialized
+    assert raw_payload not in serialized
+    assert prompt_sentinel not in serialized
+    assert "raw_metadata" not in serialized
+    assert "provider_request_id" not in serialized
+    assert "Authorization" not in serialized
+    assert "Bearer" not in serialized
+    assert "metadata" not in serialized
+    assert "prompt" not in serialized.lower()
+    _clear_provider_factory()
+
+
 def test_solve_openai_expert_complex_route_preserves_requested_plan_shape(monkeypatch):
     monkeypatch.setenv("MODEL_PROVIDER", "openai")
     prompt = (


### PR DESCRIPTION
### Motivation

- Prevent the expert `/v1/solve` path from returning HTTP 200 with empty `final_answer`/`answer` when the Step 2 provider call succeeds but yields empty or whitespace text.
- Ensure a safe, allowlisted SAFE-OUT-style response is returned for this edge case without leaking secrets or raw provider data.
- Keep existing clarify, block, trivial expert-route, and non-empty pass-through behavior unchanged.

### Description

- Add a spec file `.specs/SOLVE-EXPERT-EMPTY-ANSWER-GUARD-001.md` that documents the guard, root cause, scope, safety, and acceptance criteria.
- Register the new spec in `.specs/INDEX.md`.
- Implement a minimal runtime guard in `service/app.py` that, after assembling the expert answer, records a SAFE-OUT and returns a typed provider SAFE-OUT response when the assembled `expert_answer` is empty following clarify/block/fallback logic.
- Add focused tests to `tests/test_api_endpoints.py` that assert: an empty/whitespace Step 2 answer returns a SAFE-OUT (non-200) response, the SAFE-OUT body uses the allowlisted schema and safe message, and the response does not leak API keys, prompts, raw payloads, or other sensitive metadata.

### Testing

- Ran focused expert-route tests: `pytest -q tests/test_api_endpoints.py -k "expert or sanitizer"` and the tests passed.
- Ran related API/security focused tests: `pytest -q tests/test_security.py tests/test_api_endpoints.py` and they passed.
- Ran full test suite: `python -m pytest -q` and it passed (some pre-existing live-smoke tests skipped by environment); no new failures introduced.
- Ran `git diff --check` and repository checks produced no whitespace/conflict errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fca9b0c9c83298851719b0470c3a3)