### PR TITLE
Add limited operator test post-results decision framework

### DIFF
--- a/docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision-framework/README.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision-framework/README.md
@@ -1,0 +1,48 @@
+# Limited Operator Test Post-Results Decision Framework
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-POST-RESULTS-DECISION-FRAMEWORK-001`
+
+Status: decision framework prepared before any results are imported or interpreted.
+
+## Purpose
+
+Define the allowed decision space after actual limited operator-test results are imported and interpreted in a later, separate lane. This framework is intentionally pre-committed so post-results decisions are constrained by repo-preserved rules rather than adjusted after seeing feedback.
+
+## Source evidence
+
+This framework is based on the preserved packet and recent portable-contract decision history:
+
+- `docs/evals/runs/20260604-alpha-limited-operator-test/README.md`
+- `docs/evals/runs/20260604-alpha-limited-operator-test/operator-test-task-set.md`
+- `docs/evals/runs/20260604-alpha-limited-operator-test/operator-test-claim-boundaries.md`
+- `docs/evals/runs/20260604-post-minimal-behavior-finalization/minimal-contract-decision.md`
+- `docs/evals/runs/20260604-alpha-brevity-control-refinement/README.md`
+
+## Files in this framework
+
+- `README.md`
+- `post-results-decision-framework.md`
+- `allowed-next-lanes.md`
+- `blocked-next-lanes.md`
+- `decision-templates.md`
+
+## Scope
+
+This lane only defines decision rules for use after a future import-and-interpretation lane exists. It does not import, fabricate, infer, score, rescore, unblind, or interpret operator-test results.
+
+## Non-actions
+
+This framework does not:
+
+- import operator feedback or result logs
+- invent operator feedback, defects, scores, or outcomes
+- inspect maps, raw outputs, scorer packets, or scored artifacts
+- update Google Sheets or external planning ledgers
+- start Batch C
+- call providers
+- use `/v1/solve`
+- modify runtime, provider, model, routing, capture, scoring, or unblinding behavior
+
+## Evidence boundary
+
+Until a later lane imports and interprets actual operator-test artifacts, the evidence boundary remains: packet prepared, test results not represented here, portable-surface-only claim limits preserved.

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision-framework/allowed-next-lanes.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision-framework/allowed-next-lanes.md
@@ -1,0 +1,98 @@
+# Allowed Next Lanes
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-POST-RESULTS-DECISION-FRAMEWORK-001`
+
+Status: allowed post-results lane menu defined before results import or interpretation.
+
+## Use boundary
+
+These lanes become selectable only after a separate lane imports and interprets actual limited operator-test results. This file does not choose a lane, import results, interpret feedback, or claim readiness.
+
+## Lane menu
+
+### `ALPHA-LIMITED-OPERATOR-TEST-SECOND-PASS-001`
+
+Use when the interpreted evidence supports keeping the current portable contract unchanged for another manual operator pass.
+
+Allowed scope:
+
+- prepare or run a second portable-surface operator pass under a separately approved lane;
+- preserve operator feedback and defects;
+- maintain claim boundaries from the limited operator-test packet.
+
+Not allowed:
+
+- Batch C execution;
+- runtime or `/v1/solve` measurement;
+- provider orchestration;
+- production, MVP, or benchmark claims.
+
+### `ALPHA-PORTABLE-CONTRACT-FOLLOWUP-REFINEMENT-001`
+
+Use when interpreted feedback identifies bounded portable-contract defects that warrant targeted refinement.
+
+Allowed scope:
+
+- refine portable contract wording or docs within the interpreted defect boundary;
+- add or update focused portable-surface tests if code changes are separately authorized;
+- preserve answer-first, brevity/control, evidence-boundary, stop-condition, and artifact-discipline goals.
+
+Not allowed:
+
+- runtime, provider, model, routing, capture, scoring, rescoring, or unblinding changes;
+- broad refactors;
+- readiness, benchmark, or validation claims.
+
+### `ALPHA-OPERATOR-TEST-EVIDENCE-REPAIR-001`
+
+Use when imported artifacts, provenance, logs, preservation notes, or claim-boundary records are incomplete or inconsistent.
+
+Allowed scope:
+
+- repair documentation of the evidence chain;
+- reconcile missing or inconsistent preservation records;
+- document why a decision cannot yet be made.
+
+Not allowed:
+
+- fabricating feedback, defects, outcomes, scores, or conclusions;
+- mutating protected raw/scored artifacts or operator maps;
+- using external ledgers as source evidence when repo artifacts conflict.
+
+### `ALPHA-PORTABLE-SURFACE-READINESS-REVIEW-001`
+
+Use only when interpreted limited operator-test evidence is strong, defects are low, and the review remains portable-surface bounded.
+
+Allowed scope:
+
+- prepare a review of whether the portable surface is ready for a later, separately approved progression decision;
+- enumerate remaining evidence gaps and blocked claims;
+- preserve limited-evidence language.
+
+Not allowed:
+
+- production-readiness conclusion;
+- MVP validation;
+- runtime or provider readiness;
+- `/v1/solve` claims;
+- Batch C execution.
+
+### `ALPHA-BATCH-C-READINESS-REVIEW-001`
+
+Use only as review, not execution, and only if imported and interpreted evidence is strong, defects are low, and the review explicitly preserves all blocked execution boundaries.
+
+Allowed scope:
+
+- evaluate whether a future Batch C execution proposal should be drafted;
+- list prerequisites, evidence gaps, and stop conditions;
+- confirm what remains unproven.
+
+Not allowed:
+
+- executing Batch C;
+- preparing scored packets, capture runs, unblinding, rescoring, or provider calls;
+- claiming Batch C readiness as established by operator feedback alone.
+
+## Selection rule
+
+Select exactly one next lane per post-results decision. If the evidence supports more than one lane, choose the narrowest lane that resolves the immediate blocker before considering broader review.

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision-framework/allowed-next-lanes.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision-framework/allowed-next-lanes.md
@@ -27,6 +27,36 @@ Not allowed:
 - provider orchestration;
 - production, MVP, or benchmark claims.
 
+
+### `ALPHA-LIMITED-OPERATOR-TEST-RERUN-001`
+
+Use when the first limited operator-test run cannot support interpretation because it was incomplete, blocked, or invalid.
+
+Applies when:
+
+- the first operator run was incomplete;
+- the tested surface was wrong or blocked;
+- the evidence bundle was too incomplete for interpretation;
+- a stop condition requires rerun after repair; or
+- the operator did not complete enough tasks.
+
+Allowed scope:
+
+- redo the limited portable-surface operator test under a separately approved rerun lane;
+- preserve corrected execution notes, operator feedback, defects, and evidence-chain records;
+- document why the prior run cannot be used as a valid first pass.
+
+Not allowed:
+
+- filling gaps in the prior run by memory, inference, external ledgers, or invented results;
+- treating an incomplete, blocked, or invalid first run as a valid pass;
+- Batch C execution, runtime work, provider calls, `/v1/solve` measurement, or readiness claims.
+
+Distinction from second pass:
+
+- `ALPHA-LIMITED-OPERATOR-TEST-SECOND-PASS-001` is a follow-up run after a valid first pass.
+- `ALPHA-LIMITED-OPERATOR-TEST-RERUN-001` is a redo because the first run was incomplete, blocked, or invalid.
+
 ### `ALPHA-PORTABLE-CONTRACT-FOLLOWUP-REFINEMENT-001`
 
 Use when interpreted feedback identifies bounded portable-contract defects that warrant targeted refinement.

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision-framework/blocked-next-lanes.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision-framework/blocked-next-lanes.md
@@ -1,0 +1,54 @@
+# Blocked Next Lanes and Claims
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-POST-RESULTS-DECISION-FRAMEWORK-001`
+
+Status: blocked boundaries preserved before results import or interpretation.
+
+## Rule
+
+The following lanes, activities, and claims remain blocked unless a later, separate, evidence-backed spec explicitly justifies and authorizes them. Imported operator-test feedback alone is not sufficient to unlock these items.
+
+## Blocked activities
+
+- Batch C execution
+- runtime wiring
+- `/v1/solve` measurement
+- provider orchestration
+- production readiness work or claims
+- MVP validation work or claims
+- public user testing
+- benchmark success claims
+- exact billing claims
+
+## Additional protected surfaces
+
+This framework also does not authorize changes to:
+
+- provider adapters;
+- model configuration;
+- routing behavior;
+- capture, scoring, rescoring, or unblinding scripts;
+- raw outputs, scored artifacts, sanitized scorer-facing packets, or operator maps;
+- Google Sheets or external planning ledgers.
+
+## Required blocked-language examples
+
+Do not state or imply:
+
+- “Batch C can run now.”
+- “The runtime is ready.”
+- “`/v1/solve` has been measured.”
+- “Provider orchestration works.”
+- “Alpha is production-ready.”
+- “MVP readiness is validated.”
+- “Public user testing is approved.”
+- “The benchmark passed.”
+- “Exact billing is proven.”
+
+## Safe replacement framing
+
+Use bounded language such as:
+
+- “The post-results decision remains portable-surface bounded.”
+- “Operator feedback may support a second pass, targeted refinement, evidence repair, pause, or readiness-review preparation.”
+- “Any Batch C, runtime, provider, production, MVP, public-testing, benchmark, or exact-billing claim requires a separate justified lane.”

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision-framework/decision-templates.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision-framework/decision-templates.md
@@ -73,9 +73,9 @@ Source interpretation artifact: `<path-to-post-results-interpretation>`
 Evidence boundary: imported artifacts were insufficient for a stable post-results decision.
 
 Reason rerun is required:
-- `<missing task coverage, incomplete feedback, procedural ambiguity, or equivalent issue>`
+- `<first run incomplete, wrong/blocked surface, incomplete evidence bundle, stop-condition rerun requirement, insufficient completed tasks, or equivalent issue>`
 
-Next lane: `<rerun lane ID or ALPHA-LIMITED-OPERATOR-TEST-SECOND-PASS-001 if approved as the corrected pass>`
+Next lane: `ALPHA-LIMITED-OPERATOR-TEST-RERUN-001`
 
 Blocked:
 - filling gaps from memory

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision-framework/decision-templates.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision-framework/decision-templates.md
@@ -1,0 +1,168 @@
+# Decision Templates
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-POST-RESULTS-DECISION-FRAMEWORK-001`
+
+Status: post-results decision templates prepared before results import or interpretation.
+
+## Template: keep
+
+```md
+# Post-Results Decision: Keep Current Portable Contract
+
+Decision: keep current portable contract for a second operator pass.
+
+Source interpretation artifact: `<path-to-post-results-interpretation>`
+
+Evidence boundary: imported and interpreted limited operator-test feedback only; portable surface only.
+
+Rationale:
+- `<summarize interpreted support without adding new results>`
+- `<summarize why defects do not require immediate refinement>`
+
+Next lane: `ALPHA-LIMITED-OPERATOR-TEST-SECOND-PASS-001`
+
+Blocked:
+- Batch C execution
+- runtime wiring
+- `/v1/solve` measurement
+- provider orchestration
+- production readiness
+- MVP validation
+- public user testing
+- benchmark success
+- exact billing claims
+
+Confirmation: this decision does not score, rescore, unblind, call providers, update Sheets, execute Batch C, or modify runtime/provider/model/routing behavior.
+```
+
+## Template: refine
+
+```md
+# Post-Results Decision: Targeted Portable-Contract Refinement
+
+Decision: targeted refinement.
+
+Source interpretation artifact: `<path-to-post-results-interpretation>`
+
+Evidence boundary: imported and interpreted limited operator-test feedback only; portable surface only.
+
+Defects to address:
+- `<bounded defect family>`
+- `<bounded defect family>`
+
+Out of scope:
+- runtime/provider/model/routing changes
+- capture, scoring, rescoring, or unblinding changes
+- Batch C execution
+- readiness, benchmark, MVP, production, or public-testing claims
+
+Next lane: `ALPHA-PORTABLE-CONTRACT-FOLLOWUP-REFINEMENT-001`
+
+Confirmation: this decision authorizes only a narrow follow-up refinement lane and does not invent results or broaden the evidence boundary.
+```
+
+## Template: rerun
+
+```md
+# Post-Results Decision: Rerun Limited Operator Test
+
+Decision: rerun limited operator test.
+
+Source interpretation artifact: `<path-to-post-results-interpretation>`
+
+Evidence boundary: imported artifacts were insufficient for a stable post-results decision.
+
+Reason rerun is required:
+- `<missing task coverage, incomplete feedback, procedural ambiguity, or equivalent issue>`
+
+Next lane: `<rerun lane ID or ALPHA-LIMITED-OPERATOR-TEST-SECOND-PASS-001 if approved as the corrected pass>`
+
+Blocked:
+- filling gaps from memory
+- fabricating feedback, defects, outcomes, or scores
+- Batch C execution
+- runtime, provider, `/v1/solve`, production, MVP, public-testing, benchmark, or exact-billing claims
+
+Confirmation: this decision does not treat incomplete artifacts as results and does not authorize protected-surface changes.
+```
+
+## Template: pause
+
+```md
+# Post-Results Decision: Pause Progression
+
+Decision: pause progression.
+
+Source interpretation artifact: `<path-to-post-results-interpretation>`
+
+Evidence boundary: imported and interpreted limited operator-test feedback only; portable surface only.
+
+Reason progression is paused:
+- `<serious defect, unsafe claim behavior, stop-condition failure, artifact-discipline failure, or unresolved ambiguity>`
+
+Required before progression resumes:
+- `<repair, refinement, rerun, or explicit future spec>`
+
+Next lane: `<none, ALPHA-OPERATOR-TEST-EVIDENCE-REPAIR-001, or ALPHA-PORTABLE-CONTRACT-FOLLOWUP-REFINEMENT-001>`
+
+Confirmation: no readiness-review, Batch C review, Batch C execution, runtime work, provider work, `/v1/solve` measurement, scoring, rescoring, unblinding, or claims expansion is authorized.
+```
+
+## Template: readiness review
+
+```md
+# Post-Results Decision: Prepare Readiness Review
+
+Decision: prepare readiness-review lane only.
+
+Source interpretation artifact: `<path-to-post-results-interpretation>`
+
+Evidence boundary: imported and interpreted limited operator-test feedback only; portable surface only.
+
+Why review is allowed:
+- `<interpreted evidence is strong>`
+- `<defects are low>`
+- `<provenance is preserved>`
+
+Next lane: `ALPHA-PORTABLE-SURFACE-READINESS-REVIEW-001` or `ALPHA-BATCH-C-READINESS-REVIEW-001`
+
+Review-only limits:
+- no Batch C execution
+- no runtime wiring
+- no `/v1/solve` measurement
+- no provider orchestration
+- no production-readiness claim
+- no MVP-validation claim
+- no benchmark-success claim
+- no exact-billing claim
+
+Confirmation: this decision prepares review only and does not execute or validate the reviewed lane.
+```
+
+## Template: blocked
+
+```md
+# Post-Results Decision: Blocked Request
+
+Requested lane or claim: `<requested blocked lane or claim>`
+
+Decision: blocked unless separately justified by a future evidence-backed spec.
+
+Reason blocked:
+- `<explain why imported operator feedback does not authorize this activity or claim>`
+
+Allowed alternative, if any: `<one allowed lane from allowed-next-lanes.md or none>`
+
+Blocked activities and claims preserved:
+- Batch C execution
+- runtime wiring
+- `/v1/solve` measurement
+- provider orchestration
+- production readiness
+- MVP validation
+- public user testing
+- benchmark success
+- exact billing claims
+
+Confirmation: this blocked decision does not import, invent, score, rescore, unblind, call providers, update Sheets, execute Batch C, or modify runtime/provider/model/routing behavior.
+```

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision-framework/post-results-decision-framework.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision-framework/post-results-decision-framework.md
@@ -39,7 +39,7 @@ This decision may authorize a narrow portable-contract follow-up refinement. It 
 
 Allowed when the operator run is procedurally incomplete, affected by execution ambiguity, missing required task coverage, missing required feedback fields, or otherwise insufficient to support a stable interpretation.
 
-This decision may authorize rerunning the limited manual operator test or a tightly corrected version of it. It must not fill gaps by memory, inference, invented results, or external planning-ledger claims.
+This decision may authorize `ALPHA-LIMITED-OPERATOR-TEST-RERUN-001` to redo the limited manual operator test or a tightly corrected version of it. It must not fill gaps by memory, inference, invented results, or external planning-ledger claims.
 
 ### 4. Repair evidence chain
 
@@ -76,7 +76,7 @@ Every post-results decision must state:
 When more than one decision seems plausible:
 
 1. choose evidence repair over interpretation if provenance is weak;
-2. choose rerun over refinement if task coverage or feedback completeness is insufficient;
+2. choose `ALPHA-LIMITED-OPERATOR-TEST-RERUN-001` over refinement if task coverage or feedback completeness is insufficient;
 3. choose targeted refinement over readiness review if defects are material but bounded;
-4. choose second pass over readiness review if feedback is positive but sample/evidence breadth remains limited; and
+4. choose `ALPHA-LIMITED-OPERATOR-TEST-SECOND-PASS-001` over readiness review if a valid first pass is positive but sample/evidence breadth remains limited; and
 5. choose pause if any decision would require inventing results, expanding claims, or crossing protected surfaces.

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision-framework/post-results-decision-framework.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision-framework/post-results-decision-framework.md
@@ -1,0 +1,82 @@
+# Post-Results Decision Framework
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-POST-RESULTS-DECISION-FRAMEWORK-001`
+
+Status: allowed decisions defined before results import or interpretation.
+
+## Preconditions before using this framework
+
+This framework may be applied only after a separate, explicit lane has:
+
+1. imported actual limited operator-test artifacts from the manual operator run;
+2. preserved the evidence chain without mutating source artifacts;
+3. interpreted the imported feedback and defects within the portable-surface claim boundary; and
+4. documented the interpretation without scoring, rescoring, unblinding, provider calls, runtime measurement, or Batch C execution unless separately authorized by a later spec.
+
+If those preconditions are not satisfied, the only allowed decision is to continue treating the operator-test packet as prepared but not yet usable for post-results decisions.
+
+## Decision principles
+
+Post-results decisions must be grounded in imported and interpreted operator feedback only. They must not convert operator feedback into benchmark proof, MVP validation, production readiness, broad Alpha superiority, `/v1/solve` behavior, provider behavior, routing behavior, or exact billing evidence.
+
+The decision maker must select the narrowest lane that addresses the interpreted evidence. If evidence is incomplete, inconsistent, missing provenance, or outside the portable surface, the decision must prefer evidence repair or pause over progression.
+
+## Allowed decisions
+
+### 1. Keep current portable contract for a second operator pass
+
+Allowed when interpreted feedback indicates the current portable contract is usable enough to preserve unchanged for another manual operator pass, but the evidence is still too limited for readiness claims.
+
+This decision may authorize a second-pass operator-test lane that repeats or extends manual portable-surface feedback collection. It must not authorize Batch C execution, runtime wiring, provider orchestration, `/v1/solve` measurement, or production-readiness claims.
+
+### 2. Targeted refinement
+
+Allowed when interpreted feedback identifies specific, bounded defects in answer-first behavior, brevity/control, claim-boundary handling, evidence discipline, stop-condition behavior, artifact handling, or next-action quality.
+
+This decision may authorize a narrow portable-contract follow-up refinement. It must preserve existing useful behavior and must not broaden into runtime, provider, model, routing, capture, scoring, rescoring, or unblinding changes.
+
+### 3. Rerun limited operator test
+
+Allowed when the operator run is procedurally incomplete, affected by execution ambiguity, missing required task coverage, missing required feedback fields, or otherwise insufficient to support a stable interpretation.
+
+This decision may authorize rerunning the limited manual operator test or a tightly corrected version of it. It must not fill gaps by memory, inference, invented results, or external planning-ledger claims.
+
+### 4. Repair evidence chain
+
+Allowed when artifacts, provenance, preservation notes, result logs, defect logs, or claim-boundary records are incomplete, inconsistent, or not repo-preserved enough to support a decision.
+
+This decision may authorize an evidence-repair lane limited to artifact preservation, provenance clarification, missing-template correction, or documentation reconciliation. It must not reinterpret absent evidence as results and must not alter protected raw/scored artifacts or operator maps.
+
+### 5. Pause progression
+
+Allowed when interpreted feedback reveals serious defects, unsafe claim behavior, fabricated-result risk, stop-condition failure, artifact-discipline failure, or any ambiguity that makes progression unsafe.
+
+This decision blocks progression until a later approved lane resolves the issue. It may recommend a repair, refinement, or rerun lane, but it must not proceed to readiness review or Batch C review.
+
+### 6. Prepare readiness-review lane only if evidence is strong and defects are low
+
+Allowed only when imported and interpreted operator-test evidence is strong, internally consistent, repo-preserved, portable-surface bounded, and shows low defect severity/frequency.
+
+This decision may prepare a readiness-review lane. Readiness review means review only: it may assess whether future progression should be considered, but it does not execute Batch C, validate MVP readiness, prove benchmark success, establish production readiness, or authorize runtime/provider/model/routing changes.
+
+## Decision output requirements
+
+Every post-results decision must state:
+
+- selected decision;
+- source interpretation artifact used;
+- evidence boundary;
+- defects or evidence gaps that drove the decision;
+- explicitly blocked lanes and claims;
+- exact next lane, if any; and
+- confirmation that no scoring, rescoring, unblinding, provider calls, `/v1/solve` measurement, Batch C execution, Google Sheets update, or runtime/provider/model/routing change is authorized by the decision itself.
+
+## Tie-breakers
+
+When more than one decision seems plausible:
+
+1. choose evidence repair over interpretation if provenance is weak;
+2. choose rerun over refinement if task coverage or feedback completeness is insufficient;
+3. choose targeted refinement over readiness review if defects are material but bounded;
+4. choose second pass over readiness review if feedback is positive but sample/evidence breadth remains limited; and
+5. choose pause if any decision would require inventing results, expanding claims, or crossing protected surfaces.


### PR DESCRIPTION
### Motivation

- Pre-commit a docs-only decision framework that constrains post-results decisions for `ALPHA-LIMITED-OPERATOR-TEST-POST-RESULTS-DECISION-FRAMEWORK-001` before any operator results are imported or interpreted. 
- Ensure post-results choices follow repo-preserved evidence boundaries and avoid expanding into runtime, provider, scoring, or Batch C surfaces. 
- Provide maintainers a clear, auditable set of allowed actions and reusable templates to reduce ad-hoc decisions after results are available.

### Description

- Added a new docs directory `docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision-framework/` containing `README.md`, `post-results-decision-framework.md`, `allowed-next-lanes.md`, `blocked-next-lanes.md`, and `decision-templates.md` that together define the framework. 
- `post-results-decision-framework.md` codifies preconditions, decision principles, and the allowed decisions: keep for a second operator pass, targeted refinement, rerun limited operator test, repair evidence chain, pause progression, and prepare a readiness-review lane only when evidence is strong and defects are low. 
- `allowed-next-lanes.md` enumerates the permitted next lanes: `ALPHA-LIMITED-OPERATOR-TEST-SECOND-PASS-001`, `ALPHA-PORTABLE-CONTRACT-FOLLOWUP-REFINEMENT-001`, `ALPHA-OPERATOR-TEST-EVIDENCE-REPAIR-001`, `ALPHA-PORTABLE-SURFACE-READINESS-REVIEW-001`, and `ALPHA-BATCH-C-READINESS-REVIEW-001` (review-only). 
- `blocked-next-lanes.md` and `decision-templates.md` preserve blocked activities and provide templates for `keep`, `refine`, `rerun`, `pause`, `readiness review`, and `blocked` decisions while explicitly blocking Batch C execution, runtime wiring, `/v1/solve` measurement, provider orchestration, production/MVP/public-testing/benchmark/exact-billing claims, and protected surface changes.

### Testing

- Ran `git status --short` and `git diff --check` locally and committed the new files; confirmed the HEAD commit adds only files under `docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision-framework/`. 
- Attempted `git diff --name-only main...HEAD` but the local `main` ref was unavailable in this checkout (non-blocking for this docs-only change). 
- Scanned added files for any imported/fabricated result language and found no imported or fabricated operator-test results. 
- Ran focused automated tests: `python -m pytest -q` completed but failures are unrelated to these docs changes; failing tests observed were `tests/test_api_endpoints.py::test_solve_openai_provider_errors_return_safe_responses` (model name mismatch observed: `gpt-5-mini` vs expected `gpt-5`), `tests/test_cost_tracking.py::test_cost_tracking` (missing `artifacts/costs.csv`), and `tests/test_security.py::test_a3_1_prompt_subset_passes_solve_input_validation` (response content mismatch), indicating existing runtime/provider expectations in the test environment rather than a regression from this docs-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21c3a138748329aaf4d7d761aff6f1)