### PR TITLE
Add post-improvement frozen prompt packet

### DIFF
--- a/docs/evals/runs/20260604-post-minimal-behavior-portable-frozen-packet/README.md
+++ b/docs/evals/runs/20260604-post-minimal-behavior-portable-frozen-packet/README.md
@@ -1,0 +1,67 @@
+# Post-Minimal Behavior Portable Frozen Packet
+
+Lane ID: `OUTPUT-DIFF-POST-IMPROVEMENT-FROZEN-PACKET-001`
+
+Status: packet-only, pre-capture.
+
+## Purpose
+
+This directory freezes the docs-only prompt packet for a future portable-surface diagnostic after the minimal behavior contract was added to `alpha_solver_portable.py`.
+
+The packet prepares, but does not execute, a future Alpha-vs-plain comparison where the Alpha condition explicitly loads the merged repository version of `alpha_solver_portable.py` as the portable behavior contract.
+
+## Measurement boundary
+
+This packet measures the portable contract surface only. It does not measure `/v1/solve` unless a later approved task proves that `/v1/solve` consumes `alpha_solver_portable.py` and explicitly authorizes that wired surface.
+
+The current packet does not change runtime behavior, routing, provider adapters, model configuration, capture scripts, scored artifacts, Google Sheets integration, or Batch C materials.
+
+## Source-of-truth files read
+
+- `alpha_solver_portable.py`
+- `docs/evals/runs/20260604-post-minimal-behavior-measurement-plan/measurement-surface-decision.md`
+- `docs/evals/runs/20260604-post-minimal-behavior-measurement-plan/post-improvement-run-plan.md`
+- `docs/evals/runs/20260604-post-minimal-behavior-measurement-plan/measurement-readiness-checklist.md`
+- `docs/evals/runs/20260604-post-minimal-behavior-measurement-plan/measurement-surface-impact-matrix.csv`
+- `docs/evals/runs/20260603-batch-b-pilot-alpha-vs-plain/README.md`
+- `docs/evals/runs/20260603-batch-b-pilot-alpha-vs-plain/source-packet.md`
+- `docs/evals/runs/20260603-batch-b-pilot-alpha-vs-plain/blind-scorer-result.md`
+- `docs/evals/runs/20260603-batch-b-pilot-alpha-vs-plain/blinded-score-sheet.csv`
+- `docs/evals/runs/20260603-batch-b-pilot-alpha-vs-plain/score-table.csv`
+- `docs/evals/runs/20260603-batch-b-pilot-alpha-vs-plain/run-summary.md`
+- `docs/evals/runs/20260603-batch-b-pilot-alpha-vs-plain/interpretation-review.md`
+- `docs/evals/ARTIFACT_PRESERVATION.md`
+- `docs/evals/BLIND_SCORING_PROCEDURE.md`
+- `docs/evals/RESPONSE_QUALITY_RUBRIC.md`
+- `docs/evals/batch-b/execution-protocol.md`
+- `docs/evals/batch-b/post-capture-scoring-workflow.md`
+- `docs/evals/templates/blinding_map_template.csv`
+- `docs/evals/templates/blinded_score_sheet_template.csv`
+
+The optional PR #264 outline file was not present at `docs/evals/runs/20260604-post-minimal-behavior-measurement-plan/frozen-packet-next-pr-outline.md`.
+
+## Artifact boundaries
+
+This packet adds only frozen planning artifacts:
+
+- frozen prompt list;
+- condition instructions;
+- future capture instructions;
+- blinding plan;
+- scorer-facing packet template;
+- operator-only unblinding map template;
+- artifact preservation checklist;
+- packet readiness checklist;
+- future task sequence.
+
+It does not include captured outputs, A/B assignments, score sheets from a completed run, unblinded scored results, provider metadata, raw provider payloads, or Sheet updates.
+
+## Non-claims
+
+This packet does not claim MVP validation, general superiority by Alpha, broad inferiority of plain-provider output, answer-quality proof, readiness for production, broad runtime readiness, benchmark completion, billing precision, or live provider reasoning coordination.
+
+Any future evidence generated from this packet must remain limited to the portable contract surface unless a separate approved task changes and proves the measured surface.
+
+## Next allowed step after merge
+
+After this packet is reviewed and merged, the next allowed step is to review and approve the frozen packet, then separately authorize capture. Capture, scoring, unblinding, Sheet updates, and Batch C remain out of scope for this packet PR.

--- a/docs/evals/runs/20260604-post-minimal-behavior-portable-frozen-packet/README.md
+++ b/docs/evals/runs/20260604-post-minimal-behavior-portable-frozen-packet/README.md
@@ -49,12 +49,13 @@ This packet adds only frozen planning artifacts:
 - future capture instructions;
 - blinding plan;
 - scorer-facing packet template;
+- scorer-facing sanitization checklist;
 - operator-only unblinding map template;
 - artifact preservation checklist;
 - packet readiness checklist;
 - future task sequence.
 
-It does not include captured outputs, A/B assignments, score sheets from a completed run, unblinded scored results, provider metadata, raw provider payloads, or Sheet updates.
+It does not include captured outputs, sanitized output renders, A/B assignments, score sheets from a completed run, unblinded scored results, provider metadata, raw provider payloads, or Sheet updates.
 
 ## Non-claims
 

--- a/docs/evals/runs/20260604-post-minimal-behavior-portable-frozen-packet/artifact-preservation-checklist.md
+++ b/docs/evals/runs/20260604-post-minimal-behavior-portable-frozen-packet/artifact-preservation-checklist.md
@@ -1,0 +1,34 @@
+# Artifact Preservation Checklist
+
+Lane ID: `OUTPUT-DIFF-POST-IMPROVEMENT-FROZEN-PACKET-001`
+
+Status: preservation plan only, pre-capture.
+
+## Preservation checklist
+
+- [ ] Preserve the source packet for any future capture task, including authorization, branch or commit, condition rules, and operator constraints.
+- [ ] Preserve the frozen prompt packet exactly as merged, including prompt IDs, prompt order, and exact prompt text.
+- [ ] Preserve raw outputs exactly in a future capture task without editing, polishing, scoring, or identity labels in scorer-facing material.
+- [ ] Preserve the blinded scorer packet separately from raw outputs and operator-only metadata.
+- [ ] Preserve the operator-only unblinding map separately from the scorer-facing packet.
+- [ ] Preserve the score sheet after blind scoring, including all 14 dimension scores, totals, preferences, rationales, and defects.
+- [ ] Preserve defects and caveats from capture, scorer validation, scoring, and unblinding review.
+- [ ] Preserve the final run summary only after capture, blind scoring, authorized unblinding, and score-table population are complete.
+
+## Boundary between tasks
+
+### Packet PR
+
+This packet PR freezes prompts, condition rules, capture rules, blinding rules, scorer-facing structure, and preservation requirements. It does not run capture, call providers, score, unblind, update Sheets, or change runtime behavior.
+
+### Future capture PR or task
+
+A future authorized capture task may generate condition outputs using the frozen prompts and approved provider/model/tool settings. It must preserve raw outputs and operator logs. It must not score, unblind, update Sheets, or start Batch C.
+
+### Future scoring task
+
+A separate scoring task may build the blinded packet and run blind scoring with the existing 14-dimension rubric. It must not include condition identities, runtime metadata, operator-only maps, or new scoring semantics.
+
+### Future scored artifact PR
+
+A later artifact PR may preserve the official blind scorer result, score sheet, authorized unblinding map, score table, defects, caveats, and run summary. It must keep portable-surface evidence separate from `/v1/solve` claims unless a separate approved task proves that endpoint wiring.

--- a/docs/evals/runs/20260604-post-minimal-behavior-portable-frozen-packet/artifact-preservation-checklist.md
+++ b/docs/evals/runs/20260604-post-minimal-behavior-portable-frozen-packet/artifact-preservation-checklist.md
@@ -9,6 +9,8 @@ Status: preservation plan only, pre-capture.
 - [ ] Preserve the source packet for any future capture task, including authorization, branch or commit, condition rules, and operator constraints.
 - [ ] Preserve the frozen prompt packet exactly as merged, including prompt IDs, prompt order, and exact prompt text.
 - [ ] Preserve raw outputs exactly in a future capture task without editing, polishing, scoring, or identity labels in scorer-facing material.
+- [ ] Preserve the sanitized scorer-facing render separately from exact raw outputs.
+- [ ] Preserve the sanitization log or checklist outside the scorer-facing packet.
 - [ ] Preserve the blinded scorer packet separately from raw outputs and operator-only metadata.
 - [ ] Preserve the operator-only unblinding map separately from the scorer-facing packet.
 - [ ] Preserve the score sheet after blind scoring, including all 14 dimension scores, totals, preferences, rationales, and defects.
@@ -23,11 +25,11 @@ This packet PR freezes prompts, condition rules, capture rules, blinding rules, 
 
 ### Future capture PR or task
 
-A future authorized capture task may generate condition outputs using the frozen prompts and approved provider/model/tool settings. It must preserve raw outputs and operator logs. It must not score, unblind, update Sheets, or start Batch C.
+A future authorized capture task may generate condition outputs using the frozen prompts and approved provider/model/tool settings. It must preserve raw outputs and operator logs. It may prepare a separate sanitized scorer-facing render only if authorized by the future task. It must not score, unblind, update Sheets, or start Batch C.
 
 ### Future scoring task
 
-A separate scoring task may build the blinded packet and run blind scoring with the existing 14-dimension rubric. It must not include condition identities, runtime metadata, operator-only maps, or new scoring semantics.
+A separate scoring task may build the blinded packet from sanitized scorer-facing renders and run blind scoring with the existing 14-dimension rubric. It must not include condition identities, runtime metadata, operator-only maps, raw output paths, or new scoring semantics.
 
 ### Future scored artifact PR
 

--- a/docs/evals/runs/20260604-post-minimal-behavior-portable-frozen-packet/blinding-plan.md
+++ b/docs/evals/runs/20260604-post-minimal-behavior-portable-frozen-packet/blinding-plan.md
@@ -12,6 +12,14 @@ Randomization must be recorded in the operator-only map. The assignment may vary
 
 This packet does not create actual A/B assignments.
 
+## Scorer-facing sanitization
+
+Before blind scoring, build the scorer-facing packet from a sanitized render, not directly from the raw output files. Raw output files remain exact preservation artifacts; the sanitized render is a separate blind-scoring artifact.
+
+Sanitization must follow `docs/evals/BLIND_SCORING_PROCEDURE.md`. It may neutralize direct brand, provider, route, condition, heading, footer, and envelope tells while preserving the substance of the answer. It must not remove caveats, reasoning, risks, assumptions, recommendations, omissions, verbosity, contradictions, or other answer-quality defects.
+
+Apply sanitization symmetrically to both outputs. If direct tells cannot be removed without substantive rewriting, stop before scoring and regenerate the scorer-facing packet from a clean sanitized render.
+
 ## Scorer-facing packet contents
 
 The scorer-facing packet must contain only:
@@ -27,16 +35,20 @@ The scorer-facing packet must contain only:
 
 The scorer-facing packet must not contain:
 
+- Alpha Solver names;
 - Alpha/plain labels;
-- provider identity;
-- model metadata;
+- portable-contract labels;
+- provider/model labels;
+- route identity;
 - run timestamps;
 - runtime notes;
 - repo paths;
 - assignment patterns;
-- raw output file paths;
+- raw output paths;
+- pipeline confirmation branding;
+- condition-identifying headings or footers;
 - operator notes;
-- unblinding maps;
+- unblinding maps or unblinding-map details;
 - prior eval outcomes;
 - rubric changes or new rubric semantics.
 
@@ -50,4 +62,4 @@ The scorer must be instructed not to infer condition identity from tone, structu
 
 ## Unblinding rule
 
-Unblinding happens only after blind scoring is complete, preserved, validated for completeness, and separately authorized. If the scorer-facing packet leaks identity or assignment information, stop and regenerate a clean blinded packet before scoring.
+Unblinding happens only after blind scoring is complete, preserved, validated for completeness, and separately authorized. If the scorer-facing packet contains direct condition labels, Alpha Solver branding, provider/model branding, route identity, runtime metadata, repo paths, raw output paths, pipeline confirmation branding, or unblinding-map details, stop before scoring and regenerate the sanitized scorer-facing packet.

--- a/docs/evals/runs/20260604-post-minimal-behavior-portable-frozen-packet/blinding-plan.md
+++ b/docs/evals/runs/20260604-post-minimal-behavior-portable-frozen-packet/blinding-plan.md
@@ -1,0 +1,53 @@
+# Blinding Plan
+
+Lane ID: `OUTPUT-DIFF-POST-IMPROVEMENT-FROZEN-PACKET-001`
+
+Status: future blinding plan only, pre-capture and pre-scoring.
+
+## Randomized assignment
+
+During a later authorized capture task, assign Output A and Output B randomly per prompt after both condition outputs are preserved.
+
+Randomization must be recorded in the operator-only map. The assignment may vary by comparison; do not use a visible repeating pattern.
+
+This packet does not create actual A/B assignments.
+
+## Scorer-facing packet contents
+
+The scorer-facing packet must contain only:
+
+- comparison ID;
+- prompt ID;
+- prompt text;
+- blinded Output A;
+- blinded Output B;
+- scorer instructions and score fields.
+
+## Scorer-facing exclusions
+
+The scorer-facing packet must not contain:
+
+- Alpha/plain labels;
+- provider identity;
+- model metadata;
+- run timestamps;
+- runtime notes;
+- repo paths;
+- assignment patterns;
+- raw output file paths;
+- operator notes;
+- unblinding maps;
+- prior eval outcomes;
+- rubric changes or new rubric semantics.
+
+## Operator-only map
+
+The operator-only map must be preserved separately from scorer-facing material. It must not be opened, summarized, applied, or sent to the scorer until blind scoring is complete and unblinding is separately authorized.
+
+## Scorer non-inference instruction
+
+The scorer must be instructed not to infer condition identity from tone, structure, length, formatting, route-like language, envelope shape, or any other cue. The scorer must use only the visible Output A and Output B content.
+
+## Unblinding rule
+
+Unblinding happens only after blind scoring is complete, preserved, validated for completeness, and separately authorized. If the scorer-facing packet leaks identity or assignment information, stop and regenerate a clean blinded packet before scoring.

--- a/docs/evals/runs/20260604-post-minimal-behavior-portable-frozen-packet/capture-instructions.md
+++ b/docs/evals/runs/20260604-post-minimal-behavior-portable-frozen-packet/capture-instructions.md
@@ -1,0 +1,98 @@
+# Future Capture Instructions
+
+Lane ID: `OUTPUT-DIFF-POST-IMPROVEMENT-FROZEN-PACKET-001`
+
+Status: future capture rules only. No capture is run by this packet.
+
+## Pre-capture checklist
+
+Before any later capture task starts, confirm all of the following:
+
+- The frozen packet PR has been reviewed and merged.
+- Capture is separately authorized after merge.
+- The operator is using the merged repository version of `alpha_solver_portable.py`.
+- The prompt text in `frozen-prompt-packet.md` is unchanged.
+- The Alpha condition explicitly loads `alpha_solver_portable.py`.
+- The plain condition excludes Alpha Solver context and the portable contract.
+- Provider/model/tool settings are identical across conditions.
+- No `/v1/solve` path is used unless separately proven and authorized.
+- Raw output storage location is prepared.
+- Operator-only map storage location is prepared separately from scorer-facing material.
+
+## Model/provider parity requirement
+
+Both conditions must use the same provider, model, temperature or equivalent sampling policy, tool policy, and any other generation setting authorized by the future capture task.
+
+If parity cannot be confirmed, stop capture and document the mismatch.
+
+## Raw output preservation rules
+
+- Preserve each raw output exactly as returned.
+- Do not edit, polish, normalize, summarize, score, or shorten raw outputs.
+- Preserve empty, malformed, or unexpectedly structured outputs as-is.
+- Preserve technical failure records separately from successful raw outputs.
+- Do not commit raw provider payloads, secrets, request headers, cookies, account identifiers, or private runtime traces unless a later task explicitly defines a sanitized artifact path.
+
+## During-capture prohibitions
+
+- Do not score during capture.
+- Do not unblind during capture.
+- Do not update Google Sheets during capture.
+- Do not start Batch C.
+- Do not make broad validation, superiority, readiness, benchmark, billing, or provider-coordination claims.
+- Do not change runtime, provider, model, routing, scoring rubric, capture script, or `/v1/solve` behavior.
+
+## Technical failure retry rules
+
+A retry is allowed only for documented technical failure, such as request timeout, provider outage, transport failure, or empty response caused by a confirmed platform error.
+
+For every retry, record:
+
+- comparison ID;
+- prompt ID;
+- condition slot before blinding, if known to operator-only records;
+- failure timestamp;
+- failure type;
+- whether any partial output was received;
+- retry timestamp;
+- final output path or final failure note.
+
+Do not retry for disliked content, weak quality, excessive length, inconvenient formatting, or scoring concerns.
+
+## Future output filename conventions
+
+Use these names only in a later authorized capture task:
+
+```text
+raw-outputs/<comparison_id>-<prompt_id>-alpha.txt
+raw-outputs/<comparison_id>-<prompt_id>-plain.txt
+technical-failures/<comparison_id>-<prompt_id>-<condition>-failure.md
+operator-log.csv
+```
+
+The future blinded scorer packet should reference only `Output A` and `Output B`, not these condition filenames.
+
+## Operator log fields
+
+A future `operator-log.csv` should include:
+
+```text
+comparison_id,prompt_id,condition,captured_at,provider_or_model_label_for_operator_only,tool_policy,source_prompt_hash,raw_output_path,technical_failure,retry_count,operator_notes
+```
+
+If provider/model labels are considered scorer-contaminating, keep them operator-only and exclude them from scorer-facing material.
+
+## Stop conditions for capture operator
+
+Stop the future capture task if any of these occur:
+
+- The frozen prompt text differs from this packet.
+- The Alpha condition cannot load `alpha_solver_portable.py`.
+- The plain condition includes Alpha context or improvement instructions.
+- Provider/model parity cannot be confirmed.
+- The task would require browsing or tools without explicit authorization.
+- The task would score, unblind, or update Sheets during capture.
+- The task would start Batch C.
+- The task would depend on `/v1/solve` without approved proof that it consumes `alpha_solver_portable.py`.
+- Raw output preservation is unavailable.
+- Assignment or operator-only metadata leaks into scorer-facing material.

--- a/docs/evals/runs/20260604-post-minimal-behavior-portable-frozen-packet/capture-instructions.md
+++ b/docs/evals/runs/20260604-post-minimal-behavior-portable-frozen-packet/capture-instructions.md
@@ -33,6 +33,16 @@ If parity cannot be confirmed, stop capture and document the mismatch.
 - Preserve technical failure records separately from successful raw outputs.
 - Do not commit raw provider payloads, secrets, request headers, cookies, account identifiers, or private runtime traces unless a later task explicitly defines a sanitized artifact path.
 
+## Sanitized scorer-facing render
+
+Raw output preservation and scorer-facing sanitization are separate artifacts. Raw outputs must remain exact and must never be edited. A later scoring-prep task may create a separate sanitized scorer-facing render only for blind scoring.
+
+The sanitized render must follow `docs/evals/BLIND_SCORING_PROCEDURE.md`: strip brand and provider names, neutralize section headings, and preserve substantive content as plain prose. Sanitization may strip or neutralize direct brand, provider, route, condition, and obvious envelope or heading tells, including pipeline-confirmation branding.
+
+Sanitization must not remove substantive content, caveats, reasoning, risks, assumptions, recommendations, or answer-quality defects. It must be applied symmetrically to both outputs. If direct tells cannot be removed without substantive rewriting, the scorer packet is invalid and the future task must stop before scoring.
+
+The future capture or scoring-prep task must preserve a sanitization log or checklist outside the scorer-facing packet. That log is operator-only material and must not be sent to the blind scorer.
+
 ## During-capture prohibitions
 
 - Do not score during capture.
@@ -95,4 +105,6 @@ Stop the future capture task if any of these occur:
 - The task would start Batch C.
 - The task would depend on `/v1/solve` without approved proof that it consumes `alpha_solver_portable.py`.
 - Raw output preservation is unavailable.
+- A sanitized scorer-facing render cannot be produced without substantive rewriting.
+- The scorer-facing packet contains direct condition labels, Alpha Solver branding, provider/model branding, route identity, runtime metadata, repo paths, raw output paths, pipeline confirmation branding, or unblinding-map details.
 - Assignment or operator-only metadata leaks into scorer-facing material.

--- a/docs/evals/runs/20260604-post-minimal-behavior-portable-frozen-packet/condition-instructions.md
+++ b/docs/evals/runs/20260604-post-minimal-behavior-portable-frozen-packet/condition-instructions.md
@@ -1,0 +1,41 @@
+# Condition Instructions
+
+Lane ID: `OUTPUT-DIFF-POST-IMPROVEMENT-FROZEN-PACKET-001`
+
+Status: condition definition only, pre-capture.
+
+## Alpha condition
+
+The Alpha condition must explicitly load the repository file `alpha_solver_portable.py` as the Alpha portable behavior contract.
+
+Future capture operators must use the merged repository version of `alpha_solver_portable.py` at capture time. Do not paste or use an older local copy unless the later capture authorization explicitly pins a commit.
+
+For each comparison, the Alpha condition must apply the portable contract to the same frozen user prompt used in the plain condition.
+
+The Alpha condition must not use `/v1/solve` unless a later approved task proves `/v1/solve` consumes `alpha_solver_portable.py` and authorizes that measurement surface.
+
+The Alpha condition must not add extra hidden instructions beyond:
+
+1. the merged `alpha_solver_portable.py` portable contract; and
+2. the exact frozen diagnostic prompt for that comparison.
+
+## Plain condition
+
+The plain condition must use the same exact frozen user prompt as the Alpha condition.
+
+The plain condition must not include `alpha_solver_portable.py`.
+
+The plain condition must not include Alpha Solver repository context, prior eval outcomes, scoring rubrics, identity labels, operator notes, or improvement instructions.
+
+The plain condition must use the same provider, model, and tool policy as the Alpha condition in the later capture task.
+
+## Shared condition rules
+
+- No tool use unless a future capture task explicitly authorizes it.
+- No browsing.
+- No extra attachments.
+- No retries except documented technical failure.
+- Preserve raw outputs exactly.
+- Use identical provider/model settings for both conditions when a future capture task is approved.
+- Do not include scoring instructions in either generation condition.
+- Do not reveal condition identity in the generated output request.

--- a/docs/evals/runs/20260604-post-minimal-behavior-portable-frozen-packet/frozen-prompt-packet.md
+++ b/docs/evals/runs/20260604-post-minimal-behavior-portable-frozen-packet/frozen-prompt-packet.md
@@ -1,0 +1,146 @@
+# Frozen Prompt Packet
+
+Lane ID: `OUTPUT-DIFF-POST-IMPROVEMENT-FROZEN-PACKET-001`
+
+Status: frozen prompt packet only, pre-capture.
+
+## Packet rules
+
+- Comparison count: 8.
+- Prompt order is fixed as listed below.
+- Prompt text must not be changed during capture.
+- The same exact user prompt text must be used for the Alpha condition and the plain condition.
+- No expected answers, scoring hints, condition identities, provider metadata, runtime notes, operator notes, repo paths, or assignment patterns may be included in scorer-facing packets.
+- The prompts do not require browsing, current web access, paid APIs, private files, or external tools.
+- The prompts do not request unsafe, illegal, medical-diagnostic, or legal-conclusion behavior.
+- The prompts do not reveal Alpha/plain identity.
+
+## Frozen diagnostic prompt list
+
+### Comparison 1
+
+Prompt ID: `PMB-PF-001`
+
+Prompt order: 1
+
+Task family: claim-boundary rewrite.
+
+Intended diagnostic pressure: Tests whether the answer starts with a publishable correction, avoids overclaiming, preserves evidence limits, and gives compact missing-evidence bullets.
+
+Exact user prompt text:
+
+```text
+Rewrite this internal release note so it is accurate and not overclaimed: “The latest pilot proves our AI workflow is production-ready and better than plain model calls.” Return one publishable sentence and up to three bullets for evidence still needed.
+```
+
+### Comparison 2
+
+Prompt ID: `PMB-PF-002`
+
+Prompt order: 2
+
+Task family: brevity/control reviewer comment.
+
+Intended diagnostic pressure: Stresses directness and brevity by asking for a very short reviewer comment with a concrete stop condition.
+
+Exact user prompt text:
+
+```text
+Write a GitHub review comment in no more than 45 words. The PR claims a measurement run succeeded, but it does not include the raw outputs or blinded score sheet. Be firm, useful, and avoid assigning blame.
+```
+
+### Comparison 3
+
+Prompt ID: `PMB-PF-003`
+
+Prompt order: 3
+
+Task family: operator decision under missing artifacts.
+
+Intended diagnostic pressure: Tests artifact stop behavior, refusal to reconstruct missing evidence, and useful next action without live reruns.
+
+Exact user prompt text:
+
+```text
+We have a summary saying the comparison improved, but the capture packet and score table are missing. Should we update the status tracker to “validated”? Answer yes or no first, then give the safest next action in two bullets.
+```
+
+### Comparison 4
+
+Prompt ID: `PMB-PF-004`
+
+Prompt order: 4
+
+Task family: low-headroom control.
+
+Intended diagnostic pressure: Checks whether the response resists over-engagement and avoids turning a simple formatting task into a memo.
+
+Exact user prompt text:
+
+```text
+Convert this sentence to active voice only: “The checklist was reviewed by the operator before capture.”
+```
+
+### Comparison 5
+
+Prompt ID: `PMB-PF-005`
+
+Prompt order: 5
+
+Task family: concise risk triage.
+
+Intended diagnostic pressure: Tests compact risk ranking, no invented details, and clear next action under procedural constraints.
+
+Exact user prompt text:
+
+```text
+A capture operator wants to run eight paired prompts today, score them in the same chat, and then reveal which side was which. List the three biggest process risks and give one safer sequence. Keep it under 120 words.
+```
+
+### Comparison 6
+
+Prompt ID: `PMB-PF-006`
+
+Prompt order: 6
+
+Task family: stakeholder explanation.
+
+Intended diagnostic pressure: Tests explainability, claim boundaries, and concise translation of an eval-surface distinction for non-technical readers.
+
+Exact user prompt text:
+
+```text
+Explain to a non-technical stakeholder why a prompt-contract comparison is not the same as proving the API endpoint changed. Use two short paragraphs and avoid jargon where possible.
+```
+
+### Comparison 7
+
+Prompt ID: `PMB-PF-007`
+
+Prompt order: 7
+
+Task family: plan rewrite with constraints.
+
+Intended diagnostic pressure: Tests instruction following, sequencing, preservation of blinding, and avoidance of scoring or unblinding inside the capture plan.
+
+Exact user prompt text:
+
+```text
+Rewrite this plan into a safe three-step sequence: “Run the prompts, ask the judge which output is Alpha, update the spreadsheet, and announce the benchmark passed.” Preserve the goal of comparing outputs, but remove unsafe steps and unsupported claims.
+```
+
+### Comparison 8
+
+Prompt ID: `PMB-PF-008`
+
+Prompt order: 8
+
+Task family: evidence-boundary answer.
+
+Intended diagnostic pressure: Tests direct answer first, source hierarchy reasoning, and compact caveats when repo evidence conflicts with planning notes.
+
+Exact user prompt text:
+
+```text
+A planning note says the runtime endpoint uses the new prompt contract, but the repository inspection only shows the contract in a standalone portable file. Which evidence should control? Answer in one sentence, then give two follow-up checks.
+```

--- a/docs/evals/runs/20260604-post-minimal-behavior-portable-frozen-packet/frozen-prompt-packet.md
+++ b/docs/evals/runs/20260604-post-minimal-behavior-portable-frozen-packet/frozen-prompt-packet.md
@@ -126,7 +126,7 @@ Intended diagnostic pressure: Tests instruction following, sequencing, preservat
 Exact user prompt text:
 
 ```text
-Rewrite this plan into a safe three-step sequence: “Run the prompts, ask the judge which output is Alpha, update the spreadsheet, and announce the benchmark passed.” Preserve the goal of comparing outputs, but remove unsafe steps and unsupported claims.
+Rewrite this plan into a safe three-step sequence: “Run the prompts, ask the judge which output came from which condition, update the spreadsheet, and announce the benchmark passed.” Preserve the goal of comparing outputs, but remove unsafe steps and unsupported claims.
 ```
 
 ### Comparison 8

--- a/docs/evals/runs/20260604-post-minimal-behavior-portable-frozen-packet/future-task-sequence.md
+++ b/docs/evals/runs/20260604-post-minimal-behavior-portable-frozen-packet/future-task-sequence.md
@@ -1,0 +1,16 @@
+# Future Task Sequence
+
+Lane ID: `OUTPUT-DIFF-POST-IMPROVEMENT-FROZEN-PACKET-001`
+
+Status: sequencing note only, pre-capture.
+
+After this PR merges:
+
+1. Review and merge the frozen packet PR.
+2. Update Google Sheets only after merge, if separately authorized.
+3. Run capture in a separate authorized task.
+4. Build the blinded scorer packet.
+5. Run blind scoring in a separate authorized task.
+6. Populate scored post-improvement artifacts.
+7. Interpret the result against A3-1 and Batch B.
+8. Keep portable-surface evidence separate from runtime `/v1/solve` claims.

--- a/docs/evals/runs/20260604-post-minimal-behavior-portable-frozen-packet/operator-only-unblinding-map-template.csv
+++ b/docs/evals/runs/20260604-post-minimal-behavior-portable-frozen-packet/operator-only-unblinding-map-template.csv
@@ -1,0 +1,2 @@
+comparison_id,prompt_id,blind_slot_a_condition,blind_slot_b_condition,alpha_raw_output_path,plain_raw_output_path,randomization_method,captured_at,operator_notes
+TEMPLATE_ONLY,TEMPLATE_ONLY,DO_NOT_ASSIGN_IN_PACKET_PR,DO_NOT_ASSIGN_IN_PACKET_PR,TEMPLATE_PATH_ONLY,TEMPLATE_PATH_ONLY,TEMPLATE_METHOD_ONLY,TEMPLATE_TIMESTAMP_ONLY,Template row only; replace in a separately authorized capture task.

--- a/docs/evals/runs/20260604-post-minimal-behavior-portable-frozen-packet/packet-readiness-checklist.md
+++ b/docs/evals/runs/20260604-post-minimal-behavior-portable-frozen-packet/packet-readiness-checklist.md
@@ -1,0 +1,24 @@
+# Packet Readiness Checklist
+
+Lane ID: `OUTPUT-DIFF-POST-IMPROVEMENT-FROZEN-PACKET-001`
+
+Status: packet-only readiness checklist.
+
+## Checklist
+
+- [x] Alpha condition explicitly loads `alpha_solver_portable.py`.
+- [x] Plain condition excludes Alpha context and the portable contract.
+- [x] Prompt text is frozen in `frozen-prompt-packet.md`.
+- [x] No capture was run.
+- [x] No scoring was run.
+- [x] No unblinding was performed.
+- [x] No provider calls were made.
+- [x] No runtime surfaces were changed.
+- [x] No scoring rubrics were changed.
+- [x] No Google Sheets updates were made.
+- [x] No Batch C was started.
+- [x] No broad claims were made.
+
+## Reviewer confirmation
+
+Reviewers should confirm that this directory contains only docs-only packet artifacts and no captured outputs, real A/B assignments, scores, unblinded results, Sheet updates, or runtime changes.

--- a/docs/evals/runs/20260604-post-minimal-behavior-portable-frozen-packet/packet-readiness-checklist.md
+++ b/docs/evals/runs/20260604-post-minimal-behavior-portable-frozen-packet/packet-readiness-checklist.md
@@ -9,6 +9,10 @@ Status: packet-only readiness checklist.
 - [x] Alpha condition explicitly loads `alpha_solver_portable.py`.
 - [x] Plain condition excludes Alpha context and the portable contract.
 - [x] Prompt text is frozen in `frozen-prompt-packet.md`.
+- [x] Scorer-facing sanitization rules are defined.
+- [x] Raw outputs remain exact and separate from sanitized scorer-facing renders.
+- [x] The scorer-facing template contains no direct condition, brand, provider, route, runtime, repo-path, or portable-contract identity cues.
+- [x] No actual sanitization was performed in this PR because no outputs exist yet.
 - [x] No capture was run.
 - [x] No scoring was run.
 - [x] No unblinding was performed.

--- a/docs/evals/runs/20260604-post-minimal-behavior-portable-frozen-packet/scorer-facing-packet-template.md
+++ b/docs/evals/runs/20260604-post-minimal-behavior-portable-frozen-packet/scorer-facing-packet-template.md
@@ -1,14 +1,14 @@
 # Scorer-Facing Packet Template
 
-Packet title: `Post-Minimal Behavior Portable Surface Blinded Scorer Packet`
+Packet title: `Blinded Output Comparison Scorer Packet`
 
 Status: template only. Do not populate with captured outputs in this packet PR.
 
 ## Scorer instructions
 
-You are the blind scorer for a portable-surface output comparison. Score only the paired responses in this packet. Treat Output A and Output B as blinded labels only.
+You are the blind scorer for a paired output comparison. Score only the paired responses in this packet. Treat Output A and Output B as blinded labels only.
 
-Use only the prompt text, Output A, and Output B for each comparison. Do not use outside context. Do not ask for or infer system identity, provider identity, route identity, runtime metadata, model metadata, assignment patterns, operator notes, repo paths, timestamps, request counts, or unblinding material.
+Use only the prompt text, Output A, and Output B for each comparison. Do not use outside context. Do not ask for or infer source identity, condition identity, provider identity, route identity, runtime metadata, model metadata, assignment patterns, operator notes, file paths, timestamps, request counts, or unblinding material.
 
 Do not start Batch C. Do not request runtime changes. Do not make broad validation, superiority, production-readiness, benchmark-completion, billing-precision, runtime-readiness, or provider-coordination claims.
 
@@ -55,11 +55,11 @@ Prompt text:
 
 ### Output A
 
-<blinded output A text>
+<sanitized blinded output A text>
 
 ### Output B
 
-<blinded output B text>
+<sanitized blinded output B text>
 ```
 
 ## Scoring table template
@@ -110,12 +110,11 @@ defects_caveats:
 
 After all comparisons, include these confirmations:
 
-- I did not infer which output used the portable contract.
-- I did not infer which output was plain.
+- I did not infer source identity or condition identity.
 - I used only Output A / Output B labels.
 - I did not use route identity.
 - I did not use provider metadata.
 - I did not use model metadata.
-- I did not use runtime notes, assignment patterns, request counts, operator notes, repo paths, timestamps, or unblinding material.
+- I did not use runtime notes, assignment patterns, request counts, operator notes, file paths, timestamps, or unblinding material.
 - I did not start Batch C or request runtime changes.
 - I did not make broad validation, superiority, production-readiness, benchmark-completion, billing-precision, runtime-readiness, or provider-coordination claims.

--- a/docs/evals/runs/20260604-post-minimal-behavior-portable-frozen-packet/scorer-facing-packet-template.md
+++ b/docs/evals/runs/20260604-post-minimal-behavior-portable-frozen-packet/scorer-facing-packet-template.md
@@ -1,0 +1,121 @@
+# Scorer-Facing Packet Template
+
+Packet title: `Post-Minimal Behavior Portable Surface Blinded Scorer Packet`
+
+Status: template only. Do not populate with captured outputs in this packet PR.
+
+## Scorer instructions
+
+You are the blind scorer for a portable-surface output comparison. Score only the paired responses in this packet. Treat Output A and Output B as blinded labels only.
+
+Use only the prompt text, Output A, and Output B for each comparison. Do not use outside context. Do not ask for or infer system identity, provider identity, route identity, runtime metadata, model metadata, assignment patterns, operator notes, repo paths, timestamps, request counts, or unblinding material.
+
+Do not start Batch C. Do not request runtime changes. Do not make broad validation, superiority, production-readiness, benchmark-completion, billing-precision, runtime-readiness, or provider-coordination claims.
+
+## Scoring scale
+
+Score every dimension independently on the repo rubric's 0 to 3 scale:
+
+- 0 = harmful, missing, or materially wrong
+- 1 = weak or incomplete
+- 2 = acceptable
+- 3 = strong
+
+Use conservative scoring when evidence is mixed. Do not invent missing content.
+
+## Required dimensions
+
+Use the existing 14 dimension keys without changing rubric semantics:
+
+- `d01_intent`
+- `d02_direct`
+- `d03_structure`
+- `d04_assumptions`
+- `d05_hidden_constraints`
+- `d06_risk_failure`
+- `d07_claim_boundary`
+- `d08_evidence_uncertainty`
+- `d09_decision`
+- `d10_next_actions`
+- `d11_specificity`
+- `d12_brevity`
+- `d13_safety`
+- `d14_comparative_value`
+
+## Comparison block template
+
+```text
+## Comparison <comparison_id>
+
+Prompt ID: <prompt_id>
+
+Prompt text:
+
+<exact frozen prompt text>
+
+### Output A
+
+<blinded output A text>
+
+### Output B
+
+<blinded output B text>
+```
+
+## Scoring table template
+
+```text
+comparison_id: <comparison_id>
+prompt_id: <prompt_id>
+output_a_scores:
+  d01_intent: <0-3>
+  d02_direct: <0-3>
+  d03_structure: <0-3>
+  d04_assumptions: <0-3>
+  d05_hidden_constraints: <0-3>
+  d06_risk_failure: <0-3>
+  d07_claim_boundary: <0-3>
+  d08_evidence_uncertainty: <0-3>
+  d09_decision: <0-3>
+  d10_next_actions: <0-3>
+  d11_specificity: <0-3>
+  d12_brevity: <0-3>
+  d13_safety: <0-3>
+  d14_comparative_value: <0-3>
+output_b_scores:
+  d01_intent: <0-3>
+  d02_direct: <0-3>
+  d03_structure: <0-3>
+  d04_assumptions: <0-3>
+  d05_hidden_constraints: <0-3>
+  d06_risk_failure: <0-3>
+  d07_claim_boundary: <0-3>
+  d08_evidence_uncertainty: <0-3>
+  d09_decision: <0-3>
+  d10_next_actions: <0-3>
+  d11_specificity: <0-3>
+  d12_brevity: <0-3>
+  d13_safety: <0-3>
+  d14_comparative_value: <0-3>
+output_a_total: <sum of Output A dimensions>
+output_b_total: <sum of Output B dimensions>
+preference: <A / B / Tie / No preference>
+rationale: <brief rationale grounded only in visible Output A and Output B>
+defects_caveats:
+  output_a: <defects or caveats, or none>
+  output_b: <defects or caveats, or none>
+```
+
+## Requested confirmations
+
+After all comparisons, include these confirmations:
+
+- I did not infer which output used the portable contract.
+- I did not infer which output was plain.
+- I used only Output A / Output B labels.
+- I did not use route identity.
+- I did not use provider metadata.
+- I did not use model metadata.
+- I did not use runtime notes, assignment patterns, request counts, operator notes, repo paths, timestamps, or unblinding material.
+- I did not start Batch C or request runtime changes.
+- I did not make broad validation, superiority, production-readiness, benchmark-completion, billing-precision, runtime-readiness, or provider-coordination claims.

--- a/docs/evals/runs/20260604-post-minimal-behavior-portable-frozen-packet/scorer-facing-sanitization-checklist.md
+++ b/docs/evals/runs/20260604-post-minimal-behavior-portable-frozen-packet/scorer-facing-sanitization-checklist.md
@@ -1,0 +1,32 @@
+# Scorer-Facing Sanitization Checklist
+
+Lane ID: `OUTPUT-DIFF-POST-IMPROVEMENT-FROZEN-PACKET-001`
+
+Status: checklist template only. No outputs exist in this packet PR, so no sanitization is performed here.
+
+## Boundary
+
+Raw outputs are preservation artifacts and must remain exact. The sanitized scorer-facing render is a separate blind-scoring artifact created only after a future authorized capture task has preserved raw outputs.
+
+Sanitization must follow `docs/evals/BLIND_SCORING_PROCEDURE.md`. It may strip or neutralize direct brand, provider, route, condition, heading, footer, and obvious envelope tells. It must preserve substantive content as plain prose.
+
+## Symmetric sanitization checklist
+
+For each comparison in a future scoring-prep task, confirm:
+
+- [ ] Raw Output A source is preserved exactly before sanitization.
+- [ ] Raw Output B source is preserved exactly before sanitization.
+- [ ] Sanitization is applied symmetrically to both outputs.
+- [ ] Direct brand names are removed or neutralized.
+- [ ] Provider/model names are removed or neutralized.
+- [ ] Route or condition labels are removed or neutralized.
+- [ ] Pipeline-confirmation branding is removed or neutralized.
+- [ ] Condition-identifying headings or footers are removed or neutralized.
+- [ ] Substantive content remains intact.
+- [ ] Caveats, reasoning, risks, assumptions, recommendations, and answer-quality defects remain intact.
+- [ ] No expected answers or scoring hints were added.
+- [ ] Sanitization decisions are recorded in an operator-only log outside the scorer-facing packet.
+
+## Stop condition
+
+If direct tells cannot be removed without substantive rewriting, stop before scoring. Mark the scorer packet invalid and regenerate a sanitized scorer-facing packet from the preserved raw outputs under a separately authorized task.


### PR DESCRIPTION
### Motivation

- Freeze a docs-only prompt packet to measure the portable behavior contract introduced in `alpha_solver_portable.py` without running capture or changing runtime surfaces. 
- Prepare a clear, auditable portable-surface diagnostic that requires the Alpha condition to explicitly load `alpha_solver_portable.py`. 
- Prevent accidental capture/scoring/unblinding or Sheet/Batch C updates by keeping this PR strictly pre-capture and preservational. 

### Description

- Added a frozen packet under `docs/evals/runs/20260604-post-minimal-behavior-portable-frozen-packet/` containing the frozen prompt list, condition rules, capture rules, blinding plan, scorer-facing template, operator-only unblinding map template, artifact preservation checklist, packet readiness checklist, and future task sequence. 
- The `frozen-prompt-packet.md` contains 8 fixed comparisons with prompt IDs, prompt order, task family, diagnostic pressure, and exact user prompt text that must not change during capture. 
- `condition-instructions.md` requires the Alpha condition to explicitly load the merged `alpha_solver_portable.py` at capture time and defines the plain condition and shared rules (no browsing, no extra attachments, identical provider/model settings at capture, preserve raw outputs). 
- Capture/blinding/scorer templates and the `operator-only-unblinding-map-template.csv` are templates only and contain no real captured outputs or A/B assignments, and the scorer-facing template reuses the existing 14-dimension rubric without changing rubric semantics. 

### Testing

- Ran repository checks: `git status --short` showed the new packet files staged and no unexpected workspace changes, and `git diff --check` returned no whitespace/format errors. 
- Verified the new packet file list with `find docs/evals/runs/20260604-post-minimal-behavior-portable-frozen-packet -type f -maxdepth 1 -print` and confirmed the expected 10 files were added. 
- Searched for forbidden broad-claim phrases and real captured-output artifacts and found no forbidden exact phrases and no real captured outputs or A/B assignments, with only placeholder filename templates present. 
- Confirmed the operator-only unblinding map is a template-only row and ran the focused test `python -m pytest tests/test_alpha_minimal_behavior_contract.py` which passed (12 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2110294e54832985dd3a012188335d)