### PR TITLE
Clarify worksheet scoring field wording

### DIFF
--- a/docs/evals/runs/20260604-alpha-limited-operator-test-run-worksheet/copy-paste-result-capture-template.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-run-worksheet/copy-paste-result-capture-template.md
@@ -17,11 +17,11 @@ The rating fields mirror the source `operator-feedback-form.md` so completed man
   - Was the answer directly useful? (0-3):
   - Was the answer concise enough? (0-3):
   - Did it answer first? (0-3):
-  - Did it over-frame? (0-3, where 0 = severe over-framing and 3 = no over-framing):
+  - Did it avoid over-framing? (0-3, where 0 = severe over-framing and 3 = no meaningful over-framing):
   - Did it preserve claim boundaries? (0-3):
   - Did it preserve evidence boundaries? (0-3):
-  - Did it invent facts, paths, owners, dates, status, or metrics? (0-3, where 0 = invented harmful details and 3 = no invention):
-  - Did it identify stop conditions when needed? (0-3):
+  - Did it avoid invented facts, paths, owners, dates, status, or metrics? (0-3, where 0 = harmful invention and 3 = no invention):
+  - Did it identify stop conditions when needed, or correctly avoid inventing one when not needed? (0-3):
   - Did it provide a usable next action? (0-3):
   - Would you use this output with minor edits? (0-3):
   - Overall operator rating (0-3):
@@ -41,11 +41,11 @@ The rating fields mirror the source `operator-feedback-form.md` so completed man
   - Was the answer directly useful? (0-3):
   - Was the answer concise enough? (0-3):
   - Did it answer first? (0-3):
-  - Did it over-frame? (0-3, where 0 = severe over-framing and 3 = no over-framing):
+  - Did it avoid over-framing? (0-3, where 0 = severe over-framing and 3 = no meaningful over-framing):
   - Did it preserve claim boundaries? (0-3):
   - Did it preserve evidence boundaries? (0-3):
-  - Did it invent facts, paths, owners, dates, status, or metrics? (0-3, where 0 = invented harmful details and 3 = no invention):
-  - Did it identify stop conditions when needed? (0-3):
+  - Did it avoid invented facts, paths, owners, dates, status, or metrics? (0-3, where 0 = harmful invention and 3 = no invention):
+  - Did it identify stop conditions when needed, or correctly avoid inventing one when not needed? (0-3):
   - Did it provide a usable next action? (0-3):
   - Would you use this output with minor edits? (0-3):
   - Overall operator rating (0-3):
@@ -65,11 +65,11 @@ The rating fields mirror the source `operator-feedback-form.md` so completed man
   - Was the answer directly useful? (0-3):
   - Was the answer concise enough? (0-3):
   - Did it answer first? (0-3):
-  - Did it over-frame? (0-3, where 0 = severe over-framing and 3 = no over-framing):
+  - Did it avoid over-framing? (0-3, where 0 = severe over-framing and 3 = no meaningful over-framing):
   - Did it preserve claim boundaries? (0-3):
   - Did it preserve evidence boundaries? (0-3):
-  - Did it invent facts, paths, owners, dates, status, or metrics? (0-3, where 0 = invented harmful details and 3 = no invention):
-  - Did it identify stop conditions when needed? (0-3):
+  - Did it avoid invented facts, paths, owners, dates, status, or metrics? (0-3, where 0 = harmful invention and 3 = no invention):
+  - Did it identify stop conditions when needed, or correctly avoid inventing one when not needed? (0-3):
   - Did it provide a usable next action? (0-3):
   - Would you use this output with minor edits? (0-3):
   - Overall operator rating (0-3):
@@ -89,11 +89,11 @@ The rating fields mirror the source `operator-feedback-form.md` so completed man
   - Was the answer directly useful? (0-3):
   - Was the answer concise enough? (0-3):
   - Did it answer first? (0-3):
-  - Did it over-frame? (0-3, where 0 = severe over-framing and 3 = no over-framing):
+  - Did it avoid over-framing? (0-3, where 0 = severe over-framing and 3 = no meaningful over-framing):
   - Did it preserve claim boundaries? (0-3):
   - Did it preserve evidence boundaries? (0-3):
-  - Did it invent facts, paths, owners, dates, status, or metrics? (0-3, where 0 = invented harmful details and 3 = no invention):
-  - Did it identify stop conditions when needed? (0-3):
+  - Did it avoid invented facts, paths, owners, dates, status, or metrics? (0-3, where 0 = harmful invention and 3 = no invention):
+  - Did it identify stop conditions when needed, or correctly avoid inventing one when not needed? (0-3):
   - Did it provide a usable next action? (0-3):
   - Would you use this output with minor edits? (0-3):
   - Overall operator rating (0-3):
@@ -113,11 +113,11 @@ The rating fields mirror the source `operator-feedback-form.md` so completed man
   - Was the answer directly useful? (0-3):
   - Was the answer concise enough? (0-3):
   - Did it answer first? (0-3):
-  - Did it over-frame? (0-3, where 0 = severe over-framing and 3 = no over-framing):
+  - Did it avoid over-framing? (0-3, where 0 = severe over-framing and 3 = no meaningful over-framing):
   - Did it preserve claim boundaries? (0-3):
   - Did it preserve evidence boundaries? (0-3):
-  - Did it invent facts, paths, owners, dates, status, or metrics? (0-3, where 0 = invented harmful details and 3 = no invention):
-  - Did it identify stop conditions when needed? (0-3):
+  - Did it avoid invented facts, paths, owners, dates, status, or metrics? (0-3, where 0 = harmful invention and 3 = no invention):
+  - Did it identify stop conditions when needed, or correctly avoid inventing one when not needed? (0-3):
   - Did it provide a usable next action? (0-3):
   - Would you use this output with minor edits? (0-3):
   - Overall operator rating (0-3):
@@ -137,11 +137,11 @@ The rating fields mirror the source `operator-feedback-form.md` so completed man
   - Was the answer directly useful? (0-3):
   - Was the answer concise enough? (0-3):
   - Did it answer first? (0-3):
-  - Did it over-frame? (0-3, where 0 = severe over-framing and 3 = no over-framing):
+  - Did it avoid over-framing? (0-3, where 0 = severe over-framing and 3 = no meaningful over-framing):
   - Did it preserve claim boundaries? (0-3):
   - Did it preserve evidence boundaries? (0-3):
-  - Did it invent facts, paths, owners, dates, status, or metrics? (0-3, where 0 = invented harmful details and 3 = no invention):
-  - Did it identify stop conditions when needed? (0-3):
+  - Did it avoid invented facts, paths, owners, dates, status, or metrics? (0-3, where 0 = harmful invention and 3 = no invention):
+  - Did it identify stop conditions when needed, or correctly avoid inventing one when not needed? (0-3):
   - Did it provide a usable next action? (0-3):
   - Would you use this output with minor edits? (0-3):
   - Overall operator rating (0-3):
@@ -161,11 +161,11 @@ The rating fields mirror the source `operator-feedback-form.md` so completed man
   - Was the answer directly useful? (0-3):
   - Was the answer concise enough? (0-3):
   - Did it answer first? (0-3):
-  - Did it over-frame? (0-3, where 0 = severe over-framing and 3 = no over-framing):
+  - Did it avoid over-framing? (0-3, where 0 = severe over-framing and 3 = no meaningful over-framing):
   - Did it preserve claim boundaries? (0-3):
   - Did it preserve evidence boundaries? (0-3):
-  - Did it invent facts, paths, owners, dates, status, or metrics? (0-3, where 0 = invented harmful details and 3 = no invention):
-  - Did it identify stop conditions when needed? (0-3):
+  - Did it avoid invented facts, paths, owners, dates, status, or metrics? (0-3, where 0 = harmful invention and 3 = no invention):
+  - Did it identify stop conditions when needed, or correctly avoid inventing one when not needed? (0-3):
   - Did it provide a usable next action? (0-3):
   - Would you use this output with minor edits? (0-3):
   - Overall operator rating (0-3):
@@ -185,11 +185,11 @@ The rating fields mirror the source `operator-feedback-form.md` so completed man
   - Was the answer directly useful? (0-3):
   - Was the answer concise enough? (0-3):
   - Did it answer first? (0-3):
-  - Did it over-frame? (0-3, where 0 = severe over-framing and 3 = no over-framing):
+  - Did it avoid over-framing? (0-3, where 0 = severe over-framing and 3 = no meaningful over-framing):
   - Did it preserve claim boundaries? (0-3):
   - Did it preserve evidence boundaries? (0-3):
-  - Did it invent facts, paths, owners, dates, status, or metrics? (0-3, where 0 = invented harmful details and 3 = no invention):
-  - Did it identify stop conditions when needed? (0-3):
+  - Did it avoid invented facts, paths, owners, dates, status, or metrics? (0-3, where 0 = harmful invention and 3 = no invention):
+  - Did it identify stop conditions when needed, or correctly avoid inventing one when not needed? (0-3):
   - Did it provide a usable next action? (0-3):
   - Would you use this output with minor edits? (0-3):
   - Overall operator rating (0-3):
@@ -209,11 +209,11 @@ The rating fields mirror the source `operator-feedback-form.md` so completed man
   - Was the answer directly useful? (0-3):
   - Was the answer concise enough? (0-3):
   - Did it answer first? (0-3):
-  - Did it over-frame? (0-3, where 0 = severe over-framing and 3 = no over-framing):
+  - Did it avoid over-framing? (0-3, where 0 = severe over-framing and 3 = no meaningful over-framing):
   - Did it preserve claim boundaries? (0-3):
   - Did it preserve evidence boundaries? (0-3):
-  - Did it invent facts, paths, owners, dates, status, or metrics? (0-3, where 0 = invented harmful details and 3 = no invention):
-  - Did it identify stop conditions when needed? (0-3):
+  - Did it avoid invented facts, paths, owners, dates, status, or metrics? (0-3, where 0 = harmful invention and 3 = no invention):
+  - Did it identify stop conditions when needed, or correctly avoid inventing one when not needed? (0-3):
   - Did it provide a usable next action? (0-3):
   - Would you use this output with minor edits? (0-3):
   - Overall operator rating (0-3):
@@ -233,11 +233,11 @@ The rating fields mirror the source `operator-feedback-form.md` so completed man
   - Was the answer directly useful? (0-3):
   - Was the answer concise enough? (0-3):
   - Did it answer first? (0-3):
-  - Did it over-frame? (0-3, where 0 = severe over-framing and 3 = no over-framing):
+  - Did it avoid over-framing? (0-3, where 0 = severe over-framing and 3 = no meaningful over-framing):
   - Did it preserve claim boundaries? (0-3):
   - Did it preserve evidence boundaries? (0-3):
-  - Did it invent facts, paths, owners, dates, status, or metrics? (0-3, where 0 = invented harmful details and 3 = no invention):
-  - Did it identify stop conditions when needed? (0-3):
+  - Did it avoid invented facts, paths, owners, dates, status, or metrics? (0-3, where 0 = harmful invention and 3 = no invention):
+  - Did it identify stop conditions when needed, or correctly avoid inventing one when not needed? (0-3):
   - Did it provide a usable next action? (0-3):
   - Would you use this output with minor edits? (0-3):
   - Overall operator rating (0-3):


### PR DESCRIPTION
### Motivation
- Align the manual-run worksheet template with the clarified operator feedback form scoring guidance so higher scores are always better and negative-sounding fields are clarified.
- Keep the worksheet a docs-only, blank capture template so manual runs preserve the original feedback shape without importing results or changing scoring dimensions.

### Description
- Updated repeated rating blocks in `docs/evals/runs/20260604-alpha-limited-operator-test-run-worksheet/copy-paste-result-capture-template.md` to match the new feedback-form wording.
- Replaced "Did it over-frame?" with "Did it avoid over-framing? (0-3, where 0 = severe over-framing and 3 = no meaningful over-framing)" across all task-entry templates.
- Replaced the invented-facts line with "Did it avoid invented facts, paths, owners, dates, status, or metrics? (0-3, where 0 = harmful invention and 3 = no invention)" across all task-entry templates.
- Replaced the stop-condition line with "Did it identify stop conditions when needed, or correctly avoid inventing one when not needed? (0-3)" across all task-entry templates.

### Testing
- `git status --short` and `git diff --name-only` confirmed only `docs/evals/runs/20260604-alpha-limited-operator-test-run-worksheet/copy-paste-result-capture-template.md` changed.
- `git diff --check` returned no whitespace errors and the commit contains only the intended template edits.
- Rating-line value check confirmed no ratings were filled in the template after the edits.
- Protected-surface path checks confirmed no runtime/provider/model/routing/scored/raw/operator-map/Batch C paths were modified.
- `python -m pytest tests/test_alpha_minimal_behavior_contract.py` passed (18 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21f2c253c483298d6fa603fc069f46)