### PR TITLE
Prove local LLM portable-contract consumption path

### DIFF
--- a/alpha/local_llm/__init__.py
+++ b/alpha/local_llm/__init__.py
@@ -1,0 +1,17 @@
+"""Local LLM proof helpers.
+
+This package is intentionally not wired into the production solve path. It
+contains fake-client-only seams used to prove portable-contract consumption.
+"""
+
+from .portable_contract import (  # noqa: F401
+    DEFAULT_CONTRACT_PATH,
+    FakeLocalLLMProofClient,
+    LocalLLMProofRequest,
+    LocalLLMProofResult,
+    PortableContract,
+    PortableContractError,
+    build_local_llm_proof_request,
+    load_portable_contract,
+    run_fake_local_llm_contract_proof,
+)

--- a/alpha/local_llm/portable_contract.py
+++ b/alpha/local_llm/portable_contract.py
@@ -1,0 +1,240 @@
+"""Fake-client proof seam for portable-contract local LLM request construction.
+
+The helpers in this module are intentionally inert: they read the portable
+contract from disk, build a local-LLM-shaped request, and optionally pass that
+request to an injected fake client. They do not call Ollama, OpenAI, Anthropic,
+other providers, or the deterministic v91 ``_tree_of_thought`` path.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from hashlib import sha256
+from pathlib import Path
+from typing import Any, Mapping, Protocol
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CONTRACT_PATH = _REPO_ROOT / "alpha_solver_portable.py"
+_LOCAL_LLM_PROOF_MODE = "local_llm"
+_FAKE_BACKEND_CLASS = "fake-local-llm-proof"
+_NON_EVIDENCE_LABEL = "non_evidence_fake_client_contract_consumption_proof"
+
+
+class PortableContractError(RuntimeError):
+    """Raised when the portable prompt source cannot be trusted."""
+
+
+@dataclass(frozen=True)
+class PortableContract:
+    """Loaded portable contract text and safe source fingerprint metadata."""
+
+    text: str
+    source_path: str
+    sha256: str
+    fingerprint_algorithm: str = "sha256"
+
+    @property
+    def fingerprint(self) -> str:
+        """Return the stable prompt-source fingerprint."""
+
+        return self.sha256
+
+    @property
+    def metadata(self) -> dict[str, str]:
+        """Return safe metadata that identifies the prompt source."""
+
+        return {
+            "prompt_source_path": self.source_path,
+            "prompt_source_fingerprint": self.fingerprint,
+            "prompt_source_sha256": self.sha256,
+            "prompt_source_fingerprint_algorithm": self.fingerprint_algorithm,
+        }
+
+
+@dataclass(frozen=True)
+class LocalLLMProofRequest:
+    """Local-LLM-shaped request built without contacting a real backend."""
+
+    system: str
+    user_prompt: str
+    metadata: Mapping[str, Any]
+    model: str = "fake-local-llm"
+    backend_class: str = _FAKE_BACKEND_CLASS
+
+
+@dataclass(frozen=True)
+class LocalLLMProofResult:
+    """Result from the fake-client proof path.
+
+    ``behavior_evidence`` is always false. Successful fake output only proves
+    request construction and prompt-source preservation, not answer quality or
+    runtime readiness.
+    """
+
+    request: LocalLLMProofRequest
+    output_text: str
+    status: str
+    reason: str
+    behavior_evidence: bool = False
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+class LocalLLMProofClient(Protocol):
+    """Protocol for injected fake clients used by tests."""
+
+    def generate(self, request: LocalLLMProofRequest) -> str:
+        """Return fake text for a proof request."""
+
+
+@dataclass
+class FakeLocalLLMProofClient:
+    """Tiny fake client that records requests and never performs I/O."""
+
+    output_text: str = "fake proof output: portable contract consumed"
+    fail: bool = False
+    calls: list[LocalLLMProofRequest] = field(default_factory=list)
+
+    def generate(self, request: LocalLLMProofRequest) -> str:
+        self.calls.append(request)
+        if self.fail:
+            raise PortableContractError("fake local LLM proof client failed")
+        return self.output_text
+
+
+def _display_path(path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return resolved.relative_to(_REPO_ROOT).as_posix()
+    except ValueError:
+        return resolved.as_posix()
+
+
+def load_portable_contract(
+    path: str | Path | None = None, *, expected_sha256: str | None = None
+) -> PortableContract:
+    """Load ``alpha_solver_portable.py`` as prompt text and fingerprint it.
+
+    The loader fails closed when the file is missing, empty, unreadable, or does
+    not match a caller-supplied SHA-256 fingerprint.
+    """
+
+    contract_path = Path(path) if path is not None else DEFAULT_CONTRACT_PATH
+    try:
+        text = contract_path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise PortableContractError(
+            f"portable contract not found: {_display_path(contract_path)}"
+        ) from exc
+    except OSError as exc:
+        raise PortableContractError(
+            f"portable contract could not be read: {_display_path(contract_path)}"
+        ) from exc
+
+    if not text.strip():
+        raise PortableContractError(f"portable contract is empty: {_display_path(contract_path)}")
+
+    digest = sha256(text.encode("utf-8")).hexdigest()
+    if expected_sha256 is not None and digest != expected_sha256:
+        raise PortableContractError("portable contract sha256 mismatch")
+
+    return PortableContract(text=text, source_path=_display_path(contract_path), sha256=digest)
+
+
+def build_local_llm_proof_request(
+    user_prompt: str,
+    *,
+    contract: PortableContract | None = None,
+    contract_path: str | Path | None = None,
+    expected_sha256: str | None = None,
+    provider_mode: str = _LOCAL_LLM_PROOF_MODE,
+) -> LocalLLMProofRequest:
+    """Build a fake local-LLM request that consumes the portable contract.
+
+    ``MODEL_PROVIDER=local`` remains the deterministic smoke/offline mode, so
+    this proof helper accepts only the distinct ``local_llm`` mode label.
+    """
+
+    normalized_mode = provider_mode.strip().lower()
+    if normalized_mode != _LOCAL_LLM_PROOF_MODE:
+        raise PortableContractError(
+            "local LLM proof requires provider_mode=local_llm; "
+            "MODEL_PROVIDER=local remains smoke-only"
+        )
+    if not user_prompt.strip():
+        raise PortableContractError("user prompt is required for local LLM proof request")
+
+    loaded_contract = contract or load_portable_contract(
+        contract_path, expected_sha256=expected_sha256
+    )
+    metadata: dict[str, Any] = {
+        **loaded_contract.metadata,
+        "provider_mode": _LOCAL_LLM_PROOF_MODE,
+        "backend_class": _FAKE_BACKEND_CLASS,
+        "no_real_provider_call": True,
+        "behavior_evidence": False,
+        "evidence_label": _NON_EVIDENCE_LABEL,
+    }
+    return LocalLLMProofRequest(
+        system=loaded_contract.text,
+        user_prompt=user_prompt,
+        metadata=metadata,
+    )
+
+
+def run_fake_local_llm_contract_proof(
+    user_prompt: str,
+    *,
+    client: LocalLLMProofClient,
+    contract: PortableContract | None = None,
+    contract_path: str | Path | None = None,
+    expected_sha256: str | None = None,
+) -> LocalLLMProofResult:
+    """Run the fake-client proof path and label unsafe outputs as non-evidence.
+
+    This function proves request construction only. It never upgrades fake output
+    into behavior evidence and fails closed for fake-client errors, empty output,
+    or prompt echo.
+    """
+
+    request = build_local_llm_proof_request(
+        user_prompt,
+        contract=contract,
+        contract_path=contract_path,
+        expected_sha256=expected_sha256,
+    )
+    result_metadata = {**request.metadata, "behavior_evidence": False}
+    try:
+        output_text = client.generate(request)
+    except Exception as exc:  # fake-client-only failure normalization
+        return LocalLLMProofResult(
+            request=request,
+            output_text="",
+            status="failed_closed",
+            reason=f"fake_client_failure:{exc.__class__.__name__}",
+            metadata=result_metadata,
+        )
+
+    if not output_text.strip():
+        return LocalLLMProofResult(
+            request=request,
+            output_text=output_text,
+            status="failed_closed",
+            reason="empty_output_non_evidence",
+            metadata=result_metadata,
+        )
+    if output_text.strip() == user_prompt.strip():
+        return LocalLLMProofResult(
+            request=request,
+            output_text=output_text,
+            status="failed_closed",
+            reason="prompt_echo_non_evidence",
+            metadata=result_metadata,
+        )
+
+    return LocalLLMProofResult(
+        request=request,
+        output_text=output_text,
+        status="non_evidence",
+        reason="fake_client_contract_consumption_only",
+        metadata=result_metadata,
+    )

--- a/docs/evals/runs/20260604-alpha-local-llm-contract-consumption-proof/README.md
+++ b/docs/evals/runs/20260604-alpha-local-llm-contract-consumption-proof/README.md
@@ -22,11 +22,16 @@ smoke/offline deterministic behavior and is not overloaded for local LLM use.
 
 - `alpha/local_llm/__init__.py`
 - `alpha/local_llm/portable_contract.py`
+- `pyproject.toml`
 - `tests/test_local_llm_contract_consumption_proof.py`
 - `docs/evals/runs/20260604-alpha-local-llm-contract-consumption-proof/README.md`
 - `docs/evals/runs/20260604-alpha-local-llm-contract-consumption-proof/contract-consumption-proof.md`
 - `docs/evals/runs/20260604-alpha-local-llm-contract-consumption-proof/proof-preservation-checklist.md`
 - `docs/evals/runs/20260604-alpha-local-llm-contract-consumption-proof/recommended-next-lane.md`
+
+## Packaging preservation update
+
+PR #283 follow-up adds `alpha.local_llm` to the explicit setuptools package list so wheel/sdist installs include the proof helper package instead of passing only repo-root imports.
 
 ## What was proven
 
@@ -66,6 +71,8 @@ smoke/offline deterministic behavior and is not overloaded for local LLM use.
 - `python -m pytest tests/test_local_llm_contract_consumption_proof.py -q`
 - `python -m pytest tests/test_alpha_minimal_behavior_contract.py -q`
 - `MODEL_PROVIDER=local python scripts/check_env.py`
+- `python -m pip install --no-deps --target /tmp/alpha-solver-pkgcheck .`
+- `PYTHONPATH=/tmp/alpha-solver-pkgcheck python -c "import alpha.local_llm.portable_contract as pc; print(pc.__name__)"`
 
 ## Next recommended lane
 

--- a/docs/evals/runs/20260604-alpha-local-llm-contract-consumption-proof/README.md
+++ b/docs/evals/runs/20260604-alpha-local-llm-contract-consumption-proof/README.md
@@ -1,0 +1,72 @@
+# Alpha Local LLM Contract Consumption Proof
+
+Lane ID: `ALPHA-LOCAL-LLM-CONTRACT-CONSUMPTION-PROOF-001`
+
+Status: fake-client contract-consumption proof only.
+
+## Purpose
+
+Prove that Alpha Solver can load the intended portable behavior contract from
+`alpha_solver_portable.py`, construct a local-LLM-style request with that
+contract as the prompt source, preserve safe prompt-source fingerprint metadata,
+and avoid v91 / `_tree_of_thought` fallback in the proof path.
+
+## Scope
+
+This lane adds a minimal, isolated proof seam. It does not wire local LLM
+behavior into `/v1/solve`, `/dashboard/expert-preview`, the provider registry,
+or `MODEL_PROVIDER=local`. The existing `MODEL_PROVIDER=local` behavior remains
+smoke/offline deterministic behavior and is not overloaded for local LLM use.
+
+## Files changed
+
+- `alpha/local_llm/__init__.py`
+- `alpha/local_llm/portable_contract.py`
+- `tests/test_local_llm_contract_consumption_proof.py`
+- `docs/evals/runs/20260604-alpha-local-llm-contract-consumption-proof/README.md`
+- `docs/evals/runs/20260604-alpha-local-llm-contract-consumption-proof/contract-consumption-proof.md`
+- `docs/evals/runs/20260604-alpha-local-llm-contract-consumption-proof/proof-preservation-checklist.md`
+- `docs/evals/runs/20260604-alpha-local-llm-contract-consumption-proof/recommended-next-lane.md`
+
+## What was proven
+
+- `alpha_solver_portable.py` can be loaded as direct prompt-source text.
+- The prompt source is fingerprinted with SHA-256 and labeled with the safe
+  source path `alpha_solver_portable.py`.
+- A local-LLM-style fake request can keep the portable contract in the `system`
+  field and the user prompt in a separate `user_prompt` field.
+- Request metadata identifies the prompt source path, prompt source fingerprint,
+  fake backend class, `local_llm` proof mode, no real provider call, and no
+  behavior evidence.
+- The proof path does not import `alpha_solver_entry.py`, does not import
+  `alpha-solver-v91-python.py`, and does not call `_tree_of_thought`.
+- `provider_mode=local` is rejected for this proof helper so that
+  `MODEL_PROVIDER=local` remains smoke-only.
+- Missing contract files and SHA-256 mismatches fail closed.
+- Empty output, prompt echo, and fake-client failure are labeled as failed-closed
+  non-evidence conditions.
+
+## What was not proven
+
+- No Ollama adapter was implemented.
+- No local model was called.
+- No OpenAI, Anthropic, or other provider was called.
+- `/v1/solve` behavior was not used as evidence.
+- `/dashboard/expert-preview` behavior was not used as evidence.
+- No operator-test results were imported.
+- No Batch C, scoring, validation, superiority, production-readiness, runtime
+  readiness, provider-orchestration, or exact-billing claim is made.
+
+## Checks run
+
+- `git status --short`
+- `git diff --check`
+- `git diff --name-only main...HEAD` where available, with a fallback to
+  `git diff --name-only --cached --diff-filter=ACMRT` before commit because this workspace has no `main` ref.
+- `python -m pytest tests/test_local_llm_contract_consumption_proof.py -q`
+- `python -m pytest tests/test_alpha_minimal_behavior_contract.py -q`
+- `MODEL_PROVIDER=local python scripts/check_env.py`
+
+## Next recommended lane
+
+Recommended next lane: `ALPHA-LOCAL-LLM-PROVIDER-ADAPTER-001`.

--- a/docs/evals/runs/20260604-alpha-local-llm-contract-consumption-proof/contract-consumption-proof.md
+++ b/docs/evals/runs/20260604-alpha-local-llm-contract-consumption-proof/contract-consumption-proof.md
@@ -1,0 +1,50 @@
+# Contract Consumption Proof
+
+Lane ID: `ALPHA-LOCAL-LLM-CONTRACT-CONSUMPTION-PROOF-001`
+
+## How `alpha_solver_portable.py` is loaded
+
+The proof helper reads `alpha_solver_portable.py` from the repository root as
+UTF-8 text. It treats the file contents as the prompt source rather than
+importing runtime functions from the file. This preserves the intended portable
+behavior contract as auditable prompt text.
+
+The loader fails closed if the file is missing, cannot be read, is empty, or
+does not match a caller-supplied expected SHA-256 fingerprint.
+
+## Metadata preserved
+
+The loaded contract records safe metadata:
+
+- `prompt_source_path`: `alpha_solver_portable.py`
+- `prompt_source_fingerprint`: the SHA-256 digest of the loaded file text
+- `prompt_source_sha256`: the same SHA-256 digest, named explicitly
+- `prompt_source_fingerprint_algorithm`: `sha256`
+
+The fake request also records:
+
+- `provider_mode`: `local_llm`
+- `backend_class`: `fake-local-llm-proof`
+- `no_real_provider_call`: `true`
+- `behavior_evidence`: `false`
+- `evidence_label`: `non_evidence_fake_client_contract_consumption_proof`
+
+## How v91 / `_tree_of_thought` fallback is avoided
+
+The proof seam lives in `alpha/local_llm/portable_contract.py` and is not wired
+into `service.app.solve()`, `/v1/solve`, or `/dashboard/expert-preview`. It does
+not import `alpha_solver_entry.py` and does not load `alpha-solver-v91-python.py`.
+Its fake-client tests guard those imports and verify the proof path completes
+without them.
+
+The helper requires the distinct proof mode label `local_llm`. Passing `local`
+is rejected so that the existing `MODEL_PROVIDER=local` smoke/offline path is not
+overloaded or confused with local LLM behavior.
+
+## Why no model behavior is claimed
+
+The fake client records the constructed request and returns controlled fake text.
+It never calls Ollama, OpenAI, Anthropic, or any provider. The proof result always
+sets `behavior_evidence=false`; successful fake output is labeled only as a
+request-construction and prompt-source-consumption proof. Empty output, prompt
+echo, and fake-client failure fail closed as non-evidence conditions.

--- a/docs/evals/runs/20260604-alpha-local-llm-contract-consumption-proof/proof-preservation-checklist.md
+++ b/docs/evals/runs/20260604-alpha-local-llm-contract-consumption-proof/proof-preservation-checklist.md
@@ -1,0 +1,24 @@
+# Proof Preservation Checklist
+
+Lane ID: `ALPHA-LOCAL-LLM-CONTRACT-CONSUMPTION-PROOF-001`
+
+- [x] No real model calls.
+- [x] No provider calls.
+- [x] No Ollama calls.
+- [x] No OpenAI calls.
+- [x] No Anthropic calls.
+- [x] No operator results imported.
+- [x] No operator-test tasks executed.
+- [x] No Batch C work started.
+- [x] No Google Sheets update.
+- [x] No scored artifacts changed.
+- [x] No raw outputs changed.
+- [x] No operator maps inspected.
+- [x] No `/v1/solve` behavior evidence.
+- [x] No `/dashboard/expert-preview` behavior evidence.
+- [x] No runtime readiness claim.
+- [x] No production readiness claim.
+- [x] No provider orchestration claim.
+- [x] No validation claim.
+- [x] No superiority claim.
+- [x] Existing `MODEL_PROVIDER=local` smoke/offline behavior remains separate.

--- a/docs/evals/runs/20260604-alpha-local-llm-contract-consumption-proof/recommended-next-lane.md
+++ b/docs/evals/runs/20260604-alpha-local-llm-contract-consumption-proof/recommended-next-lane.md
@@ -1,0 +1,15 @@
+# Recommended Next Lane
+
+Lane ID: `ALPHA-LOCAL-LLM-CONTRACT-CONSUMPTION-PROOF-001`
+
+Recommend exactly one next lane: `ALPHA-LOCAL-LLM-PROVIDER-ADAPTER-001`.
+
+This recommendation is conditional on preserving the boundaries proven here: a
+future adapter lane should remain separate from `MODEL_PROVIDER=local`, consume
+`alpha_solver_portable.py` or an approved transformed equivalent with safe
+prompt-source fingerprint metadata, fail closed on missing/mismatched contract
+state, and avoid silent fallback to v91 / `_tree_of_thought`.
+
+The next lane should still avoid validation, superiority, production-readiness,
+runtime-readiness, Batch C, operator-result, and provider-orchestration claims
+unless separately approved by a later scoped lane.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ packages = [
     "alpha.core",
     "alpha.adapters",
     "alpha.providers",
+    "alpha.local_llm",
     "alpha.executors",
     "alpha.reasoning",
     "alpha.router",

--- a/tests/test_local_llm_contract_consumption_proof.py
+++ b/tests/test_local_llm_contract_consumption_proof.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from hashlib import sha256
+from pathlib import Path
+
+import pytest
+
+from alpha.local_llm.portable_contract import (
+    FakeLocalLLMProofClient,
+    PortableContractError,
+    build_local_llm_proof_request,
+    load_portable_contract,
+    run_fake_local_llm_contract_proof,
+)
+
+
+def test_loads_alpha_solver_portable_as_prompt_source_with_fingerprint():
+    contract = load_portable_contract()
+    expected_text = Path("alpha_solver_portable.py").read_text(encoding="utf-8")
+
+    assert contract.source_path == "alpha_solver_portable.py"
+    assert contract.text == expected_text
+    assert "LLM_PERSONA_PROTOCOL" in contract.text
+    assert contract.sha256 == sha256(expected_text.encode("utf-8")).hexdigest()
+    assert contract.metadata == {
+        "prompt_source_path": "alpha_solver_portable.py",
+        "prompt_source_fingerprint": contract.sha256,
+        "prompt_source_sha256": contract.sha256,
+        "prompt_source_fingerprint_algorithm": "sha256",
+    }
+
+
+def test_builds_local_llm_style_request_with_contract_and_separate_user_prompt():
+    user_prompt = "Draft a compact Alpha Solver proof summary."
+
+    request = build_local_llm_proof_request(user_prompt)
+
+    assert "LLM_PERSONA_PROTOCOL" in request.system
+    assert request.user_prompt == user_prompt
+    assert user_prompt not in request.system
+    assert request.metadata["prompt_source_path"] == "alpha_solver_portable.py"
+    assert request.metadata["prompt_source_fingerprint"]
+    assert (
+        request.metadata["prompt_source_sha256"]
+        == request.metadata["prompt_source_fingerprint"]
+    )
+    assert request.metadata["backend_class"] == "fake-local-llm-proof"
+    assert request.metadata["provider_mode"] == "local_llm"
+    assert request.metadata["no_real_provider_call"] is True
+    assert request.metadata["behavior_evidence"] is False
+    assert (
+        request.metadata["evidence_label"]
+        == "non_evidence_fake_client_contract_consumption_proof"
+    )
+
+
+def test_fake_client_proof_records_request_without_real_provider_call():
+    client = FakeLocalLLMProofClient(output_text="fake structured response")
+
+    result = run_fake_local_llm_contract_proof("Explain this proof.", client=client)
+
+    assert result.status == "non_evidence"
+    assert result.behavior_evidence is False
+    assert result.metadata["no_real_provider_call"] is True
+    assert result.metadata["backend_class"] == "fake-local-llm-proof"
+    assert len(client.calls) == 1
+    assert client.calls[0] is result.request
+    assert "Alpha Solver" in result.request.system
+    assert result.request.user_prompt == "Explain this proof."
+
+
+def test_fake_client_proof_does_not_import_or_call_v91_or_tree_of_thought(monkeypatch):
+    imported_names: list[str] = []
+    real_import = __import__
+
+    def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+        imported_names.append(name)
+        if name in {"alpha_solver_entry", "alpha-solver-v91-python"}:
+            raise AssertionError(f"forbidden import: {name}")
+        return real_import(name, globals, locals, fromlist, level)
+
+    for module_name in ["alpha_solver_entry", "alpha-solver-v91-python"]:
+        monkeypatch.delitem(sys.modules, module_name, raising=False)
+    monkeypatch.setattr("builtins.__import__", guarded_import)
+
+    client = FakeLocalLLMProofClient(output_text="fake structured response")
+    result = run_fake_local_llm_contract_proof("Prove no v91 fallback.", client=client)
+
+    assert result.status == "non_evidence"
+    assert "alpha_solver_entry" not in imported_names
+    assert "alpha-solver-v91-python" not in imported_names
+    assert "alpha_solver_entry" not in sys.modules
+    assert "alpha-solver-v91-python" not in sys.modules
+
+
+def test_model_provider_local_label_is_rejected_for_proof_mode():
+    with pytest.raises(PortableContractError, match="MODEL_PROVIDER=local remains smoke-only"):
+        build_local_llm_proof_request("Do not overload local smoke.", provider_mode="local")
+
+
+def test_existing_model_provider_local_openai_gate_remains_separate(monkeypatch):
+    service_app = importlib.import_module("service.app")
+
+    monkeypatch.setenv("MODEL_PROVIDER", "local")
+
+    assert service_app._is_openai_provider_enabled() is False
+
+
+def test_missing_contract_fails_closed(tmp_path):
+    missing = tmp_path / "alpha_solver_portable.py"
+
+    with pytest.raises(PortableContractError, match="portable contract not found"):
+        load_portable_contract(missing)
+
+
+def test_prompt_source_hash_mismatch_fails_closed(tmp_path):
+    contract_path = tmp_path / "alpha_solver_portable.py"
+    contract_path.write_text("portable contract text", encoding="utf-8")
+
+    with pytest.raises(PortableContractError, match="sha256 mismatch"):
+        load_portable_contract(contract_path, expected_sha256="0" * 64)
+
+
+def test_empty_output_prompt_echo_and_fake_client_failure_fail_closed():
+    empty = run_fake_local_llm_contract_proof(
+        "Explain proof.", client=FakeLocalLLMProofClient(output_text="  ")
+    )
+    echo = run_fake_local_llm_contract_proof(
+        "Explain proof.", client=FakeLocalLLMProofClient(output_text="Explain proof.")
+    )
+    failed = run_fake_local_llm_contract_proof(
+        "Explain proof.", client=FakeLocalLLMProofClient(fail=True)
+    )
+
+    assert empty.status == "failed_closed"
+    assert empty.reason == "empty_output_non_evidence"
+    assert empty.behavior_evidence is False
+    assert echo.status == "failed_closed"
+    assert echo.reason == "prompt_echo_non_evidence"
+    assert echo.behavior_evidence is False
+    assert failed.status == "failed_closed"
+    assert failed.reason.startswith("fake_client_failure:")
+    assert failed.behavior_evidence is False


### PR DESCRIPTION
### Motivation
- Provide a narrow, fake-client-only proof lane `ALPHA-LOCAL-LLM-CONTRACT-CONSUMPTION-PROOF-001` that demonstrates the repo can load `alpha_solver_portable.py` as a prompt source, fingerprint it, and build a local-LLM-style request without calling any real provider or falling back to the v91 `_tree_of_thought` path.
- Preserve the existing `MODEL_PROVIDER=local` smoke/offline behavior by requiring a distinct proof mode and failing closed on unsafe conditions.

### Description
- Add a minimal sealed proof seam under `alpha/local_llm` with `portable_contract.py` implementing `load_portable_contract()` to read `alpha_solver_portable.py` and compute a SHA-256 fingerprint, a `PortableContract` dataclass, and safe `metadata` fields.
- Implement `build_local_llm_proof_request()` to construct a local-LLM-shaped request with the portable contract in `system`, the user prompt separately in `user_prompt`, and metadata including `prompt_source_path`, `prompt_source_fingerprint`, `provider_mode='local_llm'`, `backend_class='fake-local-llm-proof'`, `no_real_provider_call`, and non-evidence labeling.
- Provide a tiny fake client `FakeLocalLLMProofClient` and `run_fake_local_llm_contract_proof()` which records requests, normalizes fake-client failures, fails closed on empty output or prompt-echo, and always marks successful fake outputs as `non_evidence` (no behavior claim).
- Add focused tests and docs: `tests/test_local_llm_contract_consumption_proof.py` plus documentation under `docs/evals/runs/20260604-alpha-local-llm-contract-consumption-proof/` describing scope, proof boundaries, and the recommended next lane `ALPHA-LOCAL-LLM-PROVIDER-ADAPTER-001`.

### Testing
- Ran `pytest tests/test_local_llm_contract_consumption_proof.py` and the suite passed, verifying contract loading, SHA-256 fingerprinting, request construction, metadata presence, fail-closed behaviors, and that the proof path does not import `alpha_solver_entry` or `alpha-solver-v91-python` (tests passed).
- Ran `pytest tests/test_alpha_minimal_behavior_contract.py` to ensure existing portable-contract tests remain green and they passed.
- Executed environment check `MODEL_PROVIDER=local python scripts/check_env.py` to confirm local smoke defaults remain intact and it passed; no real model or provider calls were made during testing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21f34e39e483299cea43a84337c21d)