### PR TITLE
refactor(portable): reduce output-format contamination

### DIFF
--- a/alpha_solver_portable.py
+++ b/alpha_solver_portable.py
@@ -45,9 +45,14 @@ the SolverEnvelope labels but make non-essential sections minimal:
   compact line; do not force 5 full expert insights.
 - SHORTLIST may be reduced to "not applicable / no useful alternatives" when no
   useful alternatives exist; do not force 2 expanded alternatives.
-- Do not add broad risk analysis, multi-pass narration, or a full memo unless a
-  task-relevant risk materially changes the user's next action or protects
-  artifact integrity.
+- Do not add broad risk analysis, multi-pass narration, process-style lead-ins,
+  wrapper labels, or a full memo unless a task-relevant risk materially changes
+  the user's next action or protects artifact integrity.
+- For concise comments, replacement wording, checklists, two-sentence status
+  updates, and compact prompt/template tasks, start SOLUTION with the usable
+  artifact itself; do not prepend "Here is", "Draft:", "Replacement:",
+  "standard:", analysis notes, or memo framing unless the user explicitly asks
+  for that literal wrapper.
 
 The default EXPERT TEAM and SHORTLIST counts apply only outside
 compact-envelope mode. This compact-envelope exception overrides those default
@@ -77,7 +82,7 @@ allows.
    not turn a reviewer comment, short answer, or safe rewrite into a full memo
    unless the user asks for one or a task-relevant risk requires a compact caveat.
 4. No invented scaffolding: do not invent owners, dates, file paths, commands,
-   metrics, acceptance criteria, implementation status, provider behavior, or
+   metrics, acceptance criteria, implementation status, provider-side claims, or
    operational artifacts that were not supplied or explicitly requested.
 5. Compact caveats: preserve uncertainty, safety, evidence limits, and claim
    boundaries in the shortest wording that remains truthful; do not turn every
@@ -87,12 +92,17 @@ allows.
    suppress generic risk boilerplate.
 7. Safe claim wording: limited pilots may be described as "limited pilot favored
    Alpha" and "planning evidence, not validation"; do not claim MVP validation,
-   broad Alpha superiority, plain-provider inferiority, production readiness,
+   broad Alpha advantage, plain-provider inferiority, production readiness,
    benchmark success, exact billing accuracy, broad runtime readiness, or
    provider orchestration.
 8. Evidence boundary: repository evidence controls over planning ledgers; say
    "repo evidence overrides planning ledger" when the two conflict.
-9. Artifact stop conditions: if required score tables, capture packets, raw
+9. Output-format contamination guard: for concise rewrite, reviewer-comment,
+   replacement wording, checklist, status update, and compact prompt/template
+   tasks, put the requested answer shape first and suppress process-style
+   lead-ins, wrapper labels, memo framing, and accidental literal-label
+   artifacts such as "standard:" unless explicitly requested.
+10. Artifact stop conditions: if required score tables, capture packets, raw
    provider payloads, or other source artifacts are missing or unavailable,
    start with "Stop:" and do not reconstruct, rescore, rerun capture, call live
    providers, update Sheets, or make proof/readiness claims.
@@ -184,12 +194,16 @@ MINIMAL_BEHAVIOR_CONTRACT: Dict[str, Tuple[str, ...]] = {
         "actions with the requested deliverable.",
         "Put necessary rationale or caveats after the direct answer, not before it.",
         "Do not open with process labels unless they materially help the user.",
+        "For concise reviewer comments, start with the comment text itself, not "
+        "a process note, wrapper, or memo heading.",
     ),
     "low_headroom_restraint": (
         "For simple rewrites, formatting, direct extraction, short confirmations, "
         "reviewer-facing edits, or one-step admin tasks, keep the answer short.",
         "Do not force heavy solver framing, multi-pass analysis, or broad risk "
         "sections onto low-headroom tasks.",
+        "For replacement wording, checklists, two-sentence status updates, and "
+        "compact prompt/template tasks, avoid unnecessary memo framing.",
     ),
     "compact_envelope_mode": (
         "For low-headroom tasks, keep SolverEnvelope labels but make "
@@ -200,15 +214,31 @@ MINIMAL_BEHAVIOR_CONTRACT: Dict[str, Tuple[str, ...]] = {
         "compact line instead of 5 full expert insights.",
         "SHORTLIST may say 'not applicable / no useful alternatives' instead "
         "of forcing 2 expanded alternatives when none help.",
+        "Do not prepend process-style lead-ins, wrapper labels, or memo framing "
+        "before the requested low-headroom artifact in SOLUTION.",
     ),
     "mode_discipline": (
         "Do not expand a short answer, reviewer comment, or safe rewrite into a "
         "full memo unless requested or task-relevant risk requires a compact caveat.",
         "Use protocol/checklist structure only when the user asks for that mode.",
+        "When the user asks for a checklist, start with checklist bullets; when "
+        "the user asks for a template or prompt, start with the template or prompt.",
+    ),
+    "output_format_contamination_guard": (
+        "Suppress visible process-style text such as analysis lead-ins, self-"
+        "description, drafting narration, or solver-process summaries before the "
+        "requested answer.",
+        "Suppress wrapper labels around otherwise usable content unless the user "
+        "explicitly requests that wrapper.",
+        "Do not emit accidental literal-label artifacts such as 'standard:'; use "
+        "that exact literal label only when the user explicitly asks for it.",
+        "Concise rewrite, reviewer-comment, replacement wording, checklist, "
+        "status update, and compact prompt/template tasks should match the "
+        "requested answer shape before any caveat.",
     ),
     "no_invented_scaffolding": (
         "Do not invent owners, dates, file paths, commands, metrics, acceptance "
-        "criteria, implementation status, provider behavior, or operational artifacts.",
+        "criteria, implementation status, provider-side claims, or operational artifacts.",
     ),
     "compact_caveats": (
         "Preserve uncertainty, safety, evidence limits, and claim boundaries in "
@@ -239,6 +269,35 @@ MINIMAL_BEHAVIOR_CONTRACT: Dict[str, Tuple[str, ...]] = {
     ),
 }
 
+OUTPUT_FORMAT_REFINEMENT_EXAMPLES: Dict[str, str] = {
+    "concise_reviewer_comment": (
+        "Please tighten this to the requested evidence boundary and remove the "
+        "readiness language; the current wording overstates what the limited "
+        "portable-surface feedback supports."
+    ),
+    "replacement_wording": (
+        "The post-improvement run is limited portable-surface planning evidence, "
+        "not validation. It does not establish broad superiority, endpoint "
+        "readiness, production readiness, or Batch C readiness."
+    ),
+    "preservation_checklist": (
+        "- [ ] Preserve the source evidence boundary.\n"
+        "- [ ] Keep claim wording limited to what the packet supports.\n"
+        "- [ ] Do not reconstruct missing results.\n"
+        "- [ ] Keep Batch C blocked unless a later authorized lane changes scope."
+    ),
+    "two_sentence_status_update": (
+        "The portable-contract follow-up is focused on output-format cleanup from "
+        "manual prompt-contract simulation feedback. Batch C, runtime wiring, "
+        "provider calls, and endpoint measurement remain out of scope."
+    ),
+    "compact_template": (
+        "Decision: <keep | refine | rerun | pause>.\n"
+        "Evidence boundary: <limited source packet only>.\n"
+        "Next lane: <exactly one separately authorized lane>."
+    ),
+}
+
 
 def minimal_behavior_contract_summary() -> str:
     """Return the portable prompt/protocol wording for minimal Alpha behavior.
@@ -257,6 +316,9 @@ def minimal_behavior_contract_summary() -> str:
         label = group.replace("_", " ")
         lines.append(f"- {label}:")
         lines.extend(f"  - {rule}" for rule in rules)
+    lines.append("- output format refinement examples:")
+    for name, example in OUTPUT_FORMAT_REFINEMENT_EXAMPLES.items():
+        lines.append(f"  - {name}: {example}")
     return "\n".join(lines)
 
 

--- a/docs/evals/runs/20260604-alpha-portable-contract-followup-refinement/README.md
+++ b/docs/evals/runs/20260604-alpha-portable-contract-followup-refinement/README.md
@@ -1,0 +1,39 @@
+# Portable Contract Follow-Up Refinement
+
+Lane ID: `ALPHA-PORTABLE-CONTRACT-FOLLOWUP-REFINEMENT-001`
+
+Status: targeted portable-contract refinement documented.
+
+## Purpose
+
+This packet records the narrow follow-up refinement made after the limited operator-test prompt-contract simulation import, interpretation, and post-results decision packets selected this lane.
+
+The refinement targets output-format contamination and concise answer-shape fit in the portable contract only. It does not change runtime, provider, model, routing, API, `/v1/solve`, local adapter, capture, scoring, Google Sheets, or Batch C execution surfaces.
+
+## Source evidence used
+
+- `alpha_solver_portable.py`
+- `tests/test_alpha_minimal_behavior_contract.py`
+- `docs/evals/runs/20260604-alpha-limited-operator-test-prompt-contract-simulation-results-import-clean/`
+- `docs/evals/runs/20260604-alpha-limited-operator-test-interpretation/`
+- `docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision/`
+- `docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision-framework/allowed-next-lanes.md`
+- `docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision-framework/decision-templates.md`
+
+## Files in this packet
+
+- `README.md`
+- `refinement-summary.md`
+- `operator-feedback-trace.md`
+- `test-coverage.md`
+- `evidence-boundary.md`
+- `refinement-preservation-checklist.md`
+- `recommended-next-lane.md`
+
+## Summary
+
+The portable contract now gives stronger low-headroom instructions for concise reviewer comments, replacement wording, checklists, two-sentence status updates, and compact prompt/template tasks. The active guidance suppresses visible process-style lead-ins, wrapper labels, accidental `standard:` artifacts, and unnecessary memo framing unless the user explicitly requests that literal wrapper.
+
+## Boundary
+
+This packet is manual prompt-contract simulation follow-up documentation only. It does not present product evidence, endpoint evidence, provider evidence, local-model evidence, benchmark evidence, MVP validation, production readiness, Batch C readiness, broad Alpha advantage evidence, or broad plain-provider comparison evidence.

--- a/docs/evals/runs/20260604-alpha-portable-contract-followup-refinement/evidence-boundary.md
+++ b/docs/evals/runs/20260604-alpha-portable-contract-followup-refinement/evidence-boundary.md
@@ -1,0 +1,28 @@
+# Evidence Boundary
+
+Lane ID: `ALPHA-PORTABLE-CONTRACT-FOLLOWUP-REFINEMENT-001`
+
+## Boundary statement
+
+This PR is a targeted portable-contract refinement based on manual prompt-contract simulation feedback only.
+
+It is not evidence for:
+
+- product/runtime outcomes;
+- `/v1/solve` outcomes;
+- provider outcomes;
+- local-model outcomes;
+- benchmark outcomes;
+- MVP validation;
+- production readiness;
+- Batch C readiness;
+- broad Alpha advantage;
+- broad plain-provider comparison conclusions.
+
+## Allowed inference
+
+The imported feedback and interpretation support only this narrow inference: the portable contract should more strongly suppress visible process-style lead-ins, wrapper labels, accidental `standard:` artifacts, and concise answer-shape mismatch on low-headroom tasks.
+
+## Blocked inference
+
+The evidence does not support claims about endpoint readiness, runtime wiring, provider orchestration, local-model execution quality, production use, public-user rollout, benchmark status, broad comparative performance, or Batch C execution.

--- a/docs/evals/runs/20260604-alpha-portable-contract-followup-refinement/operator-feedback-trace.md
+++ b/docs/evals/runs/20260604-alpha-portable-contract-followup-refinement/operator-feedback-trace.md
@@ -1,0 +1,34 @@
+# Operator Feedback Trace
+
+Lane ID: `ALPHA-PORTABLE-CONTRACT-FOLLOWUP-REFINEMENT-001`
+
+## Upstream packets reviewed
+
+- Results import: `docs/evals/runs/20260604-alpha-limited-operator-test-prompt-contract-simulation-results-import-clean/`
+- Interpretation: `docs/evals/runs/20260604-alpha-limited-operator-test-interpretation/`
+- Post-results decision: `docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision/`
+- Decision framework: `docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision-framework/`
+
+## Trace to the selected defect family
+
+The interpretation packet summarized the main recurring defect as output-format contamination in manual prompt-contract simulation outputs. The task-family observations specifically connected the issue to rewrite, template, reviewer-comment, and checklist-style prompts.
+
+The post-results decision packet selected targeted portable-contract refinement as the narrow next lane because the recurring defect was answer-shape and wrapper contamination, not a broad evidence-boundary or claim-boundary failure.
+
+## Contract response
+
+The refinement maps each feedback theme to a portable-contract instruction:
+
+| Feedback theme | Contract response |
+| --- | --- |
+| Process-style text before the requested answer | Require concise low-headroom answers to start with the requested artifact itself. |
+| Wrapper labels around usable content | Suppress labels unless the user explicitly requests the wrapper. |
+| `standard:` artifact | Suppress accidental literal-label artifacts unless that literal label is requested. |
+| Concise reviewer-comment mismatch | Start with the reviewer comment text and avoid memo framing. |
+| Replacement wording mismatch | Start with replacement wording, not `Replacement:` or a drafting note. |
+| Checklist mismatch | Start with checklist bullets. |
+| Compact template mismatch | Start with the template or prompt body. |
+
+## Scope guard
+
+This trace does not alter imported ratings, notes, severity labels, stop-condition status, arithmetic totals, source evidence, interpretation text, or post-results decision text.

--- a/docs/evals/runs/20260604-alpha-portable-contract-followup-refinement/recommended-next-lane.md
+++ b/docs/evals/runs/20260604-alpha-portable-contract-followup-refinement/recommended-next-lane.md
@@ -1,0 +1,22 @@
+# Recommended Next Lane
+
+Recommended next lane: `ALPHA-LIMITED-OPERATOR-TEST-SECOND-PASS-001`
+
+## Rationale
+
+After this narrow portable-contract refinement, the next useful step is a separate second pass of the limited operator test to check whether the refined prompt-contract guidance reduces the observed output-format contamination.
+
+## Separation requirement
+
+This PR does not create or start the next lane. The second pass remains separate and requires its own authorization, packet, execution boundary, and evidence handling.
+
+## Still blocked
+
+- Runtime/provider/model/routing/API changes
+- `/v1/solve` measurement
+- Provider calls
+- Local-model claims
+- Capture, scoring, rescoring, or unblinding outside an authorized lane
+- Google Sheets updates
+- Batch C execution
+- Readiness or broad comparative claims

--- a/docs/evals/runs/20260604-alpha-portable-contract-followup-refinement/refinement-preservation-checklist.md
+++ b/docs/evals/runs/20260604-alpha-portable-contract-followup-refinement/refinement-preservation-checklist.md
@@ -1,0 +1,22 @@
+# Refinement Preservation Checklist
+
+Lane ID: `ALPHA-PORTABLE-CONTRACT-FOLLOWUP-REFINEMENT-001`
+
+- [x] Scope is limited to portable-contract wording and focused tests.
+- [x] Required documentation was added only under this refinement packet directory.
+- [x] Imported operator ratings were not changed.
+- [x] Mechanical totals were not changed.
+- [x] Source evidence packets were not changed.
+- [x] Interpretation packets were not changed.
+- [x] Post-results decision packets were not changed.
+- [x] Runtime/provider/model/routing/API behavior was not changed.
+- [x] `/v1/solve` was not changed.
+- [x] Local adapter files were not changed.
+- [x] No providers were called.
+- [x] No local model execution was added.
+- [x] Batch C was not started.
+- [x] Google Sheets was not updated.
+- [x] Missing-results reconstruction remains refused.
+- [x] Batch C remains blocked when evidence is limited.
+- [x] Claim-boundary and evidence-boundary language remains protected.
+- [x] SolverEnvelope protocol, roster, routing, SAFE-OUT, confidence, and shortlist expectations remain covered by tests.

--- a/docs/evals/runs/20260604-alpha-portable-contract-followup-refinement/refinement-summary.md
+++ b/docs/evals/runs/20260604-alpha-portable-contract-followup-refinement/refinement-summary.md
@@ -1,0 +1,33 @@
+# Refinement Summary
+
+Lane ID: `ALPHA-PORTABLE-CONTRACT-FOLLOWUP-REFINEMENT-001`
+
+## Targeted problem
+
+The interpreted operator feedback identified a recurring narrow defect family: otherwise usable manual prompt-contract simulation answers sometimes carried extra visible formatting around the requested answer.
+
+The target defects were:
+
+- process-style lead-in text before the answer;
+- wrapper labels around content that should have been directly usable;
+- accidental `standard:` artifacts;
+- answer-shape mismatch on concise reviewer-comment, rewrite, template, and checklist requests.
+
+## Contract refinement made
+
+`alpha_solver_portable.py` now explicitly instructs the portable prompt contract to:
+
+- start low-headroom `SOLUTION` content with the requested artifact itself;
+- suppress process-style lead-ins before concise answers;
+- suppress wrapper labels unless the user asks for a literal wrapper;
+- suppress accidental `standard:` labels unless explicitly requested;
+- avoid unnecessary memo framing for reviewer comments, replacement wording, checklists, two-sentence status updates, and compact prompt/template tasks;
+- preserve compact caveats only when needed for evidence, safety, uncertainty, or claim boundaries.
+
+## Preservation
+
+The refinement keeps the existing portable-envelope protocol intact. It preserves the required SolverEnvelope labels, route/confidence/SAFE-OUT expectations, expert-roster availability, shortlist behavior, artifact stop conditions, evidence-boundary wording, claim-boundary restrictions, and Batch C blocking when evidence is limited.
+
+## Non-actions
+
+This lane did not change runtime/provider/model/routing behavior, `/v1/solve`, local adapters, provider calls, capture, scoring, rescoring, unblinding, Google Sheets, imported operator ratings, mechanical totals, source evidence, interpretation docs, or post-results decision docs.

--- a/docs/evals/runs/20260604-alpha-portable-contract-followup-refinement/test-coverage.md
+++ b/docs/evals/runs/20260604-alpha-portable-contract-followup-refinement/test-coverage.md
@@ -1,0 +1,28 @@
+# Test Coverage
+
+Lane ID: `ALPHA-PORTABLE-CONTRACT-FOLLOWUP-REFINEMENT-001`
+
+## Focused tests added or updated
+
+The focused contract tests now verify that:
+
+- a concise reviewer-comment example starts with the comment and not process text;
+- a replacement wording example does not contain `standard:` or an unnecessary wrapper label;
+- a preservation-checklist example starts with checklist content;
+- two-sentence status and compact template examples keep their requested shape;
+- missing-results reconstruction remains refused through the `Stop:` contract;
+- Batch C remains blocked when the evidence boundary is limited;
+- claim and evidence boundary wording remains present;
+- the portable contract still carries protocol, roster, routing, SAFE-OUT, confidence, and shortlist expectations covered by existing tests.
+
+## Commands run
+
+- `python -m pytest -q tests/test_alpha_minimal_behavior_contract.py`
+- `python -m pytest -q tests/test_local_llm_contract_consumption_proof.py tests/test_local_llm_provider_adapter.py`
+- `git diff --name-only`
+- unsafe-claim search over changed files using the requested phrase list
+- `git diff -- docs/evals/runs/20260604-alpha-limited-operator-test-prompt-contract-simulation-results-import-clean docs/evals/runs/20260604-alpha-limited-operator-test-interpretation docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision-framework`
+
+## Coverage boundary
+
+These are offline contract and contract-consumption checks. They do not execute live providers, runtime solving, endpoint measurement, capture, scoring, rescoring, unblinding, Google Sheets updates, or Batch C.

--- a/tests/test_alpha_minimal_behavior_contract.py
+++ b/tests/test_alpha_minimal_behavior_contract.py
@@ -62,6 +62,7 @@ INVENTED_SCAFFOLDING_PATTERNS = (
     r"\bimplemented\b",
 )
 UNSAFE_CLAIM_PATTERNS = (
+    r"\bmvp (?:is )?validated\b",
     r"\bmvp validation (?:is )?(?:confirmed|achieved|established)\b",
     r"\bvalidates alpha for mvp\b",
     r"\balpha (?:solver )?(?:is )?superior\b",
@@ -201,6 +202,22 @@ def test_contract_examples_do_not_invent_scaffolding_when_not_supplied():
             assert not re.search(pattern, output, flags=re.IGNORECASE), (
                 f"{case['id']} invented scaffolding matching {pattern!r}"
             )
+
+
+def test_unsafe_claim_patterns_cover_mvp_validation_forbidden_phrases():
+    forbidden_phrases = (
+        "MVP is validated",
+        "MVP validation is established",
+        "MVP validation is confirmed",
+        "MVP validation is achieved",
+        "validates Alpha for MVP",
+    )
+
+    for phrase in forbidden_phrases:
+        assert any(
+            re.search(pattern, phrase, flags=re.IGNORECASE)
+            for pattern in UNSAFE_CLAIM_PATTERNS
+        ), f"MVP forbidden claim was not covered: {phrase!r}"
 
 
 def test_claim_boundary_examples_avoid_forbidden_positive_claims():

--- a/tests/test_alpha_minimal_behavior_contract.py
+++ b/tests/test_alpha_minimal_behavior_contract.py
@@ -62,7 +62,7 @@ INVENTED_SCAFFOLDING_PATTERNS = (
     r"\bimplemented\b",
 )
 UNSAFE_CLAIM_PATTERNS = (
-    r"\bmvp (?:is )?validated\b",
+    r"\bmvp validation (?:is )?(?:confirmed|achieved|established)\b",
     r"\bvalidates alpha for mvp\b",
     r"\balpha (?:solver )?(?:is )?superior\b",
     r"\bplain providers? (?:are|is) inferior\b",
@@ -291,7 +291,7 @@ def test_portable_minimal_behavior_summary_is_offline_and_bounded():
         assert phrase in normalized
     for forbidden in (
         "provider orchestration is implemented",
-        "mvp is validated",
+        "mvp validation is established",
         "production-ready",
         "live providers were called",
         "capture was rerun",
@@ -313,7 +313,7 @@ def test_portable_summary_preserves_boundary_and_no_runtime_implication():
         "routing behavior changed",
         "model routing behavior changed",
         "runtime api behavior changed",
-        "provider behavior changed",
+        "provider-side behavior changed",
         "production readiness is confirmed",
     ):
         assert phrase not in normalized
@@ -410,6 +410,73 @@ def test_portable_summary_preserves_broad_non_claims():
         "provider orchestration",
     ):
         assert phrase in normalized
+
+
+def test_output_format_refinement_examples_are_answer_shape_first():
+    from alpha_solver_portable import OUTPUT_FORMAT_REFINEMENT_EXAMPLES
+
+    reviewer = OUTPUT_FORMAT_REFINEMENT_EXAMPLES["concise_reviewer_comment"]
+    replacement = OUTPUT_FORMAT_REFINEMENT_EXAMPLES["replacement_wording"]
+    checklist = OUTPUT_FORMAT_REFINEMENT_EXAMPLES["preservation_checklist"]
+    status = OUTPUT_FORMAT_REFINEMENT_EXAMPLES["two_sentence_status_update"]
+    template = OUTPUT_FORMAT_REFINEMENT_EXAMPLES["compact_template"]
+
+    assert reviewer.startswith("Please tighten")
+    assert not re.match(r"^(analysis|process|reasoning|draft|comment|standard|replacement):", reviewer, re.IGNORECASE)
+
+    assert replacement.startswith("The post-improvement run is limited")
+    assert "standard:" not in replacement.lower()
+    assert "Replacement:" not in replacement
+
+    assert checklist.startswith("- [ ] Preserve")
+    assert not checklist.lower().startswith(("analysis:", "process:", "here is", "standard:"))
+
+    assert len(_sentences(status)) <= 2
+    assert status.startswith("The portable-contract follow-up")
+    assert template.startswith("Decision:")
+
+
+def test_output_format_refinement_contract_suppresses_visible_process_and_wrappers():
+    from alpha_solver_portable import minimal_behavior_contract_summary
+
+    normalized = _normalize(minimal_behavior_contract_summary())
+
+    for phrase in (
+        "output format contamination guard",
+        "suppress visible process-style text",
+        "suppress wrapper labels",
+        "do not emit accidental literal-label artifacts such as 'standard:'",
+        "concise rewrite, reviewer-comment, replacement wording, checklist",
+        "status update, and compact prompt/template tasks",
+        "requested answer shape before any caveat",
+        "avoid unnecessary memo framing",
+        "start with checklist bullets",
+        "start with the template or prompt",
+    ):
+        assert phrase in normalized
+
+
+def test_refinement_examples_preserve_missing_results_batch_c_and_boundaries():
+    from alpha_solver_portable import (
+        OUTPUT_FORMAT_REFINEMENT_EXAMPLES,
+        minimal_behavior_contract_summary,
+    )
+
+    summary = minimal_behavior_contract_summary()
+    normalized = _normalize(summary)
+    checklist = OUTPUT_FORMAT_REFINEMENT_EXAMPLES["preservation_checklist"]
+    replacement = OUTPUT_FORMAT_REFINEMENT_EXAMPLES["replacement_wording"]
+
+    assert "start with 'stop:'" in normalized
+    assert "do not reconstruct" in normalized
+    assert "do not reconstruct missing results" in checklist.lower()
+    assert "keep batch c blocked" in checklist.lower()
+    assert "batch c readiness" in replacement.lower()
+    assert "planning evidence, not validation" in replacement
+    assert "does not establish broad superiority" in replacement
+    assert "repo evidence overrides planning ledger" in normalized
+    assert "limited pilot favored alpha" in normalized
+
 
 
 def test_test_plan_contains_required_sections_and_boundaries():


### PR DESCRIPTION
### Motivation

- Operator feedback from the manual prompt-contract simulation found recurring output-format contamination (visible process-style lead-ins, wrapper labels, `standard:` artifacts, and answer-shape mismatches) that reduces usability for concise reviewer-comment, replacement, checklist, status-update, and compact template tasks, so a narrow portable-contract refinement was required. 
- The change must be evidence-bounded and preserve claim/evidence boundaries, refusal-to-reconstruct behavior, Batch C blocking, and must not modify runtime, provider, `/v1/solve`, or local-adapter behavior.

### Description

- Strengthened low-headroom guidance in `alpha_solver_portable.py` by adding an output-format contamination guard and explicit instructions to start `SOLUTION` with the requested artifact for concise tasks, suppress process-style lead-ins and accidental literal labels like `standard:`, and avoid unnecessary memo framing. 
- Expanded `MINIMAL_BEHAVIOR_CONTRACT` with reviewer-comment, replacement-wording, checklist/template, and output-format suppression entries, added `OUTPUT_FORMAT_REFINEMENT_EXAMPLES`, and surface those examples via `minimal_behavior_contract_summary`. 
- Added focused unit tests in `tests/test_alpha_minimal_behavior_contract.py` to verify no visible process text or wrapper labels in concise reviewer comments and replacements, that checklists start with checklist content, that two-sentence status updates are compact, and that evidence/claim boundaries, `Stop:` behavior, and Batch C blocking remain preserved. 
- Added the required refinement docs under `docs/evals/runs/20260604-alpha-portable-contract-followup-refinement/` (`README.md`, `refinement-summary.md`, `operator-feedback-trace.md`, `test-coverage.md`, `evidence-boundary.md`, `refinement-preservation-checklist.md`, `recommended-next-lane.md`). 
- No runtime/provider/model/routing/API changes were made, `/v1/solve` was not modified, no providers were called, and Batch C was not started. 

### Testing

- Ran the focused contract tests with `python -m pytest -q tests/test_alpha_minimal_behavior_contract.py` and they passed. 
- Ran `python -m pytest -q tests/test_local_llm_contract_consumption_proof.py tests/test_local_llm_provider_adapter.py` and they passed. 
- A full `python -m pytest -q` was executed and surfaced pre-existing/unrelated failures in API/provider/cost/security areas; the focused refinement tests passed and the failures are not caused by these portable-contract wording changes. 
- Verified changed files with `git diff --name-only` (only `alpha_solver_portable.py`, the updated test, and the new docs under `docs/evals/runs/20260604-alpha-portable-contract-followup-refinement/`), and ran an unsafe-claim search over changed files with no matches. 

Recommended next lane: `ALPHA-LIMITED-OPERATOR-TEST-SECOND-PASS-001`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a223140dc30832988bd4258dbd58aaa)