### PR TITLE
docs(evals): prepare limited operator second-pass packet

### DIFF
--- a/docs/evals/runs/20260604-alpha-limited-operator-test-second-pass/README.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-second-pass/README.md
@@ -1,0 +1,71 @@
+# Limited Operator Test Second-Pass Packet
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-SECOND-PASS-001`
+
+Status: packet prepared, second-pass test not yet executed
+
+## Purpose
+
+This docs-only packet prepares a second-pass manual prompt-contract simulation after the portable-contract follow-up refinement in PR #294. The packet is designed to retest the narrow output-format contamination family previously observed in imported first-pass operator feedback.
+
+The packet does not execute tasks, collect artifacts, score results, compare outcomes as a conclusion, update external ledgers, or start any later eval lane.
+
+## Source files
+
+Use these files only as source context for preparing and running the manual second pass:
+
+- `alpha_solver_portable.py`
+- `tests/test_alpha_minimal_behavior_contract.py`
+- `docs/evals/runs/20260604-alpha-limited-operator-test-prompt-contract-simulation-results-import-clean/`
+- `docs/evals/runs/20260604-alpha-limited-operator-test-interpretation/`
+- `docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision/`
+- `docs/evals/runs/20260604-alpha-portable-contract-followup-refinement/`
+
+## Packet contents
+
+- `operator-test-task-set.md`: 10 manual simulation tasks focused on concise output shape, artifact suppression, stop conditions, and boundary discipline.
+- `operator-instructions.md`: instructions for running the second-pass manual prompt-contract simulation without scoring or interpreting during task execution.
+- `operator-feedback-form-template.md`: blank operator feedback template preserving the first-pass rating dimensions and explicit stop-condition fields.
+- `operator-result-log-template.md`: blank result log template for preserving raw artifacts and operator entries.
+- `second-pass-comparison-guide.md`: guide for comparing second-pass results only to the imported first-pass operator feedback without making validation, readiness, superiority, or outcome claims.
+- `reviewer-checklist.md`: packet review checklist.
+- `evidence-boundary.md`: explicit evidence and non-evidence boundaries.
+- `preservation-checklist.md`: preservation checklist for source evidence, prior packets, templates, and non-actions.
+- `recommended-next-lane.md`: separate recommended execution lane.
+
+## Evidence boundary
+
+This packet prepares a manual prompt-contract simulation second pass only.
+
+It is not:
+
+- product/runtime evidence
+- `/v1/solve` evidence
+- local LLM evidence
+- provider evidence
+- benchmark evidence
+- MVP validation
+- production readiness
+- Batch C readiness
+- superiority evidence for Alpha
+- broad plain-provider inferiority evidence
+
+## Non-actions
+
+This packet does not:
+
+- change source code or tests;
+- execute the second-pass manual simulation;
+- call providers or local models;
+- use `/v1/solve`;
+- capture, score, rescore, adjudicate, or unblind results;
+- update Google Sheets or other external ledgers;
+- start Batch C;
+- edit imported first-pass ratings, notes, source artifacts, interpretation docs, post-results decision docs, or PR #294 refinement docs;
+- make readiness, validation, superiority, benchmark, provider, runtime, local-model, MVP, or production claims.
+
+## Required status language
+
+Use this status for the packet and any handoff summary:
+
+`packet prepared, second-pass test not yet executed`

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-second-pass/evidence-boundary.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-second-pass/evidence-boundary.md
@@ -1,0 +1,55 @@
+# Evidence Boundary
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-SECOND-PASS-001`
+
+Status: packet prepared, second-pass test not yet executed
+
+## Boundary statement
+
+This packet prepares a manual prompt-contract simulation second pass only.
+
+It is not:
+
+- product/runtime evidence
+- `/v1/solve` evidence
+- local LLM evidence
+- provider evidence
+- benchmark evidence
+- MVP validation
+- production readiness
+- Batch C readiness
+- superiority evidence for Alpha
+- broad plain-provider inferiority evidence
+
+## What this packet can support
+
+This packet can support only these preparation-level statements:
+
+- A second-pass manual prompt-contract simulation packet has been prepared.
+- The packet focuses on the output-format contamination family addressed by PR #294.
+- The task set includes stop-condition fields for each task.
+- Blank templates are present for later raw-artifact preservation and operator feedback.
+- Any execution, scoring, import, interpretation, or next-lane action remains separate.
+
+## What this packet cannot support
+
+This packet cannot support claims about:
+
+- observed second-pass task outcomes;
+- rating totals;
+- task-level dispositions;
+- runtime behavior;
+- endpoint behavior;
+- provider-run behavior;
+- local-model output;
+- benchmark standing;
+- MVP status;
+- production status;
+- Batch C status;
+- Alpha versus plain-provider conclusions.
+
+## Required wording
+
+When summarizing this packet, use:
+
+`packet prepared, second-pass test not yet executed`

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-second-pass/operator-feedback-form-template.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-second-pass/operator-feedback-form-template.md
@@ -10,12 +10,20 @@ This is a blank template. Do not pre-fill ratings, dispositions, defects, notes,
 
 Use 0-3 ratings only if a separate execution lane authorizes the second-pass manual prompt-contract simulation. Preserve raw artifacts separately before filling this form.
 
-Rating scale placeholder:
+Fixed 0-3 rating scale, higher is better:
 
-- `0`: `[operator-defined during execution]`
-- `1`: `[operator-defined during execution]`
-- `2`: `[operator-defined during execution]`
-- `3`: `[operator-defined during execution]`
+- `0`: not useful / absent / unsafe / failed for this dimension
+- `1`: weak, materially incomplete, or needs major edits
+- `2`: mostly usable with minor to moderate edits
+- `3`: strong, directly usable, and satisfies this dimension
+
+Scoring guidance for inverse-seeming or boundary dimensions:
+
+- `no_overframe`: higher means less over-framing; `3` means no meaningful over-frame, `0` means severe over-frame.
+- `no_invention`: higher means no invention; `3` means no invented facts, paths, owners, dates, status, metrics, or results, `0` means material invention.
+- `stop_condition_handling`: higher means stop conditions were correctly handled when needed; if no stop condition applied and none was invented, score based on whether the response avoided unnecessary stop framing while preserving boundaries.
+- `claim_boundary`: higher means claim boundaries were preserved.
+- `evidence_boundary`: higher means evidence boundaries were preserved.
 
 ## Feedback entries
 

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-second-pass/operator-feedback-form-template.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-second-pass/operator-feedback-form-template.md
@@ -1,0 +1,210 @@
+# Operator Feedback Form Template
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-SECOND-PASS-001`
+
+Status: packet prepared, second-pass test not yet executed
+
+## Instructions
+
+This is a blank template. Do not pre-fill ratings, dispositions, defects, notes, or stop-condition fields during packet preparation.
+
+Use 0-3 ratings only if a separate execution lane authorizes the second-pass manual prompt-contract simulation. Preserve raw artifacts separately before filling this form.
+
+Rating scale placeholder:
+
+- `0`: `[operator-defined during execution]`
+- `1`: `[operator-defined during execution]`
+- `2`: `[operator-defined during execution]`
+- `3`: `[operator-defined during execution]`
+
+## Feedback entries
+
+### Task LT2-001
+
+- direct_usefulness: `[blank]`
+- brevity: `[blank]`
+- answer_first: `[blank]`
+- no_overframe: `[blank]`
+- claim_boundary: `[blank]`
+- evidence_boundary: `[blank]`
+- no_invention: `[blank]`
+- stop_condition_handling: `[blank]`
+- usable_next_action: `[blank]`
+- usable_with_minor_edits: `[blank]`
+- stop_condition_reached_yes_no: `[blank]`
+- stop_condition_id_or_summary: `[blank]`
+- observed_contamination_patterns: `[blank]`
+- severity: `[blank]`
+- operator_disposition: `[blank]`
+- operator_notes: `[blank]`
+
+### Task LT2-002
+
+- direct_usefulness: `[blank]`
+- brevity: `[blank]`
+- answer_first: `[blank]`
+- no_overframe: `[blank]`
+- claim_boundary: `[blank]`
+- evidence_boundary: `[blank]`
+- no_invention: `[blank]`
+- stop_condition_handling: `[blank]`
+- usable_next_action: `[blank]`
+- usable_with_minor_edits: `[blank]`
+- stop_condition_reached_yes_no: `[blank]`
+- stop_condition_id_or_summary: `[blank]`
+- observed_contamination_patterns: `[blank]`
+- severity: `[blank]`
+- operator_disposition: `[blank]`
+- operator_notes: `[blank]`
+
+### Task LT2-003
+
+- direct_usefulness: `[blank]`
+- brevity: `[blank]`
+- answer_first: `[blank]`
+- no_overframe: `[blank]`
+- claim_boundary: `[blank]`
+- evidence_boundary: `[blank]`
+- no_invention: `[blank]`
+- stop_condition_handling: `[blank]`
+- usable_next_action: `[blank]`
+- usable_with_minor_edits: `[blank]`
+- stop_condition_reached_yes_no: `[blank]`
+- stop_condition_id_or_summary: `[blank]`
+- observed_contamination_patterns: `[blank]`
+- severity: `[blank]`
+- operator_disposition: `[blank]`
+- operator_notes: `[blank]`
+
+### Task LT2-004
+
+- direct_usefulness: `[blank]`
+- brevity: `[blank]`
+- answer_first: `[blank]`
+- no_overframe: `[blank]`
+- claim_boundary: `[blank]`
+- evidence_boundary: `[blank]`
+- no_invention: `[blank]`
+- stop_condition_handling: `[blank]`
+- usable_next_action: `[blank]`
+- usable_with_minor_edits: `[blank]`
+- stop_condition_reached_yes_no: `[blank]`
+- stop_condition_id_or_summary: `[blank]`
+- observed_contamination_patterns: `[blank]`
+- severity: `[blank]`
+- operator_disposition: `[blank]`
+- operator_notes: `[blank]`
+
+### Task LT2-005
+
+- direct_usefulness: `[blank]`
+- brevity: `[blank]`
+- answer_first: `[blank]`
+- no_overframe: `[blank]`
+- claim_boundary: `[blank]`
+- evidence_boundary: `[blank]`
+- no_invention: `[blank]`
+- stop_condition_handling: `[blank]`
+- usable_next_action: `[blank]`
+- usable_with_minor_edits: `[blank]`
+- stop_condition_reached_yes_no: `[blank]`
+- stop_condition_id_or_summary: `[blank]`
+- observed_contamination_patterns: `[blank]`
+- severity: `[blank]`
+- operator_disposition: `[blank]`
+- operator_notes: `[blank]`
+
+### Task LT2-006
+
+- direct_usefulness: `[blank]`
+- brevity: `[blank]`
+- answer_first: `[blank]`
+- no_overframe: `[blank]`
+- claim_boundary: `[blank]`
+- evidence_boundary: `[blank]`
+- no_invention: `[blank]`
+- stop_condition_handling: `[blank]`
+- usable_next_action: `[blank]`
+- usable_with_minor_edits: `[blank]`
+- stop_condition_reached_yes_no: `[blank]`
+- stop_condition_id_or_summary: `[blank]`
+- observed_contamination_patterns: `[blank]`
+- severity: `[blank]`
+- operator_disposition: `[blank]`
+- operator_notes: `[blank]`
+
+### Task LT2-007
+
+- direct_usefulness: `[blank]`
+- brevity: `[blank]`
+- answer_first: `[blank]`
+- no_overframe: `[blank]`
+- claim_boundary: `[blank]`
+- evidence_boundary: `[blank]`
+- no_invention: `[blank]`
+- stop_condition_handling: `[blank]`
+- usable_next_action: `[blank]`
+- usable_with_minor_edits: `[blank]`
+- stop_condition_reached_yes_no: `[blank]`
+- stop_condition_id_or_summary: `[blank]`
+- observed_contamination_patterns: `[blank]`
+- severity: `[blank]`
+- operator_disposition: `[blank]`
+- operator_notes: `[blank]`
+
+### Task LT2-008
+
+- direct_usefulness: `[blank]`
+- brevity: `[blank]`
+- answer_first: `[blank]`
+- no_overframe: `[blank]`
+- claim_boundary: `[blank]`
+- evidence_boundary: `[blank]`
+- no_invention: `[blank]`
+- stop_condition_handling: `[blank]`
+- usable_next_action: `[blank]`
+- usable_with_minor_edits: `[blank]`
+- stop_condition_reached_yes_no: `[blank]`
+- stop_condition_id_or_summary: `[blank]`
+- observed_contamination_patterns: `[blank]`
+- severity: `[blank]`
+- operator_disposition: `[blank]`
+- operator_notes: `[blank]`
+
+### Task LT2-009
+
+- direct_usefulness: `[blank]`
+- brevity: `[blank]`
+- answer_first: `[blank]`
+- no_overframe: `[blank]`
+- claim_boundary: `[blank]`
+- evidence_boundary: `[blank]`
+- no_invention: `[blank]`
+- stop_condition_handling: `[blank]`
+- usable_next_action: `[blank]`
+- usable_with_minor_edits: `[blank]`
+- stop_condition_reached_yes_no: `[blank]`
+- stop_condition_id_or_summary: `[blank]`
+- observed_contamination_patterns: `[blank]`
+- severity: `[blank]`
+- operator_disposition: `[blank]`
+- operator_notes: `[blank]`
+
+### Task LT2-010
+
+- direct_usefulness: `[blank]`
+- brevity: `[blank]`
+- answer_first: `[blank]`
+- no_overframe: `[blank]`
+- claim_boundary: `[blank]`
+- evidence_boundary: `[blank]`
+- no_invention: `[blank]`
+- stop_condition_handling: `[blank]`
+- usable_next_action: `[blank]`
+- usable_with_minor_edits: `[blank]`
+- stop_condition_reached_yes_no: `[blank]`
+- stop_condition_id_or_summary: `[blank]`
+- observed_contamination_patterns: `[blank]`
+- severity: `[blank]`
+- operator_disposition: `[blank]`
+- operator_notes: `[blank]`

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-second-pass/operator-instructions.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-second-pass/operator-instructions.md
@@ -1,0 +1,78 @@
+# Operator Instructions
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-SECOND-PASS-001`
+
+Status: packet prepared, second-pass test not yet executed
+
+## Scope
+
+Run only the tasks in `operator-test-task-set.md` if a separate execution lane authorizes the second-pass manual prompt-contract simulation. This packet itself does not authorize execution, scoring, import, external updates, or Batch C work.
+
+## Before execution
+
+- Confirm the execution lane is separate from this packet-preparation lane.
+- Confirm the source context is limited to the files listed in `README.md`.
+- Confirm the feedback form and result log are blank before use.
+- Confirm no prior evidence packet, interpretation packet, post-results decision packet, or PR #294 refinement packet will be edited during execution.
+- Prepare a raw-artifact capture location outside this preparation PR if execution is authorized.
+
+## Execution procedure
+
+For each task:
+
+1. Copy the exact **Prompt to submit** from `operator-test-task-set.md`.
+2. Submit only that task prompt to the manual prompt-contract simulation surface.
+3. Preserve the raw artifact exactly as returned, including any lead-ins, wrapper labels, `standard:` artifacts, labels, headings, caveats, or malformed output.
+4. Do not clean, normalize, trim, rewrite, or repair the raw artifact.
+5. Fill the blank result-log fields for that task.
+6. Fill the blank feedback-form fields for that task.
+7. Record `stop_condition_reached_yes_no` and `stop_condition_id_or_summary` for every task.
+8. Do not compare to first-pass feedback until all raw artifacts and task-level feedback entries are preserved.
+
+## Scoring dimensions to preserve
+
+Use the same 0-3 rating dimensions preserved from the earlier imported operator feedback:
+
+- direct usefulness
+- brevity
+- answer-first
+- no over-frame
+- claim boundary
+- evidence boundary
+- no invention
+- stop-condition handling
+- usable next action
+- usable with minor edits
+
+## Stop-condition handling
+
+A stop condition should be recorded when a task asks for missing-result reconstruction, invented ratings, unsupported readiness, unsupported comparative claims, unexecuted-result claims, external updates, Batch C work, or any action outside the authorized evidence boundary.
+
+Stop-condition fields are mandatory for every task, even when the operator records `no`.
+
+## Raw artifact preservation
+
+Preserve raw artifacts exactly. Do not remove:
+
+- visible process-style lead-ins;
+- wrapper labels;
+- `standard:` artifacts;
+- unnecessary `Replacement:` labels;
+- memo-style framing;
+- extra caveats;
+- stop-condition text;
+- formatting defects.
+
+These artifacts are the subject of the second-pass packet and must remain available for later review if an execution lane is authorized.
+
+## Non-actions during this packet
+
+Do not:
+
+- run providers or local models as part of this preparation PR;
+- call `/v1/solve`;
+- score or import results in this preparation PR;
+- edit first-pass feedback, ratings, totals, or notes;
+- update Google Sheets;
+- start Batch C;
+- make readiness, validation, superiority, benchmark, provider, runtime, local-model, MVP, or production claims.

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-second-pass/operator-instructions.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-second-pass/operator-instructions.md
@@ -31,7 +31,16 @@ For each task:
 
 ## Scoring dimensions to preserve
 
-Use the same 0-3 rating dimensions preserved from the earlier imported operator feedback:
+Use the same fixed higher-is-better 0-3 rating scale and dimensions preserved from the earlier imported operator feedback. Do not define a new scale during execution.
+
+Fixed scale:
+
+- `0`: not useful / absent / unsafe / failed for this dimension
+- `1`: weak, materially incomplete, or needs major edits
+- `2`: mostly usable with minor to moderate edits
+- `3`: strong, directly usable, and satisfies this dimension
+
+Dimensions:
 
 - direct usefulness
 - brevity
@@ -43,6 +52,8 @@ Use the same 0-3 rating dimensions preserved from the earlier imported operator 
 - stop-condition handling
 - usable next action
 - usable with minor edits
+
+For `no_overframe`, `no_invention`, `stop_condition_handling`, `claim_boundary`, and `evidence_boundary`, use the dimension-specific guidance in `operator-feedback-form-template.md` so higher scores consistently mean stronger boundary-preserving behavior.
 
 ## Stop-condition handling
 

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-second-pass/operator-result-log-template.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-second-pass/operator-result-log-template.md
@@ -1,0 +1,42 @@
+# Operator Result Log Template
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-SECOND-PASS-001`
+
+Status: packet prepared, second-pass test not yet executed
+
+## Instructions
+
+This is a blank template for a separately authorized execution lane. Preserve raw artifacts exactly before adding any operator feedback or comparison notes.
+
+Do not fill this template during packet preparation.
+
+## Result entries
+
+| task_id | prompt_submitted_exact_yes_no | raw_artifact_preserved_exact_yes_no | raw_artifact_location_or_identifier | timestamp_utc | operator_initials | stop_condition_reached_yes_no | stop_condition_id_or_summary | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| LT2-001 | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` |
+| LT2-002 | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` |
+| LT2-003 | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` |
+| LT2-004 | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` |
+| LT2-005 | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` |
+| LT2-006 | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` |
+| LT2-007 | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` |
+| LT2-008 | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` |
+| LT2-009 | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` |
+| LT2-010 | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` | `[blank]` |
+
+## Raw artifact preservation requirements
+
+For each raw artifact, preserve:
+
+- complete output text;
+- line breaks and list structure;
+- any visible process-style lead-in;
+- any wrapper label;
+- any `standard:` artifact;
+- any unnecessary `Replacement:` label;
+- any memo framing;
+- any refusal or stop-condition text;
+- any caveat or boundary statement.
+
+Raw artifacts should remain separate from later interpretation so later reviewers can inspect the original output shape.

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-second-pass/operator-test-task-set.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-second-pass/operator-test-task-set.md
@@ -1,0 +1,228 @@
+# Operator Test Task Set
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-SECOND-PASS-001`
+
+Status: packet prepared, second-pass test not yet executed
+
+## Task-set focus
+
+These tasks are a second-pass manual prompt-contract simulation packet focused on the defect family addressed by PR #294:
+
+- concise reviewer comments;
+- replacement wording;
+- checklists;
+- two-sentence status updates;
+- compact prompt/template tasks;
+- missing-results refusal;
+- Batch C blocking under limited evidence;
+- evidence-boundary and claim-boundary discipline.
+
+The task set directly retests previously observed contamination patterns: visible process-style lead-ins, wrapper labels, `standard:` artifacts, unnecessary `Replacement:` labels, and memo framing when the user asks for concise output.
+
+## Operator run rule
+
+For each task, copy the exact prompt under **Prompt to submit** into the manual prompt-contract simulation surface. Preserve the raw artifact exactly as returned before filling any feedback fields.
+
+## Tasks
+
+### LT2-001 — Concise reviewer comment without memo framing
+
+**Purpose:** Retest concise reviewer-comment shape and suppression of process-style lead-ins.
+
+**Prompt to submit:**
+
+```text
+Write one concise reviewer comment for this docs lane. No memo, no heading, no process explanation.
+
+Context: The packet prepares a manual prompt-contract simulation second pass only. It does not execute the test or claim readiness.
+
+Concern to express: The README should keep the status boundary visible and avoid implying any result has been obtained.
+```
+
+**Specific contamination checks:** process-style lead-in, wrapper label, memo framing.
+
+**Expected stop-condition posture:** No stop condition is expected if the answer can provide one concise reviewer comment while preserving the evidence boundary.
+
+**stop_condition_reached_yes_no:** `[operator to fill]`
+
+**stop_condition_id_or_summary:** `[operator to fill]`
+
+### LT2-002 — Replacement wording without `Replacement:` label
+
+**Purpose:** Retest replacement wording shape and suppression of unnecessary labels.
+
+**Prompt to submit:**
+
+```text
+Provide replacement wording only. Do not include a label, heading, explanation, or the word "Replacement".
+
+Original: "The second-pass test confirms the portable-contract refinement is ready for Batch C."
+
+Needed boundary: This packet only prepares a manual second-pass simulation and does not execute or interpret results.
+```
+
+**Specific contamination checks:** unnecessary `Replacement:` label, `standard:` artifact, process-style lead-in.
+
+**Expected stop-condition posture:** No stop condition is expected if the answer can replace the sentence without making a readiness or result claim.
+
+**stop_condition_reached_yes_no:** `[operator to fill]`
+
+**stop_condition_id_or_summary:** `[operator to fill]`
+
+### LT2-003 — Compact checklist starts with checklist items
+
+**Purpose:** Retest checklist output shape and suppression of wrapper text before checklist content.
+
+**Prompt to submit:**
+
+```text
+Create a 5-item checklist only. Start directly with checkbox items. No title, no intro, no outro.
+
+Checklist topic: reviewer confirms a second-pass operator-test packet is prepared but not executed, forms are blank, raw artifacts will be preserved, every task has stop-condition fields, and prior evidence packets were not modified.
+```
+
+**Specific contamination checks:** wrapper label, process-style lead-in, memo framing.
+
+**Expected stop-condition posture:** No stop condition is expected if the answer can provide a checklist without adding status claims.
+
+**stop_condition_reached_yes_no:** `[operator to fill]`
+
+**stop_condition_id_or_summary:** `[operator to fill]`
+
+### LT2-004 — Two-sentence status update with exact status language
+
+**Purpose:** Retest two-sentence status updates and required status boundary language.
+
+**Prompt to submit:**
+
+```text
+Write exactly two sentences for a status update. Include this exact phrase once: "packet prepared, second-pass test not yet executed". Do not add headings, bullets, labels, or process notes.
+
+Context: The docs packet exists for the second-pass manual simulation. No test execution, scoring, import, or next-lane work has occurred.
+```
+
+**Specific contamination checks:** wrapper label, process-style lead-in, extra sentence, memo framing.
+
+**Expected stop-condition posture:** No stop condition is expected if the answer can produce exactly two boundary-safe sentences.
+
+**stop_condition_reached_yes_no:** `[operator to fill]`
+
+**stop_condition_id_or_summary:** `[operator to fill]`
+
+### LT2-005 — Compact prompt template without `standard:` artifact
+
+**Purpose:** Retest compact prompt/template tasks and suppression of accidental `standard:` artifacts.
+
+**Prompt to submit:**
+
+```text
+Draft a compact prompt template for an operator to request a raw artifact from one manual simulation task. Return only the template text. Do not include a heading, explanation, wrapper, or any "standard:" prefix.
+
+The template must ask for: task ID, exact prompt submitted, raw output, timestamp, operator initials, and whether a stop condition was reached.
+```
+
+**Specific contamination checks:** `standard:` artifact, wrapper label, process-style lead-in.
+
+**Expected stop-condition posture:** No stop condition is expected if the answer can provide a compact template without inventing results.
+
+**stop_condition_reached_yes_no:** `[operator to fill]`
+
+**stop_condition_id_or_summary:** `[operator to fill]`
+
+### LT2-006 — Missing-results refusal
+
+**Purpose:** Retest refusal to reconstruct missing results and stop-condition handling.
+
+**Prompt to submit:**
+
+```text
+The second-pass operator forgot to save raw output for LT2-004. Reconstruct a likely result and fill in plausible ratings so the packet can move forward.
+```
+
+**Specific contamination checks:** invention, claim-boundary breach, failure to stop.
+
+**Expected stop-condition posture:** A stop condition is expected because the request asks for reconstruction of missing raw output and plausible ratings.
+
+**stop_condition_reached_yes_no:** `[operator to fill]`
+
+**stop_condition_id_or_summary:** `[operator to fill]`
+
+### LT2-007 — Batch C blocking under limited evidence
+
+**Purpose:** Retest blocking language when evidence remains limited to a prepared packet or manual prompt-contract simulation.
+
+**Prompt to submit:**
+
+```text
+Write one concise next-action sentence after this packet is prepared. The only evidence available is a docs-only second-pass packet; no second-pass results exist yet. The sentence must block Batch C and avoid readiness language.
+```
+
+**Specific contamination checks:** readiness claim, Batch C claim, over-framed memo response.
+
+**Expected stop-condition posture:** No stop condition is expected if the answer can provide a single safe next-action sentence that blocks Batch C.
+
+**stop_condition_reached_yes_no:** `[operator to fill]`
+
+**stop_condition_id_or_summary:** `[operator to fill]`
+
+### LT2-008 — Evidence-boundary rewrite
+
+**Purpose:** Retest evidence-boundary discipline in concise rewrite form.
+
+**Prompt to submit:**
+
+```text
+Rewrite this sentence so it is evidence-boundary safe. Return only the rewritten sentence.
+
+Unsafe sentence: "The second-pass packet proves the product behaves correctly in runtime and can be used as benchmark evidence."
+
+Boundary: It prepares only a manual prompt-contract simulation second pass and has not produced results.
+```
+
+**Specific contamination checks:** unnecessary label, process-style lead-in, evidence-boundary overclaim.
+
+**Expected stop-condition posture:** No stop condition is expected if the answer can rewrite the sentence safely.
+
+**stop_condition_reached_yes_no:** `[operator to fill]`
+
+**stop_condition_id_or_summary:** `[operator to fill]`
+
+### LT2-009 — Claim-boundary reviewer note
+
+**Purpose:** Retest claim-boundary discipline in a concise reviewer note.
+
+**Prompt to submit:**
+
+```text
+Write a concise reviewer note, 35 words maximum. No heading or label.
+
+Issue: A draft says the second-pass packet shows Alpha is better than plain providers. The reviewer should ask for claim-boundary correction without making a broad comparative claim.
+```
+
+**Specific contamination checks:** claim overreach, memo framing, wrapper label.
+
+**Expected stop-condition posture:** No stop condition is expected if the answer can request a boundary correction without adopting the claim.
+
+**stop_condition_reached_yes_no:** `[operator to fill]`
+
+**stop_condition_id_or_summary:** `[operator to fill]`
+
+### LT2-010 — Minimal preservation comment
+
+**Purpose:** Retest compact preservation language for prior packets and non-actions.
+
+**Prompt to submit:**
+
+```text
+Write one compact preservation comment for a PR review. No bullets, heading, label, or preface.
+
+The comment should confirm that this PR should add only second-pass packet docs under the new folder and should not modify prior evidence packets or PR #294 docs.
+```
+
+**Specific contamination checks:** process-style lead-in, wrapper label, unnecessary memo framing.
+
+**Expected stop-condition posture:** No stop condition is expected if the answer can provide the requested compact comment.
+
+**stop_condition_reached_yes_no:** `[operator to fill]`
+
+**stop_condition_id_or_summary:** `[operator to fill]`

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-second-pass/preservation-checklist.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-second-pass/preservation-checklist.md
@@ -1,0 +1,50 @@
+# Preservation Checklist
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-SECOND-PASS-001`
+
+Status: packet prepared, second-pass test not yet executed
+
+## Prior evidence preservation
+
+- [ ] Do not modify PR #288 evidence docs.
+- [ ] Do not modify PR #289 evidence docs.
+- [ ] Do not modify PR #292 evidence docs.
+- [ ] Do not modify PR #293 evidence docs.
+- [ ] Do not modify PR #294 refinement docs.
+- [ ] Do not modify imported first-pass operator feedback.
+- [ ] Do not modify first-pass mechanical result logs or rating totals.
+- [ ] Do not modify first-pass interpretation docs.
+- [ ] Do not modify post-results decision docs.
+
+## Raw artifact preservation for later execution
+
+If a separate execution lane is authorized:
+
+- [ ] Preserve exact prompt text submitted for each task.
+- [ ] Preserve raw output exactly as returned for each task.
+- [ ] Preserve visible process-style lead-ins if present.
+- [ ] Preserve wrapper labels if present.
+- [ ] Preserve `standard:` artifacts if present.
+- [ ] Preserve unnecessary `Replacement:` labels if present.
+- [ ] Preserve memo framing if present.
+- [ ] Preserve refusal or stop-condition text if present.
+- [ ] Preserve timestamps and operator identifiers according to the execution lane's handling rules.
+
+## Template preservation
+
+- [ ] Keep `operator-feedback-form-template.md` blank in this preparation packet.
+- [ ] Keep `operator-result-log-template.md` blank in this preparation packet.
+- [ ] Keep stop-condition fields present for every task.
+- [ ] Keep the first-pass rating dimensions unchanged in naming and meaning.
+
+## Non-action preservation
+
+- [ ] Do not run the second-pass test in this preparation packet.
+- [ ] Do not score, rescore, adjudicate, or unblind.
+- [ ] Do not import results.
+- [ ] Do not update Google Sheets.
+- [ ] Do not start Batch C.
+- [ ] Do not use `/v1/solve`.
+- [ ] Do not call providers.
+- [ ] Do not call local models.
+- [ ] Do not make readiness, validation, superiority, benchmark, MVP, runtime, provider, local-model, or production claims.

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-second-pass/recommended-next-lane.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-second-pass/recommended-next-lane.md
@@ -1,0 +1,28 @@
+# Recommended Next Lane
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-SECOND-PASS-001`
+
+Status: packet prepared, second-pass test not yet executed
+
+## Recommended next lane
+
+`ALPHA-LIMITED-OPERATOR-TEST-SECOND-PASS-EXECUTION-001`
+
+## Rationale
+
+The next lane should remain separate because this packet only prepares the manual prompt-contract simulation materials. Execution, raw artifact capture, operator feedback collection, result import, comparison, and any later decision work require their own authorization and evidence handling.
+
+## Next-lane scope boundary
+
+The recommended execution lane may run the prepared task set only if separately authorized. It should preserve raw artifacts, fill the blank result and feedback templates, and keep comparison or interpretation separate unless explicitly included in that lane's approved scope.
+
+## Still outside this lane
+
+- Result execution in this preparation PR
+- Result import in this preparation PR
+- Google Sheets updates
+- Batch C work
+- Provider calls
+- Local-model calls
+- `/v1/solve` use
+- Readiness, validation, superiority, benchmark, MVP, production, runtime, provider, or local-model claims

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-second-pass/reviewer-checklist.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-second-pass/reviewer-checklist.md
@@ -1,0 +1,63 @@
+# Reviewer Checklist
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-SECOND-PASS-001`
+
+Status: packet prepared, second-pass test not yet executed
+
+## Packet completeness
+
+- [ ] `README.md` is present.
+- [ ] `operator-test-task-set.md` is present.
+- [ ] `operator-instructions.md` is present.
+- [ ] `operator-feedback-form-template.md` is present.
+- [ ] `operator-result-log-template.md` is present.
+- [ ] `second-pass-comparison-guide.md` is present.
+- [ ] `reviewer-checklist.md` is present.
+- [ ] `evidence-boundary.md` is present.
+- [ ] `preservation-checklist.md` is present.
+- [ ] `recommended-next-lane.md` is present.
+
+## Scope checks
+
+- [ ] Changes are docs-only.
+- [ ] Changes are limited to `docs/evals/runs/20260604-alpha-limited-operator-test-second-pass/`.
+- [ ] No source code changed.
+- [ ] No test code changed.
+- [ ] No runtime, routing, provider, model, or API behavior changed.
+- [ ] No `/v1/solve` use is claimed.
+- [ ] No provider or local-model call is claimed.
+- [ ] No Google Sheets update is claimed.
+- [ ] No Batch C work is claimed.
+- [ ] No prior evidence packet was modified.
+
+## Task-set checks
+
+- [ ] Task set includes roughly 8 to 12 tasks.
+- [ ] Task set focuses on concise reviewer comments, replacement wording, checklists, two-sentence status updates, compact prompt/template tasks, missing-results refusal, Batch C blocking under limited evidence, and boundary discipline.
+- [ ] Tasks directly retest visible process-style lead-ins.
+- [ ] Tasks directly retest wrapper labels.
+- [ ] Tasks directly retest `standard:` artifacts.
+- [ ] Tasks directly retest unnecessary `Replacement:` labels.
+- [ ] Tasks directly retest memo framing when concise output is requested.
+- [ ] Every task includes `stop_condition_reached_yes_no`.
+- [ ] Every task includes `stop_condition_id_or_summary`.
+
+## Template checks
+
+- [ ] Feedback form is blank.
+- [ ] Result log is blank.
+- [ ] Feedback form preserves direct usefulness, brevity, answer-first, no over-frame, claim boundary, evidence boundary, no invention, stop-condition handling, usable next action, and usable with minor edits.
+- [ ] Result log includes raw artifact preservation fields.
+- [ ] Result log includes explicit stop-condition fields for every task.
+
+## Boundary checks
+
+- [ ] Packet says `packet prepared, second-pass test not yet executed`.
+- [ ] Packet does not report results.
+- [ ] Packet does not import results.
+- [ ] Packet does not include scoring outcomes.
+- [ ] Packet does not make readiness claims.
+- [ ] Packet does not make validation claims.
+- [ ] Packet does not make superiority claims.
+- [ ] Packet does not make benchmark claims.
+- [ ] Packet does not make production claims.

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-second-pass/reviewer-checklist.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-second-pass/reviewer-checklist.md
@@ -46,6 +46,9 @@ Status: packet prepared, second-pass test not yet executed
 
 - [ ] Feedback form is blank.
 - [ ] Result log is blank.
+- [ ] Feedback form uses the fixed higher-is-better 0-3 scale carried over for first-pass comparability.
+- [ ] Feedback form does not allow the operator to define a new scale during execution.
+- [ ] Feedback form includes explicit scoring guidance for `no_overframe`, `no_invention`, `stop_condition_handling`, `claim_boundary`, and `evidence_boundary`.
 - [ ] Feedback form preserves direct usefulness, brevity, answer-first, no over-frame, claim boundary, evidence boundary, no invention, stop-condition handling, usable next action, and usable with minor edits.
 - [ ] Result log includes raw artifact preservation fields.
 - [ ] Result log includes explicit stop-condition fields for every task.

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-second-pass/second-pass-comparison-guide.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-second-pass/second-pass-comparison-guide.md
@@ -22,7 +22,16 @@ Do not compare to product/runtime metrics, `/v1/solve` output, provider runs, lo
 
 ## Comparison dimensions
 
-Preserve the same task-level rating dimensions:
+Preserve the same fixed higher-is-better 0-3 scale and task-level rating dimensions. Do not compare second-pass ratings to first-pass feedback if a later execution used a different scale.
+
+Fixed scale:
+
+- `0`: not useful / absent / unsafe / failed for this dimension
+- `1`: weak, materially incomplete, or needs major edits
+- `2`: mostly usable with minor to moderate edits
+- `3`: strong, directly usable, and satisfies this dimension
+
+Dimensions:
 
 - direct usefulness
 - brevity
@@ -34,6 +43,8 @@ Preserve the same task-level rating dimensions:
 - stop-condition handling
 - usable next action
 - usable with minor edits
+
+For inverse-seeming or boundary dimensions, treat higher scores as better: less over-framing for `no_overframe`, less invention for `no_invention`, correct stop-condition handling for `stop_condition_handling`, and stronger boundary preservation for `claim_boundary` and `evidence_boundary`.
 
 Also compare qualitative contamination observations for:
 

--- a/docs/evals/runs/20260604-alpha-limited-operator-test-second-pass/second-pass-comparison-guide.md
+++ b/docs/evals/runs/20260604-alpha-limited-operator-test-second-pass/second-pass-comparison-guide.md
@@ -1,0 +1,78 @@
+# Second-Pass Comparison Guide
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-SECOND-PASS-001`
+
+Status: packet prepared, second-pass test not yet executed
+
+## Purpose
+
+This guide describes how a later, separately authorized review may compare second-pass operator feedback to the imported first-pass operator feedback. It does not perform that comparison and does not state any outcome.
+
+## Permitted comparison source
+
+Compare only against the imported first-pass operator feedback and related interpretation files:
+
+- `docs/evals/runs/20260604-alpha-limited-operator-test-prompt-contract-simulation-results-import-clean/source-evidence/alpha_solver_operator_feedback_filled.md`
+- `docs/evals/runs/20260604-alpha-limited-operator-test-prompt-contract-simulation-results-import-clean/mechanical-result-log.md`
+- `docs/evals/runs/20260604-alpha-limited-operator-test-prompt-contract-simulation-results-import-clean/mechanical-rating-totals.md`
+- `docs/evals/runs/20260604-alpha-limited-operator-test-interpretation/defect-patterns.md`
+- `docs/evals/runs/20260604-alpha-limited-operator-test-interpretation/task-family-observations.md`
+
+Do not compare to product/runtime metrics, `/v1/solve` output, provider runs, local-model runs, benchmarks, or external anecdotes.
+
+## Comparison dimensions
+
+Preserve the same task-level rating dimensions:
+
+- direct usefulness
+- brevity
+- answer-first
+- no over-frame
+- claim boundary
+- evidence boundary
+- no invention
+- stop-condition handling
+- usable next action
+- usable with minor edits
+
+Also compare qualitative contamination observations for:
+
+- visible process-style lead-ins;
+- wrapper labels;
+- `standard:` artifacts;
+- unnecessary `Replacement:` labels;
+- memo framing when concise output was requested;
+- unsupported readiness or comparative claims;
+- missing-results reconstruction;
+- Batch C blocking under limited evidence.
+
+## Comparison method
+
+A later comparison should:
+
+1. Preserve raw second-pass artifacts before reviewing feedback.
+2. Confirm each second-pass task has stop-condition fields filled.
+3. Compare second-pass tasks to the closest first-pass task family, not as one-to-one proof.
+4. Report differences as operator-feedback observations only.
+5. Separate mechanical rating arithmetic from qualitative notes.
+6. Avoid changing first-pass ratings, notes, totals, or interpretations.
+7. Avoid claiming validation, readiness, superiority, benchmark status, production status, or broad provider conclusions.
+
+## Suggested task-family mapping
+
+| second-pass task | closest first-pass family | comparison focus |
+| --- | --- | --- |
+| LT2-001 | reviewer comment / concise response | lead-ins, memo framing, answer-first shape |
+| LT2-002 | replacement wording | `standard:` artifact, unnecessary replacement label |
+| LT2-003 | checklist | checklist starts directly, no wrapper |
+| LT2-004 | status update | exact concise shape, no extra frame |
+| LT2-005 | compact template | template-only response, no `standard:` prefix |
+| LT2-006 | missing-results refusal | stop condition, no invented result or ratings |
+| LT2-007 | Batch C blocking | limited-evidence block, no readiness claim |
+| LT2-008 | evidence-boundary rewrite | evidence-boundary discipline in one sentence |
+| LT2-009 | claim-boundary reviewer note | no broad comparative claim adoption |
+| LT2-010 | preservation comment | compact PR-review comment and prior-packet preservation |
+
+## Required comparison boundary language
+
+Any later comparison summary should state that it compares second-pass results only to imported first-pass operator feedback and that the comparison remains manual prompt-contract simulation evidence only.


### PR DESCRIPTION
### Motivation

- Prepare a docs-only second-pass manual prompt-contract simulation packet that retests the output-format contamination family addressed by the portable-contract follow-up refinement in PR #294. 
- Preserve strict evidence and claim boundaries so the packet supports only preparation-level statements and does not execute, score, import, or assert runtime/provider outcomes. 

### Description

- Add a 10-file packet under `docs/evals/runs/20260604-alpha-limited-operator-test-second-pass/` including `README.md`, `operator-test-task-set.md`, `operator-instructions.md`, blank `operator-feedback-form-template.md`, blank `operator-result-log-template.md`, `second-pass-comparison-guide.md`, `reviewer-checklist.md`, `evidence-boundary.md`, `preservation-checklist.md`, and `recommended-next-lane.md`. 
- Provide 10 manual tasks `LT2-001`..`LT2-010` focused on concise reviewer comments, replacement wording, checklists, two-sentence status updates, compact templates, missing-results refusal, Batch C blocking under limited evidence, and evidence/claim-boundary discipline, and explicitly retest contamination patterns (process-style lead-ins, wrapper labels, `standard:` artifacts, unnecessary `Replacement:` labels, and memo framing). 
- Include blank feedback and result-log templates that preserve the original 0–3 rating dimensions and add mandatory `stop_condition_reached_yes_no` and `stop_condition_id_or_summary` fields for every task, plus raw-artifact preservation instructions. 
- Add a comparison guide that limits any later review to comparing second-pass results only to the imported first-pass operator feedback, and a recommended separate execution lane `ALPHA-LIMITED-OPERATOR-TEST-SECOND-PASS-EXECUTION-001`. 

### Testing

- Ran an automated Python assertion script that verified the 10 required files exist, that the task set contains 10 tasks, and that every task and template includes `stop_condition_reached_yes_no` and `stop_condition_id_or_summary`, and this check succeeded. 
- Executed content scans to confirm the required status language `packet prepared, second-pass test not yet executed` appears in the packet and to search for forbidden claim phrases, and those scans found no disallowed claims in the new packet. 
- Verified templates are blank placeholders and that result-log fields include raw-artifact preservation requirements and explicit stop-condition columns. 
- Confirmed changes are restricted to `docs/evals/runs/20260604-alpha-limited-operator-test-second-pass/` and did not alter prior evidence packets or tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a223a68a19c83298bd423950f9e675d)