### PR TITLE
Implement minimal Alpha behavior contract

### DIFF
--- a/alpha_solver_portable.py
+++ b/alpha_solver_portable.py
@@ -35,6 +35,35 @@ Every response MUST include ALL of these sections:
 7. PIPELINE CONFIRMATION — the standard footer line
 
 If you respond without this structure, you have FAILED the protocol.
+
+MINIMAL ALPHA BEHAVIOR CONTRACT
+-------------------------------
+These rules constrain answer wording inside the SOLUTION field and any other
+user-visible prose without changing providers, models, routing, SAFE-OUT, or the
+SolverEnvelope shape:
+
+1. Direct answer first: when the user asks for a yes/no decision, reviewer
+   comment, one-sentence answer, concise rewrite, or next action, begin the
+   SOLUTION with that requested deliverable before explanation.
+2. Mode discipline: obey the requested answer shape before adding structure; do
+   not turn a reviewer comment, short answer, or safe rewrite into a full memo
+   unless the user asks for one or material risk requires compact caveats.
+3. No invented scaffolding: do not invent owners, dates, file paths, commands,
+   metrics, acceptance criteria, implementation status, provider behavior, or
+   operational artifacts that were not supplied or explicitly requested.
+4. Compact caveats: preserve uncertainty, safety, evidence limits, and claim
+   boundaries in the shortest wording that remains truthful.
+5. Safe claim wording: limited pilots may be described as "limited pilot favored
+   Alpha" and "planning evidence, not validation"; do not claim MVP validation,
+   broad Alpha superiority, plain-provider inferiority, production readiness,
+   benchmark success, exact billing accuracy, broad runtime readiness, or
+   provider orchestration.
+6. Evidence boundary: repository evidence controls over planning ledgers; say
+   "repo evidence overrides planning ledger" when the two conflict.
+7. Artifact stop conditions: if required score tables, capture packets, raw
+   provider payloads, or other source artifacts are missing or unavailable,
+   start with "Stop:" and do not reconstruct, rescore, rerun capture, call live
+   providers, update Sheets, or make proof/readiness claims.
 """
 
 from __future__ import annotations
@@ -115,6 +144,57 @@ EXPERT_ROSTER: List[Dict] = [
     {"id": "critical_thinker", "name": "Critical Thinker", "domains": ["logic", "fallacy", "bias", "assumption", "counterargument"], "strength": 0.88},
     {"id": "creative_strategist", "name": "Creative Strategist", "domains": ["innovation", "brainstorm", "alternative", "unconventional", "ideation"], "strength": 0.79},
 ]
+
+MINIMAL_BEHAVIOR_CONTRACT: Dict[str, Tuple[str, ...]] = {
+    "direct_answer_first": (
+        "Begin yes/no decisions, reviewer comments, one-sentence answers, "
+        "concise rewrites, and next actions with the requested deliverable.",
+        "Put necessary rationale or caveats after the direct answer, not before it.",
+    ),
+    "mode_discipline": (
+        "Do not expand a short answer, reviewer comment, or safe rewrite into a "
+        "full memo unless requested or risk requires compact caveats.",
+        "Use protocol/checklist structure only when the user asks for that mode.",
+    ),
+    "no_invented_scaffolding": (
+        "Do not invent owners, dates, file paths, commands, metrics, acceptance "
+        "criteria, implementation status, provider behavior, or operational artifacts.",
+    ),
+    "safe_claim_wording": (
+        "Use limited-evidence wording such as 'limited pilot favored Alpha' and "
+        "'planning evidence, not validation'.",
+        "Do not claim MVP validation, broad superiority, production readiness, "
+        "benchmark success, exact billing accuracy, broad runtime readiness, or "
+        "provider orchestration.",
+    ),
+    "evidence_boundary": (
+        "Repository evidence controls over planning ledgers.",
+        "Use 'repo evidence overrides planning ledger' when sources conflict.",
+    ),
+    "artifact_stop_conditions": (
+        "If required score tables, capture packets, or raw provider payloads are "
+        "missing or unavailable, start with 'Stop:'.",
+        "Do not reconstruct, rescore, rerun capture, call live providers, update "
+        "Sheets, or make proof/readiness claims when stop conditions are present.",
+    ),
+}
+
+
+def minimal_behavior_contract_summary() -> str:
+    """Return the portable prompt/protocol wording for minimal Alpha behavior.
+
+    This helper exposes the active standalone behavior contract for offline
+    tests and prompt-loading workflows. It only summarizes wording constraints;
+    it does not alter provider, model, routing, SAFE-OUT, or /v1/solve behavior.
+    """
+
+    lines = ["Minimal Alpha behavior contract:"]
+    for group, rules in MINIMAL_BEHAVIOR_CONTRACT.items():
+        label = group.replace("_", " ")
+        lines.append(f"- {label}:")
+        lines.extend(f"  - {rule}" for rule in rules)
+    return "\n".join(lines)
+
 
 EXPERT_SELECTION_TEMPLATE: str = """
 Expert Selection Protocol:

--- a/tests/fixtures/alpha_minimal_behavior_cases.json
+++ b/tests/fixtures/alpha_minimal_behavior_cases.json
@@ -202,5 +202,6 @@
         "rescore"
       ]
     }
-  ]
+  ],
+  "portable_prompt_protocol_status": "implemented_in_alpha_solver_portable_prompt_protocol"
 }

--- a/tests/test_alpha_minimal_behavior_contract.py
+++ b/tests/test_alpha_minimal_behavior_contract.py
@@ -142,6 +142,10 @@ def test_fixture_declares_contract_only_not_runtime_enforcement():
 
     assert data["schema_version"] == "alpha-minimal-behavior-contract-fixtures-v1"
     assert data["runtime_enforcement_status"] == "not_implemented_in_this_pr"
+    assert (
+        data["portable_prompt_protocol_status"]
+        == "implemented_in_alpha_solver_portable_prompt_protocol"
+    )
     assert set(data["required_safe_wording"]) == {
         "limited pilot favored Alpha",
         "does not establish broad superiority",
@@ -236,6 +240,35 @@ def test_answer_structure_modes_have_synthetic_examples():
     assert "protocol-checklist" in mode_to_ids["protocol_checklist"]
 
 
+def test_portable_minimal_behavior_summary_is_offline_and_bounded():
+    from alpha_solver_portable import minimal_behavior_contract_summary
+
+    summary = minimal_behavior_contract_summary()
+    normalized = _normalize(summary)
+
+    for phrase in (
+        "direct answer first",
+        "mode discipline",
+        "no invented scaffolding",
+        "safe claim wording",
+        "evidence boundary",
+        "artifact stop conditions",
+        "limited pilot favored alpha",
+        "planning evidence, not validation",
+        "repo evidence overrides planning ledger",
+        "start with 'stop:'",
+    ):
+        assert phrase in normalized
+    for forbidden in (
+        "provider orchestration is implemented",
+        "mvp is validated",
+        "production-ready",
+        "live providers were called",
+        "capture was rerun",
+        "sheets were updated",
+    ):
+        assert forbidden not in normalized
+
 def test_test_plan_contains_required_sections_and_boundaries():
     text = _read(TEST_PLAN)
     normalized = _normalize(text)
@@ -257,8 +290,32 @@ def test_test_plan_contains_required_sections_and_boundaries():
         assert phrase in normalized
 
 
-def test_protected_runtime_contract_file_is_unchanged_by_this_lane():
+def test_portable_contract_contains_minimal_behavior_protocol_wording():
     assert PORTABLE_CONTRACT.exists()
     text = _read(PORTABLE_CONTRACT)
+    normalized = _normalize(text)
+
     for marker in ("LLM_PERSONA_PROTOCOL", "SAFE-OUT", "SolverEnvelope"):
         assert marker in text
+    for phrase in (
+        "MINIMAL ALPHA BEHAVIOR CONTRACT",
+        "Direct answer first",
+        "Mode discipline",
+        "No invented scaffolding",
+        "Compact caveats",
+        "Safe claim wording",
+        "Evidence boundary",
+        "Artifact stop conditions",
+        "MINIMAL_BEHAVIOR_CONTRACT",
+        "minimal_behavior_contract_summary",
+    ):
+        assert phrase in text
+    for phrase in (
+        "without changing providers, models, routing, safe-out, or the solverenvelope shape",
+        "limited pilot favored alpha",
+        "planning evidence, not validation",
+        "repo evidence overrides planning ledger",
+        "start with \"stop:\"",
+        "does not alter provider, model, routing, safe-out, or /v1/solve behavior",
+    ):
+        assert phrase in normalized


### PR DESCRIPTION
### Motivation
- Make the committed offline minimal Alpha behavior contract operational in the portable prompt/protocol surface so offline golden tests can verify the authored wording without changing runtime/provider behavior. 
- Keep the scope narrow to wording, mode discipline, evidence/claim boundaries, and artifact stop conditions as described in the planning artifacts and tests added in PR #262.

### Description
- Inserted explicit minimal behavior wording into the portable prompt/protocol surface by adding a `MINIMAL ALPHA BEHAVIOR CONTRACT` block in `alpha_solver_portable.py` and a machine-friendly `MINIMAL_BEHAVIOR_CONTRACT` + `minimal_behavior_contract_summary()` helper that summarizes the portable contract for offline checks. Files changed: `alpha_solver_portable.py`, `tests/fixtures/alpha_minimal_behavior_cases.json`, `tests/test_alpha_minimal_behavior_contract.py`.
- Key behavior-contract changes: direct-answer-first / mode discipline, no invented scaffolding, compact caveats, safe claim wording (e.g., use "limited pilot favored Alpha" and "planning evidence, not validation"), explicit evidence-boundary wording (`repo evidence overrides planning ledger`), and artifact stop-condition wording (answers start with `Stop:` and explicitly forbid reconstructing/rescoring/rerunning capture/calling live providers/updating Sheets when artifacts are missing).
- Updated the offline fixture to indicate the portable prompt/protocol surface implements the contract (`"portable_prompt_protocol_status": "implemented_in_alpha_solver_portable_prompt_protocol"`) and updated offline tests to assert the new portable summary and required wording is present; no runtime code paths, routing, provider, model, or `/v1/solve` behavior were altered.

### Testing
- Ran focused offline checks: `python -m pytest -q tests/test_alpha_minimal_behavior_contract.py` — PASSED.
- Sanity and static checks: `python -m py_compile alpha_solver_portable.py` — PASSED; `git diff --check` — PASSED; helper check using `minimal_behavior_contract_summary()` — PASSED.
- Full test-suite: `python -m pytest -q` was executed but failed on unrelated existing provider/model and infra expectations (examples: provider model-name expectation tests in `tests/test_api_endpoints.py` expecting `gpt-5` but observed `gpt-5-mini`, cost-tracking artifact presence in `tests/test_cost_tracking.py`, and a security/input-validation expectation in `tests/test_security.py`); these failures are pre-existing and outside the narrow wording changes in this PR.
- Tests not run / intentionally avoided: any live-provider, capture, rescoring, Google Sheets, or Batch C operations were not run because the lane is offline-only and the implementation forbids such actions in this change.

Confirmations
- This PR does not change provider, model, routing, or provider orchestration behavior.
- This PR does not change `/v1/solve` behavior or runtime algorithms.
- This PR did not call live providers, rerun capture, rescore outputs, update Google Sheets, or start Batch C.

Strict non-claims
- This change does not claim MVP validation, broad Alpha superiority, plain-provider inferiority, production readiness, benchmark success, exact billing accuracy, broad runtime readiness, or provider orchestration.

Recommended next action
- Review and merge this narrow portable prompt/protocol implementation to satisfy the offline golden tests, then (if operator-approved) open a separate, narrowly scoped runtime implementation PR that preserves the protected surfaces and adds runtime tests and measurement as a follow-on.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20f97def6483298842256a4177f4be)