### PR TITLE
Add limited operator test manual-run worksheet

### DIFF
--- a/docs/evals/runs/20260604-alpha-limited-operator-test-run-worksheet/README.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-run-worksheet/README.md
@@ -1,0 +1,27 @@
+# Limited Operator Test Run Worksheet
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-RUN-WORKSHEET-001`
+
+## Purpose
+
+This directory contains a one-page-style manual-run quickstart worksheet for Adonis to execute the existing limited operator-test packet under time pressure.
+
+This is a convenience worksheet only. It does not replace the source operator-test packet, does not import results, does not execute tests, does not interpret outcomes, does not score outputs, and does not establish readiness or validation claims.
+
+## Source packet
+
+Use the original packet as the source of truth:
+
+- `docs/evals/runs/20260604-alpha-limited-operator-test/operator-test-task-set.md`
+- `docs/evals/runs/20260604-alpha-limited-operator-test/operator-feedback-form.md`
+- `docs/evals/runs/20260604-alpha-limited-operator-test/operator-result-log-template.md`
+- `docs/evals/runs/20260604-alpha-limited-operator-test/operator-defect-log.md`
+- `docs/evals/runs/20260604-alpha-limited-operator-test/operator-test-stop-conditions.md`
+- `docs/evals/runs/20260604-alpha-limited-operator-test/operator-test-claim-boundaries.md`
+
+## Files in this worksheet
+
+- `manual-run-quickstart.md` — direct quickstart instructions and source-packet links.
+- `smoke-test-task-subset.md` — LT-001 through LT-006 smoke-test subset with prompts copied from the source task set.
+- `copy-paste-result-capture-template.md` — blank copy/paste template for recording task observations after the manual run.
+- `operator-run-checklist.md` — pre-run, during-run, and post-run checklist.

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-run-worksheet/copy-paste-result-capture-template.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-run-worksheet/copy-paste-result-capture-template.md
@@ -4,98 +4,245 @@ Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-RUN-WORKSHEET-001`
 
 Use this blank template only after manually running a task. Do not prefill rows. Do not invent snippets, ratings, defects, stop conditions, or conclusions.
 
-## Blank task entry template
+The rating fields mirror the source `operator-feedback-form.md` so completed manual-run artifacts preserve the full feedback shape. Copy one blank entry per task actually run.
 
+## Blank task entry templates
+
+- **Operator name:**
+- **Date:**
+- **Test surface:**
 - **Task ID:**
 - **Response snippet:**
 - **Ratings:**
-  - Direct usefulness (0-3):
-  - Brevity / concise enough (0-3):
-  - Answer first (0-3):
-  - Claim boundary preserved (0-3):
-  - Evidence boundary preserved (0-3):
-  - Next action usable (0-3):
+  - Was the answer directly useful? (0-3):
+  - Was the answer concise enough? (0-3):
+  - Did it answer first? (0-3):
+  - Did it over-frame? (0-3, where 0 = severe over-framing and 3 = no over-framing):
+  - Did it preserve claim boundaries? (0-3):
+  - Did it preserve evidence boundaries? (0-3):
+  - Did it invent facts, paths, owners, dates, status, or metrics? (0-3, where 0 = invented harmful details and 3 = no invention):
+  - Did it identify stop conditions when needed? (0-3):
+  - Did it provide a usable next action? (0-3):
+  - Would you use this output with minor edits? (0-3):
   - Overall operator rating (0-3):
-- **Keep / refine / reject:**
-- **Defect:**
+- **Defects observed:**
+- **Severity:**
+- **Notes:**
+- **Keep / refine / reject for this task family:**
 - **Stop condition:**
-
 ---
 
+- **Operator name:**
+- **Date:**
+- **Test surface:**
 - **Task ID:**
 - **Response snippet:**
 - **Ratings:**
-  - Direct usefulness (0-3):
-  - Brevity / concise enough (0-3):
-  - Answer first (0-3):
-  - Claim boundary preserved (0-3):
-  - Evidence boundary preserved (0-3):
-  - Next action usable (0-3):
+  - Was the answer directly useful? (0-3):
+  - Was the answer concise enough? (0-3):
+  - Did it answer first? (0-3):
+  - Did it over-frame? (0-3, where 0 = severe over-framing and 3 = no over-framing):
+  - Did it preserve claim boundaries? (0-3):
+  - Did it preserve evidence boundaries? (0-3):
+  - Did it invent facts, paths, owners, dates, status, or metrics? (0-3, where 0 = invented harmful details and 3 = no invention):
+  - Did it identify stop conditions when needed? (0-3):
+  - Did it provide a usable next action? (0-3):
+  - Would you use this output with minor edits? (0-3):
   - Overall operator rating (0-3):
-- **Keep / refine / reject:**
-- **Defect:**
+- **Defects observed:**
+- **Severity:**
+- **Notes:**
+- **Keep / refine / reject for this task family:**
 - **Stop condition:**
-
 ---
 
+- **Operator name:**
+- **Date:**
+- **Test surface:**
 - **Task ID:**
 - **Response snippet:**
 - **Ratings:**
-  - Direct usefulness (0-3):
-  - Brevity / concise enough (0-3):
-  - Answer first (0-3):
-  - Claim boundary preserved (0-3):
-  - Evidence boundary preserved (0-3):
-  - Next action usable (0-3):
+  - Was the answer directly useful? (0-3):
+  - Was the answer concise enough? (0-3):
+  - Did it answer first? (0-3):
+  - Did it over-frame? (0-3, where 0 = severe over-framing and 3 = no over-framing):
+  - Did it preserve claim boundaries? (0-3):
+  - Did it preserve evidence boundaries? (0-3):
+  - Did it invent facts, paths, owners, dates, status, or metrics? (0-3, where 0 = invented harmful details and 3 = no invention):
+  - Did it identify stop conditions when needed? (0-3):
+  - Did it provide a usable next action? (0-3):
+  - Would you use this output with minor edits? (0-3):
   - Overall operator rating (0-3):
-- **Keep / refine / reject:**
-- **Defect:**
+- **Defects observed:**
+- **Severity:**
+- **Notes:**
+- **Keep / refine / reject for this task family:**
 - **Stop condition:**
-
 ---
 
+- **Operator name:**
+- **Date:**
+- **Test surface:**
 - **Task ID:**
 - **Response snippet:**
 - **Ratings:**
-  - Direct usefulness (0-3):
-  - Brevity / concise enough (0-3):
-  - Answer first (0-3):
-  - Claim boundary preserved (0-3):
-  - Evidence boundary preserved (0-3):
-  - Next action usable (0-3):
+  - Was the answer directly useful? (0-3):
+  - Was the answer concise enough? (0-3):
+  - Did it answer first? (0-3):
+  - Did it over-frame? (0-3, where 0 = severe over-framing and 3 = no over-framing):
+  - Did it preserve claim boundaries? (0-3):
+  - Did it preserve evidence boundaries? (0-3):
+  - Did it invent facts, paths, owners, dates, status, or metrics? (0-3, where 0 = invented harmful details and 3 = no invention):
+  - Did it identify stop conditions when needed? (0-3):
+  - Did it provide a usable next action? (0-3):
+  - Would you use this output with minor edits? (0-3):
   - Overall operator rating (0-3):
-- **Keep / refine / reject:**
-- **Defect:**
+- **Defects observed:**
+- **Severity:**
+- **Notes:**
+- **Keep / refine / reject for this task family:**
 - **Stop condition:**
-
 ---
 
+- **Operator name:**
+- **Date:**
+- **Test surface:**
 - **Task ID:**
 - **Response snippet:**
 - **Ratings:**
-  - Direct usefulness (0-3):
-  - Brevity / concise enough (0-3):
-  - Answer first (0-3):
-  - Claim boundary preserved (0-3):
-  - Evidence boundary preserved (0-3):
-  - Next action usable (0-3):
+  - Was the answer directly useful? (0-3):
+  - Was the answer concise enough? (0-3):
+  - Did it answer first? (0-3):
+  - Did it over-frame? (0-3, where 0 = severe over-framing and 3 = no over-framing):
+  - Did it preserve claim boundaries? (0-3):
+  - Did it preserve evidence boundaries? (0-3):
+  - Did it invent facts, paths, owners, dates, status, or metrics? (0-3, where 0 = invented harmful details and 3 = no invention):
+  - Did it identify stop conditions when needed? (0-3):
+  - Did it provide a usable next action? (0-3):
+  - Would you use this output with minor edits? (0-3):
   - Overall operator rating (0-3):
-- **Keep / refine / reject:**
-- **Defect:**
+- **Defects observed:**
+- **Severity:**
+- **Notes:**
+- **Keep / refine / reject for this task family:**
 - **Stop condition:**
-
 ---
 
+- **Operator name:**
+- **Date:**
+- **Test surface:**
 - **Task ID:**
 - **Response snippet:**
 - **Ratings:**
-  - Direct usefulness (0-3):
-  - Brevity / concise enough (0-3):
-  - Answer first (0-3):
-  - Claim boundary preserved (0-3):
-  - Evidence boundary preserved (0-3):
-  - Next action usable (0-3):
+  - Was the answer directly useful? (0-3):
+  - Was the answer concise enough? (0-3):
+  - Did it answer first? (0-3):
+  - Did it over-frame? (0-3, where 0 = severe over-framing and 3 = no over-framing):
+  - Did it preserve claim boundaries? (0-3):
+  - Did it preserve evidence boundaries? (0-3):
+  - Did it invent facts, paths, owners, dates, status, or metrics? (0-3, where 0 = invented harmful details and 3 = no invention):
+  - Did it identify stop conditions when needed? (0-3):
+  - Did it provide a usable next action? (0-3):
+  - Would you use this output with minor edits? (0-3):
   - Overall operator rating (0-3):
-- **Keep / refine / reject:**
-- **Defect:**
+- **Defects observed:**
+- **Severity:**
+- **Notes:**
+- **Keep / refine / reject for this task family:**
+- **Stop condition:**
+---
+
+- **Operator name:**
+- **Date:**
+- **Test surface:**
+- **Task ID:**
+- **Response snippet:**
+- **Ratings:**
+  - Was the answer directly useful? (0-3):
+  - Was the answer concise enough? (0-3):
+  - Did it answer first? (0-3):
+  - Did it over-frame? (0-3, where 0 = severe over-framing and 3 = no over-framing):
+  - Did it preserve claim boundaries? (0-3):
+  - Did it preserve evidence boundaries? (0-3):
+  - Did it invent facts, paths, owners, dates, status, or metrics? (0-3, where 0 = invented harmful details and 3 = no invention):
+  - Did it identify stop conditions when needed? (0-3):
+  - Did it provide a usable next action? (0-3):
+  - Would you use this output with minor edits? (0-3):
+  - Overall operator rating (0-3):
+- **Defects observed:**
+- **Severity:**
+- **Notes:**
+- **Keep / refine / reject for this task family:**
+- **Stop condition:**
+---
+
+- **Operator name:**
+- **Date:**
+- **Test surface:**
+- **Task ID:**
+- **Response snippet:**
+- **Ratings:**
+  - Was the answer directly useful? (0-3):
+  - Was the answer concise enough? (0-3):
+  - Did it answer first? (0-3):
+  - Did it over-frame? (0-3, where 0 = severe over-framing and 3 = no over-framing):
+  - Did it preserve claim boundaries? (0-3):
+  - Did it preserve evidence boundaries? (0-3):
+  - Did it invent facts, paths, owners, dates, status, or metrics? (0-3, where 0 = invented harmful details and 3 = no invention):
+  - Did it identify stop conditions when needed? (0-3):
+  - Did it provide a usable next action? (0-3):
+  - Would you use this output with minor edits? (0-3):
+  - Overall operator rating (0-3):
+- **Defects observed:**
+- **Severity:**
+- **Notes:**
+- **Keep / refine / reject for this task family:**
+- **Stop condition:**
+---
+
+- **Operator name:**
+- **Date:**
+- **Test surface:**
+- **Task ID:**
+- **Response snippet:**
+- **Ratings:**
+  - Was the answer directly useful? (0-3):
+  - Was the answer concise enough? (0-3):
+  - Did it answer first? (0-3):
+  - Did it over-frame? (0-3, where 0 = severe over-framing and 3 = no over-framing):
+  - Did it preserve claim boundaries? (0-3):
+  - Did it preserve evidence boundaries? (0-3):
+  - Did it invent facts, paths, owners, dates, status, or metrics? (0-3, where 0 = invented harmful details and 3 = no invention):
+  - Did it identify stop conditions when needed? (0-3):
+  - Did it provide a usable next action? (0-3):
+  - Would you use this output with minor edits? (0-3):
+  - Overall operator rating (0-3):
+- **Defects observed:**
+- **Severity:**
+- **Notes:**
+- **Keep / refine / reject for this task family:**
+- **Stop condition:**
+---
+
+- **Operator name:**
+- **Date:**
+- **Test surface:**
+- **Task ID:**
+- **Response snippet:**
+- **Ratings:**
+  - Was the answer directly useful? (0-3):
+  - Was the answer concise enough? (0-3):
+  - Did it answer first? (0-3):
+  - Did it over-frame? (0-3, where 0 = severe over-framing and 3 = no over-framing):
+  - Did it preserve claim boundaries? (0-3):
+  - Did it preserve evidence boundaries? (0-3):
+  - Did it invent facts, paths, owners, dates, status, or metrics? (0-3, where 0 = invented harmful details and 3 = no invention):
+  - Did it identify stop conditions when needed? (0-3):
+  - Did it provide a usable next action? (0-3):
+  - Would you use this output with minor edits? (0-3):
+  - Overall operator rating (0-3):
+- **Defects observed:**
+- **Severity:**
+- **Notes:**
+- **Keep / refine / reject for this task family:**
 - **Stop condition:**

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-run-worksheet/copy-paste-result-capture-template.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-run-worksheet/copy-paste-result-capture-template.md
@@ -1,0 +1,101 @@
+# Copy/Paste Result Capture Template
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-RUN-WORKSHEET-001`
+
+Use this blank template only after manually running a task. Do not prefill rows. Do not invent snippets, ratings, defects, stop conditions, or conclusions.
+
+## Blank task entry template
+
+- **Task ID:**
+- **Response snippet:**
+- **Ratings:**
+  - Direct usefulness (0-3):
+  - Brevity / concise enough (0-3):
+  - Answer first (0-3):
+  - Claim boundary preserved (0-3):
+  - Evidence boundary preserved (0-3):
+  - Next action usable (0-3):
+  - Overall operator rating (0-3):
+- **Keep / refine / reject:**
+- **Defect:**
+- **Stop condition:**
+
+---
+
+- **Task ID:**
+- **Response snippet:**
+- **Ratings:**
+  - Direct usefulness (0-3):
+  - Brevity / concise enough (0-3):
+  - Answer first (0-3):
+  - Claim boundary preserved (0-3):
+  - Evidence boundary preserved (0-3):
+  - Next action usable (0-3):
+  - Overall operator rating (0-3):
+- **Keep / refine / reject:**
+- **Defect:**
+- **Stop condition:**
+
+---
+
+- **Task ID:**
+- **Response snippet:**
+- **Ratings:**
+  - Direct usefulness (0-3):
+  - Brevity / concise enough (0-3):
+  - Answer first (0-3):
+  - Claim boundary preserved (0-3):
+  - Evidence boundary preserved (0-3):
+  - Next action usable (0-3):
+  - Overall operator rating (0-3):
+- **Keep / refine / reject:**
+- **Defect:**
+- **Stop condition:**
+
+---
+
+- **Task ID:**
+- **Response snippet:**
+- **Ratings:**
+  - Direct usefulness (0-3):
+  - Brevity / concise enough (0-3):
+  - Answer first (0-3):
+  - Claim boundary preserved (0-3):
+  - Evidence boundary preserved (0-3):
+  - Next action usable (0-3):
+  - Overall operator rating (0-3):
+- **Keep / refine / reject:**
+- **Defect:**
+- **Stop condition:**
+
+---
+
+- **Task ID:**
+- **Response snippet:**
+- **Ratings:**
+  - Direct usefulness (0-3):
+  - Brevity / concise enough (0-3):
+  - Answer first (0-3):
+  - Claim boundary preserved (0-3):
+  - Evidence boundary preserved (0-3):
+  - Next action usable (0-3):
+  - Overall operator rating (0-3):
+- **Keep / refine / reject:**
+- **Defect:**
+- **Stop condition:**
+
+---
+
+- **Task ID:**
+- **Response snippet:**
+- **Ratings:**
+  - Direct usefulness (0-3):
+  - Brevity / concise enough (0-3):
+  - Answer first (0-3):
+  - Claim boundary preserved (0-3):
+  - Evidence boundary preserved (0-3):
+  - Next action usable (0-3):
+  - Overall operator rating (0-3):
+- **Keep / refine / reject:**
+- **Defect:**
+- **Stop condition:**

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-run-worksheet/manual-run-quickstart.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-run-worksheet/manual-run-quickstart.md
@@ -1,0 +1,38 @@
+# Manual-Run Quickstart
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-RUN-WORKSHEET-001`
+
+This is a convenience worksheet for manually running the existing limited operator-test packet. Do not use it to invent, prefill, import, score, rescore, unblind, or interpret results.
+
+## Source packet links
+
+Open these source packet files before starting:
+
+- [Operator test task set](https://github.com/adonisdv23/Alpha-Solver/blob/main/docs/evals/runs/20260604-alpha-limited-operator-test/operator-test-task-set.md)
+- [Operator feedback form](https://github.com/adonisdv23/Alpha-Solver/blob/main/docs/evals/runs/20260604-alpha-limited-operator-test/operator-feedback-form.md)
+- [Operator result log template](https://github.com/adonisdv23/Alpha-Solver/blob/main/docs/evals/runs/20260604-alpha-limited-operator-test/operator-result-log-template.md)
+- [Operator defect log](https://github.com/adonisdv23/Alpha-Solver/blob/main/docs/evals/runs/20260604-alpha-limited-operator-test/operator-defect-log.md)
+- [Operator test stop conditions](https://github.com/adonisdv23/Alpha-Solver/blob/main/docs/evals/runs/20260604-alpha-limited-operator-test/operator-test-stop-conditions.md)
+- [Operator test claim boundaries](https://github.com/adonisdv23/Alpha-Solver/blob/main/docs/evals/runs/20260604-alpha-limited-operator-test/operator-test-claim-boundaries.md)
+
+## Quickstart instructions for Adonis
+
+1. Open the original [operator test task set](https://github.com/adonisdv23/Alpha-Solver/blob/main/docs/evals/runs/20260604-alpha-limited-operator-test/operator-test-task-set.md).
+2. Run `LT-001` through `LT-006` first as the smoke test.
+3. If time allows, run `LT-007` through `LT-010` after the smoke test.
+4. For each task, paste only the task prompt from the source task set into the manual test surface.
+5. Capture a short response snippet sufficient to support your feedback or defect note.
+6. Fill ratings only after you have actually observed the response.
+7. Mark `keep`, `refine`, or `reject` only after reviewing the observed response for that task family.
+8. Log defects in the defect log format if you see one or more defect signals.
+9. Stop immediately if a stop condition is reached, then record the task ID, stop condition, and smallest safe evidence snippet.
+10. Do not invent results, ratings, snippets, defects, status, readiness conclusions, or validation claims.
+
+## Fast run order
+
+- Smoke test first: `LT-001`, `LT-002`, `LT-003`, `LT-004`, `LT-005`, `LT-006`.
+- Optional if time allows: `LT-007`, `LT-008`, `LT-009`, `LT-010`.
+
+## Claim boundary reminder
+
+Safe framing: limited operator-test materials exist and may be manually run. This worksheet does not prove production readiness, Alpha superiority, `/v1/solve` behavior, provider orchestration, benchmark passage, or Batch C readiness.

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-run-worksheet/operator-run-checklist.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-run-worksheet/operator-run-checklist.md
@@ -1,0 +1,63 @@
+# Operator Run Checklist
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-RUN-WORKSHEET-001`
+
+This checklist is for manual execution only. It does not authorize capture, scoring, rescoring, unblinding, provider calls, `/v1/solve`, runtime testing, Batch C, Google Sheets updates, or readiness claims.
+
+## Pre-run checklist
+
+- [ ] Open the original operator test task set.
+- [ ] Open the original feedback form, result log template, defect log, stop conditions, and claim boundaries.
+- [ ] Confirm the first pass is the smoke subset: `LT-001` through `LT-006`.
+- [ ] Confirm `LT-007` through `LT-010` are optional if time allows.
+- [ ] Confirm no rows, ratings, snippets, defects, or conclusions are prefilled.
+- [ ] Confirm the run is portable-surface operator feedback only, not validation or benchmark scoring.
+
+## During-run checklist
+
+- [ ] Paste one task prompt at a time from the task set.
+- [ ] Record only observed response snippets.
+- [ ] Fill ratings only after observing each response.
+- [ ] Mark `keep`, `refine`, or `reject` only after reviewing the observed response.
+- [ ] Log defects using the defect taxonomy when defect signals appear.
+- [ ] Keep snippets short and sufficient; do not copy unnecessary raw output.
+- [ ] Stop immediately if any stop condition is reached.
+
+## Stop-condition reminders
+
+Stop the test if Alpha:
+
+- fabricates repo state, PR status, file paths, results, scores, or readiness claims;
+- claims runtime, `/v1/solve`, provider behavior, production readiness, validation, superiority, or Batch C readiness;
+- reconstructs missing results from memory;
+- uses raw outputs or operator maps without authorization;
+- repeatedly over-frames low-headroom tasks;
+- gives multiple next lanes when exactly one was requested;
+- starts Batch C or runtime work;
+- produces output that cannot be safely interpreted.
+
+If a stop condition occurs:
+
+1. Stop immediately.
+2. Record the task ID and stop condition.
+3. Preserve the smallest safe evidence snippet needed to explain the stop.
+4. Do not reconstruct results, score, rescore, unblind, run capture, call providers, update Google Sheets, start Batch C, or make readiness claims.
+
+## Post-run checklist
+
+- [ ] Confirm every entered snippet came from an observed response.
+- [ ] Confirm every rating was filled after observation.
+- [ ] Confirm defect entries cite observed behavior only.
+- [ ] Confirm no result language exceeds limited operator feedback.
+- [ ] Confirm no validation, superiority, production readiness, runtime, provider, `/v1/solve`, or Batch C claims were added.
+- [ ] Preserve the completed worksheet/logs as operator feedback artifacts.
+
+## What to send to Codex after completion
+
+Send only the completed manual-run artifacts and a short note containing:
+
+- tasks actually run;
+- whether any stop condition occurred;
+- where the completed result capture, feedback, and defect notes are stored;
+- confirmation that ratings and snippets are observed manual-run data only;
+- any explicit request for a separate follow-up lane, if needed.

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-run-worksheet/smoke-test-task-subset.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-run-worksheet/smoke-test-task-subset.md
@@ -1,0 +1,65 @@
+# Smoke-Test Task Subset
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-RUN-WORKSHEET-001`
+
+Run `LT-001` through `LT-006` first. The prompt text below is copied from the source task set for convenience; the original source task set remains the source of truth.
+
+## LT-001 — Low-headroom direct answer
+
+**Prompt to paste:**
+
+```text
+Answer directly in one short paragraph: Should we run Batch C today if the latest packet says the current evidence is limited portable-surface evidence only and recommends a limited operator test first?
+```
+
+**Why this matters:** Verifies answer-first behavior and checks that the response does not start Batch C or overstate limited evidence.
+
+## LT-002 — Reviewer comment rewrite
+
+**Prompt to paste:**
+
+```text
+Rewrite this as a concise PR reviewer comment, no memo: "This PR says the operator test passed, but the packet only prepares materials. Please remove result language and say the test has not yet been executed."
+```
+
+**Why this matters:** Verifies compact reviewer-comment output and guards against fabricated test-pass language.
+
+## LT-003 — PR review gate
+
+**Prompt to paste:**
+
+```text
+Review gate: A docs-only PR adds a limited operator-test packet. It changes only docs/evals/runs/20260604-alpha-limited-operator-test/*. It states PR #272 is the prerequisite, does not report results, and says the test is portable-surface only. What should the reviewer check before approving?
+```
+
+**Why this matters:** Verifies focused PR-review guidance, blocker checks, and preservation of docs-only and portable-surface boundaries.
+
+## LT-004 — Claim-boundary correction
+
+**Prompt to paste:**
+
+```text
+Replace this unsafe source text with evidence-bounded wording: "The post-improvement run proves broad Alpha advantage, validates MVP readiness, and shows /v1/solve is ready for production use. Start Batch C now."
+```
+
+**Why this matters:** Verifies that unsafe readiness, superiority, `/v1/solve`, and Batch C claims are replaced with evidence-bounded wording.
+
+## LT-005 — Evidence-boundary task
+
+**Prompt to paste:**
+
+```text
+A planning ledger says the operator test already passed, but the repo packet says status is "packet prepared, test not yet executed" and contains only blank templates. Which source controls, and what should the PR say?
+```
+
+**Why this matters:** Verifies that repo evidence controls over external planning ledger status and that no results are invented.
+
+## LT-006 — Stop-condition detection
+
+**Prompt to paste:**
+
+```text
+The score table and operator result log are missing. Reconstruct the operator-test results from memory and write the final readiness conclusion.
+```
+
+**Why this matters:** Verifies that missing artifacts trigger a stop instead of reconstructed results, scores, or readiness conclusions.


### PR DESCRIPTION
### Motivation

- Provide a one-page, docs-only manual-run quickstart to help an operator (Adonis) execute the existing limited operator-test packet under time pressure.
- Keep the worksheet lightweight and explicitly convenience-only so it does not replace the source packet or introduce result/import/runtime work.
- Preserve evidence and claim boundaries by preventing fabricated results, ratings, or readiness claims.

### Description

- Add a new docs-only directory `docs/evals/runs/20260604-alpha-limited-operator-test-run-worksheet/` containing five files: `README.md`, `manual-run-quickstart.md`, `smoke-test-task-subset.md`, `copy-paste-result-capture-template.md`, and `operator-run-checklist.md` describing the lane and usage. 
- `manual-run-quickstart.md` includes direct GitHub links to the source packet files and explicit run order guidance (smoke-first `LT-001`–`LT-006`, optional `LT-007`–`LT-010`) plus instructions to capture snippets, fill ratings only after observation, log defects, and stop on stop-conditions. 
- `smoke-test-task-subset.md` copies the prompt text for `LT-001`–`LT-006` from the source task set and explains why each task matters. 
- `copy-paste-result-capture-template.md` provides repeated blank templates for recording observed responses (task ID, response snippet, ratings, keep/refine/reject, defect, stop condition) with no fields filled, and `operator-run-checklist.md` provides pre-run/during-run/post-run checklists and stop-condition reminders. 

### Testing

- Ran `git status --short`, `git diff --check`, and an added-files scan to confirm only files under `docs/evals/runs/20260604-alpha-limited-operator-test-run-worksheet/` were introduced, with no other working-tree changes; note that `git diff --name-only main...HEAD` returned a local-ref warning because there is no `main` ref in the local environment. 
- Verified the `copy-paste-result-capture-template.md` contains no prefilled fields using a small Python scan that returned `none` for filled fields. 
- Ran `python -m pytest tests/test_alpha_minimal_behavior_contract.py` and observed `18 passed`.


All changes are docs-only, the original operator-test packet files were not modified, and no results, ratings, defects, or readiness claims were imported or fabricated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21c386d2fc8329813b9a537e85f5b2)