### PR TITLE
Refine Alpha brevity and control contract

### DIFF
--- a/alpha_solver_portable.py
+++ b/alpha_solver_portable.py
@@ -25,16 +25,35 @@ STRICT OUTPUT REQUIREMENTS
 ⚠️  CRITICAL: Do NOT skip the envelope structure.
 ⚠️  CRITICAL: Do NOT omit confidence scores, routing, or pipeline confirmation.
 
-Every response MUST include ALL of these sections:
+Every response MUST include ALL of these labels:
 1. SOLUTION — the actual answer
 2. CONFIDENCE — percentage (e.g., "85%")
 3. ROUTE — basic|structured|constrained with rationale
-4. EXPERT TEAM — 5 selected experts with their insights
+4. EXPERT TEAM — default full mode: 5 selected experts with their insights
 5. SAFE-OUT STATE — route taken and phases
-6. SHORTLIST — 2+ alternative answers with confidence scores
+6. SHORTLIST — default full mode: 2+ alternative answers with confidence scores
 7. PIPELINE CONFIRMATION — the standard footer line
 
-If you respond without this structure, you have FAILED the protocol.
+COMPACT-ENVELOPE EXCEPTION FOR LOW-HEADROOM TASKS
+--------------------------------------------------
+For simple rewrites, formatting, direct extraction, short confirmations,
+reviewer-facing edits, one-step admin tasks, or other low-headroom prompts, keep
+the SolverEnvelope labels but make non-essential sections minimal:
+- SOLUTION must contain the direct answer first.
+- CONFIDENCE, ROUTE, and SAFE-OUT STATE should be one concise line each.
+- EXPERT TEAM may be collapsed to "not expanded for low-headroom task" or one
+  compact line; do not force 5 full expert insights.
+- SHORTLIST may be reduced to "not applicable / no useful alternatives" when no
+  useful alternatives exist; do not force 2 expanded alternatives.
+- Do not add broad risk analysis, multi-pass narration, or a full memo unless a
+  task-relevant risk materially changes the user's next action or protects
+  artifact integrity.
+
+This compact-envelope exception overrides the default EXPERT TEAM and SHORTLIST
+counts for low-headroom tasks, but it does not remove the envelope labels unless
+the user or a future protocol explicitly permits label omission. If you respond
+without the required labels or an allowed compact section, you have FAILED the
+protocol.
 
 MINIMAL ALPHA BEHAVIOR CONTRACT
 -------------------------------
@@ -170,6 +189,16 @@ MINIMAL_BEHAVIOR_CONTRACT: Dict[str, Tuple[str, ...]] = {
         "reviewer-facing edits, or one-step admin tasks, keep the answer short.",
         "Do not force heavy solver framing, multi-pass analysis, or broad risk "
         "sections onto low-headroom tasks.",
+    ),
+    "compact_envelope_mode": (
+        "For low-headroom tasks, keep SolverEnvelope labels but make "
+        "non-essential sections minimal.",
+        "SOLUTION contains the direct answer first; CONFIDENCE, ROUTE, and "
+        "SAFE-OUT STATE stay concise.",
+        "EXPERT TEAM may say 'not expanded for low-headroom task' or use one "
+        "compact line instead of 5 full expert insights.",
+        "SHORTLIST may say 'not applicable / no useful alternatives' instead "
+        "of forcing 2 expanded alternatives when none help.",
     ),
     "mode_discipline": (
         "Do not expand a short answer, reviewer comment, or safe rewrite into a "

--- a/alpha_solver_portable.py
+++ b/alpha_solver_portable.py
@@ -40,27 +40,39 @@ MINIMAL ALPHA BEHAVIOR CONTRACT
 -------------------------------
 These rules constrain answer wording inside the SOLUTION field and any other
 user-visible prose without changing providers, models, routing, SAFE-OUT, or the
-SolverEnvelope shape:
+SolverEnvelope shape. The envelope is a portable prompt structure, not a reason
+to over-expand simple user requests; keep each section as short as the task
+allows.
 
 1. Direct answer first: when the user asks for a yes/no decision, reviewer
-   comment, one-sentence answer, concise rewrite, or next action, begin the
-   SOLUTION with that requested deliverable before explanation.
-2. Mode discipline: obey the requested answer shape before adding structure; do
+   comment, one-sentence answer, concise rewrite, direct extraction, short
+   confirmation, or next action, begin the SOLUTION with that requested
+   deliverable before explanation. Do not open with process labels unless they
+   materially help the user.
+2. Low-headroom restraint: for simple rewrites, formatting, direct extraction,
+   short confirmations, reviewer-facing edits, or one-step admin tasks, keep the
+   answer short and do not force heavy solver framing, multi-pass analysis, or
+   broad risk sections.
+3. Mode discipline: obey the requested answer shape before adding structure; do
    not turn a reviewer comment, short answer, or safe rewrite into a full memo
-   unless the user asks for one or material risk requires compact caveats.
-3. No invented scaffolding: do not invent owners, dates, file paths, commands,
+   unless the user asks for one or a task-relevant risk requires a compact caveat.
+4. No invented scaffolding: do not invent owners, dates, file paths, commands,
    metrics, acceptance criteria, implementation status, provider behavior, or
    operational artifacts that were not supplied or explicitly requested.
-4. Compact caveats: preserve uncertainty, safety, evidence limits, and claim
-   boundaries in the shortest wording that remains truthful.
-5. Safe claim wording: limited pilots may be described as "limited pilot favored
+5. Compact caveats: preserve uncertainty, safety, evidence limits, and claim
+   boundaries in the shortest wording that remains truthful; do not turn every
+   uncertainty into a long risk block.
+6. Task-relevant risk: include risk or failure-mode analysis only when it
+   materially changes the user's next action or protects artifact integrity;
+   suppress generic risk boilerplate.
+7. Safe claim wording: limited pilots may be described as "limited pilot favored
    Alpha" and "planning evidence, not validation"; do not claim MVP validation,
    broad Alpha superiority, plain-provider inferiority, production readiness,
    benchmark success, exact billing accuracy, broad runtime readiness, or
    provider orchestration.
-6. Evidence boundary: repository evidence controls over planning ledgers; say
+8. Evidence boundary: repository evidence controls over planning ledgers; say
    "repo evidence overrides planning ledger" when the two conflict.
-7. Artifact stop conditions: if required score tables, capture packets, raw
+9. Artifact stop conditions: if required score tables, capture packets, raw
    provider payloads, or other source artifacts are missing or unavailable,
    start with "Stop:" and do not reconstruct, rescore, rerun capture, call live
    providers, update Sheets, or make proof/readiness claims.
@@ -148,17 +160,35 @@ EXPERT_ROSTER: List[Dict] = [
 MINIMAL_BEHAVIOR_CONTRACT: Dict[str, Tuple[str, ...]] = {
     "direct_answer_first": (
         "Begin yes/no decisions, reviewer comments, one-sentence answers, "
-        "concise rewrites, and next actions with the requested deliverable.",
+        "concise rewrites, direct extractions, short confirmations, and next "
+        "actions with the requested deliverable.",
         "Put necessary rationale or caveats after the direct answer, not before it.",
+        "Do not open with process labels unless they materially help the user.",
+    ),
+    "low_headroom_restraint": (
+        "For simple rewrites, formatting, direct extraction, short confirmations, "
+        "reviewer-facing edits, or one-step admin tasks, keep the answer short.",
+        "Do not force heavy solver framing, multi-pass analysis, or broad risk "
+        "sections onto low-headroom tasks.",
     ),
     "mode_discipline": (
         "Do not expand a short answer, reviewer comment, or safe rewrite into a "
-        "full memo unless requested or risk requires compact caveats.",
+        "full memo unless requested or task-relevant risk requires a compact caveat.",
         "Use protocol/checklist structure only when the user asks for that mode.",
     ),
     "no_invented_scaffolding": (
         "Do not invent owners, dates, file paths, commands, metrics, acceptance "
         "criteria, implementation status, provider behavior, or operational artifacts.",
+    ),
+    "compact_caveats": (
+        "Preserve uncertainty, safety, evidence limits, and claim boundaries in "
+        "the shortest wording that remains truthful.",
+        "Do not turn every uncertainty into a long risk block.",
+    ),
+    "task_relevant_risk": (
+        "Include risk or failure-mode analysis only when it materially changes "
+        "the user's next action or protects artifact integrity.",
+        "Suppress generic risk boilerplate.",
     ),
     "safe_claim_wording": (
         "Use limited-evidence wording such as 'limited pilot favored Alpha' and "
@@ -188,7 +218,11 @@ def minimal_behavior_contract_summary() -> str:
     it does not alter provider, model, routing, SAFE-OUT, or /v1/solve behavior.
     """
 
-    lines = ["Minimal Alpha behavior contract:"]
+    lines = [
+        "Minimal Alpha behavior contract:",
+        "Boundary: wording constraints only; does not alter provider, model, "
+        "routing, SAFE-OUT, or /v1/solve behavior.",
+    ]
     for group, rules in MINIMAL_BEHAVIOR_CONTRACT.items():
         label = group.replace("_", " ")
         lines.append(f"- {label}:")

--- a/alpha_solver_portable.py
+++ b/alpha_solver_portable.py
@@ -49,7 +49,8 @@ the SolverEnvelope labels but make non-essential sections minimal:
   task-relevant risk materially changes the user's next action or protects
   artifact integrity.
 
-This compact-envelope exception overrides the default EXPERT TEAM and SHORTLIST
+The default EXPERT TEAM and SHORTLIST counts apply only outside
+compact-envelope mode. This compact-envelope exception overrides those default
 counts for low-headroom tasks, but it does not remove the envelope labels unless
 the user or a future protocol explicitly permits label omission. If you respond
 without the required labels or an allowed compact section, you have FAILED the

--- a/docs/evals/runs/20260604-alpha-brevity-control-refinement/README.md
+++ b/docs/evals/runs/20260604-alpha-brevity-control-refinement/README.md
@@ -22,6 +22,7 @@ PR #270 interpreted the post-improvement result as Alpha 314 / Plain 303 / Alpha
 
 - Strengthened answer-first wording for direct answers, concise rewrites, direct extractions, short confirmations, and next actions.
 - Added low-headroom restraint wording for simple rewrites, formatting, reviewer-facing edits, and one-step admin tasks.
+- Resolved the envelope-vs-low-headroom conflict by adding a compact-envelope / minimal-section mode: low-headroom tasks keep SolverEnvelope labels while allowing non-essential sections such as EXPERT TEAM and SHORTLIST to stay minimal.
 - Added compact caveat and task-relevant risk wording to suppress generic risk boilerplate while preserving truthful uncertainty and claim boundaries.
 - Kept artifact stop conditions, evidence-boundary behavior, and safe claim wording intact.
 
@@ -32,7 +33,7 @@ PR #270 interpreted the post-improvement result as Alpha 314 / Plain 303 / Alpha
 - No unblinding.
 - No Google Sheets update.
 - No Batch C materials.
-- No runtime API, provider adapter, model configuration, routing, or `/v1/solve` behavior changes.
+- No runtime API, provider adapter, model configuration, routing, or `/v1/solve` behavior changes; compact-envelope mode is portable prompt-contract wording only.
 - No provider calls.
 - No scored artifacts, raw outputs, sanitized scorer-facing packets, or operator maps changed.
 

--- a/docs/evals/runs/20260604-alpha-brevity-control-refinement/README.md
+++ b/docs/evals/runs/20260604-alpha-brevity-control-refinement/README.md
@@ -1,0 +1,45 @@
+# Alpha Brevity Control Refinement
+
+Lane ID: `ALPHA-BREVITY-CONTROL-REFINEMENT-001`
+
+## Objective
+
+Refine the minimal portable Alpha behavior contract so it remains useful on higher-headroom tasks while reducing unnecessary expansion on concise, reviewer-facing, low-headroom, or answer-first prompts.
+
+## Source interpretation
+
+This lane consumes PR #270's final decision: `Refine current contract`.
+
+PR #270 interpreted the post-improvement result as Alpha 314 / Plain 303 / Alpha-minus-plain +11, with Alpha wins 5, Plain wins 1, and 2 ties. The interpretation classified the result as `B. Mixed improvement with brevity/control concern`, supporting a narrow contract refinement rather than broad runtime, production, or superiority claims.
+
+## Files changed
+
+- `alpha_solver_portable.py`
+- `tests/test_alpha_minimal_behavior_contract.py`
+- `docs/evals/runs/20260604-alpha-brevity-control-refinement/README.md`
+
+## What changed
+
+- Strengthened answer-first wording for direct answers, concise rewrites, direct extractions, short confirmations, and next actions.
+- Added low-headroom restraint wording for simple rewrites, formatting, reviewer-facing edits, and one-step admin tasks.
+- Added compact caveat and task-relevant risk wording to suppress generic risk boilerplate while preserving truthful uncertainty and claim boundaries.
+- Kept artifact stop conditions, evidence-boundary behavior, and safe claim wording intact.
+
+## What did not change
+
+- No capture run.
+- No scoring or rescoring.
+- No unblinding.
+- No Google Sheets update.
+- No Batch C materials.
+- No runtime API, provider adapter, model configuration, routing, or `/v1/solve` behavior changes.
+- No provider calls.
+- No scored artifacts, raw outputs, sanitized scorer-facing packets, or operator maps changed.
+
+## Non-claims
+
+This refinement does not claim MVP validation, broad Alpha superiority, broad plain-provider inferiority, production readiness, benchmark success, exact billing accuracy, runtime readiness, provider orchestration, self-healing, adaptive learning, self-optimization, autonomous optimization, `/v1/solve` behavior, runtime API behavior, provider behavior, or model routing behavior.
+
+## Recommended future validation step
+
+Recommended next validation lane: run a narrow offline portable-surface validation for answer-first, brevity/control, compact caveats, and preservation of claim-boundary and artifact-discipline behavior before considering any broader measurement lane.

--- a/docs/evals/runs/20260604-alpha-brevity-control-refinement/README.md
+++ b/docs/evals/runs/20260604-alpha-brevity-control-refinement/README.md
@@ -22,7 +22,7 @@ PR #270 interpreted the post-improvement result as Alpha 314 / Plain 303 / Alpha
 
 - Strengthened answer-first wording for direct answers, concise rewrites, direct extractions, short confirmations, and next actions.
 - Added low-headroom restraint wording for simple rewrites, formatting, reviewer-facing edits, and one-step admin tasks.
-- Resolved the envelope-vs-low-headroom conflict by adding a compact-envelope / minimal-section mode: low-headroom tasks keep SolverEnvelope labels while allowing non-essential sections such as EXPERT TEAM and SHORTLIST to stay minimal.
+- Resolved the envelope-vs-low-headroom conflict by adding a compact-envelope / minimal-section mode: low-headroom tasks keep SolverEnvelope labels while allowing non-essential sections such as EXPERT TEAM and SHORTLIST to stay minimal, with default expanded counts applying only outside compact-envelope mode.
 - Added compact caveat and task-relevant risk wording to suppress generic risk boilerplate while preserving truthful uncertainty and claim boundaries.
 - Kept artifact stop conditions, evidence-boundary behavior, and safe claim wording intact.
 

--- a/tests/test_alpha_minimal_behavior_contract.py
+++ b/tests/test_alpha_minimal_behavior_contract.py
@@ -250,6 +250,7 @@ def test_portable_minimal_behavior_summary_is_offline_and_bounded():
         "direct answer first",
         "mode discipline",
         "low headroom restraint",
+        "compact envelope mode",
         "no invented scaffolding",
         "compact caveats",
         "task relevant risk",
@@ -266,6 +267,10 @@ def test_portable_minimal_behavior_summary_is_offline_and_bounded():
         "do not open with process labels",
         "keep the answer short",
         "do not force heavy solver framing",
+        "keep solverenvelope labels",
+        "non-essential sections minimal",
+        "not expanded for low-headroom task",
+        "not applicable / no useful alternatives",
         "do not turn every uncertainty into a long risk block",
         "suppress generic risk boilerplate",
     ):
@@ -320,6 +325,49 @@ def test_portable_summary_requires_answer_first_low_headroom_and_compact_caveats
         assert phrase in normalized
 
 
+
+def test_portable_contract_resolves_envelope_low_headroom_conflict():
+    text = _read(PORTABLE_CONTRACT)
+    normalized = _normalize(text)
+
+    assert "compact-envelope exception for low-headroom tasks" in normalized
+    assert "keep the solverenvelope labels" in normalized
+    assert "make non-essential sections minimal" in normalized
+    assert "solution must contain the direct answer first" in normalized
+    assert "overrides the default expert team and shortlist counts" in normalized
+    assert "does not remove the envelope labels" in normalized
+
+
+def test_low_headroom_envelope_sections_may_be_minimal_not_expanded():
+    text = _read(PORTABLE_CONTRACT)
+    normalized = _normalize(text)
+
+    assert "confidence, route, and safe-out state should be one concise line each" in normalized
+    assert "not expanded for low-headroom task" in normalized
+    assert "do not force 5 full expert insights" in normalized
+    assert "not applicable / no useful alternatives" in normalized
+    assert "do not force 2 expanded alternatives" in normalized
+    assert "do not add broad risk analysis" in normalized
+    assert "multi-pass narration" in normalized
+    assert "full memo" in normalized
+
+
+def test_portable_summary_exposes_compact_envelope_exception():
+    from alpha_solver_portable import minimal_behavior_contract_summary
+
+    normalized = _normalize(minimal_behavior_contract_summary())
+
+    for phrase in (
+        "compact envelope mode",
+        "keep solverenvelope labels",
+        "non-essential sections minimal",
+        "solution contains the direct answer first",
+        "instead of 5 full expert insights",
+        "not applicable / no useful alternatives",
+        "instead of forcing 2 expanded alternatives",
+    ):
+        assert phrase in normalized
+
 def test_portable_summary_preserves_broad_non_claims():
     from alpha_solver_portable import minimal_behavior_contract_summary
 
@@ -369,6 +417,7 @@ def test_portable_contract_contains_minimal_behavior_protocol_wording():
         "Direct answer first",
         "Mode discipline",
         "Low-headroom restraint",
+        "COMPACT-ENVELOPE EXCEPTION",
         "No invented scaffolding",
         "Compact caveats",
         "Task-relevant risk",

--- a/tests/test_alpha_minimal_behavior_contract.py
+++ b/tests/test_alpha_minimal_behavior_contract.py
@@ -103,6 +103,20 @@ def _normalize(text: str) -> str:
     return re.sub(r"\s+", " ", text).strip().lower()
 
 
+def _compact_envelope_block() -> str:
+    text = _read(PORTABLE_CONTRACT)
+    start = text.index("COMPACT-ENVELOPE EXCEPTION FOR LOW-HEADROOM TASKS")
+    end = text.index("MINIMAL ALPHA BEHAVIOR CONTRACT")
+    return text[start:end]
+
+
+def _strict_output_requirements_block() -> str:
+    text = _read(PORTABLE_CONTRACT)
+    start = text.index("STRICT OUTPUT REQUIREMENTS")
+    end = text.index("COMPACT-ENVELOPE EXCEPTION FOR LOW-HEADROOM TASKS")
+    return text[start:end]
+
+
 def _sentences(text: str) -> list[str]:
     return [part for part in re.split(r"(?<=[.!?])\s+", text.strip()) if part]
 
@@ -325,31 +339,43 @@ def test_portable_summary_requires_answer_first_low_headroom_and_compact_caveats
         assert phrase in normalized
 
 
-
 def test_portable_contract_resolves_envelope_low_headroom_conflict():
     text = _read(PORTABLE_CONTRACT)
-    normalized = _normalize(text)
+    strict_block = _normalize(_strict_output_requirements_block())
+    compact_block = _normalize(_compact_envelope_block())
 
-    assert "compact-envelope exception for low-headroom tasks" in normalized
-    assert "keep the solverenvelope labels" in normalized
-    assert "make non-essential sections minimal" in normalized
-    assert "solution must contain the direct answer first" in normalized
-    assert "overrides the default expert team and shortlist counts" in normalized
-    assert "does not remove the envelope labels" in normalized
+    assert "every response must include all of these labels" in strict_block
+    assert "every response must include all of these sections" not in strict_block
+    assert "default full mode: 5 selected experts" in strict_block
+    assert "default full mode: 2+ alternative answers" in strict_block
+    assert text.index("default full mode: 5 selected experts") < text.index(
+        "COMPACT-ENVELOPE EXCEPTION FOR LOW-HEADROOM TASKS"
+    )
+    assert text.index("COMPACT-ENVELOPE EXCEPTION FOR LOW-HEADROOM TASKS") < text.index(
+        "MINIMAL ALPHA BEHAVIOR CONTRACT"
+    )
+    assert "default expert team and shortlist counts apply only outside" in compact_block
+    assert "overrides those default counts for low-headroom tasks" in compact_block
+    assert "does not remove the envelope labels" in compact_block
 
 
 def test_low_headroom_envelope_sections_may_be_minimal_not_expanded():
-    text = _read(PORTABLE_CONTRACT)
-    normalized = _normalize(text)
+    compact_block = _normalize(_compact_envelope_block())
 
-    assert "confidence, route, and safe-out state should be one concise line each" in normalized
-    assert "not expanded for low-headroom task" in normalized
-    assert "do not force 5 full expert insights" in normalized
-    assert "not applicable / no useful alternatives" in normalized
-    assert "do not force 2 expanded alternatives" in normalized
-    assert "do not add broad risk analysis" in normalized
-    assert "multi-pass narration" in normalized
-    assert "full memo" in normalized
+    assert "keep the solverenvelope labels" in compact_block
+    assert "make non-essential sections minimal" in compact_block
+    assert "solution must contain the direct answer first" in compact_block
+    assert (
+        "confidence, route, and safe-out state should be one concise line each"
+        in compact_block
+    )
+    assert "not expanded for low-headroom task" in compact_block
+    assert "do not force 5 full expert insights" in compact_block
+    assert "not applicable / no useful alternatives" in compact_block
+    assert "do not force 2 expanded alternatives" in compact_block
+    assert "do not add broad risk analysis" in compact_block
+    assert "multi-pass narration" in compact_block
+    assert "full memo" in compact_block
 
 
 def test_portable_summary_exposes_compact_envelope_exception():
@@ -368,6 +394,7 @@ def test_portable_summary_exposes_compact_envelope_exception():
     ):
         assert phrase in normalized
 
+
 def test_portable_summary_preserves_broad_non_claims():
     from alpha_solver_portable import minimal_behavior_contract_summary
 
@@ -383,6 +410,7 @@ def test_portable_summary_preserves_broad_non_claims():
         "provider orchestration",
     ):
         assert phrase in normalized
+
 
 def test_test_plan_contains_required_sections_and_boundaries():
     text = _read(TEST_PLAN)

--- a/tests/test_alpha_minimal_behavior_contract.py
+++ b/tests/test_alpha_minimal_behavior_contract.py
@@ -249,7 +249,10 @@ def test_portable_minimal_behavior_summary_is_offline_and_bounded():
     for phrase in (
         "direct answer first",
         "mode discipline",
+        "low headroom restraint",
         "no invented scaffolding",
+        "compact caveats",
+        "task relevant risk",
         "safe claim wording",
         "evidence boundary",
         "artifact stop conditions",
@@ -257,6 +260,14 @@ def test_portable_minimal_behavior_summary_is_offline_and_bounded():
         "planning evidence, not validation",
         "repo evidence overrides planning ledger",
         "start with 'stop:'",
+        "direct extractions",
+        "short confirmations",
+        "requested deliverable",
+        "do not open with process labels",
+        "keep the answer short",
+        "do not force heavy solver framing",
+        "do not turn every uncertainty into a long risk block",
+        "suppress generic risk boilerplate",
     ):
         assert phrase in normalized
     for forbidden in (
@@ -268,6 +279,62 @@ def test_portable_minimal_behavior_summary_is_offline_and_bounded():
         "sheets were updated",
     ):
         assert forbidden not in normalized
+
+
+def test_portable_summary_preserves_boundary_and_no_runtime_implication():
+    from alpha_solver_portable import minimal_behavior_contract_summary
+
+    summary = minimal_behavior_contract_summary()
+    normalized = _normalize(summary)
+
+    assert "minimal alpha behavior contract" in normalized
+    assert "does not alter provider, model, routing, safe-out, or /v1/solve behavior" in normalized
+    for phrase in (
+        "provider orchestration is implemented",
+        "routing behavior changed",
+        "model routing behavior changed",
+        "runtime api behavior changed",
+        "provider behavior changed",
+        "production readiness is confirmed",
+    ):
+        assert phrase not in normalized
+
+
+def test_portable_summary_requires_answer_first_low_headroom_and_compact_caveats():
+    from alpha_solver_portable import minimal_behavior_contract_summary
+
+    normalized = _normalize(minimal_behavior_contract_summary())
+
+    for phrase in (
+        "begin yes/no decisions",
+        "requested deliverable",
+        "put necessary rationale or caveats after the direct answer",
+        "do not open with process labels unless they materially help the user",
+        "for simple rewrites, formatting, direct extraction",
+        "one-step admin tasks",
+        "keep the answer short",
+        "do not force heavy solver framing",
+        "shortest wording that remains truthful",
+        "do not turn every uncertainty into a long risk block",
+    ):
+        assert phrase in normalized
+
+
+def test_portable_summary_preserves_broad_non_claims():
+    from alpha_solver_portable import minimal_behavior_contract_summary
+
+    normalized = _normalize(minimal_behavior_contract_summary())
+
+    for phrase in (
+        "do not claim mvp validation",
+        "broad superiority",
+        "production readiness",
+        "benchmark success",
+        "exact billing accuracy",
+        "broad runtime readiness",
+        "provider orchestration",
+    ):
+        assert phrase in normalized
 
 def test_test_plan_contains_required_sections_and_boundaries():
     text = _read(TEST_PLAN)
@@ -301,8 +368,10 @@ def test_portable_contract_contains_minimal_behavior_protocol_wording():
         "MINIMAL ALPHA BEHAVIOR CONTRACT",
         "Direct answer first",
         "Mode discipline",
+        "Low-headroom restraint",
         "No invented scaffolding",
         "Compact caveats",
+        "Task-relevant risk",
         "Safe claim wording",
         "Evidence boundary",
         "Artifact stop conditions",


### PR DESCRIPTION
### Motivation

- PR #270 recommended a narrow refinement lane to address a `B. Mixed improvement with brevity/control concern` outcome, so the portable contract must enforce stronger answer-first and brevity/control discipline while preserving Alpha's useful behaviors. 

### Description

- Updated `alpha_solver_portable.py` to strengthen answer-first wording, add a `low-headroom_restraint` rule, add `compact_caveats` and `task_relevant_risk` rules, and clarify the portable boundary (wording-only, does not change providers/routing/`/v1/solve`).
- Updated `MINIMAL_BEHAVIOR_CONTRACT` and `minimal_behavior_contract_summary()` to expose the new concise/caveat/risk restraints and to include a short boundary note that the contract is wording-only.
- Updated `tests/test_alpha_minimal_behavior_contract.py` to assert answer-first, low-headroom restraint, compact caveat, and task-relevant risk language, and to add focused assertions ensuring no provider/model/routing/runtime implication is present.
- Added a short lane README at `docs/evals/runs/20260604-alpha-brevity-control-refinement/README.md` describing lane ID, objective, files changed, what changed / did not change, non-claims, and the recommended next validation step.
- Changes are intentionally minimal and auditable: wording/spec-only edits; preserved artifact stop conditions, evidence-boundary behavior, safe-claim wording, hidden-constraint detection, and artifact discipline.

### Testing

- Ran `git diff --check` and `git status --short` to validate working tree consistency (passed).
- Ran focused tests: `python -m pytest tests/test_alpha_minimal_behavior_contract.py` — all focused assertions passed (`15 passed`).
- Ran a repository-wide test run (`python -m pytest -q`) and observed failures unrelated to these wording-only changes (examples: provider model name expectation `gpt-5` vs `gpt-5-mini`, a cost-tracking artifact assertion, and an input-validation prompt-subset expectation); those failures are pre-existing and not caused by this lane and were noted in the checks summary.
- Confirmed no runtime/provider/model/routing files were modified, and no scored artifacts, Google Sheets files, or Batch C materials were changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a213954270c83299c5b116dec364854)