### PR TITLE
Guard against empty provider final answers (SAFE-OUT) and add tests/spec

### DIFF
--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -67,6 +67,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `RES-08.md` | CODE SPEC — RES-08 · Budget Simulator + Evidence Pack (RES) |
 | `REVIEW-P0P1.md` | CODE SPEC — REVIEW-P0P1 · P0 + P1 Bulk Review (MVP Readiness) (RES_06) |
 | `SOLVE-EXPERT-EMPTY-ANSWER-GUARD-001.md` | SOLVE-EXPERT-EMPTY-ANSWER-GUARD-001 · Expert Route Empty Primary Answer Guard |
+| `SOLVE-PROVIDER-FINAL-ANSWER-EMPTY-GUARD-001.md` | SOLVE-PROVIDER-FINAL-ANSWER-EMPTY-GUARD-001 · Provider Final Answer Empty Output Guard |
 | `SOLVE-SANITIZER-FALSE-POSITIVE-001.md` | SOLVE-SANITIZER-FALSE-POSITIVE-001 · Narrow Import-Substring Sanitizer Fix |
 | `UI-JOBS-001.md` | UI-JOBS-001 · Dashboard Job History & Metrics (RES_Dash) |
 | `UI-PREVIEW-001.md` | UI-PREVIEW-001 · Authenticated Expert Preview UI |

--- a/.specs/SOLVE-PROVIDER-FINAL-ANSWER-EMPTY-GUARD-001.md
+++ b/.specs/SOLVE-PROVIDER-FINAL-ANSWER-EMPTY-GUARD-001.md
@@ -1,0 +1,94 @@
+# SOLVE-PROVIDER-FINAL-ANSWER-EMPTY-GUARD-001 · Provider Final Answer Empty Output Guard
+
+## Purpose
+
+Prevent `/v1/solve` provider final-answer success envelopes from returning HTTP
+200 with an empty or whitespace-only `final_answer` when the provider call itself
+returns successfully but yields no usable answer text.
+
+## Context
+
+During the clean A3-1 operator-supervised capture attempt for
+`OUTPUT-DIFF-A3-FIRST-SCORED-RUN-ARTIFACT-001`, the run stopped after six of the
+eight required outputs because the HHE-009 plain `/v1/solve` surface returned
+HTTP 200 with `final_answer=""` while the OpenAI Responses API result was marked
+`finish_reason="incomplete"`.
+
+PR #237 fixed the HHE-009 sanitizer false-positive blocker. PR #238 guarded the
+complex expert route against an empty Step 2 primary answer. The plain provider
+success path still accepted a successful `ProviderResult` with empty or
+whitespace text and serialized that text directly into the final answer envelope.
+
+## Scope
+
+In scope:
+
+- Guard final HTTP 200 provider answer envelopes against empty or whitespace-only
+  answer text.
+- Use the existing typed provider SAFE-OUT response path for empty final-answer
+  output.
+- Preserve existing provider error SAFE-OUT responses.
+- Preserve non-empty provider success responses.
+- Preserve the PR #238 complex expert-route empty Step 2 guard.
+- Preserve the PR #237 sanitizer behavior for benign `IMPORTANT` / import
+  substrings and risky import statements.
+- Add no-network regression coverage for plain provider empty output,
+  whitespace-only output, redaction safety, non-empty success preservation, and
+  related expert-route preservation.
+
+Out of scope:
+
+- A3-1 capture, scoring, unblinding, or artifact population.
+- Batch B execution.
+- Google Sheets or backlog workbook updates.
+- Provider prompt refactors or broad routing changes.
+- SAFE-OUT taxonomy refactors beyond the existing normalized provider error
+  response fields.
+- Dashboard, budget, replay, observability, MCP, or eval artifact changes.
+- Claims of MVP validation, Alpha Solver superiority, answer-quality
+  superiority, production readiness, broad runtime readiness, benchmark success,
+  exact billing accuracy, or provider reasoning orchestration.
+
+## Requirements
+
+1. A provider final-answer success path must not return HTTP 200 when the final
+   answer text is empty or whitespace-only.
+2. Empty provider final-answer output must return a typed provider SAFE-OUT-style
+   response with a non-empty `final_answer`, `safe_out=true`, and no `answer`
+   field.
+3. The empty-output response must not leak API keys, authorization headers,
+   bearer tokens, raw provider payloads, raw prompts, raw metadata, tracebacks,
+   environment dumps, config dumps, or unsafe internal metadata.
+4. The guard should validate final response assembly rather than every provider
+   execution call, because the expert route uses provider calls for Step 1
+   preview parsing and Step 2 answer assembly.
+5. The plain OpenAI provider path and the trivial expert direct final-answer path
+   must be guarded.
+6. Existing non-empty plain provider success behavior must be preserved.
+7. Existing complex expert empty-answer guard behavior from PR #238 must be
+   preserved.
+8. Existing sanitizer behavior from PR #237 must be preserved.
+9. No live provider calls are required for validation.
+
+## Acceptance criteria
+
+- A fake-provider plain `/v1/solve` request returning `ProviderResult(text="",
+  finish_reason="incomplete")` returns a provider SAFE-OUT-style failure instead
+  of HTTP 200 with an empty `final_answer`.
+- A fake-provider plain `/v1/solve` request returning whitespace-only text
+  returns the same safe failure shape.
+- The empty-output SAFE-OUT body is allowlist-built and does not include secrets,
+  raw prompt text, raw provider payloads, raw metadata, tracebacks, or unsafe
+  internal metadata.
+- Non-empty plain provider success still returns HTTP 200 with the expected
+  `final_answer` and no `answer` field.
+- Focused PR #238 expert empty-answer and expert route preservation tests still
+  pass.
+- Focused PR #237 sanitizer tests still pass.
+
+## Backlog impact
+
+`OUTPUT-DIFF-A3-FIRST-SCORED-RUN-ARTIFACT-001` remains blocked until this fix is
+merged and any applicable operator bookkeeping is complete. A3-1 capture must not
+be retried from this PR, and previous partial failed-capture outputs must not be
+reused.

--- a/service/app.py
+++ b/service/app.py
@@ -387,6 +387,25 @@ def _provider_request_error_event(
     )
 
 
+_PROVIDER_EMPTY_FINAL_ANSWER_MESSAGE = "Provider returned an empty answer."
+
+
+def _provider_empty_final_answer_error(result: ProviderResult) -> ProviderError:
+    return ProviderError(
+        provider=result.provider,
+        category="unknown",
+        retryable=False,
+        safe_message=_PROVIDER_EMPTY_FINAL_ANSWER_MESSAGE,
+        request_id=result.request_id,
+        retry_count=result.retry_count,
+    )
+
+
+def _provider_empty_final_answer_response(request: Request, result: ProviderResult) -> JSONResponse:
+    record_safe_out(request.url.path)
+    return _provider_error_response(_provider_empty_final_answer_error(result))
+
+
 def _provider_success_response(result: ProviderResult, model_set: ModelSet) -> Dict[str, Any]:
     return {
         "final_answer": result.text,
@@ -947,6 +966,8 @@ async def solve(req: SolveRequest, request: Request) -> JSONResponse:
                         provider_client=provider_client,
                         provider_request=provider_request,
                     )
+                    if not provider_result.text.strip():
+                        return _provider_empty_final_answer_response(request, provider_result)
                     return JSONResponse(
                         _expert_response(
                             answer=provider_result.text,
@@ -1067,6 +1088,8 @@ async def solve(req: SolveRequest, request: Request) -> JSONResponse:
                 request, _provider_request_error_event(provider_request, safe_error)
             )
             return _provider_error_response(safe_error)
+        if not provider_result.text.strip():
+            return _provider_empty_final_answer_response(request, provider_result)
         return JSONResponse(_provider_success_response(provider_result, model_set))
 
     start = time.time()

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -441,12 +441,12 @@ def test_solve_openai_unknown_provider_exception_emits_no_accounting(monkeypatch
     _clear_provider_accounting_sink()
 
 
-def _provider_result(text, *, request_id="req-expert", model="gpt-test"):
+def _provider_result(text, *, request_id="req-expert", model="gpt-test", finish_reason="stop"):
     return ProviderResult(
         provider="openai",
         model=model,
         text=text,
-        finish_reason="stop",
+        finish_reason=finish_reason,
         usage=ProviderUsage(input_tokens=1, output_tokens=1, total_tokens=2),
         cost=ProviderCost(estimated_usd=0.0, source="price_hint"),
         latency_ms=1,
@@ -1121,6 +1121,140 @@ def test_solve_openai_non_expert_route_preserves_pass_through_shape(monkeypatch)
     assert "answer" not in body
     assert len(fake.requests) == 1
     assert fake.requests[0].metadata["route"] == "tot"
+    _clear_provider_factory()
+
+
+@pytest.mark.parametrize(
+    ("provider_text", "finish_reason"),
+    [
+        ("", "incomplete"),
+        (" \n\t ", "stop"),
+    ],
+)
+def test_solve_openai_plain_empty_final_answer_returns_safe_out(
+    monkeypatch, provider_text, finish_reason
+):
+    monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    fake = FakeProviderClient(
+        [
+            _provider_result(
+                provider_text,
+                request_id="req-empty-provider-final",
+                finish_reason=finish_reason,
+            )
+        ]
+    )
+    app.state.provider_client_factory = lambda _model_set: fake
+    client, key = _client()
+
+    resp = client.post(
+        "/v1/solve",
+        json={"query": "hello provider", "context": {"route": "tot"}},
+        headers={"X-API-Key": key, "X-Request-ID": "req-empty-provider-final"},
+    )
+
+    assert resp.status_code == 502
+    body = resp.json()
+    _assert_provider_safe_out_schema(
+        body,
+        category="unknown",
+        retryable=False,
+        request_id="req-empty-provider-final",
+    )
+    assert body["final_answer"] == "SAFE-OUT: Provider returned an empty answer."
+    assert body["final_answer"].strip()
+    assert "answer" not in body
+    assert len(fake.requests) == 1
+    assert fake.requests[0].metadata["route"] == "tot"
+    _clear_provider_factory()
+
+
+def test_solve_openai_plain_empty_final_answer_safe_out_does_not_leak_raw_data(
+    monkeypatch,
+):
+    monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    secret = "sk-test-plain-empty-secret"
+    raw_payload = "plain-empty-raw-provider-payload"
+    prompt_sentinel = "PLAIN_EMPTY_PROMPT_MUST_NOT_LEAK"
+    fake = FakeProviderClient(
+        [
+            ProviderResult(
+                provider="openai",
+                model="gpt-test",
+                text="",
+                finish_reason="incomplete",
+                usage=ProviderUsage(input_tokens=1, output_tokens=0, total_tokens=1),
+                cost=ProviderCost(estimated_usd=0.0, source="price_hint"),
+                latency_ms=1,
+                request_id="req-empty-plain-redact",
+                raw_metadata={
+                    "raw": raw_payload,
+                    "api_key": secret,
+                    "Authorization": f"Bearer {secret}",
+                    "prompt": prompt_sentinel,
+                    "provider_request_id": "provider-req-empty-plain-redact",
+                },
+            )
+        ]
+    )
+    app.state.provider_client_factory = lambda _model_set: fake
+    client, key = _client()
+
+    resp = client.post(
+        "/v1/solve",
+        json={"query": f"Review {prompt_sentinel} and return a short answer."},
+        headers={"X-API-Key": key, "X-Request-ID": "req-empty-plain-redact"},
+    )
+
+    assert resp.status_code == 502
+    body = resp.json()
+    _assert_provider_safe_out_schema(
+        body,
+        category="unknown",
+        retryable=False,
+        request_id="req-empty-plain-redact",
+    )
+    serialized = resp.text
+    assert secret not in serialized
+    assert key not in serialized
+    assert raw_payload not in serialized
+    assert prompt_sentinel not in serialized
+    assert "raw_metadata" not in serialized
+    assert "provider_request_id" not in serialized
+    assert "Authorization" not in serialized
+    assert "Bearer" not in serialized
+    assert "metadata" not in serialized
+    assert "traceback" not in serialized.lower()
+    assert "prompt" not in serialized.lower()
+    assert "answer" not in body
+    _clear_provider_factory()
+
+
+def test_solve_openai_expert_trivial_empty_final_answer_returns_safe_out(monkeypatch):
+    monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    fake = FakeProviderClient(
+        [_provider_result("", request_id="req-empty-trivial", finish_reason="incomplete")]
+    )
+    app.state.provider_client_factory = lambda _model_set: fake
+    client, key = _client()
+
+    resp = client.post(
+        "/v1/solve",
+        json={"query": "Define alpha.", "context": {"route": "expert"}},
+        headers={"X-API-Key": key, "X-Request-ID": "req-empty-trivial"},
+    )
+
+    assert resp.status_code == 502
+    body = resp.json()
+    _assert_provider_safe_out_schema(
+        body,
+        category="unknown",
+        retryable=False,
+        request_id="req-empty-trivial",
+    )
+    assert body["final_answer"].strip()
+    assert "answer" not in body
+    assert len(fake.requests) == 1
     _clear_provider_factory()
 
 


### PR DESCRIPTION
### Motivation

- Prevent `/v1/solve` from returning HTTP 200 with an empty or whitespace-only `final_answer` when a provider call succeeds but yields no usable text.
- Ensure the plain provider and trivial expert direct-answer paths emit a typed provider SAFE-OUT instead of leaking raw provider data or returning an empty envelope.

### Description

- Added a new spec file `SOLVE-PROVIDER-FINAL-ANSWER-EMPTY-GUARD-001.md` and registered it in `.specs/INDEX.md` describing the guard and acceptance criteria.
- Introduced `_PROVIDER_EMPTY_FINAL_ANSWER_MESSAGE`, `_provider_empty_final_answer_error`, and `_provider_empty_final_answer_response` helpers to build a SAFE-OUT `ProviderError` and return the error response while calling `record_safe_out`.
- Updated `solve` logic in `service/app.py` to check `if not provider_result.text.strip()` and return the SAFE-OUT response for both the non-expert provider path and the trivial expert direct-answer path.
- Adjusted test helper `_provider_result` signature to accept `finish_reason` and added tests in `tests/test_api_endpoints.py` that assert empty/whitespace provider outputs produce a 502 SAFE-OUT, do not leak secrets/raw payloads, and preserve expert-route behavior.

### Testing

- Ran the API endpoint test suite in `tests/test_api_endpoints.py`, including `test_solve_openai_plain_empty_final_answer_returns_safe_out`, `test_solve_openai_plain_empty_final_answer_safe_out_does_not_leak_raw_data`, and `test_solve_openai_expert_trivial_empty_final_answer_returns_safe_out`, and they all passed under `pytest`.
- Existing provider-related endpoint tests were also exercised and continued to pass after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fcf08ccd88329a7a09c1a7520a6a9)