### PR TITLE
feat(local-llm): add provider adapter seam

### DIFF
--- a/alpha/local_llm/__init__.py
+++ b/alpha/local_llm/__init__.py
@@ -15,3 +15,12 @@ from .portable_contract import (  # noqa: F401
     load_portable_contract,
     run_fake_local_llm_contract_proof,
 )
+from .provider_adapter import (  # noqa: F401
+    LocalLLMAdapterMessage,
+    LocalLLMAdapterRequest,
+    LocalLLMAdapterResult,
+    LocalLLMProviderBackend,
+    StubLocalLLMProviderBackend,
+    build_local_llm_adapter_request,
+    run_local_llm_provider_adapter,
+)

--- a/alpha/local_llm/provider_adapter.py
+++ b/alpha/local_llm/provider_adapter.py
@@ -1,0 +1,205 @@
+"""Inert local LLM provider-adapter seam for portable-contract requests.
+
+This module builds a provider-adapter-shaped request from
+``alpha_solver_portable.py`` and sends it only to an injected backend. It does
+not call Ollama, OpenAI, Anthropic, other hosted providers, or the deterministic
+v91 ``_tree_of_thought`` fallback. Successful stub output is wiring evidence
+only and is never behavior, runtime, or readiness evidence.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Protocol
+
+from .portable_contract import PortableContract, PortableContractError, load_portable_contract
+
+_LOCAL_LLM_ADAPTER_MODE = "local_llm"
+_ADAPTER_BACKEND_CLASS = "stub-local-llm-provider-adapter"
+_ADAPTER_EVIDENCE_LABEL = "non_evidence_local_llm_provider_adapter_wiring"
+_DISABLED_MODEL_LABEL = "local-llm-disabled-unconfigured"
+
+
+@dataclass(frozen=True)
+class LocalLLMAdapterMessage:
+    """Single role/content message for an inert local LLM adapter request."""
+
+    role: str
+    content: str
+
+
+@dataclass(frozen=True)
+class LocalLLMAdapterRequest:
+    """Local-LLM-shaped request that preserves contract and user boundaries."""
+
+    system: str
+    user_prompt: str
+    messages: tuple[LocalLLMAdapterMessage, LocalLLMAdapterMessage]
+    metadata: Mapping[str, Any]
+    model: str = _DISABLED_MODEL_LABEL
+    provider_mode: str = _LOCAL_LLM_ADAPTER_MODE
+    backend_class: str = _ADAPTER_BACKEND_CLASS
+
+
+@dataclass(frozen=True)
+class LocalLLMAdapterResult:
+    """Normalized adapter result.
+
+    ``behavior_evidence`` is always false. A non-failed result proves only that
+    request construction, prompt-source preservation, and injected-backend
+    handoff occurred.
+    """
+
+    request: LocalLLMAdapterRequest
+    output_text: str
+    status: str
+    reason: str
+    behavior_evidence: bool = False
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+class LocalLLMProviderBackend(Protocol):
+    """Injected local-backend seam used by offline tests and future adapters."""
+
+    def generate(self, request: LocalLLMAdapterRequest) -> str:
+        """Return text for an adapter request."""
+
+
+@dataclass
+class StubLocalLLMProviderBackend:
+    """Offline stub backend that records requests and performs no I/O."""
+
+    output_text: str = "stub local LLM adapter output: request accepted"
+    fail: bool = False
+    calls: list[LocalLLMAdapterRequest] = field(default_factory=list)
+
+    def generate(self, request: LocalLLMAdapterRequest) -> str:
+        self.calls.append(request)
+        if self.fail:
+            raise PortableContractError("stub local LLM provider adapter failed")
+        return self.output_text
+
+
+def _normalize_mode(provider_mode: str) -> str:
+    normalized = provider_mode.strip().lower()
+    if normalized != _LOCAL_LLM_ADAPTER_MODE:
+        raise PortableContractError(
+            "local LLM provider adapter requires provider_mode=local_llm; "
+            "MODEL_PROVIDER=local remains smoke-only"
+        )
+    return normalized
+
+
+def build_local_llm_adapter_request(
+    user_prompt: str,
+    *,
+    contract: PortableContract | None = None,
+    contract_path: str | None = None,
+    expected_sha256: str | None = None,
+    provider_mode: str = _LOCAL_LLM_ADAPTER_MODE,
+    model: str = _DISABLED_MODEL_LABEL,
+) -> LocalLLMAdapterRequest:
+    """Build an inert provider-adapter request from the portable contract.
+
+    The portable contract is loaded as the system/contract message and the user
+    prompt is preserved as a separate user message. The function accepts only the
+    distinct ``local_llm`` mode label so ``MODEL_PROVIDER=local`` remains the
+    existing smoke-only mode unless a separate approved lane changes it.
+    """
+
+    normalized_mode = _normalize_mode(provider_mode)
+    if not user_prompt.strip():
+        raise PortableContractError("user prompt is required for local LLM adapter request")
+
+    loaded_contract = contract or load_portable_contract(
+        contract_path, expected_sha256=expected_sha256
+    )
+    messages = (
+        LocalLLMAdapterMessage(role="system", content=loaded_contract.text),
+        LocalLLMAdapterMessage(role="user", content=user_prompt),
+    )
+    metadata: dict[str, Any] = {
+        **loaded_contract.metadata,
+        "provider_mode": normalized_mode,
+        "backend_class": _ADAPTER_BACKEND_CLASS,
+        "model": model,
+        "no_real_provider_call": True,
+        "real_provider_call_enabled": False,
+        "behavior_evidence": False,
+        "evidence_label": _ADAPTER_EVIDENCE_LABEL,
+    }
+    return LocalLLMAdapterRequest(
+        system=loaded_contract.text,
+        user_prompt=user_prompt,
+        messages=messages,
+        metadata=metadata,
+        model=model,
+        provider_mode=normalized_mode,
+    )
+
+
+def _is_prompt_echo(output_text: str, request: LocalLLMAdapterRequest) -> bool:
+    stripped = output_text.strip()
+    return stripped in {request.user_prompt.strip(), request.system.strip()}
+
+
+def run_local_llm_provider_adapter(
+    user_prompt: str,
+    *,
+    backend: LocalLLMProviderBackend,
+    contract: PortableContract | None = None,
+    contract_path: str | None = None,
+    expected_sha256: str | None = None,
+    provider_mode: str = _LOCAL_LLM_ADAPTER_MODE,
+    model: str = _DISABLED_MODEL_LABEL,
+) -> LocalLLMAdapterResult:
+    """Run the inert adapter against an injected backend and fail closed.
+
+    This seam performs no default provider calls. Adapter/backend errors, empty
+    output, and prompt echo are normalized as ``failed_closed`` non-evidence.
+    """
+
+    request = build_local_llm_adapter_request(
+        user_prompt,
+        contract=contract,
+        contract_path=contract_path,
+        expected_sha256=expected_sha256,
+        provider_mode=provider_mode,
+        model=model,
+    )
+    result_metadata = {**request.metadata, "behavior_evidence": False}
+    try:
+        output_text = backend.generate(request)
+    except Exception as exc:  # injected-backend-only failure normalization
+        return LocalLLMAdapterResult(
+            request=request,
+            output_text="",
+            status="failed_closed",
+            reason=f"adapter_error:{exc.__class__.__name__}",
+            metadata=result_metadata,
+        )
+
+    if not output_text.strip():
+        return LocalLLMAdapterResult(
+            request=request,
+            output_text=output_text,
+            status="failed_closed",
+            reason="empty_model_output_non_evidence",
+            metadata=result_metadata,
+        )
+    if _is_prompt_echo(output_text, request):
+        return LocalLLMAdapterResult(
+            request=request,
+            output_text=output_text,
+            status="failed_closed",
+            reason="prompt_echo_non_evidence",
+            metadata=result_metadata,
+        )
+
+    return LocalLLMAdapterResult(
+        request=request,
+        output_text=output_text,
+        status="non_evidence",
+        reason="local_llm_provider_adapter_wiring_only",
+        metadata=result_metadata,
+    )

--- a/docs/evals/runs/20260604-alpha-local-llm-provider-adapter/README.md
+++ b/docs/evals/runs/20260604-alpha-local-llm-provider-adapter/README.md
@@ -1,0 +1,53 @@
+# Alpha Local LLM Provider Adapter
+
+Lane ID: `ALPHA-LOCAL-LLM-PROVIDER-ADAPTER-001`
+
+Status: provider-adapter wiring proof only.
+
+## Purpose
+
+Add a narrow local LLM provider-adapter seam that builds on the fake-client
+contract-consumption proof. The seam constructs an adapter-shaped request from
+`alpha_solver_portable.py`, keeps the portable contract as system/contract
+content, keeps the user prompt separate, and records prompt-source metadata.
+
+## Scope
+
+This lane is intentionally inert by default. It adds an injected-backend adapter
+interface under `alpha/local_llm/` and offline tests that use only a stub backend.
+It does not wire local LLM behavior into `/v1/solve`, dashboard preview, the
+runtime provider registry, or `MODEL_PROVIDER=local`.
+
+## Files changed
+
+- `alpha/local_llm/__init__.py`
+- `alpha/local_llm/provider_adapter.py`
+- `tests/test_local_llm_provider_adapter.py`
+- `docs/evals/runs/20260604-alpha-local-llm-provider-adapter/README.md`
+- `docs/evals/runs/20260604-alpha-local-llm-provider-adapter/adapter-design.md`
+- `docs/evals/runs/20260604-alpha-local-llm-provider-adapter/evidence-boundary.md`
+- `docs/evals/runs/20260604-alpha-local-llm-provider-adapter/adapter-preservation-checklist.md`
+- `docs/evals/runs/20260604-alpha-local-llm-provider-adapter/recommended-next-lane.md`
+
+## What this lane may prove
+
+- A local-LLM-shaped adapter request can be built from `alpha_solver_portable.py`.
+- The request preserves the portable contract path and SHA-256 fingerprint.
+- The system/contract content and user prompt remain separate message entries.
+- The adapter path uses a distinct `local_llm` label.
+- The adapter path does not use v91 `_tree_of_thought` fallback.
+- The adapter fails closed for empty output, prompt echo, and injected-backend
+  errors.
+- Stub tests run offline without model servers or provider keys.
+
+## What this lane does not prove
+
+- No local LLM behavior is proven.
+- No Ollama behavior is proven.
+- No hosted provider behavior is proven.
+- No `/v1/solve` readiness is proven.
+- No dashboard preview readiness is proven.
+- No runtime readiness, MVP validation, production readiness, Alpha quality,
+  Alpha superiority, broad plain-provider inferiority, Batch C readiness,
+  benchmark success, exact billing accuracy, or provider orchestration is
+  claimed.

--- a/docs/evals/runs/20260604-alpha-local-llm-provider-adapter/adapter-design.md
+++ b/docs/evals/runs/20260604-alpha-local-llm-provider-adapter/adapter-design.md
@@ -1,0 +1,41 @@
+# Adapter Design
+
+## Design target
+
+The adapter seam is a narrow request-construction and injected-backend handoff
+layer. It is intentionally separate from the existing fake-client
+contract-consumption proof while reusing the same portable contract loader.
+
+## Request shape
+
+The adapter request contains:
+
+- `system`: the full text loaded from `alpha_solver_portable.py`.
+- `user_prompt`: the caller-supplied user prompt.
+- `messages`: a two-entry tuple with a `system` message for the portable
+  contract and a `user` message for the user prompt.
+- `metadata`: prompt-source path, SHA-256 fingerprint, fingerprint algorithm,
+  adapter mode, backend class, model label, and non-evidence flags.
+
+## Mode label
+
+The adapter accepts only `provider_mode="local_llm"`. Passing
+`provider_mode="local"` fails closed so existing `MODEL_PROVIDER=local` remains
+smoke-only until a separate approved lane changes it.
+
+## Backend behavior
+
+The adapter accepts an injected backend implementing `generate(request) -> str`.
+The included stub backend records calls and returns configured text without
+network, local model, Ollama, OpenAI, Anthropic, or hosted-provider access.
+
+## Failure behavior
+
+The adapter reports `failed_closed` non-evidence results for:
+
+- missing, unreadable, empty, or fingerprint-mismatched portable contracts;
+- empty model output;
+- prompt echo;
+- injected-backend errors.
+
+Successful stub output remains wiring-only non-evidence.

--- a/docs/evals/runs/20260604-alpha-local-llm-provider-adapter/adapter-preservation-checklist.md
+++ b/docs/evals/runs/20260604-alpha-local-llm-provider-adapter/adapter-preservation-checklist.md
@@ -1,0 +1,18 @@
+# Adapter Preservation Checklist
+
+- [x] Loads `alpha_solver_portable.py` through the portable contract loader.
+- [x] Preserves `prompt_source_path` as `alpha_solver_portable.py`.
+- [x] Preserves the SHA-256 prompt-source fingerprint.
+- [x] Uses the loaded portable contract as system/contract content.
+- [x] Keeps the user prompt separate from the system/contract content.
+- [x] Uses the distinct `local_llm` adapter mode label.
+- [x] Rejects `provider_mode="local"` so `MODEL_PROVIDER=local` remains
+  smoke-only.
+- [x] Avoids v91 `_tree_of_thought` fallback.
+- [x] Uses an injected stub backend in tests.
+- [x] Performs no default Ollama, local model, OpenAI, Anthropic, or hosted
+  provider calls.
+- [x] Fails closed on empty output.
+- [x] Fails closed on prompt echo.
+- [x] Fails closed on injected-backend error.
+- [x] Labels successful stub output as non-evidence wiring only.

--- a/docs/evals/runs/20260604-alpha-local-llm-provider-adapter/evidence-boundary.md
+++ b/docs/evals/runs/20260604-alpha-local-llm-provider-adapter/evidence-boundary.md
@@ -1,0 +1,34 @@
+# Evidence Boundary
+
+## Allowed evidence
+
+This lane may be cited only as evidence that the local LLM provider-adapter seam
+can build and hand off a request in offline stub tests while preserving prompt
+source metadata.
+
+## Non-claims
+
+This lane must not be cited as evidence of:
+
+- local LLM behavior;
+- Ollama behavior;
+- hosted provider behavior;
+- `/v1/solve` readiness;
+- dashboard preview readiness;
+- runtime readiness;
+- MVP validation;
+- production readiness;
+- Alpha quality;
+- Alpha superiority;
+- broad plain-provider inferiority;
+- Batch C readiness;
+- benchmark success;
+- exact billing accuracy;
+- provider orchestration.
+
+## Boundary wording
+
+Safe wording: "The lane proves adapter wiring only with an offline stub backend."
+
+Unsafe wording: any statement that treats stub output as model behavior,
+readiness, validation, or provider execution evidence.

--- a/docs/evals/runs/20260604-alpha-local-llm-provider-adapter/recommended-next-lane.md
+++ b/docs/evals/runs/20260604-alpha-local-llm-provider-adapter/recommended-next-lane.md
@@ -1,0 +1,25 @@
+# Recommended Next Lane
+
+Recommended next lane: `ALPHA-LOCAL-LLM-ADAPTER-REVIEW-GATE-001`.
+
+## Purpose
+
+Review the provider-adapter seam before any real local-provider integration is
+considered. The review should verify that prompt-source preservation, failure
+normalization, mode labeling, and evidence boundaries remain intact.
+
+## Suggested review questions
+
+1. Does the adapter keep `alpha_solver_portable.py` as the system/contract
+   source and preserve SHA-256 metadata?
+2. Does the adapter keep user prompt content separate from contract content?
+3. Does `MODEL_PROVIDER=local` remain smoke-only?
+4. Do tests avoid network, local model servers, Ollama, and provider keys?
+5. Do docs avoid behavior, readiness, validation, superiority, benchmark,
+   billing, Batch C, and orchestration claims?
+
+## Not recommended in the next lane
+
+Do not begin real Ollama calls, hosted-provider calls, `/v1/solve` integration,
+dashboard preview integration, operator-test interpretation, imported evidence
+modification, or Batch C work in the review gate.

--- a/tests/test_local_llm_provider_adapter.py
+++ b/tests/test_local_llm_provider_adapter.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import sys
+from hashlib import sha256
+from pathlib import Path
+
+import pytest
+
+from alpha.local_llm.portable_contract import PortableContractError, load_portable_contract
+from alpha.local_llm.provider_adapter import (
+    StubLocalLLMProviderBackend,
+    build_local_llm_adapter_request,
+    run_local_llm_provider_adapter,
+)
+
+
+def test_adapter_builds_local_llm_shaped_request_from_portable_contract():
+    user_prompt = "Summarize the adapter wiring boundary."
+
+    request = build_local_llm_adapter_request(user_prompt)
+
+    assert request.provider_mode == "local_llm"
+    assert request.backend_class == "stub-local-llm-provider-adapter"
+    assert request.model == "local-llm-disabled-unconfigured"
+    assert request.messages[0].role == "system"
+    assert request.messages[0].content == request.system
+    assert request.messages[1].role == "user"
+    assert request.messages[1].content == user_prompt
+    assert "LLM_PERSONA_PROTOCOL" in request.system
+    assert request.user_prompt == user_prompt
+    assert user_prompt not in request.system
+    assert request.metadata["provider_mode"] == "local_llm"
+    assert request.metadata["no_real_provider_call"] is True
+    assert request.metadata["real_provider_call_enabled"] is False
+    assert request.metadata["behavior_evidence"] is False
+    assert (
+        request.metadata["evidence_label"]
+        == "non_evidence_local_llm_provider_adapter_wiring"
+    )
+
+
+def test_adapter_preserves_portable_contract_path_and_fingerprint():
+    contract = load_portable_contract()
+    expected_text = Path("alpha_solver_portable.py").read_text(encoding="utf-8")
+
+    request = build_local_llm_adapter_request("Keep the prompt sources separate.")
+
+    assert contract.source_path == "alpha_solver_portable.py"
+    assert request.metadata["prompt_source_path"] == "alpha_solver_portable.py"
+    assert request.metadata["prompt_source_fingerprint"] == sha256(
+        expected_text.encode("utf-8")
+    ).hexdigest()
+    assert (
+        request.metadata["prompt_source_sha256"]
+        == request.metadata["prompt_source_fingerprint"]
+    )
+    assert request.metadata["prompt_source_fingerprint_algorithm"] == "sha256"
+
+
+def test_adapter_keeps_user_prompt_separate_from_system_contract_text():
+    user_prompt = "User-only adapter prompt marker 20260604."
+
+    request = build_local_llm_adapter_request(user_prompt)
+
+    assert request.system == request.messages[0].content
+    assert request.user_prompt == request.messages[1].content
+    assert request.messages[0].role == "system"
+    assert request.messages[1].role == "user"
+    assert user_prompt not in request.system
+
+
+def test_adapter_does_not_import_or_call_v91_tree_of_thought(monkeypatch):
+    imported_names: list[str] = []
+    real_import = __import__
+
+    def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+        imported_names.append(name)
+        if name in {"alpha_solver_entry", "alpha-solver-v91-python"}:
+            raise AssertionError(f"forbidden import: {name}")
+        return real_import(name, globals, locals, fromlist, level)
+
+    for module_name in ["alpha_solver_entry", "alpha-solver-v91-python"]:
+        monkeypatch.delitem(sys.modules, module_name, raising=False)
+    monkeypatch.setattr("builtins.__import__", guarded_import)
+
+    backend = StubLocalLLMProviderBackend(output_text="adapter wiring only")
+    result = run_local_llm_provider_adapter("Explain the seam.", backend=backend)
+
+    assert result.status == "non_evidence"
+    assert len(backend.calls) == 1
+    assert "alpha_solver_entry" not in imported_names
+    assert "alpha-solver-v91-python" not in imported_names
+
+
+def test_model_provider_local_remains_smoke_only_for_adapter():
+    with pytest.raises(PortableContractError, match="MODEL_PROVIDER=local remains smoke-only"):
+        build_local_llm_adapter_request(
+            "This must not use smoke local mode.", provider_mode="local"
+        )
+
+
+def test_adapter_fails_closed_on_empty_output():
+    backend = StubLocalLLMProviderBackend(output_text="   ")
+
+    result = run_local_llm_provider_adapter("Produce adapter output.", backend=backend)
+
+    assert result.status == "failed_closed"
+    assert result.reason == "empty_model_output_non_evidence"
+    assert result.behavior_evidence is False
+    assert result.metadata["behavior_evidence"] is False
+
+
+def test_adapter_fails_closed_on_prompt_echo():
+    user_prompt = "Do not echo this prompt."
+    backend = StubLocalLLMProviderBackend(output_text=user_prompt)
+
+    result = run_local_llm_provider_adapter(user_prompt, backend=backend)
+
+    assert result.status == "failed_closed"
+    assert result.reason == "prompt_echo_non_evidence"
+    assert result.behavior_evidence is False
+
+
+def test_adapter_fails_closed_on_backend_error():
+    backend = StubLocalLLMProviderBackend(fail=True)
+
+    result = run_local_llm_provider_adapter("Exercise adapter error.", backend=backend)
+
+    assert result.status == "failed_closed"
+    assert result.reason == "adapter_error:PortableContractError"
+    assert result.output_text == ""
+    assert result.metadata["no_real_provider_call"] is True
+
+
+def test_adapter_fails_closed_on_missing_contract(tmp_path):
+    missing_contract = tmp_path / "missing-alpha-solver-portable.py"
+
+    with pytest.raises(PortableContractError, match="portable contract not found"):
+        build_local_llm_adapter_request(
+            "Missing contract should fail closed.", contract_path=missing_contract
+        )
+
+
+def test_adapter_fails_closed_on_empty_contract(tmp_path):
+    empty_contract = tmp_path / "alpha_solver_portable.py"
+    empty_contract.write_text("   ", encoding="utf-8")
+
+    with pytest.raises(PortableContractError, match="portable contract is empty"):
+        build_local_llm_adapter_request(
+            "Empty contract should fail closed.", contract_path=empty_contract
+        )
+
+
+def test_adapter_fails_closed_on_fingerprint_mismatch(tmp_path):
+    contract = tmp_path / "alpha_solver_portable.py"
+    contract.write_text("LLM_PERSONA_PROTOCOL = 'test contract'\n", encoding="utf-8")
+
+    with pytest.raises(PortableContractError, match="sha256 mismatch"):
+        build_local_llm_adapter_request(
+            "Fingerprint mismatch should fail closed.",
+            contract_path=contract,
+            expected_sha256="0" * 64,
+        )


### PR DESCRIPTION
### Motivation
- Provide a narrow, offline-proof seam that constructs a local-LLM-shaped adapter request from the portable contract while preserving prompt-source metadata and avoiding any real provider calls. 
- Reuse the existing portable-contract loader and fake-client proof approach to add an injectable adapter backend for future review without changing runtime `/v1/solve`, dashboard, or `MODEL_PROVIDER=local` behavior. 
- Ensure strict evidence boundaries and fail-closed behavior so tests can run offline with a stub backend and no secrets or network access.

### Description
- Added an inert provider-adapter module under `alpha/local_llm/provider_adapter.py` that defines request/result dataclasses, a `LocalLLMProviderBackend` protocol, and a `StubLocalLLMProviderBackend` stub. 
- Implemented `build_local_llm_adapter_request` to load `alpha_solver_portable.py` as the `system` message, keep the user prompt separate, preserve SHA-256 fingerprint metadata, and require `provider_mode="local_llm"` so `MODEL_PROVIDER=local` remains smoke-only. 
- Implemented `run_local_llm_provider_adapter` which calls the injected backend and normalizes adapter/backend errors, empty output, and prompt-echo into `failed_closed` non-evidence results while successful stub output is labeled `non_evidence`. 
- Exported the new adapter symbols through `alpha.local_llm` and added focused docs under `docs/evals/runs/20260604-alpha-local-llm-provider-adapter/` describing design, evidence boundary, preservation checklist, and recommended next lane; no Ollama, OpenAI, Anthropic, hosted-provider, or v91/_tree_of_thought codepaths are used. 
- Files changed: `alpha/local_llm/__init__.py`, `alpha/local_llm/provider_adapter.py`, `tests/test_local_llm_provider_adapter.py`, and docs added under `docs/evals/runs/20260604-alpha-local-llm-provider-adapter/`.

### Testing
- Ran `pytest` for the new adapter tests: `tests/test_local_llm_provider_adapter.py` passed (all tests green). 
- Re-ran existing relevant suites: `tests/test_local_llm_contract_consumption_proof.py` and `tests/test_alpha_minimal_behavior_contract.py` passed (no regressions). 
- Verified commit-level checks: `git diff --check` returned clean, and repository scans found no provider keys, private URLs, or runtime secrets and docs preserve wiring-only evidence boundary. 
- All automated checks in this PR run succeeded; adapter tests exercise fingerprint preservation, system/user separation, no v91 fallback, smoke-only `MODEL_PROVIDER=local` preservation, and fail-closed behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a221b3bce808329a4c6d062c3cecc2d)