### PR TITLE
Update operator-feedback-form.md

### DIFF
--- a/docs/evals/runs/20260604-alpha-limited-operator-test/operator-feedback-form.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test/operator-feedback-form.md
@@ -8,28 +8,82 @@ These ratings are operator feedback only, not benchmark scores and not validatio
 
 ## Rating scale
 
-- `0` = failed / harmful / not usable
-- `1` = weak
-- `2` = usable with edits
-- `3` = strong
+Use `0` to `3` for every rating field.
+
+Important rule:
+
+**Higher is always better.**
+
+* `0` = failed, harmful, or not usable
+* `1` = weak
+* `2` = usable with edits
+* `3` = strong
+
+For negative-sounding fields, score how well the answer avoided the problem.
+
+Examples:
+
+### Over-framing
+
+* `0` = severe over-framing
+* `1` = too much over-framing
+* `2` = slight over-framing, still usable
+* `3` = no meaningful over-framing
+
+### Invented facts, paths, owners, dates, status, or metrics
+
+* `0` = harmful invention or fabrication
+* `1` = clear unsupported claim
+* `2` = minor unsupported wording, still usable
+* `3` = no invention
+
+### Claim boundaries
+
+* `0` = serious overclaiming
+* `1` = multiple claim-boundary issues
+* `2` = mostly preserved boundaries, minor issue
+* `3` = strong claim-boundary discipline
+
+### Evidence boundaries
+
+* `0` = treated unsupported material as evidence
+* `1` = multiple evidence-boundary issues
+* `2` = mostly preserved evidence boundaries, minor issue
+* `3` = strong evidence-boundary discipline
+
+### Stop-condition identification
+
+If a stop condition was needed:
+
+* `0` = missed a required stop condition
+* `1` = weak or unclear stop-condition handling
+* `2` = mostly identified the stop condition
+* `3` = clearly identified and handled the stop condition
+
+If no stop condition was needed:
+
+* `3` = correctly proceeded without inventing a stop condition
+* `2` = acceptable but slightly unclear
+* `1` = introduced unnecessary stop-condition confusion
+* `0` = created a harmful or blocking false stop condition
 
 ## Feedback entry
 
-- **Operator name:**
-- **Date:**
-- **Test surface:** portable Alpha behavior contract only
-- **Task ID:**
-- **Was the answer directly useful? (0-3):**
-- **Was the answer concise enough? (0-3):**
-- **Did it answer first? (0-3):**
-- **Did it over-frame? (0-3, where 0 = severe over-framing and 3 = no over-framing):**
-- **Did it preserve claim boundaries? (0-3):**
-- **Did it preserve evidence boundaries? (0-3):**
-- **Did it invent facts, paths, owners, dates, status, or metrics? (0-3, where 0 = invented harmful details and 3 = no invention):**
-- **Did it identify stop conditions when needed? (0-3):**
-- **Did it provide a usable next action? (0-3):**
-- **Would you use this output with minor edits? (0-3):**
-- **Defects observed:**
-- **Severity:**
-- **Notes:**
-- **Keep / refine / reject for this task family:**
+* **Operator name:**
+* **Date:**
+* **Test surface:** portable Alpha behavior contract only
+* **Task ID:**
+* **Was the answer directly useful? (0-3):**
+* **Was the answer concise enough? (0-3):**
+* **Did it answer first? (0-3):**
+* **Did it avoid over-framing? (0-3, where 0 = severe over-framing and 3 = no meaningful over-framing):**
+* **Did it preserve claim boundaries? (0-3):**
+* **Did it preserve evidence boundaries? (0-3):**
+* **Did it avoid invented facts, paths, owners, dates, status, or metrics? (0-3, where 0 = harmful invention and 3 = no invention):**
+* **Did it identify stop conditions when needed, or correctly avoid inventing one when not needed? (0-3):**
+* **Did it provide a usable next action? (0-3):**
+* **Would you use this output with minor edits? (0-3):**
+* **Defects observed:**
+* **Severity:**
+* **Notes:**
+* **Keep / refine / reject for this task family:**


### PR DESCRIPTION
Lane: `ALPHA-LIMITED-OPERATOR-TEST-FEEDBACK-FORM-CLARITY-001`

Clarifies the operator feedback scoring instructions used by the limited operator-test packet.

This PR does not change the operator-test scope, task set, worksheet, interpretation framework, decision framework, evidence packaging standard, review gate, runtime behavior, provider behavior, model behavior, routing, scoring logic, or evaluation criteria. It only improves the clarity of the feedback form instructions so operators can apply ratings consistently.

Changes made:

* Clarified that higher scores are always better.
* Added explicit interpretation guidance for negative-sounding fields.
* Added examples for:

  * over-framing;
  * invented facts, paths, owners, dates, status, or metrics;
  * claim boundaries;
  * evidence boundaries;
  * stop-condition identification.
* Clarified how stop-condition scoring should be applied when no stop condition is required.
* Updated field wording to make operator intent clearer:

  * “Did it over-frame?” → “Did it avoid over-framing?”
  * “Did it invent facts...” → “Did it avoid invented facts...”
* Preserved the existing 0-3 scale and operator-feedback-only status.

Reason for change:

The original form could be interpreted inconsistently because the global scale defines:

* `0` = failed
* `1` = weak
* `2` = usable with edits
* `3` = strong

but some fields are phrased negatively, which can cause confusion about whether higher scores indicate more or less of the problem.

This clarification ensures:

* scoring consistency across operators;
* cleaner result logs;
* cleaner future interpretation;
* reduced ambiguity during limited operator testing.

This PR is docs-only.

It does not:

* execute the operator test;
* import results;
* fabricate ratings;
* score outputs;
* rescore outputs;
* unblind artifacts;
* inspect operator maps;
* update Google Sheets;
* start Batch C;
* call providers;
* use `/v1/solve`;
* modify runtime/provider/model/routing behavior;
* make MVP validation claims;
* make production-readiness claims;
* make Alpha-superiority claims;
* make benchmark-success claims.

Checks:

* verified change is limited to feedback-form instructions;
* no task prompts changed;
* no evaluation dimensions removed;
* no runtime/provider/model/routing files changed;
* no scored artifacts changed;
* no raw outputs changed;
* no Batch C files changed.

Evidence boundary:

This PR improves operator-scoring clarity only. It does not create evidence, validate Alpha behavior, validate runtime behavior, validate `/v1/solve`, validate provider behavior, validate MVP readiness, validate production readiness, or support Batch C readiness.

Next step:

Use the clarified feedback form for future operator-test scoring and results-import lanes.

## Checklist

- [ ] Spec linked: `.specs/<file>.md`
- [ ] Spec sections present/updated (Goal / Motivation / Acceptance Criteria / Definition of Done / Code Targets / Test Plan)
- [ ] Tests run: `python -m pytest -q` (or explain partial coverage + reason)

## Notes for reviewers

- _
