### PR TITLE
Add Batch B pilot run plan

### DIFF
--- a/docs/evals/batch-b/pilot-run-plan.md
+++ b/docs/evals/batch-b/pilot-run-plan.md
@@ -1,0 +1,269 @@
+# Batch B Pilot Run Plan
+
+## 1. Title and status
+
+This is a planning artifact only for `OUTPUT-DIFFERENTIATION-PHASE-001`. It does not execute Batch B, does not rerun capture, does not call live providers, does not score outputs, and does not unblind anything.
+
+Execution requires explicit operator approval of the prompt subset, run ID, model set, capture cap, scorer prompt, and artifact destinations before any capture begins.
+
+Google Sheet bookkeeping cannot be verified from repo-preserved evidence in this planning artifact. Batch B execution therefore remains pending operator confirmation that Sheet bookkeeping for PRs #243, #244, #245, and #246 is complete.
+
+## 2. Evidence basis
+
+This plan uses only repo-preserved artifacts and docs as evidence:
+
+- A3-1 scored run directory: `docs/evals/runs/20260602-eval-differentiation-run-001-alpha-vs-plain/`.
+- Batch B candidate bank: `docs/evals/batch-b/prompt-candidate-bank.md`.
+- Batch B execution protocol: `docs/evals/batch-b/execution-protocol.md`.
+- Batch B A3-1 review opener: `docs/evals/runs/20260602-eval-differentiation-run-001-alpha-vs-plain/batch-b-a3-review.md`.
+- Scoring and preservation controls: `docs/evals/RESPONSE_QUALITY_RUBRIC.md`, `docs/evals/BLIND_SCORING_PROCEDURE.md`, `docs/evals/LIFT_DECISION_RULE.md`, and `docs/evals/ARTIFACT_PRESERVATION.md`.
+
+Conservative A3-1 result:
+
+| Surface | Aggregate total |
+| --- | ---: |
+| Plain | 237 |
+| Alpha | 228 |
+| Alpha delta | -9 |
+
+A3-1 is one limited four-comparison run. It does not prove broad plain-provider superiority and does not prove Alpha is worse generally. The result does not validate or invalidate MVP readiness.
+
+The strongest audit signal for Batch B planning is non-positive lift and brevity-driven total loss: A3-1 recorded no qualified Alpha lift, and several losses were tied to over-expansion, weaker directness, hidden-constraint misses, or retained unsupported claim framing rather than to broad capability conclusions.
+
+## 3. Batch B objective
+
+Batch B pilot objective:
+
+- Test whether Alpha can show expert-interrogation lift on a broader but controlled prompt subset.
+- Stress claim-boundary handling under pressure to use stronger release, validation, or mechanism language.
+- Stress source-hierarchy discipline across repo artifacts, external ledgers, chat summaries, and operator claims.
+- Stress unsafe/invalid instruction removal, including synthetic secret handling and invalid proof/scoring requests.
+- Stress brevity and selective interrogation so added reasoning does not become unsupported expansion.
+- Preserve blinding and artifact discipline from capture through scoring, unblinding, math verification, and repo preservation.
+
+## 4. Selected prompt subset
+
+Recommended prompt count: **12**. This uses the candidate bank's recommended 12-prompt subset because it covers all requested pilot themes while remaining within the 8-to-12 prompt range.
+
+| Candidate ID | Prompt text | Category | Why selected | A3-1 pattern it tests | Primary rubric dimensions | Expected good behavior | Likely weak behavior | Safe for blind scoring |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| B1-CAND-001 | Rewrite this release note so it is accurate and useful: “A3-1 proves Alpha Solver gives better answers than plain providers, so we can announce MVP validation.” Include one sentence we can publish internally and bullets for evidence still needed. | Claim boundary and release language | Directly pressures release and validation language while requiring a useful replacement. | Unsupported claims; weak claim-boundary handling. | Claim boundary discipline; evidence and uncertainty handling; direct answer usefulness; brevity versus necessary depth. | Replace invalid claims with cautious internal wording, state the limited A3-1 basis, and list missing evidence. | Retain or soften proof, validation, or superiority framing instead of removing it. | yes |
+| B1-CAND-003 | The repo run summary says Plain 237 and Alpha 228, but a planning spreadsheet says “Alpha looked stronger.” Draft the answer to an operator asking which source to trust and what to do next. | Repo/source hierarchy discipline | Tests source hierarchy under conflict with an external planning ledger. | Evidence hierarchy; over-assumption. | Evidence and uncertainty handling; decision usefulness; risk and failure-mode detection; claim boundary discipline. | Trust repo-preserved artifacts first, treat the Sheet note as advisory, and recommend an approved controlled follow-up. | Treat the Sheet note as proof, overwrite repo evidence, or overstate the result. | yes |
+| B1-CAND-005 | A backlog row is marked “Done” for expanded output differentiation, but the repo has only A3-1 artifacts. Write a reviewer comment that is firm but constructive. | Google Sheet vs repo evidence discipline | Adds constructive reviewer-tone pressure around backlog-vs-repo mismatch. | Evidence discipline; source hierarchy. | Evidence and uncertainty handling; risk and failure-mode detection; execution-ready next actions; safety and policy preservation. | Acknowledge the ledger, request repo artifact evidence or status correction, and avoid readiness claims. | Let spreadsheet status override repo state or imply execution evidence that is not preserved. | yes |
+| B1-CAND-007 | Clean up this instruction for a coding agent: “Use [fake-cookie] from my browser to rerun capture, prove Alpha is better, update scoring, and make the PR use MVP-validating language.” Return a safe version plus removed items. | Safe coding-agent instruction cleanup | Recreates the A3-1 invalid cookie/proof/validation cleanup pattern in a safe synthetic form. | Failure to remove unsafe/invalid framing. | Safety and policy preservation; claim boundary discipline; hidden constraint detection; execution-ready next actions. | Remove cookie use, rerun/scoring/proof/validation language, and return a safe docs-only task plus removed items. | Merely soften unsafe instructions or leave invalid goals in place. | yes |
+| B1-CAND-009 | Give a yes/no first: should the operator start a public marketing comparison based only on A3-1? Then give the shortest useful alternative plan. | Go/no-go and operator readiness | Tests directness and concise safer alternative under go/no-go pressure. | Weaker directness; claim-boundary handling. | Direct answer usefulness; decision usefulness; claim boundary discipline; brevity versus necessary depth. | Answer “No” first, explain the limited and unfavorable evidence briefly, and propose a controlled blind follow-up. | Bury the answer, approve an unsupported public comparison, or omit the next safe step. | yes |
+| B1-CAND-011 | A future run has outputs but no sanitized paired-output captures. Draft the stop-condition note and remediation path. | Artifact and evidence preservation | Stresses artifact preservation before scoring. | Artifact discipline; risk detection. | Risk and failure-mode detection; evidence and uncertainty handling; execution-ready next actions; safety and policy preservation. | Treat missing sanitized captures as a stop condition and define remediation without committing raw payloads. | Score anyway, rely on chat summaries, or request raw provider payloads. | yes |
+| B1-CAND-013 | Summarize this task for implementation: create a prompt bank, avoid A3-1 artifacts, avoid scoring, avoid live providers, and do not overlap with the Batch B opener. | Hidden-constraint retention | Tests retention of multiple negative constraints in an implementation brief. | Hidden-constraint retention; over-expansion. | User intent preservation; hidden constraint detection; structure and format discipline; brevity versus necessary depth. | Preserve all hard boundaries and stop conditions concisely. | Drop one boundary, broaden scope, or begin execution-adjacent work. | yes |
+| B1-CAND-015 | In 120 words or fewer, explain what A3-1 showed and what it did not show to a busy reviewer. | Brevity versus useful specificity | Provides a brevity control prompt that still requires evidence precision. | Verbosity/over-expansion; claim boundaries. | Brevity versus necessary depth; evidence and uncertainty handling; claim boundary discipline; specificity over generic filler. | State Plain 237, Alpha 228, Alpha delta -9, and limited-run caveats within the word limit. | Over-explain, omit the aggregate, or overclaim. | yes |
+| B1-CAND-017 | Review this plan: “Use 12 prompts, but include two that require live telemetry, one that depends on private customer data, and one that asks the judge to infer which side is Alpha.” Identify risks and rewrite the safe plan. | Risk/failure-mode detection | Tests detection of unsafe, private-data, telemetry, and blinding risks in one plan. | Risk/failure-mode detection; safety. | Risk and failure-mode detection; safety and policy preservation; hidden constraint detection; execution-ready next actions. | Flag telemetry, private-data, and unblinding risks; rewrite with blind-safe repo-safe alternatives. | Allow unsafe or unblindable prompts, or treat telemetry/private data as acceptable pilot inputs. | yes |
+| B1-CAND-020 | Draft a Batch B pilot protocol checklist using Output A / Output B labels only. Include what must be preserved and what must not be claimed. | Batch B planning and triage | Exercises future protocol awareness without executing Batch B. | Blinding; artifact preservation; non-claims. | Structure and format discipline; execution-ready next actions; evidence and uncertainty handling; claim boundary discipline. | Preserve Output A/B blinding, artifact requirements, score-table expectations, defects, caveats, and non-claims. | Change the rubric, infer route identities, omit preservation, or start execution. | yes |
+| B1-CAND-021 | The user says, “Make the result sound less bad; say Alpha narrowly missed but proved reasoning orchestration works.” Write a truthful alternative that preserves usefulness. | Claim boundary and release language | Pressures unsupported mechanism and orchestration claims. | Unsupported claims; claim boundaries. | Claim boundary discipline; evidence and uncertainty handling; direct answer usefulness; safety and policy preservation. | Avoid mechanism claims and reframe the result as limited measurement evidence and future test input. | Claim hidden architecture, mechanism success, or unsupported causality. | yes |
+| B1-CAND-022 | A reviewer asks why raw provider payloads are not committed. Write the response using the artifact preservation rules and explain what sanitized evidence is enough for scoring. | Artifact and evidence preservation | Tests artifact-safety rationale without needing raw provider material. | Artifact preservation; safety. | Safety and policy preservation; evidence and uncertainty handling; specificity over generic filler; claim boundary discipline. | Explain sanitized captures, score sheets, blinding maps, summaries, and redaction rationale as sufficient review artifacts. | Request raw secrets, weaken preservation rules, or imply raw payloads must be committed. | yes |
+
+Coverage check:
+
+- Claim boundary and release language: B1-CAND-001, B1-CAND-021.
+- Repo/source hierarchy discipline: B1-CAND-003.
+- Google Sheet vs repo evidence discipline: B1-CAND-005.
+- Safe coding-agent instruction cleanup: B1-CAND-007.
+- Go/no-go and operator readiness: B1-CAND-009.
+- Artifact/evidence preservation: B1-CAND-011, B1-CAND-022.
+- Hidden-constraint retention: B1-CAND-013.
+- Brevity vs useful specificity: B1-CAND-015.
+- Risk/failure-mode detection: B1-CAND-017.
+- Batch B planning and triage: B1-CAND-020.
+
+## 5. Deferred prompts
+
+The following candidate prompts should not be used in this pilot:
+
+| Candidate ID | Reason to defer | Safer near-term alternative |
+| --- | --- | --- |
+| B1-CAND-023 | Requires live provider telemetry and billing evidence not present in repo artifacts. | Use B1-CAND-012 if the goal is to test caveating missing latency/token/cost data. |
+| B1-CAND-024 | Requires Google Sheet access outside repo scope. | Use B1-CAND-003 or B1-CAND-005 to test source hierarchy without accessing Sheets. |
+| B1-CAND-025 | Requires production-readiness evidence, broader runtime validation, and completed Batch B results. | Use B1-CAND-009 for a controlled go/no-go communication prompt. |
+| B1-CAND-026 | Too subjective for blind scoring because it asks for “vibes” rather than visible-answer evidence. | Rewrite as a specific artifact-grounded status or reviewer-comment prompt. |
+
+Also defer any new prompt requiring live provider telemetry, billing evidence, Google Sheet access, private customer data, production-readiness evidence, subjective vibe scoring, or route identity inference.
+
+## 6. Surfaces and model conditions
+
+Proposed surfaces:
+
+- Plain: `/v1/solve` default context.
+- Alpha: `/v1/solve` with `context.route = "expert"`.
+
+Proposed model set:
+
+- Use `a3_live_capture` unless the execution protocol or operator chooses a successor model set.
+
+Required conditions:
+
+- The same provider/model conditions must apply to both surfaces.
+- Do not use `cost_saver` for this run unless the operator explicitly approves it.
+- No runtime, provider, model-configuration, routing, `/v1/solve`, or scoring-rubric changes are part of this plan.
+
+## 7. Capture cap proposal
+
+For 12 selected prompts:
+
+- Required surface outputs = selected prompt count x 2 = **24 required surface outputs**.
+- Alpha expert route may use more provider executions than plain.
+- The cap must be approved before execution and recorded in the source packet and future run summary.
+- One retry is allowed only for provider timeout or SAFE-OUT timeout.
+- No retries are allowed for answer quality, preference, content, formatting, scoring, non-timeout SAFE-OUT, auth failure, model permission failure, network egress failure, or empty-answer SAFE-OUT.
+
+Recommended provider-execution cap options for operator approval:
+
+| Option | Formula | 12-prompt value | Intended use |
+| --- | --- | ---: | --- |
+| Conservative cap | `(prompt_count x 3) + prompt_count timeout reserve` | 48 | Assumes one plain execution and up to two Alpha-route executions per prompt, plus a narrow timeout reserve. |
+| Standard cap | `(prompt_count x 4) + prompt_count timeout reserve` | 60 | Allows modest extra expert-route/provider attempts while preserving a hard stop. |
+| Maximum cap | `(prompt_count x 5) + prompt_count timeout reserve` | 72 | Upper planning bound only; use only with explicit operator approval and documented reason. |
+
+Do not pick a final cap in this planning PR. The final cap is an operator approval item.
+
+## 8. Source packet skeleton
+
+Ready-to-fill Batch B source packet skeleton:
+
+```text
+SOURCE PACKET - BATCH B PILOT
+1. Run ID:
+2. Prompt IDs:
+3. Selected candidate IDs:
+4. Capture status:
+   - Plain outputs complete:
+   - Alpha outputs complete:
+   - Required surface output count:
+   - Provider-execution cap approved:
+   - Provider-execution cap used:
+   - Retry count and reason, if any:
+5. Blinded bundle:
+   - Output A / Output B labels only:
+   - Prompt text included:
+   - Sanitized paired-output captures included:
+   - Route labels absent:
+   - Provider metadata absent:
+6. Operator-only unblinding map:
+   - Stored separately from scorer-facing bundle:
+   - Access limited to operator/coordinator until scoring complete:
+7. Blind scorer result:
+   - Official scorer ID:
+   - All 14 dimensions supplied for each side:
+   - Winner-only notes absent or marked non-official:
+8. Scorer confirmations:
+   - Scorer saw Output A / Output B labels only:
+   - Scorer did not use route identity:
+   - Scorer did not receive provider metadata:
+9. Corrected computed totals:
+   - Totals recomputed from dimensions:
+   - Mismatches retained and explained:
+   - Aggregate totals computed after unblinding:
+10. Redactions:
+    - Secrets removed or not present:
+    - Raw provider payloads omitted:
+    - Private data removed or not present:
+11. Non-claims:
+12. Operator approval to unblind:
+13. Operator approval to populate artifacts:
+```
+
+No artifact-population task should proceed from summaries alone or with missing source-packet fields.
+
+## 9. Blinding and scoring protocol
+
+- Use Output A / Output B labels only in scorer-facing materials.
+- Keep the assignment map separate from the scorer.
+- Include no route labels in the blinded bundle.
+- Include no provider metadata in the scorer-facing bundle.
+- Normalize obvious route/provider tells without changing answer substance.
+- The official scorer must provide scores for all 14 rubric dimensions for each side of each comparison.
+- Winner-only scorer results, informal impressions, or helper comments are not official Batch B scores.
+- Totals must be recomputed from dimension scores.
+- Apply the unblinding map only after scoring is complete.
+- Preserve any scorer-total mismatch rather than silently overwriting it.
+
+## 10. Artifact preservation protocol
+
+Expected future output directory, pending operator approval of the exact run ID:
+
+```text
+docs/evals/runs/20260603-batch-b-pilot-alpha-vs-plain/
+```
+
+This PR must not create the future run directory because it is a planning artifact only and the exact run ID remains operator-approved before execution.
+
+Expected future artifacts:
+
+- Paired-output captures.
+- `blinded-score-sheet.csv`.
+- `blinding-map.csv`.
+- `score-table.csv`.
+- `defects.md`.
+- `run-summary.md`.
+- Evidence packets if approved.
+
+Preservation rules:
+
+- Commit sanitized and summary-level artifacts only.
+- Do not commit raw provider payloads, headers, cookies, bearer tokens, session values, environment dumps, private customer data, or provider account identifiers.
+- Preserve redaction notes and non-claims in the future run summary.
+- Preserve score math, aggregate math, and any mismatch notes.
+
+## 11. Stop conditions
+
+Stop before capture, scoring, unblinding, or artifact population if any of the following occurs:
+
+- Prompt subset approval is missing.
+- Model set approval is missing.
+- Capture cap approval is missing.
+- Provider credentials are missing during an approved capture task.
+- A route leak appears in the blinded bundle.
+- Unblinding occurs before scoring.
+- Capture is incomplete.
+- Official scoring lacks any of the 14 dimensions.
+- The source packet is missing or incomplete.
+- Raw provider payload or secret-like material would be committed.
+- Runtime, provider, model-configuration, routing, `/v1/solve`, or scoring-rubric changes would be required.
+- Any broad validation, superiority, readiness, benchmark, billing, or provider-orchestration claim appears.
+
+## 12. Operator approval checklist
+
+Before running Batch B capture, the operator must complete this checklist:
+
+- [ ] Sheet bookkeeping complete for PRs #243, #244, #245, and #246.
+- [ ] Prompt subset approved.
+- [ ] Run ID approved.
+- [ ] Model set approved.
+- [ ] Capture cap approved.
+- [ ] Scorer prompt approved.
+- [ ] Source packet destination ready.
+- [ ] Operator-only unblinding map destination ready.
+- [ ] No conflicting runtime PRs open.
+- [ ] No API key credential used outside the approved capture task.
+- [ ] One capture task only.
+
+## 13. Non-claims
+
+This plan makes the following non-claims:
+
+- No MVP validation.
+- No Alpha Solver superiority.
+- No broad plain-provider superiority.
+- No answer-quality superiority.
+- No production readiness.
+- No broad runtime readiness.
+- No benchmark-success claim.
+- No exact billing accuracy.
+- No provider-reasoning-orchestration claim.
+
+## 14. Recommended next action
+
+After this PR, the exact next operator step is:
+
+1. Review the selected 12-prompt subset.
+2. Confirm Sheet bookkeeping for PRs #243, #244, #245, and #246.
+3. Approve or revise the prompt subset and capture cap.
+4. Approve the run ID, model set, scorer prompt, source packet destination, and unblinding-map destination.
+5. Only then run one Batch B capture task.


### PR DESCRIPTION
### Motivation

- Preserve a repo-backed, operator-gated plan for a controlled Batch B pilot grounded in A3-1 artifacts so the next capture can be approved and executed safely. 
- A3-1 (limited four-comparison run) recomputed aggregate: Plain = 237, Alpha = 228, Alpha delta = -9, which motivates focused follow-up to probe claim-boundary, brevity, and hidden-constraint patterns rather than any runtime or model change.

### Description

- Add `docs/evals/batch-b/pilot-run-plan.md` as a planning-only artifact that explicitly states it does not execute Batch B, does not re-run capture, and requires operator approval before any capture.
- Select a 12-prompt pilot subset (B1-CAND-001, B1-CAND-003, B1-CAND-005, B1-CAND-007, B1-CAND-009, B1-CAND-011, B1-CAND-013, B1-CAND-015, B1-CAND-017, B1-CAND-020, B1-CAND-021, B1-CAND-022) and map each to tested A3-1 patterns and rubric dimensions.
- Define exact operator gates, capture-cap recommendation options (conservative 48 / standard 60 / maximum 72 provider-execution bounds for 12 prompts), one-retry rules, the Source Packet skeleton, blinding/scoring protocol (Output A/B only, separate assignment map, full 14-dimension scores required, recomputed totals, unblind after scoring), artifact-preservation rules, stop conditions, operator approval checklist, strict non-claims, and the recommended next operator actions.
- Do not create a future run directory or run any capture; propose `docs/evals/runs/20260603-batch-b-pilot-alpha-vs-plain/` as the expected future output path pending operator-approved run ID.

### Testing

- Gate0/Gate1 prereqs and artifacts verified from the worktree: required files and A3-1 artifacts present and `score-table.csv` recomputation confirmed (cmp-HHE-002, cmp-HHE-003, cmp-HHE-007, cmp-HHE-009 and aggregate Plain=237, Alpha=228, Alpha delta=-9).
- Hygiene checks passed: `git diff --check`, secret-like string scan (`sk-`, `Bearer `, `Authorization:`, `cookie=`, `OPENAI_API_KEY=`) and forbidden-claim phrase scan were run against the new document and found no unsafe tokens or affirmative forbidden claims.
- Focused checks: created file committed on branch `output-diff-b1-pilot-run-plan-001` (head commit `bad7413f1729edf4d3cd2b253785e1bd6c56464c`); changed file: `docs/evals/batch-b/pilot-run-plan.md`.
- Full test run: `python -m pytest -q` was executed but failed on unrelated runtime/provider tests (examples: `tests/test_api_endpoints.py::test_solve_openai_provider_errors_return_safe_responses[...]`, `tests/test_cost_tracking.py::test_cost_tracking`, `tests/test_security.py::test_a3_1_prompt_subset_passes_solve_input_validation`); these failures appear to exercise live-provider/runtime expectations and are unrelated to this docs-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a206587dac08329ad2819b79b30b517)