### PR TITLE
Add operator-test Batch C and runtime firewall

### DIFF
--- a/docs/evals/runs/20260604-alpha-operator-test-batch-c-runtime-firewall/README.md
+++ b/docs/evals/runs/20260604-alpha-operator-test-batch-c-runtime-firewall/README.md
@@ -1,0 +1,59 @@
+# Alpha Operator-Test Batch C and Runtime Firewall
+
+Lane ID: `ALPHA-OPERATOR-TEST-BATCH-C-RUNTIME-FIREWALL-001`
+
+Status: docs-only firewall memo prepared; no runtime work, results import, interpretation, scoring, or Batch C work performed.
+
+## Purpose
+
+This memo creates an explicit firewall around the limited operator-test lane so that packet preparation, future operator feedback, future result import, or future interpretation cannot be treated as permission to start Batch C, runtime wiring, `/v1/solve` validation, provider orchestration, MVP validation, billing validation, or production-readiness claims.
+
+This lane exists because the limited operator-test packet is deliberately narrow: it prepares internal manual operator-test materials for the portable Alpha behavior contract only. Packet preparation is not user testing, future operator feedback is not Batch C readiness, future result import is not validation, and future interpretation is not production readiness.
+
+## Source-of-truth inputs read
+
+- `docs/evals/runs/20260604-alpha-limited-operator-test/README.md`
+- `docs/evals/runs/20260604-alpha-limited-operator-test/operator-test-claim-boundaries.md`
+- `docs/evals/runs/20260604-post-minimal-behavior-finalization/post-improvement-interpretation.md`
+- `docs/evals/runs/20260604-post-minimal-behavior-finalization/minimal-contract-decision.md`
+- `docs/evals/runs/20260604-alpha-brevity-control-refinement/README.md`
+
+## Files in this firewall packet
+
+- `README.md`
+- `batch-c-runtime-firewall.md`
+- `forbidden-claim-and-action-table.md`
+- `readiness-review-gates.md`
+- `safe-language-bank.md`
+
+## Scope boundary
+
+This is a docs-only firewall memo. It does not:
+
+- import results
+- fabricate results
+- start Batch C
+- create Batch C prompts
+- interpret operator-test outcomes
+- score or rescore anything
+- modify runtime code
+- use `/v1/solve`
+- call providers
+- update Google Sheets or other external ledgers
+- modify scored artifacts, raw outputs, sanitized scorer-facing packets, operator maps, or existing result records
+
+## Firewall principles
+
+- Limited operator-test feedback is not Batch C readiness.
+- Packet preparation is not user testing.
+- Results import is not validation.
+- Interpretation is not production readiness.
+- Batch C requires a separate readiness decision.
+- Runtime work requires a separate wiring/readiness review.
+- `/v1/solve` remains unproven unless separately measured.
+- Provider orchestration remains blocked unless separately authorized and measured.
+- Exact billing remains blocked unless separately instrumented, measured, and reviewed.
+
+## Allowed downstream use
+
+This firewall may be cited to keep future work narrow. It may support a later readiness review by stating what evidence is still missing, but it does not itself grant readiness, validation, or implementation authorization.

--- a/docs/evals/runs/20260604-alpha-operator-test-batch-c-runtime-firewall/batch-c-runtime-firewall.md
+++ b/docs/evals/runs/20260604-alpha-operator-test-batch-c-runtime-firewall/batch-c-runtime-firewall.md
@@ -1,0 +1,70 @@
+# Batch C and Runtime Firewall
+
+Lane ID: `ALPHA-OPERATOR-TEST-BATCH-C-RUNTIME-FIREWALL-001`
+
+Status: firewall established; no Batch C, runtime, provider, billing, or `/v1/solve` work authorized by this memo.
+
+## Firewall statement
+
+Limited operator-test preparation and any later limited operator-test feedback must remain separated from Batch C, runtime wiring, provider orchestration, `/v1/solve`, MVP validation, billing validation, and production-readiness decisions.
+
+The limited operator-test lane prepares or collects operator usability feedback on the portable Alpha behavior contract. It is not a Batch C execution lane, not a runtime measurement lane, not a provider orchestration lane, not a billing lane, and not a production-readiness lane.
+
+## Required separations
+
+### Packet preparation is not user testing
+
+The limited operator-test packet prepared materials only. Preparing prompts, templates, stop conditions, claim boundaries, result-log templates, defect logs, and preservation checklists does not mean any user has tested Alpha and does not produce validation evidence.
+
+### Operator feedback is not Batch C readiness
+
+Future limited operator feedback may reveal usability signals or defects. That feedback is not a readiness decision for Batch C and cannot be used to skip Batch C planning, prompt approval, artifact-preservation rules, measurement design, or readiness review.
+
+### Results import is not validation
+
+If a future repo task imports operator-test feedback or filled templates, that import only preserves records. Importing records does not validate the MVP, prove superiority, prove runtime behavior, prove provider behavior, prove billing, or authorize broader measurement.
+
+### Interpretation is not production readiness
+
+A future interpretation may summarize operator feedback or defects within the limited operator-test boundary. Interpretation does not prove production readiness, runtime readiness, MVP validation, public-launch readiness, or broad Alpha-vs-plain generalization.
+
+### Batch C requires a separate readiness decision
+
+Batch C remains blocked until a separate Batch C readiness decision explicitly approves its scope, prompt set, measurement plan, preservation method, scoring method, stop conditions, and non-claim boundaries.
+
+### Runtime work requires a separate wiring/readiness review
+
+Runtime wiring, runtime API work, model-routing work, provider-adapter work, and `/v1/solve` measurement remain blocked until a separate runtime wiring/readiness review authorizes exact surfaces, instrumentation, safety checks, expected evidence, and rollback boundaries.
+
+## Runtime and provider non-claims
+
+This firewall does not prove or authorize:
+
+- `/v1/solve` behavior
+- runtime API behavior
+- provider behavior
+- provider orchestration
+- provider-adapter readiness
+- model routing behavior
+- exact billing accuracy
+- billing instrumentation sufficiency
+- production readiness
+- MVP validation
+- public launch readiness
+
+`/v1/solve` remains unproven unless separately measured on the actual runtime surface. Provider orchestration remains blocked unless separately authorized, wired, measured, and reviewed. Exact billing remains blocked unless separately instrumented, measured, reconciled, and reviewed.
+
+## Protected surfaces
+
+This memo does not change and must not be used to change protected surfaces, including:
+
+- runtime APIs
+- `/v1/solve`
+- provider adapters
+- model routing
+- billing or budget guard logic
+- SAFE-OUT behavior
+- SolverEnvelope behavior
+- observability, replay, or determinism behavior
+- scored artifacts or scorer-facing materials
+- raw outputs or operator-only maps

--- a/docs/evals/runs/20260604-alpha-operator-test-batch-c-runtime-firewall/forbidden-claim-and-action-table.md
+++ b/docs/evals/runs/20260604-alpha-operator-test-batch-c-runtime-firewall/forbidden-claim-and-action-table.md
@@ -1,0 +1,34 @@
+# Forbidden Claim and Action Table
+
+Lane ID: `ALPHA-OPERATOR-TEST-BATCH-C-RUNTIME-FIREWALL-001`
+
+Status: forbidden claims and actions recorded for firewall use.
+
+| Trigger or evidence | Forbidden claim | Forbidden action | Required safe framing |
+|---|---|---|---|
+| Limited operator-test packet exists | “User testing completed.” | Treat packet preparation as evidence of validation. | Packet preparation is not user testing. |
+| Limited operator-test packet exists | “Batch C ready.” | Start Batch C or create Batch C prompts. | Batch C requires a separate readiness decision. |
+| Operator feedback is later collected | “Batch C readiness proven.” | Skip readiness review and begin Batch C. | Limited operator-test feedback is not Batch C readiness. |
+| Operator feedback is later collected | “MVP validated.” | Publish validation or launch-readiness claims. | Operator feedback may identify usability defects only. |
+| Operator feedback is later collected | “Production-ready.” | Start production-readiness documentation. | Interpretation is not production readiness. |
+| Operator feedback is later collected | “Runtime-ready.” | Begin runtime wiring or model-routing changes. | Runtime work requires separate wiring/readiness review. |
+| Operator result templates are later imported | “Validation complete.” | Treat preservation import as scoring, validation, or benchmark success. | Results import is not validation. |
+| Operator result templates are later imported | “Scoring completed.” | Create scores, rescoring, or benchmark totals without an approved scoring lane. | Importing records preserves records only. |
+| Future interpretation summarizes feedback | “Public launch ready.” | Expand into public-launch, MVP, or production claims. | Interpretation may remain limited to operator feedback only. |
+| Future interpretation identifies positive feedback | “Alpha is broadly superior.” | Generalize beyond the limited portable-surface evidence. | Feedback is prompt/operator/surface limited. |
+| Future interpretation identifies few defects | “Provider orchestration works.” | Enable or claim provider orchestration. | Provider orchestration remains blocked. |
+| Future interpretation identifies few defects | “Exact billing proven.” | Claim billing accuracy or reconcile live costs. | Exact billing remains blocked. |
+| Future interpretation identifies few defects | “`/v1/solve` works.” | Claim runtime API behavior or use `/v1/solve` as validated. | `/v1/solve` remains unproven unless separately measured. |
+| Post-improvement scored result remains positive | “Batch C should start automatically.” | Treat prior portable-surface score as Batch C authorization. | Prior scored evidence was limited and did not authorize Batch C. |
+| Brevity refinement is complete | “Runtime behavior improved.” | Claim runtime, provider, routing, or `/v1/solve` changes. | Brevity refinement changed portable contract wording only. |
+
+## Always forbidden in this lane
+
+- Importing or fabricating results.
+- Starting Batch C.
+- Creating Batch C prompts.
+- Calling providers.
+- Using `/v1/solve`.
+- Modifying runtime APIs, provider adapters, model routing, billing, budget guard, SAFE-OUT, SolverEnvelope, replay, observability, or determinism behavior.
+- Updating Google Sheets or external status ledgers.
+- Modifying scored artifacts, raw outputs, sanitized scorer-facing packets, or operator-only maps.

--- a/docs/evals/runs/20260604-alpha-operator-test-batch-c-runtime-firewall/readiness-review-gates.md
+++ b/docs/evals/runs/20260604-alpha-operator-test-batch-c-runtime-firewall/readiness-review-gates.md
@@ -1,0 +1,125 @@
+# Readiness Review Gates
+
+Lane ID: `ALPHA-OPERATOR-TEST-BATCH-C-RUNTIME-FIREWALL-001`
+
+Status: gates documented; no gate is passed by this memo.
+
+## Gate rule
+
+No downstream gate is passed by the existence of this firewall memo, by packet preparation, by future limited operator feedback, by future result import, or by future interpretation. Each gate requires a separate explicit readiness decision.
+
+## Gate 1: operator-test execution gate
+
+Required before claiming an operator test was executed:
+
+- The approved packet must have been run manually by the named operator or another approved operator.
+- Filled feedback and defect records must exist as records, not invented summaries.
+- Stop conditions must be checked.
+- Preservation boundaries must be followed.
+
+Not enough:
+
+- Packet preparation.
+- Empty templates.
+- Planned tasks.
+- Informal statements that feedback exists without preserved records.
+
+## Gate 2: results-import gate
+
+Required before importing future operator-test records:
+
+- Confirm the import is records-only.
+- Preserve source records without rewriting them into validation claims.
+- State that results import is not validation.
+- Avoid scoring, rescoring, benchmark totals, or unapproved interpretation.
+
+Not enough:
+
+- Positive or negative operator comments.
+- A completed template without an approved preservation/import lane.
+- Any desire to update Google Sheets or scored artifacts.
+
+## Gate 3: interpretation gate
+
+Required before interpreting future imported operator-test feedback:
+
+- Use a separate interpretation lane.
+- Stay within the limited operator-test and portable-surface evidence boundary.
+- Distinguish usability feedback from validation.
+- Preserve non-claims around production readiness, runtime readiness, Batch C, `/v1/solve`, provider orchestration, and exact billing.
+
+Not enough:
+
+- Record import alone.
+- A small number of positive operator notes.
+- Lack of defects in a limited operator packet.
+
+## Gate 4: Batch C readiness gate
+
+Required before starting Batch C:
+
+- A separate Batch C readiness decision.
+- Approved Batch C objective and scope.
+- Approved prompt set and prompt-provenance rules.
+- Approved capture, scoring, unblinding, and preservation plan.
+- Stop conditions and non-claim boundaries.
+- Confirmation that Batch C does not depend on fabricated or imported-as-validation results.
+
+Not enough:
+
+- Limited operator-test feedback.
+- Limited operator-test interpretation.
+- Prior portable-surface scored results.
+- Completion of brevity/control refinement.
+- This firewall memo.
+
+## Gate 5: runtime wiring/readiness gate
+
+Required before runtime work:
+
+- A separate runtime wiring/readiness review.
+- Named runtime surfaces and entrypoints.
+- Instrumentation and observability requirements.
+- Safety, rollback, and protected-surface review.
+- Evidence plan for actual runtime behavior.
+- Explicit authorization for any provider, model-routing, billing, or `/v1/solve` use.
+
+Not enough:
+
+- Portable contract wording.
+- Operator-test feedback.
+- Batch C planning.
+- Docs-only interpretation.
+
+## Gate 6: `/v1/solve` measurement gate
+
+Required before claiming `/v1/solve` behavior:
+
+- Separate measurement on the actual `/v1/solve` surface.
+- Preserved request/response evidence subject to approved privacy and artifact rules.
+- Runtime instrumentation sufficient to support the claim.
+- Separate interpretation limited to measured evidence.
+
+Not enough:
+
+- Portable-surface outputs.
+- Provider-agnostic prompt-contract behavior.
+- Operator usability feedback.
+- Runtime-adjacent documentation.
+
+## Gate 7: provider orchestration and exact billing gate
+
+Required before provider orchestration or exact billing claims:
+
+- Separate provider orchestration authorization.
+- Provider-adapter and routing readiness review.
+- Billing instrumentation and reconciliation plan.
+- Preserved measurements from live or approved simulated surfaces.
+- Explicit accounting for failures, retries, fallbacks, budget guard behavior, and cost reconciliation.
+
+Not enough:
+
+- Any operator-test result.
+- Any portable-surface score.
+- Any docs-only interpretation.
+- Any unmeasured runtime assumption.

--- a/docs/evals/runs/20260604-alpha-operator-test-batch-c-runtime-firewall/safe-language-bank.md
+++ b/docs/evals/runs/20260604-alpha-operator-test-batch-c-runtime-firewall/safe-language-bank.md
@@ -1,0 +1,70 @@
+# Safe Language Bank
+
+Lane ID: `ALPHA-OPERATOR-TEST-BATCH-C-RUNTIME-FIREWALL-001`
+
+Status: safe wording prepared for future references to the limited operator-test firewall.
+
+## Safe one-line descriptions
+
+- “A docs-only firewall memo was added for `ALPHA-OPERATOR-TEST-BATCH-C-RUNTIME-FIREWALL-001`.”
+- “The firewall keeps limited operator-test work separate from Batch C, runtime wiring, `/v1/solve`, provider orchestration, exact billing, MVP validation, and production readiness.”
+- “Packet preparation is not user testing.”
+- “Limited operator-test feedback is not Batch C readiness.”
+- “Results import is not validation.”
+- “Interpretation is not production readiness.”
+- “Batch C requires a separate readiness decision.”
+- “Runtime work requires a separate wiring/readiness review.”
+- “`/v1/solve` remains unproven unless separately measured.”
+- “Provider orchestration remains blocked unless separately authorized and measured.”
+- “Exact billing remains blocked unless separately instrumented, measured, reconciled, and reviewed.”
+
+## Safe status language
+
+Use:
+
+- “Firewall prepared.”
+- “Docs-only boundary established.”
+- “No results imported.”
+- “No results fabricated.”
+- “No scoring or rescoring performed.”
+- “No Batch C prompts created.”
+- “No runtime surfaces changed.”
+- “No `/v1/solve` use or measurement occurred.”
+- “No provider calls occurred.”
+- “No Google Sheets update occurred.”
+- “No scored artifacts were modified.”
+
+Avoid:
+
+- “Ready for Batch C.”
+- “MVP validated.”
+- “Runtime-ready.”
+- “Production-ready.”
+- “Provider orchestration ready.”
+- “Billing proven.”
+- “`/v1/solve` validated.”
+- “User testing complete.”
+- “Benchmark passed.”
+- “Launch-ready.”
+
+## Safe PR summary wording
+
+Suggested safe wording for PR summaries:
+
+> Added a docs-only firewall memo that prevents limited operator-test preparation, future feedback, future result import, or future interpretation from being treated as Batch C readiness, runtime readiness, `/v1/solve` validation, provider orchestration, exact billing proof, MVP validation, or production readiness.
+
+## Safe follow-up wording
+
+If future operator-test records exist:
+
+- “The records may be imported in a records-only lane, but the import itself is not validation.”
+- “A separate interpretation lane would be required before summarizing feedback.”
+- “Even a favorable interpretation would remain limited operator feedback unless a separate validation lane says otherwise.”
+
+If future Batch C work is proposed:
+
+- “Batch C requires a separate readiness decision with approved scope, prompts, measurement plan, scoring plan, preservation plan, and non-claim boundaries.”
+
+If future runtime work is proposed:
+
+- “Runtime work requires a separate wiring/readiness review for the exact runtime surfaces, instrumentation, safety checks, providers, billing, and `/v1/solve` measurement plan.”


### PR DESCRIPTION
### Motivation

- Prevent any limited operator-test packet preparation, operator feedback, result import, or interpretation from being treated as authorization to start Batch C, perform runtime wiring, use `/v1/solve`, call providers, assert billing accuracy, or claim production readiness.
- Preserve a clear docs-only evidence boundary so future steps (Batch C, runtime work, provider orchestration, billing reconciliation) require separate explicit readiness decisions.
- Record allowed/forbidden language and gates to reduce accidental scope creep from narrow internal operator tests.

### Description

- Added a docs-only firewall under `docs/evals/runs/20260604-alpha-operator-test-batch-c-runtime-firewall/` containing `README.md`, `batch-c-runtime-firewall.md`, `forbidden-claim-and-action-table.md`, `readiness-review-gates.md`, and `safe-language-bank.md` to codify the boundary and guidance.
- The new files explicitly state the firewall principles: limited operator-test feedback is not Batch C readiness; packet preparation is not user testing; results import is not validation; interpretation is not production readiness; Batch C and runtime work require separate readiness reviews; `/v1/solve`, provider orchestration, and exact billing remain blocked unless separately measured and authorized.
- Kept the change docs-only and avoided any import/fabrication of results, runtime code changes, provider calls, `/v1/solve` use, scoring/rescoring, Google Sheets updates, or modification of protected surfaces.

### Testing

- Ran repository validation and checks: `git status --short` (showed the new firewall files), `git diff --check`, `git diff --cached --check`, and `git diff --cached --name-only` which all passed with the new files staged and no whitespace errors.
- Executed a content assertion script (`python - <<'PY' ...`) that verified only the five expected files were added and that no result markers (e.g., `Alpha total:`, `Plain total:`, `score-table.csv`) were introduced; the assertion passed.
- Noted one repository limitation: `git diff --name-only main...HEAD` failed because this environment does not have a local `main` ref; this is an environmental warning and did not affect the docs-only commit and checks (commit `fe238c5` was created on branch `alpha-operator-test-batch-c-runtime-firewall-001`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21c3b300f4832998dabd44bab9154e)