### PR TITLE
Add limited operator test evidence packaging standard

### DIFF
--- a/docs/evals/runs/20260604-alpha-limited-operator-test-evidence-packaging-standard/README.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-evidence-packaging-standard/README.md
@@ -1,0 +1,35 @@
+# Limited Operator Test Evidence Packaging Standard
+
+Standard ID: `ALPHA-LIMITED-OPERATOR-TEST-EVIDENCE-PACKAGING-STANDARD-001`
+
+Status: packaging standard only. No operator results are imported, interpreted, scored, or validated by this directory.
+
+## Purpose
+
+This directory defines how Adonis should package manual operator-test evidence from `ALPHA-LIMITED-OPERATOR-TEST-001` for a later import review without exposing private data, secrets, raw provider payloads, full unredacted transcripts, operator-only maps, or unsupported claims.
+
+The standard is intentionally limited to evidence packaging. It does not run the test, start Batch C, call `/v1/solve`, inspect raw outputs, update Google Sheets, import result rows, score feedback, or make readiness claims.
+
+## Source packet relationship
+
+This packaging standard is derived from the limited operator-test packet and its blank templates:
+
+- `../20260604-alpha-limited-operator-test/operator-test-packet.md`
+- `../20260604-alpha-limited-operator-test/operator-result-log-template.md`
+- `../20260604-alpha-limited-operator-test/operator-feedback-form.md`
+- `../20260604-alpha-limited-operator-test/operator-defect-log.md`
+- `../20260604-alpha-limited-operator-test/operator-test-claim-boundaries.md`
+
+If those source files change later, update this standard before packaging evidence for import.
+
+## Files in this standard
+
+- `evidence-packaging-standard.md` — required packaging rules, accepted evidence types, bundle structure, and blocked conditions.
+- `redaction-guidance.md` — how to redact private or sensitive details while preserving reviewable context.
+- `acceptable-evidence-examples.md` — safe example formats using placeholder data only.
+- `unacceptable-evidence-examples.md` — examples of bundles or claims that must be rejected or remediated before import.
+- `import-readiness-checklist.md` — checklist for determining whether a packaged bundle is import-ready or blocked.
+
+## Non-goals
+
+This directory must not contain actual manual-run results, raw outputs, full transcripts, scoring, interpretation, benchmark conclusions, runtime claims, provider claims, production-readiness claims, or superiority claims.

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-evidence-packaging-standard/acceptable-evidence-examples.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-evidence-packaging-standard/acceptable-evidence-examples.md
@@ -1,0 +1,98 @@
+# Acceptable Evidence Examples
+
+Standard ID: `ALPHA-LIMITED-OPERATOR-TEST-EVIDENCE-PACKAGING-STANDARD-001`
+
+Status: examples use synthetic placeholders only. They are not actual operator-test results.
+
+## Example 1: import-ready task evidence row
+
+```yaml
+task_id: ALPHA-LIMITED-OPERATOR-TEST-001-TASK-EXAMPLE
+task_family: concise reviewer comment
+operator_name: <approved-operator-name-or-pseudonym>
+test_date: <YYYY-MM-DD>
+test_surface: portable Alpha behavior contract only
+portable_surface_context: manual paste into approved portable-surface prompt context
+stop_condition_reached_yes_no: no
+stop_condition_id_or_summary: NOT_APPLICABLE
+operator_rating_direct_usefulness_0_3: <operator-entered-0-3>
+operator_rating_brevity_0_3: <operator-entered-0-3>
+operator_rating_answer_first_0_3: <operator-entered-0-3>
+operator_rating_claim_boundary_0_3: <operator-entered-0-3>
+operator_rating_evidence_boundary_0_3: <operator-entered-0-3>
+operator_rating_next_action_0_3: <operator-entered-0-3>
+overall_operator_rating_0_3: <operator-entered-0-3>
+keep_refine_reject: <operator-entered-keep-refine-reject>
+primary_defect: <operator-entered-defect-or-NOT_PROVIDED>
+notes: <sanitized operator note copied from an actual manual run>
+```
+
+Why acceptable:
+
+- cites a task ID;
+- identifies the portable test surface;
+- uses placeholders showing where actual operator-entered integer ratings would be copied;
+- avoids private data, raw payloads, full transcript text, benchmark claims, and readiness claims;
+- preserves operator feedback as feedback only.
+
+## Example 2: sanitized response snippet supporting a defect
+
+```yaml
+task_id: ALPHA-LIMITED-OPERATOR-TEST-001-TASK-EXAMPLE
+snippet_type: sanitized_response_snippet
+supports: defect evidence for unsupported claim
+snippet: "The response stated that the lane was '[BLOCKED_UNSUPPORTED_CLAIM]' even though the prompt provided no evidence for that status."
+redactions:
+  - marker: "[BLOCKED_UNSUPPORTED_CLAIM]"
+    reason: unsupported readiness wording removed from packaged snippet
+```
+
+Why acceptable:
+
+- includes only the minimal relevant excerpt;
+- labels the evidence as a snippet, not a transcript;
+- ties the snippet to one task ID;
+- avoids exposing a full response;
+- flags unsupported claim language rather than endorsing it.
+
+## Example 3: preserved operator note with private organization redacted
+
+```yaml
+task_id: ALPHA-LIMITED-OPERATOR-TEST-001-TASK-EXAMPLE
+operator_note: "The answer invented a release date for [REDACTED_PRIVATE_ORG] and should trigger the invented status defect type."
+packaging_note: "Private organization name redacted; operator meaning preserved."
+```
+
+Why acceptable:
+
+- preserves the defect observation;
+- removes the private organization name;
+- does not invent a replacement organization;
+- does not turn the note into validation or scoring interpretation.
+
+## Example 4: missing field marked honestly
+
+```yaml
+task_id: ALPHA-LIMITED-OPERATOR-TEST-001-TASK-EXAMPLE
+operator_rating_brevity_0_3: NOT_PROVIDED
+notes: "Operator provided qualitative notes but left the brevity rating blank."
+bundle_status: blocked until importer decides whether to import the qualitative note without the missing rating
+```
+
+Why acceptable:
+
+- does not fabricate a rating;
+- marks the field with an approved missing-field marker;
+- makes the import limitation explicit.
+
+## Example 5: redaction log entry
+
+| task_id | evidence_item | redaction_marker | reason | meaning_preserved_yes_no | reviewer_note |
+| --- | --- | --- | --- | --- | --- |
+| `ALPHA-LIMITED-OPERATOR-TEST-001-TASK-EXAMPLE` | `operator_note` | `[REDACTED_PRIVATE_URL]` | private ticket URL removed | yes | note still supports raw-output boundary concern |
+
+Why acceptable:
+
+- records what category was redacted;
+- does not reveal the private URL;
+- indicates whether review meaning remains intact.

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-evidence-packaging-standard/evidence-packaging-standard.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-evidence-packaging-standard/evidence-packaging-standard.md
@@ -1,0 +1,230 @@
+# Evidence Packaging Standard
+
+Standard ID: `ALPHA-LIMITED-OPERATOR-TEST-EVIDENCE-PACKAGING-STANDARD-001`
+
+Status: docs-only packaging standard. This document defines import packaging requirements and does not import, score, interpret, or validate operator-test results.
+
+## Scope
+
+This standard applies only to manual operator-test evidence produced from `ALPHA-LIMITED-OPERATOR-TEST-001` after the operator actually runs the portable Alpha behavior-contract test. It governs how Adonis packages evidence for later import review.
+
+This standard does not authorize:
+
+- importing actual results;
+- fabricating or backfilling missing results;
+- executing prompts;
+- inspecting raw provider payloads or operator-only maps;
+- updating Sheets;
+- starting Batch C;
+- using `/v1/solve`;
+- modifying runtime, provider, model, routing, SAFE-OUT, budget guard, determinism, observability, replay, or `SolverEnvelope` behavior;
+- claiming validation, production readiness, benchmark success, provider behavior, runtime behavior, or Alpha superiority.
+
+## Required bundle structure
+
+A packaged evidence bundle should be a separate artifact created after a real manual run. It should contain only sanitized, reviewable evidence needed to support later import.
+
+Recommended bundle sections:
+
+1. **Bundle metadata**
+   - Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-001`.
+   - Packaging standard ID: `ALPHA-LIMITED-OPERATOR-TEST-EVIDENCE-PACKAGING-STANDARD-001`.
+   - Operator name or approved pseudonym.
+   - Test date using `YYYY-MM-DD`.
+   - Test surface: `portable Alpha behavior contract only`.
+   - Package date using `YYYY-MM-DD`.
+   - Packager name.
+2. **Task evidence index**
+   - One row per task that was actually run.
+   - Use only task IDs from the approved operator-test task set.
+   - Include task family, status, redaction status, and whether a stop condition was reached.
+3. **Sanitized result-log fields**
+   - Fields copied from the operator result-log template when actually observed.
+   - Missing fields explicitly marked with the missing-field markers in this standard.
+4. **Operator feedback entries**
+   - One sanitized feedback entry per task that was actually run.
+   - Preserve operator notes, uncertainty, and wording except where redaction is required.
+5. **Defect entries, if any**
+   - Sanitized defect entries using the approved defect-log taxonomy.
+   - Use evidence snippets, not full transcripts.
+6. **Redaction log**
+   - What category of content was redacted, why, and whether meaning was preserved.
+   - Do not include the redacted secret or private value.
+7. **Import-readiness checklist**
+   - Completed checklist showing whether the bundle is import-ready or blocked.
+
+## Accepted evidence types
+
+Accepted evidence types are limited to sanitized artifacts that support the manual operator feedback without exposing sensitive or unsupported material:
+
+- task ID and task family from the approved task set;
+- operator name or approved pseudonym;
+- test date;
+- test surface label confirming portable Alpha behavior contract only;
+- portable-surface context in concise, non-sensitive form;
+- stop-condition yes/no and a short stop-condition ID or summary;
+- operator ratings from the feedback form or result-log template, when actually entered by the operator;
+- keep/refine/reject decision, when actually entered by the operator;
+- concise operator notes, with private details redacted;
+- defect ID, severity, taxonomy label, description, likely cause, suggested refinement, and block decision, when actually observed;
+- short response snippets that are necessary to support a note or defect;
+- redaction-log entries describing redaction categories without revealing the redacted content;
+- missing-field markers that honestly identify absent information.
+
+## Disallowed evidence types
+
+Do not package:
+
+- raw provider payloads;
+- API request or response bodies;
+- full unredacted transcripts;
+- secrets, API keys, tokens, cookies, credentials, private URLs, or environment values;
+- private personal data that is not necessary for review;
+- operator-only maps, blinding maps, unblinding maps, or raw-output maps;
+- Google Sheets contents as proof;
+- hidden scores, Alpha/plain comparisons, benchmark rows, rescoring, or scoring interpretations;
+- unsupported reconstructed details;
+- results for tasks that were not actually run;
+- generated or inferred ratings where the operator left the field blank;
+- claims that the test proves validation, readiness, runtime behavior, provider behavior, production behavior, billing behavior, self-healing, adaptive learning, autonomous optimization, Batch C readiness, public launch readiness, or superiority.
+
+## Response snippets versus full transcripts
+
+Use response snippets only when they are needed to support operator feedback, a defect, or a stop-condition note.
+
+A response snippet should:
+
+- be as short as possible while preserving the relevant evidence;
+- include enough neighboring context to avoid misrepresenting the answer;
+- omit private data and sensitive content;
+- be labeled as a snippet, not a complete transcript;
+- identify the associated task ID;
+- preserve wording relevant to the observed behavior, such as an unsupported claim or over-framing pattern;
+- avoid quoting an entire response when a shorter excerpt supports the review.
+
+A full transcript is blocked unless an approved reviewer separately authorizes a sanitized transcript for a specific reason. Even then, redact private data, secrets, raw provider payloads, and unsupported map content first.
+
+## Task ID citation rules
+
+Every evidence item must cite a task ID.
+
+Use this format:
+
+- `task_id: <approved-task-id>` for result rows, feedback entries, snippets, and defect entries.
+- `related_task_ids: [<approved-task-id>, <approved-task-id>]` only when a note spans multiple actually run tasks.
+- `task_id: UNKNOWN` is blocked unless the bundle includes an explicit remediation note explaining why the evidence cannot be imported until the task ID is recovered from approved operator notes.
+
+Do not invent task IDs, normalize task IDs from memory, or infer task IDs from response content alone. If the task ID cannot be verified from the approved operator packet or operator notes, mark the bundle blocked.
+
+## Preserving operator notes
+
+Operator notes are evidence. Preserve the operator's meaning and uncertainty.
+
+Packaging may:
+
+- redact private data;
+- replace names, identifiers, or sensitive facts with consistent placeholders;
+- trim unrelated prose;
+- normalize formatting into the result-log or feedback template;
+- add a bracketed packaging note such as `[redacted private client name]`.
+
+Packaging must not:
+
+- improve the rating;
+- downgrade the rating;
+- rewrite a weak note into a stronger claim;
+- convert uncertainty into certainty;
+- add a rationale the operator did not provide;
+- turn feedback into validation;
+- summarize away a stop condition;
+- delete defect evidence because it is inconvenient.
+
+If a note is ambiguous, preserve the ambiguity and add `packaging_note: ambiguous; do not interpret during import`.
+
+## Missing-field markers
+
+Never fabricate missing fields. Use explicit markers:
+
+- `NOT_PROVIDED` — the operator left the field blank or it is absent from the approved notes.
+- `NOT_RUN` — the task was not run.
+- `NOT_APPLICABLE` — the field does not apply to the observed task or defect.
+- `REDACTED_PRIVATE` — private personal or organizational data was removed.
+- `REDACTED_SECRET` — a secret, token, credential, cookie, key, or environment value was removed.
+- `REDACTED_RAW_PAYLOAD` — raw provider/API payload content was removed.
+- `BLOCKED_UNVERIFIED_TASK_ID` — the task ID cannot be verified.
+- `BLOCKED_UNSUPPORTED_CLAIM` — the package contains a claim that must be removed or reframed before import.
+
+Do not use numeric defaults such as `0`, `3`, or averages as placeholders for blank ratings.
+
+## Avoiding fake precision
+
+Manual operator feedback is not a benchmark score and not validation. Avoid fake precision by following these rules:
+
+- Report only the integer ratings the operator actually recorded.
+- Do not compute averages, percentages, deltas, confidence intervals, ranks, or pass rates.
+- Do not compare Alpha against plain, prior batches, or external systems in this bundle.
+- Do not infer statistical significance from a limited manual run.
+- Do not use exact-looking language such as `100% ready`, `validated`, `passed`, or `superior`.
+- Use qualitative framing: `operator feedback`, `observed by operator`, `reported in manual notes`, or `blocked for import`.
+
+## Claim boundaries
+
+Allowed framing:
+
+- `Limited operator-test evidence packaged for import review.`
+- `The bundle contains sanitized operator feedback only.`
+- `This does not prove production readiness.`
+- `This does not prove Alpha superiority.`
+- `This does not prove /v1/solve behavior.`
+- `This does not prove provider or model-routing behavior.`
+
+Forbidden framing:
+
+- `MVP validated.`
+- `Alpha is superior.`
+- `Production-ready.`
+- `Runtime-ready.`
+- `Benchmark passed.`
+- `Provider orchestration works.`
+- `Exact billing proven.`
+- `Self-healing.`
+- `Adaptive learning.`
+- `Autonomous optimization.`
+- `Batch C ready.`
+- `Public launch ready.`
+
+If a bundle includes forbidden framing, mark it blocked until the claim is removed or rewritten as limited operator feedback.
+
+## Import-ready bundle definition
+
+A result bundle is import-ready only when all of the following are true:
+
+- every evidence item is tied to an approved, actually run task ID;
+- each included rating or note is copied from an actual operator entry;
+- missing fields use approved missing-field markers;
+- snippets are short, sanitized, and necessary for review;
+- full unredacted transcripts are absent;
+- raw provider payloads are absent;
+- secrets and private details are absent or redacted;
+- operator-only maps and raw-output maps are absent;
+- no hidden scores, rescoring, Alpha/plain comparisons, or benchmark conclusions are included;
+- no unsupported readiness, validation, runtime, provider, Batch C, public launch, or superiority claims are included;
+- the redaction log is complete enough for import review;
+- the import-readiness checklist is completed and indicates no blocked condition.
+
+## Blocked bundle definition
+
+A result bundle is blocked when any of the following are true:
+
+- it includes actual results for a task that was not run;
+- it fabricates, infers, or defaults missing ratings or notes;
+- it lacks verifiable task IDs;
+- it exposes private data, secrets, raw provider payloads, full unredacted transcripts, or operator-only maps;
+- it uses Google Sheets content as proof;
+- it includes unsupported validation, readiness, benchmark, runtime, provider, billing, Batch C, public launch, or superiority claims;
+- it interprets results, scores outcomes, compares systems, or imports rows;
+- it reconstructs missing artifacts from memory or inference;
+- it starts or references Batch C execution as an outcome of packaging;
+- it changes protected runtime/provider/model/routing surfaces.
+
+A blocked bundle may be remediated only by removing unsafe content, restoring verified task IDs from approved operator notes, replacing fabricated fields with missing-field markers, and completing the checklist again.

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-evidence-packaging-standard/import-readiness-checklist.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-evidence-packaging-standard/import-readiness-checklist.md
@@ -1,0 +1,84 @@
+# Import Readiness Checklist
+
+Standard ID: `ALPHA-LIMITED-OPERATOR-TEST-EVIDENCE-PACKAGING-STANDARD-001`
+
+Status: checklist template only. Do not complete this checklist with actual results until a manual operator-test bundle exists.
+
+## Bundle identity
+
+- [ ] Bundle cites lane ID `ALPHA-LIMITED-OPERATOR-TEST-001`.
+- [ ] Bundle cites packaging standard ID `ALPHA-LIMITED-OPERATOR-TEST-EVIDENCE-PACKAGING-STANDARD-001`.
+- [ ] Bundle identifies packager and package date.
+- [ ] Bundle identifies operator name or approved pseudonym.
+- [ ] Bundle identifies test date using `YYYY-MM-DD`.
+- [ ] Bundle identifies test surface as `portable Alpha behavior contract only`.
+
+## Task evidence
+
+- [ ] Every evidence item cites an approved task ID.
+- [ ] No task ID was invented, inferred, normalized from memory, or reconstructed from response content alone.
+- [ ] Every included task was actually run.
+- [ ] Tasks not run are either excluded or marked `NOT_RUN` without ratings or fabricated notes.
+- [ ] Multi-task notes use `related_task_ids` and include only actually run task IDs.
+
+## Result fields and operator notes
+
+- [ ] Ratings are copied only from actual operator entries.
+- [ ] Blank ratings are marked `NOT_PROVIDED` and not defaulted.
+- [ ] `NOT_APPLICABLE` is used only where the field genuinely does not apply.
+- [ ] Operator notes preserve meaning, uncertainty, and defect observations.
+- [ ] Packaging notes are clearly labeled and do not add interpretation.
+- [ ] Keep/refine/reject values are copied only when actually entered by the operator.
+- [ ] Defects use the approved defect taxonomy when defects were observed.
+
+## Snippets and transcripts
+
+- [ ] Evidence uses short sanitized response snippets only when needed.
+- [ ] Snippets are labeled `sanitized_response_snippet`.
+- [ ] Snippets include enough context to support the operator note without misrepresenting the answer.
+- [ ] Full unredacted transcripts are absent.
+- [ ] Raw provider payloads are absent.
+- [ ] API request or response bodies are absent.
+- [ ] Google Sheets contents are not used as proof.
+
+## Redaction and privacy
+
+- [ ] Secrets, tokens, keys, credentials, cookies, and environment values are absent or marked `[REDACTED_SECRET]` or `[REDACTED_ENV_VALUE]`.
+- [ ] Private people, organizations, URLs, account IDs, emails, phone numbers, and confidential business details are absent or redacted with approved placeholders.
+- [ ] Operator-only maps, blinding maps, unblinding maps, and raw-output maps are absent.
+- [ ] Redaction placeholders do not contain fake realistic replacement values.
+- [ ] Redaction log lists redaction marker, reason, and whether meaning was preserved.
+- [ ] Redaction log does not reveal the original redacted values.
+- [ ] Sensitive details are absent from filenames, headings, metadata, comments, and screenshots.
+
+## Claim boundaries
+
+- [ ] Bundle frames findings as limited operator feedback only.
+- [ ] Bundle does not claim validation, readiness, benchmark success, superiority, or production suitability.
+- [ ] Bundle does not claim `/v1/solve`, runtime API, provider, model-routing, billing, self-healing, adaptive-learning, autonomous-optimization, provider-orchestration, Batch C, or public-launch behavior.
+- [ ] Bundle does not include averages, percentages, deltas, confidence intervals, rankings, pass rates, or statistical conclusions.
+- [ ] Any forbidden wording from the claim-boundaries packet has been removed or rewritten as limited operator feedback.
+
+## Protected-surface confirmation
+
+- [ ] Packaging did not execute prompts or tests.
+- [ ] Packaging did not import rows or update Sheets.
+- [ ] Packaging did not start Batch C.
+- [ ] Packaging did not call `/v1/solve`.
+- [ ] Packaging did not inspect raw outputs or operator maps.
+- [ ] Packaging did not modify runtime/provider/model/routing or other protected implementation surfaces.
+
+## Import decision
+
+Choose exactly one:
+
+- [ ] `IMPORT_READY` — all checklist items above are satisfied, no blocked condition remains, and the bundle contains only sanitized operator feedback evidence.
+- [ ] `BLOCKED` — one or more checklist items failed, missing fields are unresolved, unsafe content remains, or unsupported claims remain.
+
+If blocked, record the reason without exposing private data:
+
+```yaml
+bundle_status: BLOCKED
+blocked_reason: <short reason using approved markers where needed>
+required_remediation: <specific remediation before import review>
+```

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-evidence-packaging-standard/redaction-guidance.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-evidence-packaging-standard/redaction-guidance.md
@@ -1,0 +1,112 @@
+# Redaction Guidance
+
+Standard ID: `ALPHA-LIMITED-OPERATOR-TEST-EVIDENCE-PACKAGING-STANDARD-001`
+
+Status: redaction guidance only. This document does not contain real operator-test evidence.
+
+## Redaction principles
+
+Redaction should protect private or sensitive information while preserving the minimum context needed for import review.
+
+Use these principles:
+
+- redact before packaging for import review;
+- keep the smallest useful response snippet;
+- preserve operator ratings, stop-condition flags, defect taxonomy labels, and uncertainty;
+- replace sensitive values with category placeholders, not invented substitutes;
+- document each redaction category in a redaction log;
+- never keep a secret merely because it appears in a model response or operator note;
+- never expose raw provider payloads, operator-only maps, full unredacted transcripts, or private working notes.
+
+## Content that must be redacted
+
+Always redact:
+
+- API keys, tokens, passwords, cookies, credentials, SSH keys, signing secrets, session IDs, and environment values;
+- private personal names unless the operator name is approved for inclusion;
+- email addresses, phone numbers, addresses, account IDs, customer IDs, private URLs, ticket URLs, and private repository URLs;
+- proprietary client names, internal project names, confidential business details, and non-public incident details;
+- raw request or response payloads from providers or APIs;
+- raw output maps, operator-only maps, blinding maps, and unblinding maps;
+- full transcripts when a short snippet is sufficient;
+- any information the operator explicitly marked private or not for import.
+
+## Placeholder vocabulary
+
+Use consistent placeholders:
+
+- `[REDACTED_SECRET]`
+- `[REDACTED_PRIVATE_PERSON]`
+- `[REDACTED_PRIVATE_ORG]`
+- `[REDACTED_PRIVATE_URL]`
+- `[REDACTED_ACCOUNT_ID]`
+- `[REDACTED_EMAIL]`
+- `[REDACTED_PHONE]`
+- `[REDACTED_ENV_VALUE]`
+- `[REDACTED_RAW_PAYLOAD]`
+- `[REDACTED_OPERATOR_ONLY_MAP]`
+- `[TRIMMED_UNRELATED_TEXT]`
+
+Do not replace a real value with a fake realistic value. For example, use `[REDACTED_EMAIL]`, not `person@example.com`, unless the example is clearly synthetic and not part of an actual result bundle.
+
+## Response snippet redaction workflow
+
+For each response snippet:
+
+1. Confirm the task ID from approved operator notes.
+2. Identify the specific feedback, defect, or stop-condition point the snippet supports.
+3. Cut unrelated response text before redaction.
+4. Redact secrets, private data, raw payloads, and unsupported map content.
+5. Confirm the snippet still supports the operator note without overrepresenting the full answer.
+6. Label it as `sanitized_response_snippet`, not `transcript`.
+7. Add a redaction-log entry for each redaction category.
+
+## Redaction log format
+
+Use one row per redaction event or grouped category:
+
+| task_id | evidence_item | redaction_marker | reason | meaning_preserved_yes_no | reviewer_note |
+| --- | --- | --- | --- | --- | --- |
+| `<approved-task-id>` | `sanitized_response_snippet` | `[REDACTED_SECRET]` | secret removed | yes | snippet still shows unsupported-claim wording |
+
+Do not include the original redacted value in the log.
+
+## Preserving notes without exposing private data
+
+When operator notes contain sensitive details, preserve the operational meaning:
+
+- Original meaning: the operator saw an answer that invented a private project status.
+- Safe packaged note: `The answer appeared to invent status for [REDACTED_PRIVATE_ORG] project; operator marked invented status defect.`
+
+Do not preserve unnecessary private context:
+
+- Unsafe: `The answer said Client A's unreleased project would ship on 2026-07-15.`
+- Safe: `The answer stated a specific release status/date for [REDACTED_PRIVATE_ORG] without evidence.`
+
+## Handling missing or unsafe fields
+
+If a field is blank, unsafe, or unverifiable:
+
+- do not fill it from memory;
+- do not derive it from snippets;
+- do not ask another system to infer it;
+- mark it with the applicable missing-field or blocked marker;
+- explain the remediation needed if import is blocked.
+
+Examples:
+
+- `operator_rating_brevity_0_3: NOT_PROVIDED`
+- `task_id: BLOCKED_UNVERIFIED_TASK_ID`
+- `evidence_snippet: REDACTED_RAW_PAYLOAD`
+- `bundle_status: blocked until raw payload is removed and replaced with a safe snippet, if available`
+
+## Quality check before import review
+
+Before marking a bundle import-ready, confirm:
+
+- redactions use approved placeholders;
+- no placeholder hides a fabricated value;
+- snippets remain intelligible after redaction;
+- the redaction log does not reveal redacted content;
+- private details are not repeated in filenames, headings, comments, metadata, or screenshots;
+- no unsupported claim remains in narrative text.

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-evidence-packaging-standard/unacceptable-evidence-examples.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-evidence-packaging-standard/unacceptable-evidence-examples.md
@@ -1,0 +1,129 @@
+# Unacceptable Evidence Examples
+
+Standard ID: `ALPHA-LIMITED-OPERATOR-TEST-EVIDENCE-PACKAGING-STANDARD-001`
+
+Status: examples are synthetic anti-patterns only. They are not actual operator-test results.
+
+## Unacceptable: full unredacted transcript
+
+```text
+Task: <task id>
+Full response: <entire unredacted answer pasted here with private names, private links, and internal context>
+```
+
+Why blocked:
+
+- exposes more text than needed for import review;
+- may contain private data or unsupported claims;
+- violates the snippet-first requirement.
+
+Remediation:
+
+- replace with the shortest sanitized snippet needed to support the operator note or defect;
+- add redaction-log entries for removed private or sensitive content.
+
+## Unacceptable: raw provider payload
+
+```json
+{
+  "request": "<raw provider request>",
+  "response": "<raw provider response>",
+  "headers": {"authorization": "<secret>"}
+}
+```
+
+Why blocked:
+
+- raw provider/API payloads are disallowed;
+- secrets or environment details may be exposed;
+- provider payloads are outside the manual portable-surface evidence boundary.
+
+Remediation:
+
+- remove the payload entirely;
+- package only sanitized operator feedback and necessary snippets from the manual portable-surface answer.
+
+## Unacceptable: invented missing rating
+
+```yaml
+task_id: ALPHA-LIMITED-OPERATOR-TEST-001-TASK-EXAMPLE
+operator_rating_brevity_0_3: 3
+packaging_note: "Rating inferred because the operator wrote that the answer was short."
+```
+
+Why blocked:
+
+- missing ratings must not be inferred;
+- qualitative notes are not a substitute for an explicit rating.
+
+Remediation:
+
+- set `operator_rating_brevity_0_3: NOT_PROVIDED`;
+- preserve the qualitative note separately.
+
+## Unacceptable: unsupported readiness claim
+
+```markdown
+The limited operator test validated the MVP and proves the runtime is production-ready.
+```
+
+Why blocked:
+
+- claims validation and production readiness;
+- implies runtime behavior that this manual portable-surface test cannot prove;
+- violates claim boundaries.
+
+Remediation:
+
+- replace with: `The bundle contains sanitized limited operator feedback for import review only. It does not prove production readiness or runtime behavior.`
+
+## Unacceptable: task ID reconstructed from memory
+
+```yaml
+task_id: probably-task-7
+packaging_note: "The exact ID was missing, but this seemed like the next-lane task."
+```
+
+Why blocked:
+
+- task IDs must be verified from approved operator notes and task materials;
+- import cannot rely on memory or inference.
+
+Remediation:
+
+- use `task_id: BLOCKED_UNVERIFIED_TASK_ID`;
+- recover the verified ID from approved operator notes or exclude the item from import.
+
+## Unacceptable: operator-only map content
+
+```csv
+task_id,condition,raw_output_file
+TASK-EXAMPLE,alpha,<operator-only-map-value>
+```
+
+Why blocked:
+
+- operator-only maps, raw-output maps, and unblinding maps must not be packaged;
+- map content can contaminate later review and exceed the portable-surface evidence boundary.
+
+Remediation:
+
+- remove map-derived fields;
+- retain only task ID, operator feedback, sanitized snippets, and defect entries.
+
+## Unacceptable: fake precision summary
+
+```markdown
+The manual run achieved an 87.5% pass rate and demonstrates statistically meaningful superiority.
+```
+
+Why blocked:
+
+- computes unsupported precision from limited operator feedback;
+- makes superiority and statistical claims;
+- converts manual feedback into benchmark interpretation.
+
+Remediation:
+
+- remove calculated pass rates and superiority claims;
+- present only individual operator feedback fields that were actually recorded.


### PR DESCRIPTION
### Motivation
- Provide a docs-only packaging standard `ALPHA-LIMITED-OPERATOR-TEST-EVIDENCE-PACKAGING-STANDARD-001` that instructs how to prepare manual operator-test evidence for later import review without exposing private data, secrets, raw provider payloads, operator-only maps, or unsupported claims. 
- Ensure packaging preserves operator notes, uses explicit missing-field markers, enforces snippet-first evidence, and prevents fabrication or inferred ratings. 
- Base the standard on the existing limited operator-test packet and templates so packaging is aligned with the test artifacts and claim boundaries. 

### Description
- Add a new directory `docs/evals/runs/20260604-alpha-limited-operator-test-evidence-packaging-standard/` containing six docs: `README.md`, `evidence-packaging-standard.md`, `redaction-guidance.md`, `acceptable-evidence-examples.md`, `unacceptable-evidence-examples.md`, and `import-readiness-checklist.md`. 
- The `evidence-packaging-standard.md` defines accepted evidence types, snippet vs full-transcript rules, task ID citation rules, preservation rules for operator notes, missing-field markers (e.g., `NOT_PROVIDED`, `BLOCKED_UNVERIFIED_TASK_ID`), fake-precision avoidance, claim boundaries, import-ready criteria, and blocked-bundle conditions. 
- `redaction-guidance.md` specifies mandatory redactions, placeholder vocabulary (e.g., `[REDACTED_SECRET]`, `[REDACTED_PRIVATE_ORG]`), snippet redaction workflow, and redaction-log format; example files show synthetic placeholders only and explicitly avoid real results. 
- All changes are docs-only and constrained to the new directory; no results were imported or fabricated and no protected runtime/provider/model/spec surfaces were modified. The work was committed on branch `alpha-limited-operator-test-evidence-packaging-standard-001`. 

### Testing
- Ran `git status --short` and confirmed staged/committed changes are only under `docs/evals/runs/20260604-alpha-limited-operator-test-evidence-packaging-standard/` and showed the new files. (passed) 
- Ran `git diff --check` and `git diff --cached --check` to validate whitespace and diffs; both checks passed. (passed) 
- Verified staged paths programmatically to ensure only allowed markdown files were added and performed a focused content check to confirm no-results/no-fabrication guard text is present; both checks passed. (passed) 
- Confirmed no protected surfaces were staged by checking for protected filenames/prefixes and that no runtime/provider/model/spec files were changed; this check passed. (passed) 
- Attempted `git diff --name-only main...HEAD` which failed in this checkout because a local `main` ref is unavailable; this is an environment limitation and not a change failure. (environment warning)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21c3ac67088329b0e6e3ab3076f786)