### PR TITLE
docs(local-llm): plan provider integration

### DIFF
--- a/docs/evals/runs/20260604-alpha-local-llm-provider-integration-plan/README.md
+++ b/docs/evals/runs/20260604-alpha-local-llm-provider-integration-plan/README.md
@@ -1,0 +1,52 @@
+# Alpha Local LLM Provider Integration Plan
+
+Lane ID: `ALPHA-LOCAL-LLM-PROVIDER-INTEGRATION-PLAN-001`
+
+Status: plan/review only.
+
+## Purpose
+
+This lane records a non-executing plan for a future lane that may connect the
+existing local LLM adapter seam to a real local-provider backend. It does not
+change source code, tests, routing, runtime behavior, provider configuration, or
+operator evidence.
+
+## Source files reviewed
+
+- `alpha/local_llm/provider_adapter.py`
+- `alpha/local_llm/__init__.py`
+- `alpha/local_llm/portable_contract.py`
+- `tests/test_local_llm_provider_adapter.py`
+- `tests/test_local_llm_contract_consumption_proof.py`
+- `docs/evals/runs/20260604-alpha-local-llm-provider-adapter/`
+- `docs/evals/runs/20260604-alpha-local-llm-adapter-review-gate/`
+
+## Plan scope
+
+A future implementation lane may propose an adapter backend that receives the
+existing `LocalLLMAdapterRequest`, preserves prompt-source metadata, calls only a
+separately authorized local backend, normalizes failures, and returns a
+non-upgraded result unless an approved evidence lane later defines stronger use.
+
+The future lane must preserve the distinction between `provider_mode="local_llm"`
+and `MODEL_PROVIDER=local`. `MODEL_PROVIDER=local` remains smoke-only unless a
+later approved implementation lane explicitly changes that semantic.
+
+## Required companion documents
+
+- `integration-plan.md`
+- `provider-options.md`
+- `authorization-requirements.md`
+- `failure-handling-plan.md`
+- `test-plan.md`
+- `evidence-boundary.md`
+- `implementation-non-goals.md`
+- `recommended-next-lane.md`
+- `plan-preservation-checklist.md`
+
+## Evidence boundary
+
+This directory is planning evidence only. It is not model-output evidence,
+provider-execution evidence, API readiness evidence, dashboard readiness
+evidence, runtime evidence, validation evidence, comparative evidence, Batch C
+evidence, billing evidence, benchmark evidence, or orchestration evidence.

--- a/docs/evals/runs/20260604-alpha-local-llm-provider-integration-plan/authorization-requirements.md
+++ b/docs/evals/runs/20260604-alpha-local-llm-provider-integration-plan/authorization-requirements.md
@@ -1,0 +1,42 @@
+# Authorization Requirements
+
+No real provider call is authorized by this lane.
+
+## Required before any real provider call
+
+A later lane must obtain explicit authorization that names:
+
+- lane ID and spec path;
+- provider option selected;
+- local endpoint or command shape;
+- allowed host, port, process, or socket constraints;
+- timeout limits;
+- whether any local smoke command may run;
+- exact test command and skip/default behavior;
+- evidence label for live local smoke output;
+- rollback steps;
+- confirmation that no hosted provider, provider key, dashboard preview,
+  `/v1/solve`, or runtime routing work is included.
+
+## Prompt-source authorization requirements
+
+The future lane must preserve and check:
+
+- portable contract path;
+- SHA-256 fingerprint;
+- fingerprint algorithm;
+- user prompt separated from system/contract content;
+- expected-fingerprint mismatch as a fail-closed condition.
+
+## Mode authorization requirements
+
+The future lane must preserve `provider_mode="local_llm"` as the adapter mode.
+It must not reinterpret `MODEL_PROVIDER=local`. That value remains smoke-only
+unless a later approved implementation lane explicitly changes it and updates
+all related specs and tests.
+
+## Non-authorization
+
+This lane does not authorize local model calls, Ollama calls, hosted-provider
+calls, provider credentials, network calls, operator-test changes, runtime routing,
+API entrypoint work, dashboard preview work, or Batch C work.

--- a/docs/evals/runs/20260604-alpha-local-llm-provider-integration-plan/evidence-boundary.md
+++ b/docs/evals/runs/20260604-alpha-local-llm-provider-integration-plan/evidence-boundary.md
@@ -1,0 +1,41 @@
+# Evidence Boundary
+
+## Allowed use
+
+This lane may be cited only as planning evidence for a future local-provider
+integration path. It records requirements, options, failure handling, tests, and
+blocked work. It does not execute a provider and does not change behavior.
+
+## Not evidence for
+
+This lane is not evidence for:
+
+- local model output quality;
+- Ollama execution;
+- hosted-provider execution;
+- API readiness;
+- dashboard preview readiness;
+- runtime readiness;
+- MVP status;
+- production status;
+- Alpha quality;
+- comparative Alpha claims;
+- broad plain-provider comparison;
+- Batch C readiness or execution;
+- benchmark success;
+- exact billing results;
+- provider orchestration.
+
+## Safe wording
+
+Use wording such as:
+
+- "This lane is plan/review only."
+- "This lane defines requirements for a future spec-first implementation."
+- "No real provider call is authorized here."
+
+## Unsafe wording
+
+Avoid wording that treats this lane as execution evidence, readiness evidence,
+model-quality evidence, benchmark evidence, billing evidence, comparative
+evidence, or orchestration evidence.

--- a/docs/evals/runs/20260604-alpha-local-llm-provider-integration-plan/failure-handling-plan.md
+++ b/docs/evals/runs/20260604-alpha-local-llm-provider-integration-plan/failure-handling-plan.md
@@ -1,0 +1,36 @@
+# Failure Handling Plan
+
+A future implementation must fail closed and preserve non-upgraded evidence
+labels for all failure cases below.
+
+## Required failure cases
+
+| Failure case | Required handling |
+| --- | --- |
+| Timeout | Abort the call, return `failed_closed`, record timeout class without claiming output quality. |
+| Connection failure | Return `failed_closed`; do not retry indefinitely or fall back to hosted providers. |
+| Malformed response | Reject unexpected payloads and return `failed_closed`. |
+| Empty output | Return `failed_closed`; do not treat whitespace as output. |
+| Prompt echo | Return `failed_closed` when output equals the user prompt or system/contract content after trimming. |
+| Missing contract | Return `failed_closed` through the portable contract loader error path. |
+| Empty contract | Return `failed_closed` through the portable contract loader error path. |
+| Fingerprint mismatch | Return `failed_closed` and do not call the backend. |
+| Backend errors | Return `failed_closed` with a safe error class/reason and no provider fallback. |
+
+## Failure metadata
+
+Failure metadata should include safe labels only:
+
+- `provider_mode`;
+- backend class;
+- prompt-source path;
+- prompt-source SHA-256/fingerprint fields when available;
+- failure category;
+- non-evidence flag;
+- no credential values, provider credentials, nonpublic endpoints, or full backend logs.
+
+## Fallback restrictions
+
+A future implementation must not fall back to hosted providers, v91
+`_tree_of_thought`, runtime routing, dashboard preview, or `/v1/solve` when a
+local backend fails.

--- a/docs/evals/runs/20260604-alpha-local-llm-provider-integration-plan/implementation-non-goals.md
+++ b/docs/evals/runs/20260604-alpha-local-llm-provider-integration-plan/implementation-non-goals.md
@@ -1,0 +1,29 @@
+# Implementation Non-Goals
+
+This lane must remain docs-only. The following work remains blocked until a
+later approved lane explicitly scopes it:
+
+- source code changes;
+- test changes;
+- runtime, provider, model, routing, API, or dashboard changes;
+- `/v1/solve` use;
+- dashboard preview integration;
+- Ollama calls;
+- hosted-provider calls;
+- local model calls;
+- provider credentials;
+- network calls;
+- operator-test evidence changes;
+- PR #288, PR #289, PR #292, or PR #293 evidence changes;
+- Batch C work;
+- behavior claims;
+- readiness claims;
+- validation claims;
+- comparative claims;
+- benchmark claims;
+- billing claims;
+- provider-orchestration claims.
+
+A future lane must not remove these blocks by implication. It must name the
+specific block it intends to lift and cite the approving spec or authorization
+record.

--- a/docs/evals/runs/20260604-alpha-local-llm-provider-integration-plan/integration-plan.md
+++ b/docs/evals/runs/20260604-alpha-local-llm-provider-integration-plan/integration-plan.md
@@ -1,0 +1,62 @@
+# Integration Plan
+
+## Current seam to preserve
+
+The current adapter seam builds a request from the portable contract and an
+explicit user prompt, then hands that request to an injected backend. A future
+implementation must keep that seam shape rather than bypassing it.
+
+Preserved request properties:
+
+- portable contract text is system/contract content;
+- user prompt remains a separate user field/message;
+- prompt-source path is retained;
+- SHA-256 fingerprint is retained;
+- fingerprint algorithm is retained;
+- `provider_mode="local_llm"` remains the adapter label;
+- `MODEL_PROVIDER=local` remains smoke-only unless a later approved lane
+  explicitly changes it.
+
+## Future implementation sequence
+
+1. Create or update a `.specs/` implementation contract before code changes.
+2. Add an explicit authorization gate covering provider class, endpoint shape,
+   local environment, allowed commands, and evidence labeling.
+3. Implement an adapter backend behind the existing injected-backend protocol.
+4. Keep default behavior inert unless explicit configuration and authorization
+   are present.
+5. Add offline stub/fixture tests first.
+6. Add serialization and response-normalization tests without live provider
+   execution.
+7. Only after a separate authorization decision, add a narrow local-provider
+   smoke test that is opt-in, skipped by default, and labeled separately from
+   offline evidence.
+8. Keep runtime entrypoints, dashboard preview, hosted providers, and `/v1/solve`
+   out of scope unless a later lane explicitly authorizes them.
+
+## Data flow for a future backend
+
+1. Caller supplies a user prompt and optional expected portable-contract
+   fingerprint.
+2. Existing loader reads `alpha_solver_portable.py` and computes SHA-256.
+3. Adapter builds the request with separate system/contract and user content.
+4. Future backend converts the adapter request into the chosen local-provider
+   wire shape.
+5. Backend applies a timeout and parses the response into plain output text.
+6. Adapter failure checks reject empty output, prompt echo, malformed response,
+   backend errors, and contract errors.
+7. Result metadata preserves source path, fingerprint, algorithm, provider mode,
+   backend class, and evidence labels.
+
+## Review gates before code
+
+A future implementation must document:
+
+- exact files to change;
+- exact provider option selected;
+- exact offline tests to add;
+- exact opt-in smoke command, if any;
+- default-disabled behavior;
+- credential policy;
+- rollback plan;
+- evidence label and non-claim wording.

--- a/docs/evals/runs/20260604-alpha-local-llm-provider-integration-plan/plan-preservation-checklist.md
+++ b/docs/evals/runs/20260604-alpha-local-llm-provider-integration-plan/plan-preservation-checklist.md
@@ -1,0 +1,39 @@
+# Plan Preservation Checklist
+
+## Scope
+
+- [x] Added docs only under
+  `docs/evals/runs/20260604-alpha-local-llm-provider-integration-plan/`.
+- [x] No source code changes are part of this lane.
+- [x] No test changes are part of this lane.
+- [x] No runtime, provider, model, routing, API, or dashboard changes are part
+  of this lane.
+
+## Source-of-truth preservation
+
+- [x] Reviewed `alpha/local_llm/provider_adapter.py`.
+- [x] Reviewed `alpha/local_llm/__init__.py`.
+- [x] Reviewed `alpha/local_llm/portable_contract.py`.
+- [x] Reviewed `tests/test_local_llm_provider_adapter.py`.
+- [x] Reviewed `tests/test_local_llm_contract_consumption_proof.py`.
+- [x] Reviewed prior adapter and review-gate evidence directories.
+
+## Required plan content
+
+- [x] Future connection path from the existing adapter seam to a local backend is
+  described.
+- [x] Provider options are planning-only.
+- [x] `provider_mode="local_llm"` remains distinct from `MODEL_PROVIDER=local`.
+- [x] `MODEL_PROVIDER=local` remains smoke-only unless a later approved lane
+  explicitly changes it.
+- [x] Portable-contract path, SHA-256 fingerprint, fingerprint algorithm, and
+  user/system separation are preserved.
+- [x] Authorization requirements are defined before any real provider call.
+- [x] Timeout, connection failure, malformed response, empty output, prompt echo,
+  missing contract, empty contract, fingerprint mismatch, and backend errors are
+  covered in the failure plan.
+- [x] Test plan starts with offline stubs and fixtures.
+- [x] Separately authorized local smoke tests are deferred.
+- [x] Blocked work remains blocked until a later implementation lane.
+- [x] Exactly one recommended next lane is selected:
+  `ALPHA-LOCAL-LLM-PROVIDER-INTEGRATION-SPEC-001`.

--- a/docs/evals/runs/20260604-alpha-local-llm-provider-integration-plan/provider-options.md
+++ b/docs/evals/runs/20260604-alpha-local-llm-provider-integration-plan/provider-options.md
@@ -1,0 +1,57 @@
+# Provider Options
+
+All options in this document are planning only. This lane does not implement,
+configure, start, contact, or verify any provider.
+
+## Option A: Ollama-style local HTTP backend
+
+A future backend could translate `LocalLLMAdapterRequest` into an HTTP request
+for a locally managed service with an Ollama-style API.
+
+Planning constraints:
+
+- endpoint must be localhost or an explicitly approved local address;
+- no default network access;
+- timeout must be mandatory;
+- request body must keep system/contract and user content logically separated;
+- response parser must fail closed on missing text, unexpected JSON, empty text,
+  prompt echo, and backend error status;
+- no automatic model pull, installation, or background service start;
+- evidence must distinguish local HTTP smoke output from offline stub output.
+
+## Option B: OpenAI-compatible local endpoint
+
+A future backend could target a local server that implements an OpenAI-compatible
+chat/completions-style interface.
+
+Planning constraints:
+
+- endpoint must be local and approved for the lane;
+- hosted-provider base URLs are not allowed;
+- provider credentials are not allowed for this lane family unless a later spec says
+  otherwise;
+- model name must be an explicit local label, not a hosted model shortcut;
+- messages must preserve system/contract and user roles;
+- response parser must reject missing choices/content, malformed payloads,
+  empty content, prompt echo, timeout, and transport failures.
+
+## Option C: Direct subprocess-based local server wrapper
+
+A subprocess wrapper should remain a future option only and requires extra
+restrictions because it can start processes and consume local compute.
+
+Additional restrictions before this option can be considered:
+
+- explicit operator approval for the command and arguments;
+- no shell interpolation of prompts or paths;
+- fixed allowlist of executable path and arguments;
+- working directory, environment variables, and resource limits documented;
+- startup timeout, generation timeout, and teardown behavior documented;
+- captured logs scrubbed for prompts, credential material, and nonpublic paths before storage;
+- no automatic downloads, model pulls, package installs, or daemon persistence.
+
+## Recommendation for the next spec
+
+The next spec should select exactly one provider shape for implementation
+planning. It should prefer the smallest local endpoint option that can be tested
+with offline fixtures before any opt-in local smoke command is considered.

--- a/docs/evals/runs/20260604-alpha-local-llm-provider-integration-plan/recommended-next-lane.md
+++ b/docs/evals/runs/20260604-alpha-local-llm-provider-integration-plan/recommended-next-lane.md
@@ -1,0 +1,26 @@
+# Recommended Next Lane
+
+Exactly one recommended next lane is selected:
+
+`ALPHA-LOCAL-LLM-PROVIDER-INTEGRATION-SPEC-001`
+
+## Scope for the next lane
+
+The next lane should be spec-first. It should convert this plan into a concrete
+implementation contract, select one provider option to design around, define the
+file-change boundary, and preserve all authorization gates.
+
+## Required constraints for the next lane
+
+The next lane must:
+
+- remain non-executing unless a later explicit authorization gate approves a
+  real provider call;
+- preserve `provider_mode="local_llm"`;
+- preserve `MODEL_PROVIDER=local` as smoke-only unless explicitly changed by an
+  approved implementation lane;
+- preserve portable-contract path, SHA-256 fingerprint, fingerprint algorithm,
+  and user/system separation;
+- start with offline tests and fixtures;
+- keep runtime, dashboard preview, hosted providers, `/v1/solve`, and Batch C
+  out of scope unless explicitly approved.

--- a/docs/evals/runs/20260604-alpha-local-llm-provider-integration-plan/test-plan.md
+++ b/docs/evals/runs/20260604-alpha-local-llm-provider-integration-plan/test-plan.md
@@ -1,0 +1,36 @@
+# Test Plan
+
+## Phase 1: offline tests only
+
+The future implementation must start with tests that do not contact a provider:
+
+- request construction preserves portable-contract path;
+- SHA-256 fingerprint and fingerprint algorithm are present;
+- user prompt remains separate from system/contract content;
+- `provider_mode="local_llm"` is accepted;
+- `provider_mode="local"` is rejected so `MODEL_PROVIDER=local` remains
+  smoke-only;
+- fake backend receives the expected request shape;
+- timeout, connection failure, malformed response, empty output, prompt echo,
+  missing contract, empty contract, fingerprint mismatch, and backend errors are
+  covered through stubs or fixtures;
+- no source or test path invokes a real provider by default.
+
+## Phase 2: fixture-based parser tests
+
+If a backend wire format is selected, add static fixture tests for successful
+and failed payload parsing. These tests must not open sockets, start services,
+use keys, or require local models.
+
+## Phase 3: separately authorized local smoke tests
+
+Only a later authorization gate may permit opt-in local-provider smoke tests.
+Those tests must be skipped by default and must require explicit environment
+variables or command flags. Their output must be labeled separately from offline
+stub evidence.
+
+## Required checks for a future PR
+
+A future PR should run focused unit tests first, then `python -m pytest -q` when
+practical. Any opt-in local smoke command must be reported separately and must
+not be used to expand claims beyond the approved evidence boundary.


### PR DESCRIPTION
### Motivation
- Add a non-executing plan/review lane that records requirements and constraints for a future local LLM provider integration without changing any runtime code or tests.
- Preserve the existing adapter seam semantics including `provider_mode="local_llm"`, the distinction from `MODEL_PROVIDER=local`, and prompt-source metadata (portable contract path, SHA-256 fingerprint, algorithm, and user/system separation).
- Provide a gated, spec-first path and explicit authorization, failure, and test requirements so future work may implement a local backend only after separate approval.

### Description
- Added a docs-only evidence directory `docs/evals/runs/20260604-alpha-local-llm-provider-integration-plan/` containing 10 files: `README.md`, `integration-plan.md`, `provider-options.md`, `authorization-requirements.md`, `failure-handling-plan.md`, `test-plan.md`, `evidence-boundary.md`, `implementation-non-goals.md`, `recommended-next-lane.md`, and `plan-preservation-checklist.md`, all of which are planning/review only and do not change source or tests.
- The documents describe how a future implementation could connect `LocalLLMAdapterRequest` to a separately authorized local backend, enumerate three provider option shapes (Ollama-style HTTP, OpenAI-compatible local endpoint, subprocess wrapper), and list required preservation constraints and non-goals.
- The plan defines explicit authorization requirements, a fail-closed failure handling plan (timeout, connection failure, malformed response, empty output, prompt echo, missing/empty contract, fingerprint mismatch, backend errors), a phased test plan preferring offline stubs and fixtures, and an evidence boundary that disclaims any execution/readiness/quality claims.
- Exactly one recommended next lane is selected: `ALPHA-LOCAL-LLM-PROVIDER-INTEGRATION-SPEC-001`, and the plan requires the next lane to be spec-first and to preserve all authorization gates and preservation checks.

### Testing
- Ran focused repository checks to confirm scope and safety, including `git diff --name-only` checks to ensure changed files are limited to `docs/evals/runs/20260604-alpha-local-llm-provider-integration-plan/`, pattern scans for credential/secrets heuristics, and searches for forbidden claim phrases; these checks passed for the new docs.
- Verified plan wording and that exactly one recommended next lane value (`ALPHA-LOCAL-LLM-PROVIDER-INTEGRATION-SPEC-001`) appears in the new docs. 
- Ran `python -m pytest -q` as a broad repository smoke run and observed failures in unrelated provider/runtime tests (pre-existing expectations about provider models and runtime artifacts), so the failing tests are not caused by these docs-only changes. 
- No source code or test files were modified and no provider credentials, network calls, or execution paths were added during this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a223154702483299579de2d1635cf88)