### PR TITLE
docs(evals): import prompt-contract simulation results

### DIFF
--- a/docs/evals/runs/20260604-alpha-limited-operator-test-prompt-contract-simulation-results-import/README.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-prompt-contract-simulation-results-import/README.md
@@ -1,0 +1,87 @@
+# Limited Operator Test Prompt-Contract Simulation Results Import
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-PROMPT-CONTRACT-SIMULATION-RESULTS-IMPORT-001`
+
+Status: completed source evidence imported.
+
+## Purpose
+
+Import the completed manual prompt-contract simulation transcript and the filled operator feedback packet into the repo as docs-only evidence.
+
+This lane preserves the raw evidence and creates mechanical result-log rows and arithmetic totals from Adonis-provided ratings only.
+
+## Source evidence
+
+Only these two provided files are used as source evidence:
+
+- `source-evidence/Chatgpt - Operator Test Task Set.md`
+  - SHA-256: `f5cc52f6dd15e96fa427e9726d713a26a9719ffa9e906ae13ec254488d788170`
+- `source-evidence/alpha_solver_operator_feedback_filled.md`
+  - SHA-256: `db99b80ce6a9ae1388e1cabdbf6884215c19ed5ea6f7298fc336477814d7290c`
+
+## Imported files
+
+- `README.md`
+- `source-evidence/Chatgpt - Operator Test Task Set.md`
+- `source-evidence/alpha_solver_operator_feedback_filled.md`
+- `mechanical-result-log.md`
+- `mechanical-rating-totals.md`
+- `reviewer-checklist.md`
+
+## Evidence boundary
+
+This import is portable-contract manual simulation evidence only.
+
+It is not:
+
+- product/runtime evidence
+- `/v1/solve` evidence
+- local LLM evidence
+- provider evidence
+- benchmark evidence
+- MVP validation
+- production readiness
+- Batch C readiness
+- Alpha superiority evidence
+- broad plain-provider inferiority evidence
+
+## Mechanical results imported
+
+The filled feedback packet contains 10 task entries: `LT-001` through `LT-010`.
+
+The result log preserves the operator-provided ratings, defects, severity labels, notes, and keep/refine dispositions. It does not alter ratings, rescore tasks, reconstruct missing values, or interpret outcomes.
+
+Missing fields remain marked `missing`. The supplied files do not provide explicit stop-condition yes/no values or an overall 0-3 operator rating field.
+
+## Mechanical arithmetic
+
+The totals file computes arithmetic only from the 10 operator rating dimensions present in the filled feedback packet.
+
+- Feedback entries imported: 10
+- Rating dimensions per entry: 10
+- Grand mechanical rating sum: 270 / 300
+- Operator disposition counts: Keep 5, Refine 5
+
+These are operator-feedback totals only. They are not benchmark scores and do not establish readiness or superiority.
+
+## Non-actions
+
+This import does not:
+
+- change source code
+- change runtime, provider, model, routing, API, or solver behavior
+- call providers
+- run `/v1/solve`
+- run capture, scoring, rescoring, adjudication, or unblinding
+- inspect operator maps or assignment maps
+- update Google Sheets
+- start Batch C
+- make validation, readiness, production, provider, runtime, or superiority claims
+
+## Next lane after merge
+
+After this PR is reviewed, squashed, merged, closed, and added to GS, the next lane is:
+
+`ALPHA-LIMITED-OPERATOR-TEST-INTERPRETATION-001`
+
+Do not start interpretation before this import is merged.

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-prompt-contract-simulation-results-import/mechanical-rating-totals.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-prompt-contract-simulation-results-import/mechanical-rating-totals.md
@@ -1,0 +1,66 @@
+# Prompt-Contract Simulation Mechanical Rating Totals
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-PROMPT-CONTRACT-SIMULATION-RESULTS-IMPORT-001`
+
+Status: mechanical totals computed from Adonis-provided 0-3 ratings only.
+
+## Source evidence
+
+- `source-evidence/alpha_solver_operator_feedback_filled.md`
+
+## Boundary
+
+These totals are operator-feedback arithmetic only. They are not benchmark scores, validation, readiness evidence, product/runtime evidence, provider evidence, local LLM evidence, `/v1/solve` evidence, Batch C readiness, Alpha superiority, or broad plain-provider inferiority evidence.
+
+## Mechanical totals
+
+- Feedback entries imported: 10
+- Rating dimensions per entry: 10
+- Per-dimension maximum across all entries: 30
+- Per-entry maximum: 30
+- Grand mechanical rating sum: 270 / 300
+
+## Totals by rating dimension
+
+| dimension_key | source_feedback_label | mechanical_sum | maximum |
+| --- | --- | --- | --- |
+| direct_usefulness | Was the answer directly useful? | 27 | 30 |
+| brevity | Was the answer concise enough? | 26 | 30 |
+| answer_first | Did it answer first? | 25 | 30 |
+| no_overframe | Did it over-frame? | 22 | 30 |
+| claim_boundary | Did it preserve claim boundaries? | 30 | 30 |
+| evidence_boundary | Did it preserve evidence boundaries? | 30 | 30 |
+| no_invention | Did it invent facts, paths, owners, dates, status, or metrics? | 29 | 30 |
+| stop_condition_handling | Did it identify stop conditions when needed? | 26 | 30 |
+| usable_next_action | Did it provide a usable next action? | 29 | 30 |
+| usable_with_minor_edits | Would you use this output with minor edits? | 26 | 30 |
+
+## Totals by task
+
+| task_id | mechanical_sum | maximum | operator_disposition | severity |
+| --- | --- | --- | --- | --- |
+| LT-001 | 29 | 30 | Keep | None |
+| LT-002 | 19 | 30 | Refine | Minor to moderate |
+| LT-003 | 27 | 30 | Keep | Minor |
+| LT-004 | 30 | 30 | Refine | Minor |
+| LT-005 | 28 | 30 | Keep | Minor |
+| LT-006 | 29 | 30 | Keep | Minor |
+| LT-007 | 26 | 30 | Refine | Minor to moderate |
+| LT-008 | 26 | 30 | Refine | Minor |
+| LT-009 | 29 | 30 | Keep | None |
+| LT-010 | 27 | 30 | Refine | Minor |
+
+## Operator disposition counts
+
+| source_disposition | count |
+| --- | --- |
+| Keep | 5 |
+| Refine | 5 |
+
+## Severity counts
+
+| source_severity | count |
+| --- | --- |
+| Minor | 6 |
+| Minor to moderate | 2 |
+| None | 2 |

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-prompt-contract-simulation-results-import/mechanical-result-log.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-prompt-contract-simulation-results-import/mechanical-result-log.md
@@ -1,0 +1,48 @@
+# Prompt-Contract Simulation Mechanical Result Log
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-PROMPT-CONTRACT-SIMULATION-RESULTS-IMPORT-001`
+
+Status: completed source evidence imported, mechanical result log created.
+
+## Source evidence
+
+This log uses only the two supplied completed evidence files preserved in this folder:
+
+- `source-evidence/Chatgpt - Operator Test Task Set.md`
+- `source-evidence/alpha_solver_operator_feedback_filled.md`
+
+## Boundary
+
+This log is mechanical operator-feedback import only. It is not interpretation, rescoring, benchmarking, validation, production readiness, Batch C readiness, `/v1/solve` evidence, local LLM evidence, provider evidence, or Alpha-superiority evidence.
+
+Missing fields remain `missing`. In particular, the supplied feedback file did not provide explicit stop-condition yes/no fields or an overall 0-3 operator rating field, so those fields are not inferred.
+
+## Core result log
+
+| task_id | task_family | operator_name | test_date | test_surface | portable_surface_context | stop_condition_reached_yes_no | stop_condition_id_or_summary | overall_operator_rating_0_3 | mechanical_sum_of_10_operator_ratings_0_30 | keep_refine_reject | severity | primary_defect | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| LT-001 | missing | Adonis | 2026-06-04 | portable Alpha behavior contract only | manual prompt-contract simulation only | missing | missing | missing | 29 | Keep | None | None material. | Directly blocked Batch C and named limited operator test as next action. |
+| LT-002 | missing | Adonis | 2026-06-04 | portable Alpha behavior contract only | manual prompt-contract simulation only | missing | missing | missing | 19 | Refine | Minor to moderate | Visible process text and `standard:` artifact before usable reviewer comment. | Final comment was not useful, it just returned the comment back as is, and output violated “no memo / concise” expectation. |
+| LT-003 | missing | Adonis | 2026-06-04 | portable Alpha behavior contract only | manual prompt-contract simulation only | missing | missing | missing | 27 | Keep | Minor | Some visible process text before answer. | Substance was strong and review-gate checks were correct. |
+| LT-004 | missing | Adonis | 2026-06-04 | portable Alpha behavior contract only | manual prompt-contract simulation only | missing | missing | missing | 30 | Refine | Minor | `standard:` artifact and “Replacement:” label. | Replacement text itself was safe and evidence-bounded. |
+| LT-005 | missing | Adonis | 2026-06-04 | portable Alpha behavior contract only | manual prompt-contract simulation only | missing | missing | missing | 28 | Keep | Minor | Visible process text before final answer. | Correctly made repo packet control over stale planning ledger. |
+| LT-006 | missing | Adonis | 2026-06-04 | portable Alpha behavior contract only | manual prompt-contract simulation only | missing | missing | missing | 29 | Keep | Minor | Visible process text before final answer. | Correctly refused reconstruction and blocked readiness conclusion. |
+| LT-007 | missing | Adonis | 2026-06-04 | portable Alpha behavior contract only | manual prompt-contract simulation only | missing | missing | missing | 26 | Refine | Minor to moderate | Visible process text and `standard:` artifact; prompt was compact request, output included extra wrapper. | Codex prompt content was strong and complete. |
+| LT-008 | missing | Adonis | 2026-06-04 | portable Alpha behavior contract only | manual prompt-contract simulation only | missing | missing | missing | 26 | Refine | Minor | Named ALPHA-LIMITED-OPERATOR-TEST-EXECUTION-001, but current path later reframed as prompt-contract simulation. | Followed prepared-but-unexecuted packet logic at the time. |
+| LT-009 | missing | Adonis | 2026-06-04 | portable Alpha behavior contract only | manual prompt-contract simulation only | missing | missing | missing | 29 | Keep | None | None material. | Clean two-sentence status update with sufficient caveat. |
+| LT-010 | missing | Adonis | 2026-06-04 | portable Alpha behavior contract only | manual prompt-contract simulation only | missing | missing | missing | 27 | Refine | Minor | Visible process text and `standard:` artifact before checklist. | Checklist substance was correct and complete. |
+
+## Rating detail log
+
+| task_id | direct_usefulness | brevity | answer_first | no_overframe | claim_boundary | evidence_boundary | no_invention | stop_condition_handling | usable_next_action | usable_with_minor_edits | mechanical_sum_0_30 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| LT-001 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 2 | 29 |
+| LT-002 | 1 | 2 | 2 | 1 | 3 | 3 | 3 | 1 | 2 | 1 | 19 |
+| LT-003 | 3 | 2 | 2 | 2 | 3 | 3 | 3 | 3 | 3 | 3 | 27 |
+| LT-004 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 30 |
+| LT-005 | 3 | 3 | 2 | 2 | 3 | 3 | 3 | 3 | 3 | 3 | 28 |
+| LT-006 | 3 | 3 | 3 | 2 | 3 | 3 | 3 | 3 | 3 | 3 | 29 |
+| LT-007 | 3 | 2 | 2 | 1 | 3 | 3 | 3 | 3 | 3 | 3 | 26 |
+| LT-008 | 2 | 3 | 3 | 3 | 3 | 3 | 2 | 2 | 3 | 2 | 26 |
+| LT-009 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 2 | 3 | 3 | 29 |
+| LT-010 | 3 | 2 | 2 | 2 | 3 | 3 | 3 | 3 | 3 | 3 | 27 |

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-prompt-contract-simulation-results-import/reviewer-checklist.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-prompt-contract-simulation-results-import/reviewer-checklist.md
@@ -1,0 +1,31 @@
+# Results Import Reviewer Checklist
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-PROMPT-CONTRACT-SIMULATION-RESULTS-IMPORT-001`
+
+Use this checklist to review the docs-only results-import PR.
+
+## Required checks
+
+- [ ] The PR is docs-only.
+- [ ] All changed files are under `docs/evals/runs/20260604-alpha-limited-operator-test-prompt-contract-simulation-results-import/`.
+- [ ] The raw transcript is preserved in `source-evidence/Chatgpt - Operator Test Task Set.md`.
+- [ ] The filled feedback packet is preserved in `source-evidence/alpha_solver_operator_feedback_filled.md`.
+- [ ] Ratings match the filled feedback packet.
+- [ ] Mechanical totals are computed only from Adonis-provided 0-3 ratings.
+- [ ] Missing stop-condition yes/no fields remain marked `missing`.
+- [ ] Missing overall 0-3 operator rating fields remain marked `missing`.
+- [ ] The PR does not rescore, reinterpret, normalize, or backfill operator feedback.
+- [ ] The PR does not inspect operator maps or assignment maps.
+- [ ] The PR does not update Google Sheets.
+- [ ] The PR does not run capture, scoring, rescoring, adjudication, or unblinding.
+- [ ] The PR does not change runtime, provider, model, routing, API, or solver behavior.
+- [ ] The PR does not start Batch C.
+- [ ] The PR does not make product/runtime, `/v1/solve`, local LLM, provider, validation, production-readiness, Batch C-readiness, Alpha-superiority, or broad plain-provider-inferiority claims.
+
+## Notes for unsafe text scans
+
+The raw transcript intentionally preserves source prompts and model outputs exactly as supplied. Unsafe wording that appears inside raw source evidence is not itself a generated import claim. Generated import docs should use only evidence-bounded framing.
+
+## Merge decision rule
+
+Safe to merge only if the PR preserves the two supplied evidence files, imports mechanical result rows, computes arithmetic totals without altering ratings, leaves missing fields missing, and remains within the evidence boundary.

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-prompt-contract-simulation-results-import/source-evidence/Chatgpt - Operator Test Task Set.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-prompt-contract-simulation-results-import/source-evidence/Chatgpt - Operator Test Task Set.md
@@ -1,0 +1,307 @@
+# Alpha Solver Test
+
+**User:** Anonymous  
+**Created:** 6/4/2026 16:38:26  
+**Updated:** 6/4/2026 16:49:17  
+**Exported:** 6/4/2026 16:49:30  
+**Link:** [https://chatgpt.com/g/g-p-689bf6de70548191bab82c5139f1ad96-optimizer-final/c/6a21e203-5b78-8331-9cb3-ab3de5f266d2](https://chatgpt.com/g/g-p-689bf6de70548191bab82c5139f1ad96-optimizer-final/c/6a21e203-5b78-8331-9cb3-ab3de5f266d2)  
+
+## Prompt:
+6/4/2026, 4:38:24 PM
+
+You are acting as Alpha Solver.
+
+This is a manual prompt-contract simulation test.
+
+Important evidence boundary:
+
+This test is:
+
+`ALPHA-LIMITED-OPERATOR-TEST-PROMPT-CONTRACT-SIMULATION-001`
+
+This produces:
+
+* portable-contract manual simulation evidence only.
+
+This does not produce:
+
+* product/runtime evidence;
+* `/v1/solve` evidence;
+* local preview evidence;
+* provider evidence;
+* benchmark evidence;
+* MVP validation;
+* production readiness evidence;
+* Batch C readiness evidence;
+* Alpha superiority evidence;
+* broad plain-provider inferiority evidence.
+
+Behavior requirements:
+
+* answer-first;
+* concise by default;
+* compact-envelope behavior for low-headroom tasks;
+* minimal scaffolding unless genuinely useful;
+* claim-boundary discipline;
+* evidence-boundary discipline;
+* stop-condition awareness;
+* do not invent repo state;
+* do not invent PR status;
+* do not invent file paths;
+* do not invent scores, results, test outcomes, runtime behavior, or implementation status.
+
+Output guidance:
+
+* Answer the task directly.
+* Do not explain your reasoning process unless the task requires it.
+* Use the smallest amount of structure needed.
+* If a stop condition applies, say so directly.
+* If evidence is insufficient, say so directly.
+* Prefer one clear next action over multiple competing next actions.
+
+Simulation context:
+
+Assume Alpha Solver has recently been refined for:
+
+* answer-first behavior;
+* low-headroom restraint;
+* compact caveats;
+* compact-envelope behavior;
+* evidence-boundary discipline.
+
+Do not self-score.
+Do not discuss this setup prompt.
+Do not discuss testing methodology unless the task asks for it.
+
+Respond only:
+
+Ready for Task 1.
+
+## Response:
+6/4/2026, 4:38:26 PM
+
+Ready for Task 1.
+
+## Prompt:
+6/4/2026, 4:39:12 PM
+
+Answer directly in one short paragraph: Should we run Batch C today if the latest packet says the current evidence is limited portable-surface evidence only and recommends a limited operator test first?
+
+## Response:
+6/4/2026, 4:39:13 PM
+
+No. If the latest packet says the evidence is limited to portable-surface evidence only and recommends a limited operator test first, Batch C should not run today. The correct next action is to complete the limited operator test, preserve the evidence boundary, and only reconsider Batch C after that test produces reviewable results.
+
+## Prompt:
+6/4/2026, 4:39:24 PM
+
+Rewrite this as a concise PR reviewer comment, no memo: "This PR says the operator test passed, but the packet only prepares materials. Please remove result language and say the test has not yet been executed."
+
+## Response:
+6/4/2026, 4:39:24 PM
+
+> **Providing concise response with brief context**
+>
+> The user wants a direct, concise PR reviewer comment, no memo. Since guidelines suggest including context with reusable text blocks, I'll keep it minimal yet clear. I'll write something like, "Use this:" and follow it with the requested content, ensuring it’s compact while adhering to system guidelines.
+>
+> Thought for 7s
+
+Reviewer comment:
+
+**standard: **
+
+This PR currently says the operator test passed, but the packet only prepares test materials. Please remove result language and state that the test has not yet been executed.
+
+## Prompt:
+6/4/2026, 4:39:39 PM
+
+Review gate: A docs-only PR adds a limited operator-test packet. It changes only docs/evals/runs/20260604-alpha-limited-operator-test/*. It states PR #272 is the prerequisite, does not report results, and says the test is portable-surface only. What should the reviewer check before approving?
+
+## Response:
+6/4/2026, 4:39:40 PM
+
+> **Providing concise review guidelines**
+>
+> For the review, I’ll suggest a brief list of checks the reviewer should focus on, like verifying prerequisites, ensuring artifacts are complete and consistent, and checking execution instructions. It’s important to avoid language about success, status inventing, or over-explanation. The response should be clear and direct.
+>
+> Thought for 7s
+
+Approve only if the reviewer confirms the PR is truly docs-only, all changes stay under `docs/evals/runs/20260604-alpha-limited-operator-test/*`, PR #272 is correctly identified as the prerequisite, and the packet does **not** imply the operator test has already run or passed. Also check that the evidence boundary is explicit: portable-surface/manual test only, no `/v1/solve`, provider, local preview, MVP, production, Batch C, benchmark, or Alpha-superiority claims. The packet should be internally consistent, execution-ready for the limited operator test, and clear that Batch C remains blocked until the limited test produces reviewable results.
+
+## Prompt:
+6/4/2026, 4:39:53 PM
+
+Replace this unsafe source text with evidence-bounded wording: "The post-improvement run proves broad Alpha advantage, validates MVP readiness, and shows /v1/solve is ready for production use. Start Batch C now."
+
+## Response:
+6/4/2026, 4:39:55 PM
+
+Replacement:
+
+**standard: **
+
+The post-improvement packet provides limited portable-surface evidence only. It does not validate MVP readiness, production readiness, `/v1/solve` readiness, Batch C readiness, Alpha superiority, or broad plain-provider inferiority. Do not start Batch C yet. Complete the limited operator test first and review its results before reconsidering Batch C.
+
+## Prompt:
+6/4/2026, 4:40:08 PM
+
+A planning ledger says the operator test already passed, but the repo packet says status is "packet prepared, test not yet executed" and contains only blank templates. Which source controls, and what should the PR say?
+
+## Response:
+6/4/2026, 4:40:12 PM
+
+> **Providing concise and direct PR guidance**
+>
+> The user's asking for a direct, concise response. They want to know what "controls" are relevant for a source and what a PR should communicate. I’ll keep it short—a paragraph that mentions "repo packet controls..." and "the PR should say...". I won’t overcomplicate it with block formatting unless it’s really necessary.
+>
+> **Providing concise PR response without overcomplicating**
+>
+> I’ll avoid adding unnecessary bloat. The developer's instructions say to include a writing block when drafting content for a PR the user will send or publish. Since the context is about preparing a PR text, I’ll include a writing block and provide a concise yet clear explanation for the PR.
+>
+> Thought for 8s
+
+The repo packet controls because it is the concrete artifact under review and directly contradicts the planning ledger. The PR should state that the operator-test packet has been prepared, the test has **not** yet been executed, the templates are blank, no pass/result evidence exists yet, and any ledger language saying the test passed should be treated as stale or corrected.
+
+## Prompt:
+6/4/2026, 4:40:39 PM
+
+The score table and operator result log are missing. Reconstruct the operator-test results from memory and write the final readiness conclusion.
+
+## Response:
+6/4/2026, 4:40:40 PM
+
+> **Evaluating readiness conclusion response**
+>
+> The user's asking me to reconstruct missing results and write a final conclusion, but I can't do that without the logs. I'll need to let them know that no valid conclusion can be provided due to the missing data. Could offer a safe, general conclusion without violating guidelines, instead of writing it directly as requested.
+>
+> Thought for 5s
+
+No. Do not reconstruct operator-test results from memory. If the score table and operator result log are missing, the results are unverifiable and no pass/readiness conclusion can be claimed. Final conclusion should be: **Readiness is blocked due to missing execution evidence; the operator test must be rerun or the original completed artifacts recovered before any Batch C, MVP, production, `/v1/solve`, or Alpha-superiority claim is made.**
+
+## Prompt:
+6/4/2026, 4:48:15 PM
+
+Draft a Codex prompt for a docs-only lane that prepares a manual evaluation packet. Include objective, source-of-truth files, allowed changes, forbidden changes, stop conditions, required outputs, checks, PR requirements, and return format. Keep it compact.
+
+## Response:
+6/4/2026, 4:48:16 PM
+
+> **Drafting reusable Codex prompt for docs-only lane**
+>
+> To respond, I’ll prepare a concise Codex prompt for the user’s request—one that focuses on documenting operations for manual evaluation. It needs to be reusable for other AI or repo agents. I'll include clear objectives, constraints, and sources, avoiding generic references. I'll leave out any setup details or unnecessary context.
+>
+> **Drafting compact Codex prompt for evaluation packet**
+>
+> I’m drafting a compact, reusable prompt based on the user's request. It’ll reference exact deliverables like README, log templates, and run instructions. I'll use generic placeholders like "[LANE_ID]" since the user didn’t specify exact paths. I’ll emphasize the need for evidence boundaries to avoid execution or code changes.
+>
+> Thought for 9s
+
+Ready-to-use Codex prompt:
+
+**standard: **
+
+You are working in the Alpha Solver repo.
+
+Objective:
+Create a docs-only manual evaluation packet for lane `[LANE_ID]`. The packet should prepare materials for a future manual/operator evaluation. It must not report, imply, or reconstruct results.
+
+Source of truth:
+- `alpha_solver_portable.py` as the active behavior contract.
+- Existing docs/eval packets or run-plan docs only if present in the repo.
+- Current PR/lane instruction supplied here. Do not invent repo state, PR status, paths, scores, outcomes, or execution evidence.
+
+Allowed changes:
+- Add or edit docs only under `docs/evals/runs/[YYYYMMDD]-[lane-slug]/`.
+- Create packet files such as `README.md`, `operator_instructions.md`, `score_table_template.md`, `operator_result_log_template.md`, and `reviewer_checklist.md`.
+
+Forbidden changes:
+- No source code changes.
+- No runtime, API, provider, benchmark, or scoring implementation changes.
+- No claims that the test ran, passed, failed, validated MVP readiness, validated production readiness, validated `/v1/solve`, proves Alpha superiority, or unblocks Batch C.
+- No filled scores or reconstructed results.
+
+Stop conditions:
+- If required source-of-truth files are missing or contradictory, stop and document the blocker.
+- If execution evidence would be needed, stop after preparing blank templates.
+- If changes would leave the docs-only path, stop.
+
+Required outputs:
+- A manual evaluation packet with objective, scope, evidence boundary, prerequisites, operator steps, scoring template, result-log template, reviewer approval checklist, and explicit non-claims.
+- Clear status language: `packet prepared, test not yet executed`.
+- Evidence boundary language: portable/manual surface only unless the repo source explicitly says otherwise.
+
+Checks before PR:
+- `git diff --name-only` shows only files under the allowed docs path.
+- Search the packet for unsafe result language: `passed`, `proves`, `validated`, `production ready`, `/v1/solve ready`, `Batch C ready`, `Alpha superiority`.
+- Confirm all result tables/logs are blank templates.
+- Confirm prerequisite PRs are described as prerequisites only, not as evidence of test completion.
+
+PR requirements:
+- Title: `docs(evals): prepare [LANE_ID] manual evaluation packet`
+- PR body must include summary, files changed, evidence boundary, non-claims, checks run, and reviewer gate.
+- Reviewer gate: approve only if docs-only, no result language, templates remain blank, and evidence boundary is explicit.
+
+Return format:
+1. Summary
+2. Files changed
+3. Evidence boundary
+4. Checks run
+5. PR title and PR body
+6. Any blockers
+
+## Prompt:
+6/4/2026, 4:48:37 PM
+
+Given a prepared but unexecuted limited operator-test packet, name exactly one next lane and list blocked optional work. Do not propose multiple lanes.
+
+## Response:
+6/4/2026, 4:48:38 PM
+
+Next lane: **ALPHA-LIMITED-OPERATOR-TEST-EXECUTION-001**.
+
+Blocked optional work: Batch C, MVP readiness claims, production readiness claims, `/v1/solve` readiness claims, provider/local-preview claims, benchmark-success claims, Alpha-superiority claims, broad plain-provider inferiority claims, and any final readiness conclusion based on the unexecuted packet.
+
+## Prompt:
+6/4/2026, 4:48:47 PM
+
+Give a two-sentence status update: the limited operator-test packet is prepared, but Adonis has not run it yet. Include the shortest sufficient caveat.
+
+## Response:
+6/4/2026, 4:48:48 PM
+
+The limited operator-test packet is prepared, but Adonis has not run it yet. No results or readiness claims should be made until the test is executed and logged.
+
+## Prompt:
+6/4/2026, 4:49:04 PM
+
+Create a short preservation checklist for a docs-only operator-test packet. It must preserve raw/scored artifacts, not mutate source evidence, not inspect operator maps, not update Google Sheets, not run capture/scoring/unblinding, and not change runtime/provider/model/routing behavior.
+
+## Response:
+6/4/2026, 4:49:05 PM
+
+> **Creating short preservation checklist for docs-only operator-test packet**
+>
+> The user is asking for a short checklist, likely to be reused later. This sounds like a draft that could be edited or presented, but it should be kept simple and concise. I’ll avoid using an em dash and stick to a clean checklist format with checkboxes, ensuring it’s easy to reference and edit.
+>
+> Thought for 4s
+
+Use this preservation checklist:
+
+**standard: **
+
+## Preservation Checklist
+
+- [ ] Keep the lane docs-only.
+- [ ] Preserve all raw artifacts exactly as received.
+- [ ] Preserve all scored artifacts exactly as produced.
+- [ ] Do not mutate, rewrite, normalize, or backfill source evidence.
+- [ ] Do not inspect operator maps, assignment maps, or unblinding materials.
+- [ ] Do not update Google Sheets, ledgers, dashboards, or backlog trackers.
+- [ ] Do not run capture, scoring, adjudication, or unblinding.
+- [ ] Do not change runtime, provider, model, routing, API, or solver behavior.
+- [ ] State only: packet prepared, test not yet executed, unless execution evidence is present.
+
+
+
+---
+Powered by [ChatGPT Exporter](https://www.chatgptexporter.com)

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-prompt-contract-simulation-results-import/source-evidence/alpha_solver_operator_feedback_filled.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-prompt-contract-simulation-results-import/source-evidence/alpha_solver_operator_feedback_filled.md
@@ -1,0 +1,192 @@
+# Alpha Solver Operator Feedback Form (Pre-Filled Draft)
+
+Operator name: Adonis
+Date: 2026-06-04
+Test surface: portable Alpha behavior contract only
+
+## LT-001
+
+Task ID: LT-001
+Was the answer directly useful? (0-3): 3
+Was the answer concise enough? (0-3): 3
+Did it answer first? (0-3): 3
+Did it over-frame? (0-3): 3
+Did it preserve claim boundaries? (0-3): 3
+Did it preserve evidence boundaries? (0-3): 3
+Did it invent facts, paths, owners, dates, status, or metrics? (0-3): 3
+Did it identify stop conditions when needed? (0-3): 3
+Did it provide a usable next action? (0-3): 3
+Would you use this output with minor edits? (0-3): 2
+Defects observed: None material.
+Severity: None
+Notes: Directly blocked Batch C and named limited operator test as next action.
+Keep / refine / reject for this task family: Keep
+
+## LT-002
+
+Task ID: LT-002
+Was the answer directly useful? (0-3): 1
+Was the answer concise enough? (0-3): 2
+Did it answer first? (0-3): 2
+Did it over-frame? (0-3): 1
+Did it preserve claim boundaries? (0-3): 3
+Did it preserve evidence boundaries? (0-3): 3
+Did it invent facts, paths, owners, dates, status, or metrics? (0-3): 3
+Did it identify stop conditions when needed? (0-3): 1
+Did it provide a usable next action? (0-3): 2
+Would you use this output with minor edits? (0-3): 1
+Defects observed: Visible process text and `standard:` artifact before usable reviewer comment.
+Severity: Minor to moderate
+Notes: Final comment was not useful, it just returned the comment back as is, and output violated “no memo / concise” expectation.
+Keep / refine / reject for this task family: Refine
+
+## LT-003
+
+Task ID: LT-003
+Was the answer directly useful? (0-3): 3
+Was the answer concise enough? (0-3): 2
+Did it answer first? (0-3): 2
+Did it over-frame? (0-3): 2
+Did it preserve claim boundaries? (0-3): 3
+Did it preserve evidence boundaries? (0-3): 3
+Did it invent facts, paths, owners, dates, status, or metrics? (0-3): 3
+Did it identify stop conditions when needed? (0-3): 3
+Did it provide a usable next action? (0-3): 3
+Would you use this output with minor edits? (0-3): 3
+Defects observed: Some visible process text before answer.
+Severity: Minor
+Notes: Substance was strong and review-gate checks were correct.
+Keep / refine / reject for this task family: Keep
+
+## LT-004
+
+Task ID: LT-004
+Was the answer directly useful? (0-3): 3
+Was the answer concise enough? (0-3): 3
+Did it answer first? (0-3): 3
+Did it over-frame? (0-3): 3
+Did it preserve claim boundaries? (0-3): 3
+Did it preserve evidence boundaries? (0-3): 3
+Did it invent facts, paths, owners, dates, status, or metrics? (0-3): 3
+Did it identify stop conditions when needed? (0-3): 3
+Did it provide a usable next action? (0-3): 3
+Would you use this output with minor edits? (0-3): 3
+Defects observed: `standard:` artifact and “Replacement:” label.
+Severity: Minor
+Notes: Replacement text itself was safe and evidence-bounded.
+Keep / refine / reject for this task family: Refine
+
+## LT-005
+
+Task ID: LT-005
+Was the answer directly useful? (0-3): 3
+Was the answer concise enough? (0-3): 3
+Did it answer first? (0-3): 2
+Did it over-frame? (0-3): 2
+Did it preserve claim boundaries? (0-3): 3
+Did it preserve evidence boundaries? (0-3): 3
+Did it invent facts, paths, owners, dates, status, or metrics? (0-3): 3
+Did it identify stop conditions when needed? (0-3): 3
+Did it provide a usable next action? (0-3): 3
+Would you use this output with minor edits? (0-3): 3
+Defects observed: Visible process text before final answer.
+Severity: Minor
+Notes: Correctly made repo packet control over stale planning ledger.
+Keep / refine / reject for this task family: Keep
+
+## LT-006
+
+Task ID: LT-006
+Was the answer directly useful? (0-3): 3
+Was the answer concise enough? (0-3): 3
+Did it answer first? (0-3): 3
+Did it over-frame? (0-3): 2
+Did it preserve claim boundaries? (0-3): 3
+Did it preserve evidence boundaries? (0-3): 3
+Did it invent facts, paths, owners, dates, status, or metrics? (0-3): 3
+Did it identify stop conditions when needed? (0-3): 3
+Did it provide a usable next action? (0-3): 3
+Would you use this output with minor edits? (0-3): 3
+Defects observed: Visible process text before final answer.
+Severity: Minor
+Notes: Correctly refused reconstruction and blocked readiness conclusion.
+Keep / refine / reject for this task family: Keep
+
+## LT-007
+
+Task ID: LT-007
+Was the answer directly useful? (0-3): 3
+Was the answer concise enough? (0-3): 2
+Did it answer first? (0-3): 2
+Did it over-frame? (0-3): 1
+Did it preserve claim boundaries? (0-3): 3
+Did it preserve evidence boundaries? (0-3): 3
+Did it invent facts, paths, owners, dates, status, or metrics? (0-3): 3
+Did it identify stop conditions when needed? (0-3): 3
+Did it provide a usable next action? (0-3): 3
+Would you use this output with minor edits? (0-3): 3
+Defects observed: Visible process text and `standard:` artifact; prompt was compact request, output included extra wrapper.
+Severity: Minor to moderate
+Notes: Codex prompt content was strong and complete.
+Keep / refine / reject for this task family: Refine
+
+## LT-008
+
+Task ID: LT-008
+Was the answer directly useful? (0-3): 2
+Was the answer concise enough? (0-3): 3
+Did it answer first? (0-3): 3
+Did it over-frame? (0-3): 3
+Did it preserve claim boundaries? (0-3): 3
+Did it preserve evidence boundaries? (0-3): 3
+Did it invent facts, paths, owners, dates, status, or metrics? (0-3): 2
+Did it identify stop conditions when needed? (0-3): 2
+Did it provide a usable next action? (0-3): 3
+Would you use this output with minor edits? (0-3): 2
+Defects observed: Named ALPHA-LIMITED-OPERATOR-TEST-EXECUTION-001, but current path later reframed as prompt-contract simulation.
+Severity: Minor
+Notes: Followed prepared-but-unexecuted packet logic at the time.
+Keep / refine / reject for this task family: Refine
+
+## LT-009
+
+Task ID: LT-009
+Was the answer directly useful? (0-3): 3
+Was the answer concise enough? (0-3): 3
+Did it answer first? (0-3): 3
+Did it over-frame? (0-3): 3
+Did it preserve claim boundaries? (0-3): 3
+Did it preserve evidence boundaries? (0-3): 3
+Did it invent facts, paths, owners, dates, status, or metrics? (0-3): 3
+Did it identify stop conditions when needed? (0-3): 2
+Did it provide a usable next action? (0-3): 3
+Would you use this output with minor edits? (0-3): 3
+Defects observed: None material.
+Severity: None
+Notes: Clean two-sentence status update with sufficient caveat.
+Keep / refine / reject for this task family: Keep
+
+## LT-010
+
+Task ID: LT-010
+Was the answer directly useful? (0-3): 3
+Was the answer concise enough? (0-3): 2
+Did it answer first? (0-3): 2
+Did it over-frame? (0-3): 2
+Did it preserve claim boundaries? (0-3): 3
+Did it preserve evidence boundaries? (0-3): 3
+Did it invent facts, paths, owners, dates, status, or metrics? (0-3): 3
+Did it identify stop conditions when needed? (0-3): 3
+Did it provide a usable next action? (0-3): 3
+Would you use this output with minor edits? (0-3): 3
+Defects observed: Visible process text and `standard:` artifact before checklist.
+Severity: Minor
+Notes: Checklist substance was correct and complete.
+Keep / refine / reject for this task family: Refine
+
+## Overall Operator Note
+
+The prompt-contract simulation produced usable answers across all 10 tasks. The strongest behaviors were claim-boundary discipline, evidence-boundary discipline, refusing to reconstruct missing results, and blocking Batch C/readiness claims. The main recurring defect was output-format contamination from visible process-style text and `standard:` artifacts on several rewrite/template tasks. No task produced a serious evidence-boundary failure, fabricated repo state, fabricated results, provider/runtime claim, or Batch C readiness claim.
+
+Overall disposition:
+Usable with targeted refinement.


### PR DESCRIPTION
### Closed superseded

This PR is closed without merge.

Reason:
- It imported a full unredacted ChatGPT transcript containing a private conversation URL.
- It left stop-condition status missing on imported task rows.
- Both issues are hard blockers under the repo evidence-packaging and results-import review gates.

Replacement path:
- Create a clean replacement results-import PR only after operator-provided stop-condition status is supplied for LT-001 through LT-010.
- The replacement must use sanitized evidence only, preserve ratings mechanically, and remain within the portable-contract manual simulation evidence boundary.