### PR TITLE
Add `a3_live_capture` model set for A3 live-capture and tests

### DIFF
--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -54,6 +54,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `NEW-HEALTH-001.md` | NEW-HEALTH-001 · Health Check Endpoints |
 | `NEW-RATE-001.md` | NEW-RATE-001 · API Rate Limiting |
 | `OBS-ALERTS-001.md` | CODE SPEC — OBS-ALERTS-001 · Prometheus Alerts + CI Validation (RES_Dash) |
+| `OUTPUT-DIFF-A3-LIVE-CAPTURE-MODELSET-001.md` | OUTPUT-DIFF-A3-LIVE-CAPTURE-MODELSET-001 · A3 Live Capture Model Set |
 | `OUTPUT-DIFF-MEASUREMENT-HARDENING-001.md` | OUTPUT-DIFF-MEASUREMENT-HARDENING-001 · Output Differentiation Measurement Hardening |
 | `PROVIDER-BUDGET-001.md` | PROVIDER-BUDGET-001 · Post-call Provider Cost Accounting |
 | `PROVIDER-EXPERT-PASS-001.md` | PROVIDER-EXPERT-PASS-001 · Opt-in Expert Provider Pass |

--- a/.specs/OUTPUT-DIFF-A3-LIVE-CAPTURE-MODELSET-001.md
+++ b/.specs/OUTPUT-DIFF-A3-LIVE-CAPTURE-MODELSET-001.md
@@ -1,0 +1,72 @@
+# OUTPUT-DIFF-A3-LIVE-CAPTURE-MODELSET-001 · A3 Live Capture Model Set
+
+## Purpose
+
+Provide an explicit live-capture model set for the A3 output-differentiation
+capture lane so operator-supervised A3 runs do not rely on the existing
+`cost_saver` 1024-token output budget.
+
+## Background
+
+During diagnostic-only investigation of the blocked A3-1 capture, the HHE-009
+plain `/v1/solve` surface under `MODEL_SET=cost_saver` reached the OpenAI
+Responses API output cap before a complete answer was available:
+
+- model: `gpt-5-mini-2025-08-07`
+- response status: `incomplete`
+- incomplete reason: `max_output_tokens`
+- configured `max_output_tokens`: `1024`
+- output tokens: `1024`
+- reasoning tokens: `768`
+- `_text_from_payload` extracted text when text existed
+
+The prior clean A3-1 attempt stopped on HHE-009 plain with HTTP 502 SAFE-OUT:
+`Provider returned an empty answer.` This indicates a live-capture output-budget
+configuration blocker, not the PR #237 sanitizer false positive and not a text
+extraction bug when provider text exists.
+
+## Scope
+
+Add a dedicated model set named `a3_live_capture` in
+`service/config/model_sets.yaml`.
+
+The model set must:
+
+- use `provider: openai`;
+- use the same model family as `cost_saver` unless a later operator-approved spec
+  changes it;
+- set `max_tokens` to at least `4096`;
+- set `timeout_ms` to at least `60000`;
+- use price hints consistent with the selected model family.
+
+## Non-goals
+
+- Do not modify `default`.
+- Do not modify `cost_saver`.
+- Do not change production defaults.
+- Do not change OpenAI provider request/response behavior.
+- Do not change prompt text or HHE prompt selection.
+- Do not run or implement A3-1 capture.
+- Do not populate eval artifacts, score, unblind, update Google Sheets, or start
+  Batch B.
+
+## Acceptance Criteria
+
+1. `ModelSetRegistry` loads `a3_live_capture` successfully.
+2. `MODEL_SET=a3_live_capture` resolves to the configured provider, model,
+   `max_tokens`, and `timeout_ms`.
+3. `/v1/solve` can select `a3_live_capture` through the existing model-set
+   selection path.
+4. `ProviderRequest.max_tokens` maps to the `a3_live_capture` configured
+   `max_tokens`.
+5. Existing `default` and `cost_saver` model-set behavior remains unchanged.
+6. Existing environment validation remains valid for supported provider settings.
+7. Existing PR #237 sanitizer behavior remains covered by tests.
+8. Existing PR #238 and PR #239 empty-answer guard behavior remains covered by
+   tests.
+
+## Operator Notes
+
+A later fresh A3-1 capture may use this model set only after this config PR lands
+and any applicable operator bookkeeping is completed. Previous failed-capture
+partial outputs remain invalid and must not be reused.

--- a/service/config/model_sets.yaml
+++ b/service/config/model_sets.yaml
@@ -1,4 +1,10 @@
 model_sets:
+  a3_live_capture:
+    provider: openai
+    model: gpt-5-mini
+    max_tokens: 4096
+    timeout_ms: 60000
+    price_hint: { input_per_1k: 0.0015, output_per_1k: 0.004 }
   default:
     provider: openai
     model: gpt-5

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -290,6 +290,85 @@ def test_solve_openai_mode_uses_fake_provider_and_returns_normalized_text(monkey
     _clear_provider_accounting_sink()
 
 
+def test_solve_openai_mode_can_use_a3_live_capture_model_set(monkeypatch):
+    monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    monkeypatch.setenv("MODEL_SET", "a3_live_capture")
+    fake = FakeProviderClient(
+        [
+            ProviderResult(
+                provider="openai",
+                model="gpt-test",
+                text="provider answer",
+                finish_reason="stop",
+                usage=ProviderUsage(input_tokens=3, output_tokens=5, total_tokens=8),
+                cost=ProviderCost(estimated_usd=0.001, source="price_hint"),
+                latency_ms=12,
+                request_id="req-a3-model-set",
+            )
+        ]
+    )
+    app.state.provider_client_factory = lambda _model_set: fake
+    client, key = _client()
+
+    resp = client.post(
+        "/v1/solve",
+        json={"query": "hello provider"},
+        headers={"X-API-Key": key, "X-Request-ID": "req-a3-model-set"},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["final_answer"] == "provider answer"
+    assert body["meta"]["model_set"] == "a3_live_capture"
+    assert len(fake.requests) == 1
+    provider_request = fake.requests[0]
+    assert provider_request.model == "gpt-5-mini"
+    assert provider_request.max_tokens == 4096
+    assert provider_request.timeout_ms == 60000
+    assert provider_request.metadata["model_set"] == "a3_live_capture"
+    _clear_provider_factory()
+
+
+def test_solve_openai_mode_can_request_a3_live_capture_model_set(monkeypatch):
+    monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    fake = FakeProviderClient(
+        [
+            ProviderResult(
+                provider="openai",
+                model="gpt-test",
+                text="provider answer",
+                finish_reason="stop",
+                usage=ProviderUsage(input_tokens=3, output_tokens=5, total_tokens=8),
+                cost=ProviderCost(estimated_usd=0.001, source="price_hint"),
+                latency_ms=12,
+                request_id="req-a3-requested-model-set",
+            )
+        ]
+    )
+    app.state.provider_client_factory = lambda _model_set: fake
+    client, key = _client()
+
+    resp = client.post(
+        "/v1/solve",
+        json={
+            "query": "hello provider",
+            "context": {"model_set": "a3_live_capture"},
+        },
+        headers={"X-API-Key": key, "X-Request-ID": "req-a3-requested-model-set"},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["meta"]["model_set"] == "a3_live_capture"
+    assert len(fake.requests) == 1
+    provider_request = fake.requests[0]
+    assert provider_request.model == "gpt-5-mini"
+    assert provider_request.max_tokens == 4096
+    assert provider_request.timeout_ms == 60000
+    assert provider_request.metadata["model_set"] == "a3_live_capture"
+    _clear_provider_factory()
+
+
 def test_solve_openai_missing_credentials_returns_safe_response(monkeypatch):
     secret = "sk-test-should-not-appear"
     monkeypatch.setenv("MODEL_PROVIDER", "openai")

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -122,6 +122,18 @@ def test_check_env_success_with_provider_keys(provider, key_var):
     assert "Environment looks good" in result.stdout
 
 
+def test_check_env_accepts_a3_live_capture_model_set_with_openai_key():
+    result = _run_check_env(
+        {
+            "MODEL_PROVIDER": "openai",
+            "MODEL_SET": "a3_live_capture",
+            "OPENAI_API_KEY": "secret",
+        }
+    )
+    assert result.returncode == 0
+    assert "Environment looks good" in result.stdout
+
+
 @pytest.mark.parametrize(
     ("provider", "key_var"),
     [

--- a/tests/test_modelset_registry.py
+++ b/tests/test_modelset_registry.py
@@ -6,13 +6,29 @@ from service.models.modelset_registry import ModelSetRegistry, ModelSetError
 def test_registry_loads_sets():
     reg = ModelSetRegistry()
     names = reg.names()
+    assert "a3_live_capture" in names
     assert "default" in names and "cost_saver" in names
     # deterministic ordering
     assert names == sorted(names)
-    # ensure data accessible
-    ms = reg.get("default")
-    assert ms.provider == "openai"
-    assert ms.max_tokens == 2048
+    # ensure data accessible and existing model sets are preserved
+    default_ms = reg.get("default")
+    assert default_ms.provider == "openai"
+    assert default_ms.model == "gpt-5"
+    assert default_ms.max_tokens == 2048
+    assert default_ms.timeout_ms == 60000
+
+    saver_ms = reg.get("cost_saver")
+    assert saver_ms.provider == "openai"
+    assert saver_ms.model == "gpt-5-mini"
+    assert saver_ms.max_tokens == 1024
+    assert saver_ms.timeout_ms == 45000
+
+    a3_ms = reg.get("a3_live_capture")
+    assert a3_ms.provider == "openai"
+    assert a3_ms.model == "gpt-5-mini"
+    assert a3_ms.max_tokens == 4096
+    assert a3_ms.timeout_ms == 60000
+    assert a3_ms.price_hint == saver_ms.price_hint
 
 
 def test_invalid_schema_missing_model(tmp_path):

--- a/tests/test_modelset_switcher.py
+++ b/tests/test_modelset_switcher.py
@@ -65,3 +65,21 @@ def test_resolver_priority_and_fallback():
     assert reason.startswith("unknown-tenant-default")
     assert explain["model_set_reason"].startswith("unknown-tenant-default")
 
+
+def test_a3_live_capture_resolves_when_requested():
+    reg = ModelSetRegistry()
+    resolver = ModelSetResolver(registry=reg)
+
+    explain = {}
+    ms, reason = resolver.resolve(requested="a3_live_capture", route_explain=explain)
+
+    assert ms.name == "a3_live_capture"
+    assert ms.provider == "openai"
+    assert ms.model == "gpt-5-mini"
+    assert ms.max_tokens == 4096
+    assert ms.timeout_ms == 60000
+    assert reason == "requested"
+    assert explain == {
+        "model_set": "a3_live_capture",
+        "model_set_reason": "requested",
+    }


### PR DESCRIPTION
### Motivation

- Provide a dedicated `a3_live_capture` model set so A3 live-capture runs are not limited by the existing `cost_saver` 1024-token output budget.
- Ensure the new model set uses OpenAI, a larger `max_tokens` and longer `timeout_ms` so operator-supervised captures can complete.
- Add configuration, spec documentation, and automated checks so selection, validation, and provider request mapping are covered by tests.

### Description

- Add a new model set `a3_live_capture` to `service/config/model_sets.yaml` with `provider: openai`, `model: gpt-5-mini`, `max_tokens: 4096`, `timeout_ms: 60000`, and a `price_hint` entry.
- Add a new spec file `/.specs/OUTPUT-DIFF-A3-LIVE-CAPTURE-MODELSET-001.md` and update `/.specs/INDEX.md` to register the spec.
- Extend `tests/test_api_endpoints.py` with tests that verify the `/v1/solve` path can select `a3_live_capture` via environment (`MODEL_SET`) and via request `context` and that provider requests map to the configured `model`, `max_tokens`, and `timeout_ms`.
- Extend `tests/test_modelset_registry.py` and `tests/test_modelset_switcher.py` to assert the registry contains `a3_live_capture` and that the resolver returns it when requested, and update expectations for existing `default` and `cost_saver` sets.
- Add `tests/test_config_validation.py` acceptance test so `scripts/check_env.py` accepts `MODEL_SET=a3_live_capture` when `MODEL_PROVIDER=openai` and `OPENAI_API_KEY` is present.

### Testing

- Ran `pytest tests/test_modelset_registry.py` and the new registry assertions passed.
- Ran `pytest tests/test_modelset_switcher.py` and the resolver test for `a3_live_capture` passed.
- Ran `pytest tests/test_api_endpoints.py` and the two new endpoint tests validating model-set selection and provider request mapping passed.
- Ran `pytest tests/test_config_validation.py` and the `check_env` acceptance test for `a3_live_capture` passed, and the full test suite (`pytest -q`) succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fd7526f4483299e822a57da29d905)