### PR TITLE
docs(evals): decide post-results operator-test next lane

### DIFF
--- a/docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision/README.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision/README.md
@@ -1,0 +1,76 @@
+# Post-Results Decision: Limited Operator Prompt-Contract Simulation
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-POST-RESULTS-DECISION-001`
+
+Status: docs-only decision recorded.
+
+## Purpose
+
+This packet records the post-results decision after the imported sanitized limited-operator prompt-contract simulation results and the interpretation packet.
+
+The decision chooses exactly one next lane. It does not start that lane and does not implement any runtime, provider, model, routing, API, solver, or Batch C work.
+
+## Source files
+
+This decision is based only on these imported results and interpretation files:
+
+- `docs/evals/runs/20260604-alpha-limited-operator-test-prompt-contract-simulation-results-import-clean/README.md`
+- `docs/evals/runs/20260604-alpha-limited-operator-test-prompt-contract-simulation-results-import-clean/mechanical-result-log.md`
+- `docs/evals/runs/20260604-alpha-limited-operator-test-prompt-contract-simulation-results-import-clean/mechanical-rating-totals.md`
+- `docs/evals/runs/20260604-alpha-limited-operator-test-interpretation/README.md`
+- `docs/evals/runs/20260604-alpha-limited-operator-test-interpretation/interpretation-summary.md`
+- `docs/evals/runs/20260604-alpha-limited-operator-test-interpretation/task-family-observations.md`
+- `docs/evals/runs/20260604-alpha-limited-operator-test-interpretation/defect-patterns.md`
+- `docs/evals/runs/20260604-alpha-limited-operator-test-interpretation/evidence-boundary-review.md`
+- `docs/evals/runs/20260604-alpha-limited-operator-test-interpretation/recommended-next-lane.md`
+- `docs/evals/runs/20260604-alpha-limited-operator-test-interpretation/interpretation-preservation-checklist.md`
+
+## Selected next lane
+
+`ALPHA-LIMITED-OPERATOR-TEST-TARGETED-PORTABLE-CONTRACT-REFINEMENT-OUTPUT-FORMAT-CONTAMINATION-001`
+
+Family: targeted portable-contract refinement for output-format contamination.
+
+## Decision summary
+
+The next safest lane is a narrow targeted refinement lane focused on output-format contamination before any broader readiness review or follow-up operator test.
+
+The interpretation packet identifies a recurring task-level defect: visible process-style text, wrapper labels, and `standard:` artifacts appeared around otherwise usable content. Because the imported feedback preserved strong claim-boundary and evidence-boundary ratings, the safest next action is to correct answer shape and artifact suppression without broadening claims or changing evidence scope.
+
+## Preserved mechanical totals
+
+These imported totals are preserved and are not edited, rescored, or reinterpreted as benchmark results:
+
+- Feedback entries imported: 10
+- Rating dimensions per entry: 10
+- Grand mechanical rating sum: 270 / 300
+- Operator dispositions: Keep 5, Refine 5
+- Severity counts: None 2, Minor 6, Minor to moderate 2
+- Operator-provided stop-condition status: no 10
+
+## Evidence boundary
+
+This decision is based on portable-contract manual simulation evidence only.
+
+It is not:
+
+- product/runtime evidence
+- endpoint evidence
+- local LLM evidence
+- provider evidence
+- benchmark evidence
+- evidence that validates MVP status
+- production readiness
+- Batch C readiness
+- Alpha comparative-superiority evidence
+- broad plain-provider comparative-inferiority evidence
+
+## Packet files
+
+- `README.md`
+- `decision-summary.md`
+- `decision-options.md`
+- `selected-next-lane.md`
+- `blocked-work.md`
+- `evidence-boundary.md`
+- `decision-preservation-checklist.md`

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision/blocked-work.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision/blocked-work.md
@@ -1,0 +1,28 @@
+# Blocked Optional Work
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-POST-RESULTS-DECISION-001`
+
+The selected next lane does not authorize the following optional work.
+
+## Still blocked
+
+- Batch C work.
+- Runtime, provider, model, routing, API, or solver behavior changes.
+- Source code changes.
+- Endpoint calls or endpoint evidence claims.
+- Provider calls or provider-evidence claims.
+- Local LLM runs or local-LLM-evidence claims.
+- Google Sheets updates.
+- Rating edits, mechanical-total edits, rescoring, or unblinding.
+- Benchmark claims or benchmark packet creation.
+- Product/runtime readiness claims.
+- Production-readiness claims.
+- MVP-readiness claims.
+- Alpha comparative-superiority claims.
+- Broad plain-provider comparative-inferiority claims.
+- A follow-up operator test before the targeted refinement lane is separately completed and authorized for review.
+- A broader readiness review before the targeted output-format defect is addressed in a separate lane.
+
+## Not implemented by this packet
+
+This packet records a decision only. It does not implement the selected next lane and does not create or modify portable-contract behavior.

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision/decision-options.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision/decision-options.md
@@ -1,0 +1,33 @@
+# Decision Options Considered
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-POST-RESULTS-DECISION-001`
+
+## Option A: targeted portable-contract refinement for output-format contamination
+
+Status: selected.
+
+Rationale: this option directly targets the recurring imported-feedback defect: visible process-style text, wrapper labels, and `standard:` artifacts. It is narrow, preserves the evidence boundary, and does not require Batch C, provider work, endpoint work, runtime changes, rating edits, or readiness claims.
+
+## Option B: small follow-up prompt-contract operator test after targeted refinement
+
+Status: not selected now.
+
+Rationale: a follow-up operator test may be useful only after a narrow refinement lane exists. Starting the follow-up first would test the same known artifact risk without first addressing the defect identified by the interpretation packet.
+
+## Option C: readiness review lane that explicitly preserves the limited evidence boundary
+
+Status: not selected now.
+
+Rationale: a readiness review remains premature while the interpreted packet identifies a recurring output-format contamination pattern. A review lane can remain optional after targeted refinement and any separately authorized follow-up evidence packet.
+
+## Option D: continued hold on Batch C
+
+Status: not selected as the next lane.
+
+Rationale: continued hold on Batch C remains a blocked-work condition, not the active next lane. The selected lane keeps Batch C blocked while targeting the narrow formatting defect identified in the imported feedback.
+
+## Exactly one selected next lane
+
+Only Option A is selected:
+
+`ALPHA-LIMITED-OPERATOR-TEST-TARGETED-PORTABLE-CONTRACT-REFINEMENT-OUTPUT-FORMAT-CONTAMINATION-001`

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision/decision-preservation-checklist.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision/decision-preservation-checklist.md
@@ -1,0 +1,45 @@
+# Decision Preservation Checklist
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-POST-RESULTS-DECISION-001`
+
+Use this checklist to review the docs-only post-results decision packet.
+
+## Scope checks
+
+- [x] All changed files are under `docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision/`.
+- [x] No source code files are changed.
+- [x] No runtime, provider, model, routing, API, or solver behavior is changed.
+- [x] No endpoint call is used or claimed.
+- [x] No provider call is used or claimed.
+- [x] No local model run is used or claimed.
+- [x] No Google Sheets update is made.
+- [x] No Batch C work is started.
+- [x] The selected next lane is not implemented by this packet.
+
+## Decision checks
+
+- [x] Exactly one next lane is selected: `ALPHA-LIMITED-OPERATOR-TEST-TARGETED-PORTABLE-CONTRACT-REFINEMENT-OUTPUT-FORMAT-CONTAMINATION-001`.
+- [x] The selected lane targets output-format contamination.
+- [x] Follow-up operator testing remains blocked until separately authorized after targeted refinement.
+- [x] Broader readiness review remains blocked until separately authorized.
+- [x] Batch C remains blocked.
+
+## Rating preservation checks
+
+- [x] Ratings are preserved exactly.
+- [x] Mechanical totals are not changed.
+- [x] No rescore is added.
+- [x] Missing fields are not inferred.
+- [x] Task totals remain LT-001 29, LT-002 19, LT-003 27, LT-004 30, LT-005 28, LT-006 29, LT-007 26, LT-008 26, LT-009 29, LT-010 27.
+- [x] Grand mechanical rating sum remains 270 / 300.
+- [x] Disposition counts remain Keep 5 and Refine 5.
+- [x] Operator-provided stop-condition status remains `no` for all 10 tasks.
+
+## Evidence-boundary checks
+
+- [x] The decision uses only the imported sanitized results packet and the interpretation packet.
+- [x] The full unredacted transcript is not imported.
+- [x] Private URLs remain absent.
+- [x] Redaction boundaries are preserved.
+- [x] Stop-condition status is treated as operator-provided feedback only.
+- [x] The packet avoids broad product, benchmark, runtime, provider, readiness, superiority, and broad-comparison conclusions.

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision/decision-summary.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision/decision-summary.md
@@ -1,0 +1,59 @@
+# Decision Summary
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-POST-RESULTS-DECISION-001`
+
+## Decision
+
+Selected next lane:
+
+`ALPHA-LIMITED-OPERATOR-TEST-TARGETED-PORTABLE-CONTRACT-REFINEMENT-OUTPUT-FORMAT-CONTAMINATION-001`
+
+This is the only selected next lane in this packet.
+
+## Why this is the next safest step
+
+The interpretation packet identifies output-format contamination as the primary recurring defect in the imported operator feedback. The defect includes visible process-style text, wrapper labels, and `standard:` artifacts around otherwise usable content.
+
+A targeted portable-contract refinement lane is the safest next step because it limits the follow-up to the observed answer-shape defect while preserving the strong boundary discipline reported by the imported feedback. It also avoids jumping directly to broader readiness review, a new operator test, Batch C work, endpoint claims, provider claims, or product/runtime claims before the recurring artifact pattern has been addressed.
+
+## Preserved imported results
+
+This decision preserves the imported mechanical totals exactly:
+
+| item | preserved value |
+| --- | --- |
+| Feedback entries imported | 10 |
+| Rating dimensions per entry | 10 |
+| Grand mechanical rating sum | 270 / 300 |
+| Keep dispositions | 5 |
+| Refine dispositions | 5 |
+| Severity counts | None: 2; Minor: 6; Minor to moderate: 2 |
+| Operator-provided stop-condition status | no: 10 |
+
+## Preserved task totals
+
+| task_id | mechanical_sum | maximum | operator_disposition | severity | operator-provided stop-condition status |
+| --- | --- | --- | --- | --- | --- |
+| LT-001 | 29 | 30 | Keep | None | no |
+| LT-002 | 19 | 30 | Refine | Minor to moderate | no |
+| LT-003 | 27 | 30 | Keep | Minor | no |
+| LT-004 | 30 | 30 | Refine | Minor | no |
+| LT-005 | 28 | 30 | Keep | Minor | no |
+| LT-006 | 29 | 30 | Keep | Minor | no |
+| LT-007 | 26 | 30 | Refine | Minor to moderate | no |
+| LT-008 | 26 | 30 | Refine | Minor | no |
+| LT-009 | 29 | 30 | Keep | None | no |
+| LT-010 | 27 | 30 | Refine | Minor | no |
+
+## What this decision does not do
+
+This decision does not:
+
+- edit ratings or mechanical totals
+- rescore any task
+- infer runtime behavior
+- call or discuss endpoint behavior as evidence
+- call or discuss provider-side behavior as evidence
+- start Batch C
+- implement the selected next lane
+- make readiness, superiority, benchmark, or production claims

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision/evidence-boundary.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision/evidence-boundary.md
@@ -1,0 +1,31 @@
+# Evidence Boundary
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-POST-RESULTS-DECISION-001`
+
+## Boundary statement
+
+This decision is based on portable-contract manual simulation evidence only.
+
+The only source materials are the imported sanitized results packet and the interpretation packet listed in `README.md`.
+
+## Evidence not used
+
+This decision does not use:
+
+- product/runtime evidence
+- endpoint evidence
+- local LLM evidence
+- provider evidence
+- benchmark evidence
+- evidence that validates MVP status
+- production readiness
+- Batch C readiness
+- Alpha comparative-superiority evidence
+- broad plain-provider comparative-inferiority evidence
+- unredacted transcript content
+- operator maps or assignment maps
+- Google Sheets status changes
+
+## Boundary-preserving conclusion
+
+Within this narrow boundary, the imported feedback and interpretation packet support only a decision to address the recurring output-format contamination defect next. They do not support broader claims about runtime behavior, endpoint behavior, provider-side behavior, readiness, benchmarks, Batch C, production, or comparative system performance.

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision/selected-next-lane.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision/selected-next-lane.md
@@ -1,0 +1,26 @@
+# Selected Next Lane
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-POST-RESULTS-DECISION-001`
+
+## Selected lane
+
+`ALPHA-LIMITED-OPERATOR-TEST-TARGETED-PORTABLE-CONTRACT-REFINEMENT-OUTPUT-FORMAT-CONTAMINATION-001`
+
+## Family
+
+Targeted portable-contract refinement for output-format contamination.
+
+## Scope authorized for the next lane only
+
+The selected next lane may draft or update the portable-contract guidance needed to reduce output-format contamination observed in the imported feedback, especially:
+
+- visible process-style text before the requested answer
+- wrapper labels around otherwise usable content
+- `standard:` artifacts
+- answer-shape mismatch on concise rewrite, reviewer-comment, template, and checklist requests
+
+This post-results decision does not itself change that guidance, start the lane, edit source code, call providers, use endpoint evidence, edit ratings, or update Google Sheets.
+
+## Why this lane precedes broader work
+
+The imported interpretation identifies a narrow recurring answer-shape defect rather than a broad boundary failure. A targeted refinement lane addresses the observed defect first while preserving the limited evidence boundary. Broader readiness review and follow-up operator testing remain separate optional work and require later authorization.


### PR DESCRIPTION
### Motivation

- Record a docs-only post-results decision after the imported sanitized limited-operator prompt-contract simulation and its interpretation, and choose exactly one next lane without starting it or changing runtime/code.
- Preserve the imported mechanical totals, ratings, and the strict portable-contract evidence boundary while addressing the recurring output-format contamination defect noted in the interpretation.

### Description

- Add a post-results decision packet under `docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision/` with seven files: `README.md`, `decision-summary.md`, `decision-options.md`, `selected-next-lane.md`, `blocked-work.md`, `evidence-boundary.md`, and `decision-preservation-checklist.md` that document the decision and scope. 
- Select exactly one next lane: `ALPHA-LIMITED-OPERATOR-TEST-TARGETED-PORTABLE-CONTRACT-REFINEMENT-OUTPUT-FORMAT-CONTAMINATION-001` (targeted portable-contract refinement for output-format contamination). 
- Explicitly preserve imported mechanical totals and task ratings without edits or rescoring, and explicitly block optional work (Batch C, source/runtime/provider changes, endpoint/local-model/provider evidence, rating edits, Google Sheets updates, benchmarking, readiness/production/MVP/comparative claims). 
- Add a preservation checklist and an evidence-boundary statement to ensure the packet remains limited to portable-contract manual simulation evidence and avoids broader claims.

### Testing

- Verified staged changes are limited to the allowed path with `git diff --cached --name-only` and confirmed only markdown files under `docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision/` are included (success).
- Searched for the selected lane and decision-status markers with `rg -n` to confirm exactly one selected lane and selection language appear (success).
- Confirmed forbidden claim phrases are absent by running `rg -n 'validation|production ready|/v1/solve ready|Batch C ready|Alpha superiority|broad plain-provider inferiority|provider behavior|local LLM behavior|MVP ready'` against the new packet (no matches found).
- Ran Python checks that verify all required files are present, the preserved totals and task totals are included, the evidence boundary language is present, and that only allowed paths were changed, and then committed the packet with `git commit -m "docs(evals): decide post-results operator-test next lane"` (all checks succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a221f6255dc83298c9936a257cd0a65)