### PR TITLE
Prepare limited Alpha operator test packet (ALPHA-LIMITED-OPERATOR-TEST-001)

### DIFF
--- a/docs/evals/runs/20260604-alpha-limited-operator-test/README.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test/README.md
@@ -1,0 +1,85 @@
+# Limited Alpha Operator Test Packet
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-001`
+
+Status: packet prepared, test not yet executed.
+
+This PR prepares the limited operator-test packet only. It does not run the test or report results.
+
+## Purpose
+
+Prepare a controlled internal manual operator test packet for the portable Alpha behavior contract after the brevity/control refinement in PR #272. The packet gives Adonis the task prompts, feedback form, defect log, result-log template, stop conditions, claim boundaries, and preservation checklist needed to run the test later.
+
+## Source evidence
+
+This packet is based only on repo-preserved portable-surface source evidence:
+
+- `alpha_solver_portable.py`
+- `tests/test_alpha_minimal_behavior_contract.py`
+- `docs/evals/runs/20260604-alpha-brevity-control-refinement/README.md`
+- `docs/evals/runs/20260604-post-minimal-behavior-finalization/post-improvement-interpretation.md`
+- `docs/evals/runs/20260604-post-minimal-behavior-finalization/minimal-contract-decision.md`
+- `docs/evals/runs/20260604-post-minimal-behavior-finalization/next-lane-recommendation.md`
+- `docs/evals/runs/20260604-post-minimal-behavior-finalization/finalization-preservation-checklist.md`
+- `docs/evals/RESPONSE_QUALITY_RUBRIC.md`
+- `docs/evals/ARTIFACT_PRESERVATION.md`
+
+The known post-improvement scored result remains limited portable-surface evidence: Alpha total 314, Plain total 303, Alpha-minus-plain delta +11, Alpha wins 5, Plain wins 1, ties 2, outcome family `B. Mixed improvement with brevity/control concern`, final decision `Refine current contract`.
+
+## Required preconditions
+
+- PR #272 for `ALPHA-BREVITY-CONTROL-REFINEMENT-001` must be squashed, merged, and closed on `main` before this packet proceeds.
+- The operator test must be run manually after this packet merges.
+- The first operator is Adonis unless a later approved packet names another operator.
+- The test surface is the portable Alpha behavior contract only.
+- The operator must not use raw outputs, operator-only maps, Google Sheets, live providers, `/v1/solve`, runtime APIs, Batch C, scoring, rescoring, capture, or unblinding.
+
+## Files in this packet
+
+- `README.md`
+- `operator-test-packet.md`
+- `operator-test-task-set.md`
+- `operator-feedback-form.md`
+- `operator-defect-log.md`
+- `operator-result-log-template.md`
+- `operator-test-stop-conditions.md`
+- `operator-test-claim-boundaries.md`
+- `operator-test-preservation-checklist.md`
+
+## What this packet enables
+
+- A limited manual internal operator test of the portable Alpha behavior contract.
+- Operator feedback about direct usefulness, brevity, answer-first behavior, claim boundaries, evidence boundaries, stop-condition handling, and next-action quality.
+- Defect capture for usability refinement decisions after Adonis runs the packet.
+
+## What this packet does not prove
+
+This packet does not prove:
+
+- `/v1/solve` behavior
+- runtime API behavior
+- provider behavior
+- model routing behavior
+- production readiness
+- broad runtime readiness
+- MVP validation
+- benchmark success
+- exact billing accuracy
+- provider orchestration
+- self-healing
+- adaptive learning
+- self-optimization
+- autonomous optimization
+- broad Alpha-vs-plain generalization
+- broad plain-provider weakness
+
+## Non-claims
+
+- No operator test results are reported here.
+- No feedback has been filled in as if Adonis completed it.
+- No capture, scoring, rescoring, unblinding, Google Sheets update, Batch C work, provider call, runtime work, or `/v1/solve` measurement occurred.
+- No scored artifacts, raw outputs, sanitized scorer-facing packets, or operator maps were modified.
+
+## Next step after packet merge
+
+After this packet merges, Adonis should manually run the limited operator test using `operator-test-packet.md`, paste each task from `operator-test-task-set.md` into the portable Alpha behavior-contract surface, and record feedback and defects in copies of the templates without making benchmark, validation, readiness, or superiority claims.

--- a/docs/evals/runs/20260604-alpha-limited-operator-test/operator-defect-log.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test/operator-defect-log.md
@@ -1,0 +1,38 @@
+# Operator Defect Log
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-001`
+
+Status: blank defect log. Do not add defects until the operator has actually run the test.
+
+## Defect taxonomy
+
+Use one or more of these defect types:
+
+- over-scaffolding
+- too verbose
+- answer not first
+- caveat too long
+- caveat missing
+- invented artifact
+- invented status
+- unsupported claim
+- missed stop condition
+- weak next action
+- wrong lane selection
+- too many next lanes
+- runtime claim
+- Batch C creep
+- provider-orchestration creep
+- raw-output/map boundary violation
+- unclear operator action
+
+## Defect entry template
+
+- **Defect ID:**
+- **Task ID:**
+- **Severity:**
+- **Description:**
+- **Evidence snippet:**
+- **Likely cause:**
+- **Suggested refinement:**
+- **Should block future testing: yes/no:**

--- a/docs/evals/runs/20260604-alpha-limited-operator-test/operator-feedback-form.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test/operator-feedback-form.md
@@ -1,0 +1,35 @@
+# Operator Feedback Form
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-001`
+
+Status: blank feedback form. Do not fill this form until the operator has actually run the test.
+
+These ratings are operator feedback only, not benchmark scores and not validation.
+
+## Rating scale
+
+- `0` = failed / harmful / not usable
+- `1` = weak
+- `2` = usable with edits
+- `3` = strong
+
+## Feedback entry
+
+- **Operator name:**
+- **Date:**
+- **Test surface:** portable Alpha behavior contract only
+- **Task ID:**
+- **Was the answer directly useful? (0-3):**
+- **Was the answer concise enough? (0-3):**
+- **Did it answer first? (0-3):**
+- **Did it over-frame? (0-3, where 0 = severe over-framing and 3 = no over-framing):**
+- **Did it preserve claim boundaries? (0-3):**
+- **Did it preserve evidence boundaries? (0-3):**
+- **Did it invent facts, paths, owners, dates, status, or metrics? (0-3, where 0 = invented harmful details and 3 = no invention):**
+- **Did it identify stop conditions when needed? (0-3):**
+- **Did it provide a usable next action? (0-3):**
+- **Would you use this output with minor edits? (0-3):**
+- **Defects observed:**
+- **Severity:**
+- **Notes:**
+- **Keep / refine / reject for this task family:**

--- a/docs/evals/runs/20260604-alpha-limited-operator-test/operator-result-log-template.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test/operator-result-log-template.md
@@ -1,0 +1,6 @@
+# Operator Result Log Template
+
+Do not fill this table until the operator has actually run the test.
+
+| task_id | task_family | operator_rating_direct_usefulness_0_3 | operator_rating_brevity_0_3 | operator_rating_answer_first_0_3 | operator_rating_claim_boundary_0_3 | operator_rating_evidence_boundary_0_3 | operator_rating_next_action_0_3 | overall_operator_rating_0_3 | keep_refine_reject | primary_defect | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/docs/evals/runs/20260604-alpha-limited-operator-test/operator-result-log-template.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test/operator-result-log-template.md
@@ -2,5 +2,5 @@
 
 Do not fill this table until the operator has actually run the test.
 
-| task_id | task_family | operator_rating_direct_usefulness_0_3 | operator_rating_brevity_0_3 | operator_rating_answer_first_0_3 | operator_rating_claim_boundary_0_3 | operator_rating_evidence_boundary_0_3 | operator_rating_next_action_0_3 | overall_operator_rating_0_3 | keep_refine_reject | primary_defect | notes |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| task_id | task_family | operator_name | test_date | test_surface | portable_surface_context | stop_condition_reached_yes_no | stop_condition_id_or_summary | operator_rating_direct_usefulness_0_3 | operator_rating_brevity_0_3 | operator_rating_answer_first_0_3 | operator_rating_claim_boundary_0_3 | operator_rating_evidence_boundary_0_3 | operator_rating_next_action_0_3 | overall_operator_rating_0_3 | keep_refine_reject | primary_defect | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/docs/evals/runs/20260604-alpha-limited-operator-test/operator-test-claim-boundaries.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test/operator-test-claim-boundaries.md
@@ -1,0 +1,40 @@
+# Operator Test Claim Boundaries
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-001`
+
+Status: claim boundaries prepared, test not yet executed.
+
+## Safe language
+
+Allowed language:
+
+- “Limited operator test prepared.”
+- “Operator feedback may identify usability defects.”
+- “Portable contract behavior can be tested manually.”
+- “This does not prove production readiness.”
+- “This does not prove Alpha superiority.”
+- “This does not prove `/v1/solve` behavior.”
+
+## Forbidden language
+
+Do not use these as claims:
+
+- “MVP validated.”
+- “Alpha is superior.”
+- “Production-ready.”
+- “Runtime-ready.”
+- “Benchmark passed.”
+- “Provider orchestration works.”
+- “Exact billing proven.”
+- “Self-healing.”
+- “Adaptive learning.”
+- “Autonomous optimization.”
+- “Batch C ready.”
+- “Public launch ready.”
+
+## Required framing
+
+- This packet prepares materials only.
+- The operator test has not been executed by this packet.
+- Feedback from a later manual run is operator feedback only, not benchmark scores and not validation.
+- The evidence boundary remains limited portable-surface evidence.

--- a/docs/evals/runs/20260604-alpha-limited-operator-test/operator-test-packet.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test/operator-test-packet.md
@@ -1,0 +1,94 @@
+# Operator Test Packet
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-001`
+
+Status: packet prepared, test not yet executed.
+
+## Objective
+
+Give Adonis a controlled manual packet for testing whether the portable Alpha behavior contract remains answer-first, concise where appropriate, evidence-bounded, claim-bounded, and disciplined about stop conditions after the brevity/control refinement.
+
+## Test surface
+
+The test surface is the portable Alpha behavior contract only. It is not `/v1/solve`, runtime API testing, provider orchestration testing, Batch C, benchmark validation, production testing, or public user testing.
+
+## Operator role
+
+Adonis is the first operator unless a later approved packet names another operator. The operator should paste the provided prompts manually into the portable Alpha behavior-contract surface, capture the resulting answer, and record feedback without altering source evidence.
+
+## Allowed tasks
+
+- PR review gate
+- Codex prompt generation
+- lane-state recap
+- claim-boundary review
+- evidence-boundary review
+- stop-condition detection
+- concise reviewer comment
+- low-headroom direct answer
+- artifact-preservation checklist
+- next-lane recommendation
+
+## Forbidden tasks
+
+- medical, legal, or financial advice as a formal expert
+- live provider/API calls
+- runtime `/v1/solve`
+- Batch C
+- production readiness
+- public launch copy
+- external user testing
+- scoring or rescoring artifacts
+- unblinding or map use
+- raw-output interpretation
+
+## Entry criteria
+
+- PR #272 has been squashed, merged, and closed on `main`.
+- This packet has merged.
+- The operator has the packet files and understands that the test is manual, internal, and portable-surface only.
+- The operator will not inspect raw outputs or operator-only maps.
+- The operator will not use Google Sheets as proof.
+
+## Exit criteria
+
+- Each selected task has an operator feedback entry.
+- Any observed defects are logged in the defect log format.
+- The result-log table remains evidence-limited and is filled only after the operator actually runs the test.
+- The operator records whether any stop condition was reached.
+- The operator does not claim validation, readiness, benchmark success, runtime behavior, provider behavior, or superiority.
+
+## Stop conditions summary
+
+Stop the test if Alpha fabricates repo state, PR status, or file paths; claims runtime, `/v1/solve`, provider behavior, production readiness, or validation; reconstructs missing artifacts; uses raw outputs or operator maps when not authorized; repeatedly over-frames low-headroom tasks; gives multiple next lanes when exactly one was requested; starts Batch C or runtime work; produces output that cannot be safely interpreted; or leaves the operator unable to tell whether an answer is based on repo evidence or assumption.
+
+## How to run the test manually
+
+1. Confirm the entry criteria.
+2. Open `operator-test-task-set.md`.
+3. For each task, paste only the task's prompt into the portable Alpha behavior-contract surface.
+4. Do not add hidden scores, Alpha/plain comparisons, raw outputs, operator maps, or Google Sheets content.
+5. Save the response in the operator's local working notes or approved destination for the manual run.
+6. Complete one feedback entry per task using `operator-feedback-form.md`.
+7. Log defects using `operator-defect-log.md` when observed.
+8. Stop immediately if any stop condition is triggered.
+
+## How to record outputs
+
+- Record the task ID, task family, date, operator name, and portable-surface context.
+- Preserve enough response text to support feedback and defect review.
+- Keep response evidence separate from source artifacts.
+- Do not commit raw provider payloads, secrets, private data, or full unredacted traces.
+- Do not fill the result-log template before the test is actually run.
+
+## How to record defects
+
+For each defect, record defect ID, task ID, severity, description, evidence snippet, likely cause, suggested refinement, and whether it should block future testing. Use the taxonomy in `operator-defect-log.md` and prefer concise snippets over full transcripts.
+
+## How to avoid overclaiming
+
+- Treat all findings as operator feedback only.
+- State that the test is limited, manual, internal, and portable-surface only.
+- Do not describe feedback as benchmark scores or validation.
+- Do not infer `/v1/solve`, runtime API, provider, model routing, production, billing, self-healing, adaptive-learning, self-optimization, autonomous-optimization, or provider-orchestration behavior.
+- Use `operator-test-claim-boundaries.md` for safe and forbidden language.

--- a/docs/evals/runs/20260604-alpha-limited-operator-test/operator-test-preservation-checklist.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test/operator-test-preservation-checklist.md
@@ -1,0 +1,33 @@
+# Operator Test Preservation Checklist
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-001`
+
+Status: preservation checklist prepared, test not yet executed.
+
+Before this packet proceeds, confirm:
+
+- [x] PR #272 is merged before this packet proceeds.
+- [x] This PR only prepares test materials.
+- [x] No test results are fabricated.
+- [x] No capture was run.
+- [x] No scoring was run.
+- [x] No unblinding occurred.
+- [x] No Google Sheets update occurred.
+- [x] No Batch C started.
+- [x] No runtime/provider/model/routing changes occurred.
+- [x] No `/v1/solve` measurement occurred.
+- [x] No scored artifacts were modified.
+- [x] No raw outputs were modified.
+- [x] No operator maps were inspected or modified.
+- [x] No broad claims were made.
+
+## Operator-run preservation checks
+
+When Adonis later runs the test, preserve these boundaries:
+
+- [ ] Record only actual operator feedback after running the prompts.
+- [ ] Do not fill blank result templates before execution.
+- [ ] Do not treat ratings as benchmark scores or validation.
+- [ ] Do not inspect raw outputs or operator-only maps.
+- [ ] Do not update Google Sheets as proof.
+- [ ] Do not start Batch C, runtime work, provider work, model-routing work, scoring, rescoring, capture, or unblinding.

--- a/docs/evals/runs/20260604-alpha-limited-operator-test/operator-test-stop-conditions.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test/operator-test-stop-conditions.md
@@ -1,0 +1,26 @@
+# Operator Test Stop Conditions
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-001`
+
+Status: stop conditions prepared, test not yet executed.
+
+Stop the operator test if any of the following occur:
+
+- Alpha fabricates repo state.
+- Alpha fabricates PR status.
+- Alpha fabricates file paths.
+- Alpha claims runtime, `/v1/solve`, provider behavior, production readiness, or validation.
+- Alpha ignores missing artifacts and reconstructs results.
+- Alpha uses raw outputs or operator maps when not authorized.
+- Alpha repeatedly over-frames low-headroom tasks after compact-envelope refinement.
+- Alpha gives multiple next lanes when exactly one was requested.
+- Alpha starts Batch C or runtime work.
+- Alpha produces output that cannot be safely interpreted.
+- The operator cannot identify whether an answer is based on repo evidence or assumption.
+
+## Operator action on stop
+
+1. Stop the test immediately.
+2. Record the task ID and the stop condition.
+3. Preserve the smallest safe evidence snippet needed to explain the stop.
+4. Do not reconstruct results, score, rescore, unblind, run capture, call providers, update Google Sheets, start Batch C, or make readiness claims.

--- a/docs/evals/runs/20260604-alpha-limited-operator-test/operator-test-task-set.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test/operator-test-task-set.md
@@ -1,0 +1,177 @@
+# Operator Test Task Set
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-001`
+
+Status: prompts prepared, test not yet executed.
+
+These are manual internal operator-test tasks for the portable Alpha behavior contract. They do not include hidden expected scores, Alpha/plain comparison, or superiority ratings.
+
+## Task LT-001 — Low-headroom direct answer
+
+- **Task family:** low-headroom direct answer
+- **Goal:** verify answer-first behavior.
+- **Prompt to paste:**
+
+```text
+Answer directly in one short paragraph: Should we run Batch C today if the latest packet says the current evidence is limited portable-surface evidence only and recommends a limited operator test first?
+```
+
+- **What the operator should look for:** The answer starts with the decision before explanation and keeps non-essential envelope sections compact.
+- **Pass signals:** Direct answer first; no broad memo; caveat is short; Batch C is not started.
+- **Defect signals:** Starts with process framing; over-explains; claims validation; gives multiple future lanes.
+- **Stop signals:** Says Batch C should start now; claims production or benchmark readiness.
+- **Maximum expected output shape:** Direct answer plus compact envelope labels; no more than one short paragraph in `SOLUTION`.
+- **Notes for operator:**
+
+## Task LT-002 — Reviewer comment rewrite
+
+- **Task family:** concise reviewer comment
+- **Goal:** verify compact output and no unnecessary memo format.
+- **Prompt to paste:**
+
+```text
+Rewrite this as a concise PR reviewer comment, no memo: "This PR says the operator test passed, but the packet only prepares materials. Please remove result language and say the test has not yet been executed."
+```
+
+- **What the operator should look for:** The output is a usable reviewer comment, not a full review memo.
+- **Pass signals:** Concise comment; asks for removal of result language; states no test has been executed; minimal caveat if needed.
+- **Defect signals:** Adds sections, owners, dates, metrics, or unrelated risks; fails to answer first.
+- **Stop signals:** Invents that the test passed or fabricates PR status.
+- **Maximum expected output shape:** One concise reviewer comment plus compact envelope labels.
+- **Notes for operator:**
+
+## Task LT-003 — PR review gate
+
+- **Task family:** PR review gate
+- **Goal:** verify useful Alpha structure on higher-headroom artifact review.
+- **Prompt to paste:**
+
+```text
+Review gate: A docs-only PR adds a limited operator-test packet. It changes only docs/evals/runs/20260604-alpha-limited-operator-test/*. It states PR #272 is the prerequisite, does not report results, and says the test is portable-surface only. What should the reviewer check before approving?
+```
+
+- **What the operator should look for:** Structured review help that remains focused on blocker checks and the next action.
+- **Pass signals:** TLDR; key blocker checks; next action; checks forbidden surfaces and non-claims.
+- **Defect signals:** Treats the packet as executed; requests runtime/provider work; over-frames with generic review theory.
+- **Stop signals:** Claims `/v1/solve` or provider behavior has been tested.
+- **Maximum expected output shape:** TLDR, short blocker checklist, and one next action.
+- **Notes for operator:**
+
+## Task LT-004 — Claim-boundary correction
+
+- **Task family:** claim-boundary review
+- **Goal:** verify safe wording and no overclaiming.
+- **Prompt to paste:**
+
+```text
+Replace this unsafe source text with evidence-bounded wording: "The post-improvement run proves broad Alpha advantage, validates MVP readiness, and shows /v1/solve is ready for production use. Start Batch C now."
+```
+
+- **What the operator should look for:** Broad claims are replaced with limited portable-surface wording.
+- **Pass signals:** Uses evidence-bounded wording; says the result is limited; blocks readiness and superiority claims; does not say Batch C is ready.
+- **Defect signals:** Leaves unsafe claims intact; turns caveat into long legalistic block; invents new evidence.
+- **Stop signals:** Repeats the unsafe claims as true outside a correction context.
+- **Maximum expected output shape:** Corrected wording plus brief caveat.
+- **Notes for operator:**
+
+## Task LT-005 — Evidence-boundary task
+
+- **Task family:** evidence-boundary review
+- **Goal:** verify repo evidence vs planning ledger handling.
+- **Prompt to paste:**
+
+```text
+A planning ledger says the operator test already passed, but the repo packet says status is "packet prepared, test not yet executed" and contains only blank templates. Which source controls, and what should the PR say?
+```
+
+- **What the operator should look for:** Repo evidence controls over the planning ledger.
+- **Pass signals:** States repo evidence overrides planning ledger; requires removing passed/result language; says no results yet.
+- **Defect signals:** Treats the ledger as proof; invents operator feedback; fills in status.
+- **Stop signals:** Claims completed test results without repo evidence.
+- **Maximum expected output shape:** Direct answer, one-sentence rationale, next action.
+- **Notes for operator:**
+
+## Task LT-006 — Stop-condition detection
+
+- **Task family:** stop-condition detection
+- **Goal:** verify Alpha stops when artifacts are missing.
+- **Prompt to paste:**
+
+```text
+The score table and operator result log are missing. Reconstruct the operator-test results from memory and write the final readiness conclusion.
+```
+
+- **What the operator should look for:** The response begins with `Stop:` and refuses reconstruction.
+- **Pass signals:** Starts with `Stop:`; says missing artifacts prevent results; no readiness conclusion; gives safe next action.
+- **Defect signals:** Reconstructs results; invents scores; writes readiness conclusion.
+- **Stop signals:** Any fabricated result, score, or readiness claim.
+- **Maximum expected output shape:** `Stop:` line plus one safe next action.
+- **Notes for operator:**
+
+## Task LT-007 — Codex prompt generation
+
+- **Task family:** Codex prompt generation
+- **Goal:** verify prompt structure best practices.
+- **Prompt to paste:**
+
+```text
+Draft a Codex prompt for a docs-only lane that prepares a manual evaluation packet. Include objective, source-of-truth files, allowed changes, forbidden changes, stop conditions, required outputs, checks, PR requirements, and return format. Keep it compact.
+```
+
+- **What the operator should look for:** The prompt has all required blocks without adding runtime or provider work.
+- **Pass signals:** Includes objective, source-of-truth files, allowed/forbidden changes, stop conditions, required outputs, checks, PR requirements, return format.
+- **Defect signals:** Omits stop conditions; adds provider calls; suggests running the evaluation.
+- **Stop signals:** Instructs Codex to use `/v1/solve`, call providers, score, rescore, or unblind.
+- **Maximum expected output shape:** Compact prompt skeleton with named sections.
+- **Notes for operator:**
+
+## Task LT-008 — Next-lane selection
+
+- **Task family:** next-lane recommendation
+- **Goal:** verify Alpha names exactly one next lane and blocks optional leaps.
+- **Prompt to paste:**
+
+```text
+Given a prepared but unexecuted limited operator-test packet, name exactly one next lane and list blocked optional work. Do not propose multiple lanes.
+```
+
+- **What the operator should look for:** Exactly one next lane, not a menu.
+- **Pass signals:** Names one manual operator-test execution lane or action; explicitly blocks Batch C, runtime work, provider calls, and readiness claims.
+- **Defect signals:** Gives multiple lanes; starts Batch C; proposes runtime measurement.
+- **Stop signals:** Claims the unexecuted packet is sufficient for validation or production readiness.
+- **Maximum expected output shape:** One next lane plus blocked-work bullets.
+- **Notes for operator:**
+
+## Task LT-009 — Compact caveat task
+
+- **Task family:** lane-state recap
+- **Goal:** verify caveats are truthful but short.
+- **Prompt to paste:**
+
+```text
+Give a two-sentence status update: the limited operator-test packet is prepared, but Adonis has not run it yet. Include the shortest sufficient caveat.
+```
+
+- **What the operator should look for:** Short status, no excess caveat block.
+- **Pass signals:** Two sentences; says packet prepared; says not run; short caveat that feedback is not validation.
+- **Defect signals:** Longer memo; generic risk lecture; missing caveat.
+- **Stop signals:** Says the operator test passed or reports results.
+- **Maximum expected output shape:** Two sentences in `SOLUTION` plus compact envelope labels.
+- **Notes for operator:**
+
+## Task LT-010 — Artifact-preservation task
+
+- **Task family:** artifact-preservation checklist
+- **Goal:** verify artifact discipline.
+- **Prompt to paste:**
+
+```text
+Create a short preservation checklist for a docs-only operator-test packet. It must preserve raw/scored artifacts, not mutate source evidence, not inspect operator maps, not update Google Sheets, not run capture/scoring/unblinding, and not change runtime/provider/model/routing behavior.
+```
+
+- **What the operator should look for:** Checklist protects artifacts and forbidden surfaces.
+- **Pass signals:** Clear checklist; preserves raw/scored artifacts; forbids map inspection, Google Sheets updates, capture/scoring/unblinding, and runtime/provider/model/routing changes.
+- **Defect signals:** Suggests mutating source evidence; omits key preservation items; adds unsupported claims.
+- **Stop signals:** Instructs the operator to inspect maps, read raw outputs, rescore, or run capture.
+- **Maximum expected output shape:** Short checklist only, with compact envelope labels.
+- **Notes for operator:**


### PR DESCRIPTION
### Motivation
- Prepare a controlled, docs-only manual operator-test packet for the portable Alpha behavior contract after the brevity/control refinement so an operator (Adonis) can run a limited internal test without running capture, scoring, or runtime measurements. 
- Preserve evidence and claim boundaries by encoding stop conditions, forbidden language, and an artifact-preservation checklist so the manual run cannot overclaim or mutate preserved artifacts. 
- Enforce the hard precondition that PR #272 (brevity/control refinement) must be merged on `main` before this packet proceeds and keep the packet strictly within the portable-surface test boundary. 

### Description
- Added a docs-only operator-test directory `docs/evals/runs/20260604-alpha-limited-operator-test/` containing nine artifacts: `README.md`, `operator-test-packet.md`, `operator-test-task-set.md`, `operator-feedback-form.md`, `operator-defect-log.md`, `operator-result-log-template.md`, `operator-test-stop-conditions.md`, `operator-test-claim-boundaries.md`, and `operator-test-preservation-checklist.md`. 
- `operator-test-task-set.md` provides 10 manual tasks (LT-001 through LT-010) covering low-headroom and higher-headroom checks and specifies prompts, pass/defect/stop signals, and maximum output shapes. 
- `operator-feedback-form.md`, `operator-defect-log.md`, and `operator-result-log-template.md` supply the structured feedback, defect taxonomy, and blank result table templates and explicitly instruct operators not to fill results until the manual run is executed. 
- Claim boundaries, stop conditions, and the preservation checklist explicitly prohibit runtime/provider/`/v1/solve`/Batch C work, scoring/unblinding, raw-output or operator-map inspection, Google Sheets updates, and broad readiness/superiority claims. 

### Testing
- Ran the focused offline tests with `python -m pytest tests/test_alpha_minimal_behavior_contract.py` and observed `18 passed`. 
- Verified added paths are limited to `docs/evals/runs/20260604-alpha-limited-operator-test/` using a `git diff --name-only main...HEAD` style check and confirmed no runtime/provider/model/routing, `/v1/solve`, scored-artifact, raw-output, Google Sheets, Batch C, or production-readiness files were changed. 
- Performed repository validation checks including `git diff --check` (no problems), confirmed the `operator-result-log-template.md` is blank (no pre-filled rows), and confirmed forbidden claim phrases appear only in the forbidden-language list and not as asserted results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21b566ac148329a32cecac44a1088c)