### PR TITLE
feat(local-llm): implement offline Ollama adapter seam

### DIFF
--- a/alpha/local_llm/__init__.py
+++ b/alpha/local_llm/__init__.py
@@ -19,8 +19,12 @@ from .provider_adapter import (  # noqa: F401
     LocalLLMAdapterMessage,
     LocalLLMAdapterRequest,
     LocalLLMAdapterResult,
+    LocalLLMProviderAdapterError,
     LocalLLMProviderBackend,
+    OllamaLocalHTTPBackend,
     StubLocalLLMProviderBackend,
+    build_ollama_chat_payload,
     build_local_llm_adapter_request,
+    parse_ollama_assistant_text,
     run_local_llm_provider_adapter,
 )

--- a/alpha/local_llm/provider_adapter.py
+++ b/alpha/local_llm/provider_adapter.py
@@ -3,21 +3,28 @@
 This module builds a provider-adapter-shaped request from
 ``alpha_solver_portable.py`` and sends it only to an injected backend. It does
 not call Ollama, OpenAI, Anthropic, other hosted providers, or the deterministic
-v91 ``_tree_of_thought`` fallback. Successful stub output is wiring evidence
-only and is never behavior, runtime, or readiness evidence.
+v91 ``_tree_of_thought`` fallback. Successful stub or offline fixture output is
+wiring evidence only and is never behavior, runtime, or readiness evidence.
 """
 
 from __future__ import annotations
 
+import json
+import socket
 from dataclasses import dataclass, field
-from typing import Any, Mapping, Protocol
+from typing import Any, Callable, Mapping, Protocol
+from urllib import error as urllib_error
+from urllib import request as urllib_request
+from urllib.parse import urlparse
 
 from .portable_contract import PortableContract, PortableContractError, load_portable_contract
 
 _LOCAL_LLM_ADAPTER_MODE = "local_llm"
 _ADAPTER_BACKEND_CLASS = "stub-local-llm-provider-adapter"
+_OLLAMA_BACKEND_CLASS = "ollama-local-http-offline-adapter"
 _ADAPTER_EVIDENCE_LABEL = "non_evidence_local_llm_provider_adapter_wiring"
 _DISABLED_MODEL_LABEL = "local-llm-disabled-unconfigured"
+_ALLOWED_LOCAL_HOSTS = {"127.0.0.1", "::1", "localhost"}
 
 
 @dataclass(frozen=True)
@@ -46,8 +53,8 @@ class LocalLLMAdapterResult:
     """Normalized adapter result.
 
     ``behavior_evidence`` is always false. A non-failed result proves only that
-    request construction, prompt-source preservation, and injected-backend
-    handoff occurred.
+    request construction, prompt-source preservation, parser behavior, and
+    injected-backend handoff occurred.
     """
 
     request: LocalLLMAdapterRequest
@@ -56,6 +63,15 @@ class LocalLLMAdapterResult:
     reason: str
     behavior_evidence: bool = False
     metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+class LocalLLMProviderAdapterError(PortableContractError):
+    """Fail-closed provider-adapter error with a stable non-evidence reason."""
+
+    def __init__(self, reason_code: str, detail: str = "") -> None:
+        super().__init__(detail or reason_code)
+        self.reason_code = reason_code
+        self.detail = detail
 
 
 class LocalLLMProviderBackend(Protocol):
@@ -78,6 +94,74 @@ class StubLocalLLMProviderBackend:
         if self.fail:
             raise PortableContractError("stub local LLM provider adapter failed")
         return self.output_text
+
+
+OllamaTransport = Callable[[str, Mapping[str, Any], float], Mapping[str, Any]]
+
+
+@dataclass(frozen=True)
+class OllamaLocalHTTPBackend:
+    """Default-off Ollama-style local HTTP backend behind the injected seam.
+
+    The backend is inert unless ``enabled=True`` is passed explicitly by a later
+    authorized lane. Tests can inject ``transport`` callables to exercise request
+    mapping and response parsing without opening sockets.
+    """
+
+    endpoint: str = "http://127.0.0.1:11434/api/chat"
+    model: str = _DISABLED_MODEL_LABEL
+    timeout_seconds: float = 5.0
+    enabled: bool = False
+    transport: OllamaTransport | None = None
+
+    @property
+    def backend_class(self) -> str:
+        """Return the backend label used for non-evidence metadata/tests."""
+
+        return _OLLAMA_BACKEND_CLASS
+
+    def build_payload(self, request: LocalLLMAdapterRequest) -> dict[str, Any]:
+        """Map an adapter request to the Ollama ``/api/chat`` JSON shape."""
+
+        return build_ollama_chat_payload(request, model=self.model)
+
+    def generate(self, request: LocalLLMAdapterRequest) -> str:
+        """Generate via an explicitly enabled local endpoint or injected transport."""
+
+        if not self.enabled:
+            raise LocalLLMProviderAdapterError(
+                "ollama_backend_disabled_non_evidence",
+                "Ollama local HTTP backend is default-off and unconfigured.",
+            )
+        _validate_local_ollama_endpoint(self.endpoint)
+        if self.timeout_seconds <= 0:
+            raise LocalLLMProviderAdapterError(
+                "ollama_timeout_invalid_non_evidence", "timeout must be positive"
+            )
+
+        payload = self.build_payload(request)
+        transport = self.transport or _urllib_ollama_transport
+        try:
+            response = transport(self.endpoint, payload, self.timeout_seconds)
+        except TimeoutError as exc:
+            raise LocalLLMProviderAdapterError(
+                "ollama_timeout_non_evidence", "Ollama-style local request timed out."
+            ) from exc
+        except socket.timeout as exc:
+            raise LocalLLMProviderAdapterError(
+                "ollama_timeout_non_evidence", "Ollama-style local request timed out."
+            ) from exc
+        except urllib_error.HTTPError as exc:
+            raise LocalLLMProviderAdapterError(
+                "ollama_backend_error_non_evidence", f"HTTP status {exc.code}"
+            ) from exc
+        except OSError as exc:
+            raise LocalLLMProviderAdapterError(
+                "ollama_connection_failure_non_evidence",
+                "Ollama-style local endpoint connection failed.",
+            ) from exc
+
+        return parse_ollama_assistant_text(response, request=request)
 
 
 def _normalize_mode(provider_mode: str) -> str:
@@ -138,6 +222,86 @@ def build_local_llm_adapter_request(
     )
 
 
+def build_ollama_chat_payload(
+    request: LocalLLMAdapterRequest, *, model: str = _DISABLED_MODEL_LABEL
+) -> dict[str, Any]:
+    """Return an Ollama-style ``/api/chat`` payload without sending it."""
+
+    return {
+        "model": model,
+        "stream": False,
+        "messages": [
+            {"role": message.role, "content": message.content}
+            for message in request.messages
+        ],
+        "options": {"temperature": 0},
+    }
+
+
+def parse_ollama_assistant_text(
+    response: Mapping[str, Any], *, request: LocalLLMAdapterRequest | None = None
+) -> str:
+    """Extract assistant text from a static Ollama-style response fixture."""
+
+    if not isinstance(response, Mapping):
+        raise LocalLLMProviderAdapterError(
+            "malformed_ollama_response_non_evidence", "response is not a mapping"
+        )
+    message = response.get("message")
+    if not isinstance(message, Mapping):
+        raise LocalLLMProviderAdapterError(
+            "malformed_ollama_response_non_evidence", "missing message object"
+        )
+    content = message.get("content")
+    if not isinstance(content, str):
+        raise LocalLLMProviderAdapterError(
+            "malformed_ollama_response_non_evidence", "message content is not text"
+        )
+    if not content.strip():
+        raise LocalLLMProviderAdapterError(
+            "empty_ollama_response_non_evidence", "assistant content is empty"
+        )
+    if request is not None and _is_prompt_echo(content, request):
+        raise LocalLLMProviderAdapterError(
+            "prompt_echo_non_evidence", "assistant content echoes prompt or contract"
+        )
+    return content
+
+
+def _validate_local_ollama_endpoint(endpoint: str) -> None:
+    parsed = urlparse(endpoint)
+    if parsed.scheme != "http" or parsed.hostname not in _ALLOWED_LOCAL_HOSTS:
+        raise LocalLLMProviderAdapterError(
+            "ollama_endpoint_not_local_non_evidence",
+            "Ollama-style backend is restricted to explicit local HTTP endpoints.",
+        )
+
+
+def _urllib_ollama_transport(
+    endpoint: str, payload: Mapping[str, Any], timeout_seconds: float
+) -> Mapping[str, Any]:
+    body = json.dumps(payload).encode("utf-8")
+    http_request = urllib_request.Request(
+        endpoint,
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib_request.urlopen(http_request, timeout=timeout_seconds) as response:
+        raw = response.read().decode("utf-8")
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise LocalLLMProviderAdapterError(
+            "malformed_ollama_response_non_evidence", "response body is not JSON"
+        ) from exc
+    if not isinstance(parsed, Mapping):
+        raise LocalLLMProviderAdapterError(
+            "malformed_ollama_response_non_evidence", "response body is not a JSON object"
+        )
+    return parsed
+
+
 def _is_prompt_echo(output_text: str, request: LocalLLMAdapterRequest) -> bool:
     stripped = output_text.strip()
     return stripped in {request.user_prompt.strip(), request.system.strip()}
@@ -170,6 +334,14 @@ def run_local_llm_provider_adapter(
     result_metadata = {**request.metadata, "behavior_evidence": False}
     try:
         output_text = backend.generate(request)
+    except LocalLLMProviderAdapterError as exc:
+        return LocalLLMAdapterResult(
+            request=request,
+            output_text="",
+            status="failed_closed",
+            reason=exc.reason_code,
+            metadata=result_metadata,
+        )
     except Exception as exc:  # injected-backend-only failure normalization
         return LocalLLMAdapterResult(
             request=request,

--- a/docs/evals/runs/20260604-alpha-local-llm-provider-integration-implementation/README.md
+++ b/docs/evals/runs/20260604-alpha-local-llm-provider-integration-implementation/README.md
@@ -1,0 +1,23 @@
+# Alpha Local LLM Provider Integration Implementation
+
+Lane: `ALPHA-LOCAL-LLM-PROVIDER-INTEGRATION-IMPLEMENTATION-001`
+
+Status: offline implementation record only.
+
+This directory records the default-off Ollama-style local HTTP adapter
+implementation behind the existing injected local LLM backend seam. The lane
+uses offline unit tests and static fixture-style dictionaries only.
+
+## Files in this record
+
+1. `implementation-summary.md`
+2. `offline-test-results.md`
+3. `failure-handling-coverage.md`
+4. `evidence-boundary.md`
+5. `implementation-preservation-checklist.md`
+6. `recommended-next-lane.md`
+
+## Label
+
+All outputs in this lane are labeled non-evidence or offline fixture evidence
+only. `behavior_evidence` remains `False`.

--- a/docs/evals/runs/20260604-alpha-local-llm-provider-integration-implementation/evidence-boundary.md
+++ b/docs/evals/runs/20260604-alpha-local-llm-provider-integration-implementation/evidence-boundary.md
@@ -1,0 +1,34 @@
+# Evidence Boundary
+
+Lane: `ALPHA-LOCAL-LLM-PROVIDER-INTEGRATION-IMPLEMENTATION-001`
+
+## What this lane may show
+
+This lane may show offline adapter implementation, request mapping, parser
+behavior against static fixtures, and fail-closed handling through injected test
+transports.
+
+## What this lane does not show
+
+This lane does not show:
+
+- local LLM behavior evidence;
+- Ollama behavior evidence;
+- hosted provider evidence;
+- `/v1/solve` readiness evidence;
+- dashboard preview readiness evidence;
+- runtime readiness evidence;
+- MVP validation;
+- production readiness;
+- Alpha quality evidence;
+- Alpha comparative advantage evidence;
+- broad plain-provider inferiority evidence;
+- Batch C readiness;
+- benchmark evidence;
+- billing evidence;
+- provider-orchestration evidence.
+
+## Label preservation
+
+All outputs remain non-evidence or offline fixture evidence only.
+`behavior_evidence` remains `False`.

--- a/docs/evals/runs/20260604-alpha-local-llm-provider-integration-implementation/failure-handling-coverage.md
+++ b/docs/evals/runs/20260604-alpha-local-llm-provider-integration-implementation/failure-handling-coverage.md
@@ -1,0 +1,25 @@
+# Failure-Handling Coverage
+
+Lane: `ALPHA-LOCAL-LLM-PROVIDER-INTEGRATION-IMPLEMENTATION-001`
+
+## Covered fail-closed cases
+
+| Case | Offline coverage |
+| --- | --- |
+| Default-off backend | Disabled Ollama-style backend returns `failed_closed` before transport. |
+| Timeout | Injected transport raises `TimeoutError`; adapter returns `ollama_timeout_non_evidence`. |
+| Connection failure | Injected transport raises `OSError`; adapter returns `ollama_connection_failure_non_evidence`. |
+| Backend HTTP error | Injected transport raises `HTTPError`; adapter returns `ollama_backend_error_non_evidence`. |
+| Malformed response | Static malformed fixture returns `malformed_ollama_response_non_evidence`. |
+| Empty output | Empty static fixture returns `empty_ollama_response_non_evidence`; existing stub empty output coverage is preserved. |
+| Prompt echo | Parser and backend tests reject echoed user prompt as `prompt_echo_non_evidence`. |
+| Missing contract | Existing adapter test preserves portable-contract missing-file fail-closed behavior before backend access. |
+| Empty contract | Existing adapter test preserves empty portable-contract fail-closed behavior before backend access. |
+| Fingerprint mismatch | Existing adapter test preserves SHA-256 mismatch fail-closed behavior before backend access. |
+| Stub backend error | Existing adapter test preserves injected-backend error normalization. |
+| Non-local endpoint | Backend validates local HTTP endpoints before transport when enabled. |
+
+## No fallback behavior
+
+Failure paths do not route to hosted providers, alternate backends, deterministic
+v91 fallback, `/v1/solve`, dashboard preview, or operator-test evidence paths.

--- a/docs/evals/runs/20260604-alpha-local-llm-provider-integration-implementation/implementation-preservation-checklist.md
+++ b/docs/evals/runs/20260604-alpha-local-llm-provider-integration-implementation/implementation-preservation-checklist.md
@@ -1,0 +1,18 @@
+# Implementation Preservation Checklist
+
+Lane: `ALPHA-LOCAL-LLM-PROVIDER-INTEGRATION-IMPLEMENTATION-001`
+
+- [x] Preserved `provider_mode="local_llm"`.
+- [x] Preserved `MODEL_PROVIDER=local` as smoke-only unless a later approved lane changes it.
+- [x] Preserved portable-contract path metadata.
+- [x] Preserved SHA-256 fingerprint metadata.
+- [x] Preserved `sha256` fingerprint algorithm metadata.
+- [x] Preserved system/user prompt separation.
+- [x] Kept backend default-off and no-provider-by-default.
+- [x] Kept tests offline with injected transports and static dictionaries.
+- [x] Avoided hosted providers, provider keys, runtime route changes,
+      `/v1/solve`, dashboard preview, operator evidence, Batch C materials,
+      backlog workbooks, billing artifacts, benchmark artifacts, and provider
+      orchestration artifacts.
+- [x] Kept `behavior_evidence=False`.
+- [x] Selected exactly one recommended next lane.

--- a/docs/evals/runs/20260604-alpha-local-llm-provider-integration-implementation/implementation-summary.md
+++ b/docs/evals/runs/20260604-alpha-local-llm-provider-integration-implementation/implementation-summary.md
@@ -1,0 +1,33 @@
+# Implementation Summary
+
+Lane: `ALPHA-LOCAL-LLM-PROVIDER-INTEGRATION-IMPLEMENTATION-001`
+
+## Implemented scope
+
+- Added a default-off Ollama-style local HTTP backend class behind the existing
+  `LocalLLMProviderBackend.generate(request)` injected-backend seam.
+- Added an offline request mapper for the Ollama `/api/chat` payload shape.
+- Added a static response parser for assistant text extraction from fixture-style
+  dictionaries.
+- Added stable fail-closed reason codes for backend-disabled, timeout,
+  connection failure, backend HTTP error, malformed response, empty response,
+  prompt echo, and non-local endpoint conditions.
+- Added package exports for the backend, parser, mapper, and adapter error type.
+- Added offline tests only; no provider, model, hosted service, `/v1/solve`, or
+  dashboard path was executed.
+
+## Preserved scope
+
+- `provider_mode="local_llm"` remains the local LLM adapter mode.
+- `MODEL_PROVIDER=local` remains a separate smoke-only label.
+- The portable contract path, SHA-256 fingerprint, fingerprint algorithm, and
+  system/user prompt separation are preserved.
+- The default backend path is inert unless explicitly enabled and supplied to
+  the injected seam.
+- `behavior_evidence` remains `False`.
+
+## Implementation label
+
+This implementation proves offline adapter mapping and parser behavior only.
+It does not promote fixture output into runtime, quality, comparison, billing,
+benchmark, orchestration, MVP, Batch C, or production conclusions.

--- a/docs/evals/runs/20260604-alpha-local-llm-provider-integration-implementation/offline-test-results.md
+++ b/docs/evals/runs/20260604-alpha-local-llm-provider-integration-implementation/offline-test-results.md
@@ -1,0 +1,26 @@
+# Offline Test Results
+
+Lane: `ALPHA-LOCAL-LLM-PROVIDER-INTEGRATION-IMPLEMENTATION-001`
+
+## Commands run
+
+- `python -m pytest -q tests/test_local_llm_provider_adapter.py`
+- `python -m pytest -q tests/test_local_llm_contract_consumption_proof.py`
+
+## Result summary
+
+The focused adapter tests passed with offline fixtures and injected transports.
+The contract-consumption proof tests passed and continued to use fake-client-only
+paths.
+
+## Network/provider boundary
+
+The default-off backend test monkeypatched the URL opener to fail if a socket was
+opened, then confirmed the disabled backend fails closed before transport. No
+live provider, local model, hosted service, `/v1/solve`, or dashboard path was
+called by these tests.
+
+## Evidence label
+
+The test outputs are non-evidence or offline fixture evidence only.
+`behavior_evidence` remains `False`.

--- a/docs/evals/runs/20260604-alpha-local-llm-provider-integration-implementation/recommended-next-lane.md
+++ b/docs/evals/runs/20260604-alpha-local-llm-provider-integration-implementation/recommended-next-lane.md
@@ -1,0 +1,18 @@
+# Recommended Next Lane
+
+Exactly one next lane is recommended:
+
+`ALPHA-LOCAL-LLM-PROVIDER-INTEGRATION-REVIEW-GATE-001`
+
+## Scope
+
+Review the offline implementation, fail-closed handling, evidence labels, and
+file-change boundary before any separate future authorization record considers
+local smoke execution.
+
+## Still blocked
+
+Live provider calls, hosted provider calls, local model calls, provider keys,
+runtime routing changes, `/v1/solve` changes, dashboard preview changes,
+operator evidence changes, Batch C work, and readiness or comparison claims
+remain blocked.

--- a/tests/test_local_llm_provider_adapter.py
+++ b/tests/test_local_llm_provider_adapter.py
@@ -2,14 +2,19 @@ from __future__ import annotations
 
 import sys
 from hashlib import sha256
+from urllib import error as urllib_error
 from pathlib import Path
 
 import pytest
 
 from alpha.local_llm.portable_contract import PortableContractError, load_portable_contract
 from alpha.local_llm.provider_adapter import (
+    LocalLLMProviderAdapterError,
+    OllamaLocalHTTPBackend,
     StubLocalLLMProviderBackend,
+    build_ollama_chat_payload,
     build_local_llm_adapter_request,
+    parse_ollama_assistant_text,
     run_local_llm_provider_adapter,
 )
 
@@ -161,3 +166,189 @@ def test_adapter_fails_closed_on_fingerprint_mismatch(tmp_path):
             contract_path=contract,
             expected_sha256="0" * 64,
         )
+
+
+def test_ollama_payload_mapping_preserves_system_user_separation():
+    user_prompt = "Map this adapter request to an Ollama chat payload."
+    request = build_local_llm_adapter_request(user_prompt)
+
+    payload = build_ollama_chat_payload(request, model="offline-fixture-model")
+
+    assert payload["model"] == "offline-fixture-model"
+    assert payload["stream"] is False
+    assert payload["options"] == {"temperature": 0}
+    assert payload["messages"] == [
+        {"role": "system", "content": request.system},
+        {"role": "user", "content": user_prompt},
+    ]
+    assert user_prompt not in payload["messages"][0]["content"]
+
+
+def test_ollama_backend_uses_injected_transport_for_offline_request_mapping():
+    captured: dict[str, object] = {}
+
+    def offline_transport(endpoint, payload, timeout_seconds):
+        captured["endpoint"] = endpoint
+        captured["payload"] = payload
+        captured["timeout_seconds"] = timeout_seconds
+        return {"message": {"role": "assistant", "content": "offline fixture response"}}
+
+    request = build_local_llm_adapter_request("Use only the injected transport.")
+    backend = OllamaLocalHTTPBackend(
+        endpoint="http://127.0.0.1:11434/api/chat",
+        model="offline-fixture-model",
+        timeout_seconds=1.25,
+        enabled=True,
+        transport=offline_transport,
+    )
+
+    output_text = backend.generate(request)
+
+    assert output_text == "offline fixture response"
+    assert captured["endpoint"] == "http://127.0.0.1:11434/api/chat"
+    assert captured["timeout_seconds"] == 1.25
+    assert captured["payload"] == {
+        "model": "offline-fixture-model",
+        "stream": False,
+        "messages": [
+            {"role": "system", "content": request.system},
+            {"role": "user", "content": request.user_prompt},
+        ],
+        "options": {"temperature": 0},
+    }
+
+
+def test_ollama_backend_default_off_makes_no_network_call(monkeypatch):
+    def forbidden_urlopen(*args, **kwargs):
+        raise AssertionError("default-off backend must not open a socket")
+
+    monkeypatch.setattr("alpha.local_llm.provider_adapter.urllib_request.urlopen", forbidden_urlopen)
+    backend = OllamaLocalHTTPBackend()
+
+    result = run_local_llm_provider_adapter(
+        "Default-off backend should fail closed before transport.", backend=backend
+    )
+
+    assert result.status == "failed_closed"
+    assert result.reason == "ollama_backend_disabled_non_evidence"
+    assert result.metadata["behavior_evidence"] is False
+
+
+def test_parse_ollama_successful_assistant_text_from_static_fixture():
+    fixture = {
+        "model": "offline-fixture-model",
+        "message": {"role": "assistant", "content": "Assistant text from fixture."},
+        "done": True,
+    }
+
+    assert parse_ollama_assistant_text(fixture) == "Assistant text from fixture."
+
+
+@pytest.mark.parametrize(
+    ("fixture", "reason_code"),
+    [
+        ({}, "malformed_ollama_response_non_evidence"),
+        ({"message": None}, "malformed_ollama_response_non_evidence"),
+        ({"message": {"role": "assistant"}}, "malformed_ollama_response_non_evidence"),
+        ({"message": {"role": "assistant", "content": ["not text"]}}, "malformed_ollama_response_non_evidence"),
+        ({"message": {"role": "assistant", "content": "   "}}, "empty_ollama_response_non_evidence"),
+    ],
+)
+def test_parse_ollama_fail_closed_for_malformed_or_empty_static_fixtures(fixture, reason_code):
+    with pytest.raises(LocalLLMProviderAdapterError) as exc_info:
+        parse_ollama_assistant_text(fixture)
+
+    assert exc_info.value.reason_code == reason_code
+
+
+def test_parse_ollama_fail_closed_for_prompt_echo_with_request_context():
+    request = build_local_llm_adapter_request("Do not echo fixture prompt.")
+
+    with pytest.raises(LocalLLMProviderAdapterError) as exc_info:
+        parse_ollama_assistant_text(
+            {"message": {"role": "assistant", "content": "Do not echo fixture prompt."}},
+            request=request,
+        )
+
+    assert exc_info.value.reason_code == "prompt_echo_non_evidence"
+
+
+@pytest.mark.parametrize(
+    ("transport_error", "expected_reason"),
+    [
+        (TimeoutError("offline timeout fixture"), "ollama_timeout_non_evidence"),
+        (OSError("offline connection failure fixture"), "ollama_connection_failure_non_evidence"),
+        (
+            urllib_error.HTTPError(
+                "http://127.0.0.1:11434/api/chat", 500, "fixture backend error", {}, None
+            ),
+            "ollama_backend_error_non_evidence",
+        ),
+    ],
+)
+def test_ollama_backend_fail_closed_for_transport_errors(transport_error, expected_reason):
+    def offline_transport(endpoint, payload, timeout_seconds):
+        raise transport_error
+
+    backend = OllamaLocalHTTPBackend(enabled=True, transport=offline_transport)
+
+    result = run_local_llm_provider_adapter("Exercise fail-closed transport.", backend=backend)
+
+    assert result.status == "failed_closed"
+    assert result.reason == expected_reason
+    assert result.output_text == ""
+    assert result.behavior_evidence is False
+
+
+def test_ollama_backend_fail_closed_for_malformed_response_from_transport():
+    backend = OllamaLocalHTTPBackend(enabled=True, transport=lambda endpoint, payload, timeout: {})
+
+    result = run_local_llm_provider_adapter("Malformed response should fail closed.", backend=backend)
+
+    assert result.status == "failed_closed"
+    assert result.reason == "malformed_ollama_response_non_evidence"
+    assert result.behavior_evidence is False
+
+
+def test_ollama_backend_fail_closed_for_empty_response_from_transport():
+    backend = OllamaLocalHTTPBackend(
+        enabled=True,
+        transport=lambda endpoint, payload, timeout: {"message": {"content": "   "}},
+    )
+
+    result = run_local_llm_provider_adapter("Empty response should fail closed.", backend=backend)
+
+    assert result.status == "failed_closed"
+    assert result.reason == "empty_ollama_response_non_evidence"
+    assert result.behavior_evidence is False
+
+
+def test_ollama_backend_fail_closed_for_backend_prompt_echo():
+    user_prompt = "Backend must not echo this prompt."
+    backend = OllamaLocalHTTPBackend(
+        enabled=True,
+        transport=lambda endpoint, payload, timeout: {"message": {"content": user_prompt}},
+    )
+
+    result = run_local_llm_provider_adapter(user_prompt, backend=backend)
+
+    assert result.status == "failed_closed"
+    assert result.reason == "prompt_echo_non_evidence"
+    assert result.behavior_evidence is False
+
+
+def test_ollama_backend_fail_closed_for_nonlocal_endpoint_before_transport():
+    def forbidden_transport(endpoint, payload, timeout_seconds):
+        raise AssertionError("non-local endpoint must fail before transport")
+
+    backend = OllamaLocalHTTPBackend(
+        endpoint="https://example.invalid/api/chat",
+        enabled=True,
+        transport=forbidden_transport,
+    )
+
+    result = run_local_llm_provider_adapter("Reject non-local endpoint.", backend=backend)
+
+    assert result.status == "failed_closed"
+    assert result.reason == "ollama_endpoint_not_local_non_evidence"
+    assert result.behavior_evidence is False


### PR DESCRIPTION
### Motivation
- Implement an offline-proof integration lane for a specific local LLM provider shape (Ollama-style local HTTP) behind the existing injected `LocalLLMProviderBackend` seam while keeping live provider execution blocked.
- Preserve adapter invariants such as `provider_mode="local_llm"`, `MODEL_PROVIDER=local` staying smoke-only, portable-contract path and SHA-256 fingerprint semantics, and explicit system/user prompt separation.
- Ensure fail-closed behavior and offline-only evidence labeling so parser/mapping work can be validated with injected transports and static fixtures without any network or model calls.

### Description
- Added a default-off `OllamaLocalHTTPBackend` behind the injected backend seam with an `enabled` flag and optional injected `transport` for offline testing, and implemented endpoint validation, transport/error normalization, and stable fail-closed reason codes. 
- Implemented `build_ollama_chat_payload(request, model=...)` to map `LocalLLMAdapterRequest` to an Ollama `/api/chat` JSON payload and `parse_ollama_assistant_text(response, request=None)` to extract and validate assistant text from static fixtures. 
- Introduced `LocalLLMProviderAdapterError` for structured non-evidence failure reasons and exported new symbols (`OllamaLocalHTTPBackend`, `build_ollama_chat_payload`, `parse_ollama_assistant_text`, `LocalLLMProviderAdapterError`) from the package. 
- Added offline unit tests exercising request mapping, injected-transport parsing, and fail-closed cases (timeout, connection failure, HTTP error, malformed response, empty output, prompt echo, missing/empty/fingerprint-mismatch contract, disabled backend, non-local endpoint) and recorded implementation docs under `docs/evals/runs/20260604-alpha-local-llm-provider-integration-implementation/`.

### Testing
- Ran focused tests with `python -m pytest -q tests/test_local_llm_provider_adapter.py` and `python -m pytest -q tests/test_local_llm_contract_consumption_proof.py`, and all tests completed successfully. 
- Exercised Ollama-specific tests via `python -m pytest -q tests/test_local_llm_provider_adapter.py -k ollama` which passed using injected transports and static fixtures. 
- Verified the default-off path without network by asserting the URL opener is not used and confirming `OllamaLocalHTTPBackend(enabled=False)` fails closed before any transport. 
- Confirmed evidence labels remain non-evidence/offline-fixture-only (`behavior_evidence` remains `False`) and no secrets, provider keys, or network calls were added during tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a224eb0aae08329aa392911c89a32af)