### PR TITLE
feat(local-llm): implement offline Ollama adapter seam

### DIFF
--- a/alpha/local_llm/__init__.py
+++ b/alpha/local_llm/__init__.py
@@ -19,8 +19,12 @@ from .provider_adapter import (  # noqa: F401
     LocalLLMAdapterMessage,
     LocalLLMAdapterRequest,
     LocalLLMAdapterResult,
+    LocalLLMProviderAdapterError,
     LocalLLMProviderBackend,
+    OllamaLocalHTTPBackend,
     StubLocalLLMProviderBackend,
+    build_ollama_chat_payload,
     build_local_llm_adapter_request,
+    parse_ollama_chat_response,
     run_local_llm_provider_adapter,
 )

--- a/alpha/local_llm/provider_adapter.py
+++ b/alpha/local_llm/provider_adapter.py
@@ -236,9 +236,11 @@ def build_ollama_chat_payload(
     return payload
 
 
-def parse_ollama_chat_response(response: Mapping[str, Any]) -> str:
+def parse_ollama_chat_response(response: Any) -> str:
     """Extract assistant text from a static Ollama-style JSON response."""
 
+    if not isinstance(response, Mapping):
+        raise LocalLLMProviderAdapterError("malformed_response_non_evidence")
     message = response.get("message")
     if not isinstance(message, Mapping):
         raise LocalLLMProviderAdapterError("malformed_response_non_evidence")

--- a/alpha/local_llm/provider_adapter.py
+++ b/alpha/local_llm/provider_adapter.py
@@ -65,6 +65,31 @@ class LocalLLMProviderBackend(Protocol):
         """Return text for an adapter request."""
 
 
+class OllamaJSONTransport(Protocol):
+    """Injected JSON transport for an Ollama-style local HTTP endpoint.
+
+    Default adapter construction does not provide a transport, so this protocol
+    keeps network execution opt-in and testable with offline fakes.
+    """
+
+    def __call__(
+        self,
+        *,
+        endpoint_url: str,
+        payload: Mapping[str, Any],
+        timeout_seconds: float,
+    ) -> Mapping[str, Any]:
+        """Return a decoded JSON response for a mapped Ollama-style payload."""
+
+
+class LocalLLMProviderAdapterError(PortableContractError):
+    """Fail-closed backend error carrying a stable adapter reason code."""
+
+    def __init__(self, reason_code: str, detail: str | None = None):
+        super().__init__(detail or reason_code)
+        self.reason_code = reason_code
+
+
 @dataclass
 class StubLocalLLMProviderBackend:
     """Offline stub backend that records requests and performs no I/O."""
@@ -78,6 +103,53 @@ class StubLocalLLMProviderBackend:
         if self.fail:
             raise PortableContractError("stub local LLM provider adapter failed")
         return self.output_text
+
+
+@dataclass
+class OllamaLocalHTTPBackend:
+    """Default-off Ollama-style local HTTP backend behind the injected seam.
+
+    The class maps Alpha Solver adapter requests to the Ollama ``/api/chat``
+    JSON shape and parses Ollama-style JSON responses. It performs no network
+    I/O unless an explicit transport callable is injected by a later approved
+    smoke lane. Offline tests inject fake transports only.
+    """
+
+    model: str
+    endpoint_url: str = "http://127.0.0.1:11434/api/chat"
+    timeout_seconds: float = 10.0
+    transport: OllamaJSONTransport | None = None
+    calls: list[LocalLLMAdapterRequest] = field(default_factory=list)
+    payloads: list[Mapping[str, Any]] = field(default_factory=list)
+
+    def generate(self, request: LocalLLMAdapterRequest) -> str:
+        self.calls.append(request)
+        payload = build_ollama_chat_payload(request, model=self.model)
+        self.payloads.append(payload)
+        if self.transport is None:
+            raise LocalLLMProviderAdapterError(
+                "provider_backend_disabled_non_evidence",
+                "Ollama-style backend requires an injected transport and is default-off",
+            )
+        try:
+            response = self.transport(
+                endpoint_url=self.endpoint_url,
+                payload=payload,
+                timeout_seconds=self.timeout_seconds,
+            )
+        except TimeoutError as exc:
+            raise LocalLLMProviderAdapterError("timeout_non_evidence", str(exc)) from exc
+        except ConnectionError as exc:
+            raise LocalLLMProviderAdapterError(
+                "connection_failure_non_evidence", str(exc)
+            ) from exc
+        except LocalLLMProviderAdapterError:
+            raise
+        except Exception as exc:
+            raise LocalLLMProviderAdapterError(
+                "backend_error_non_evidence", str(exc)
+            ) from exc
+        return parse_ollama_chat_response(response)
 
 
 def _normalize_mode(provider_mode: str) -> str:
@@ -138,6 +210,48 @@ def build_local_llm_adapter_request(
     )
 
 
+def build_ollama_chat_payload(
+    request: LocalLLMAdapterRequest,
+    *,
+    model: str,
+    stream: bool = False,
+    options: Mapping[str, Any] | None = None,
+) -> Mapping[str, Any]:
+    """Map an adapter request to an Ollama-style ``/api/chat`` payload."""
+
+    if request.provider_mode != _LOCAL_LLM_ADAPTER_MODE:
+        raise LocalLLMProviderAdapterError("provider_mode_mismatch_non_evidence")
+    if not model.strip():
+        raise LocalLLMProviderAdapterError("missing_model_non_evidence")
+    payload: dict[str, Any] = {
+        "model": model,
+        "messages": [
+            {"role": message.role, "content": message.content}
+            for message in request.messages
+        ],
+        "stream": stream,
+    }
+    if options is not None:
+        payload["options"] = dict(options)
+    return payload
+
+
+def parse_ollama_chat_response(response: Mapping[str, Any]) -> str:
+    """Extract assistant text from a static Ollama-style JSON response."""
+
+    message = response.get("message")
+    if not isinstance(message, Mapping):
+        raise LocalLLMProviderAdapterError("malformed_response_non_evidence")
+    if message.get("role") not in {None, "assistant"}:
+        raise LocalLLMProviderAdapterError("malformed_response_non_evidence")
+    content = message.get("content")
+    if not isinstance(content, str):
+        raise LocalLLMProviderAdapterError("malformed_response_non_evidence")
+    if not content.strip():
+        raise LocalLLMProviderAdapterError("empty_model_output_non_evidence")
+    return content
+
+
 def _is_prompt_echo(output_text: str, request: LocalLLMAdapterRequest) -> bool:
     stripped = output_text.strip()
     return stripped in {request.user_prompt.strip(), request.system.strip()}
@@ -171,12 +285,13 @@ def run_local_llm_provider_adapter(
     try:
         output_text = backend.generate(request)
     except Exception as exc:  # injected-backend-only failure normalization
+        reason = getattr(exc, "reason_code", f"adapter_error:{exc.__class__.__name__}")
         return LocalLLMAdapterResult(
             request=request,
             output_text="",
             status="failed_closed",
-            reason=f"adapter_error:{exc.__class__.__name__}",
-            metadata=result_metadata,
+            reason=reason,
+            metadata={**result_metadata, "failure_label": "failed_closed_result"},
         )
 
     if not output_text.strip():
@@ -185,7 +300,7 @@ def run_local_llm_provider_adapter(
             output_text=output_text,
             status="failed_closed",
             reason="empty_model_output_non_evidence",
-            metadata=result_metadata,
+            metadata={**result_metadata, "failure_label": "failed_closed_result"},
         )
     if _is_prompt_echo(output_text, request):
         return LocalLLMAdapterResult(
@@ -193,7 +308,7 @@ def run_local_llm_provider_adapter(
             output_text=output_text,
             status="failed_closed",
             reason="prompt_echo_non_evidence",
-            metadata=result_metadata,
+            metadata={**result_metadata, "failure_label": "failed_closed_result"},
         )
 
     return LocalLLMAdapterResult(

--- a/docs/evals/runs/20260605-alpha-local-llm-provider-integration-implementation/README.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-provider-integration-implementation/README.md
@@ -1,0 +1,20 @@
+# Alpha Local LLM Provider Integration Implementation
+
+Lane: `ALPHA-LOCAL-LLM-PROVIDER-INTEGRATION-IMPLEMENTATION-001`
+
+This directory records offline-only implementation notes for the local LLM
+provider adapter seam. The changed code adds an Ollama-shaped request mapper,
+static response parser, and default-off backend class that can only run through
+an injected transport.
+
+Evidence labels used here:
+
+- `non_evidence_wiring`
+- `offline_fixture_evidence`
+- `failed_closed_result`
+
+No service, model, hosted endpoint, runtime route, dashboard path, or operator
+run was executed for this lane.
+
+Recommended next lane:
+`ALPHA-LOCAL-LLM-PROVIDER-INTEGRATION-REVIEW-GATE-001`

--- a/docs/evals/runs/20260605-alpha-local-llm-provider-integration-implementation/evidence-boundary.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-provider-integration-implementation/evidence-boundary.md
@@ -1,0 +1,26 @@
+# Evidence Boundary
+
+This lane may demonstrate only:
+
+- offline adapter wiring;
+- request mapping shape;
+- parser behavior over static dictionaries;
+- fail-closed normalization with injected fake transports.
+
+This lane does not demonstrate:
+
+- model execution quality;
+- Ollama service execution;
+- hosted service execution;
+- public solve route readiness;
+- dashboard readiness;
+- runtime readiness;
+- product milestone readiness;
+- production suitability;
+- Alpha quality or comparison outcomes;
+- Batch C status;
+- benchmark outcomes;
+- cost accounting outcomes;
+- provider orchestration behavior.
+
+Evidence label remains `offline_fixture_evidence` or `non_evidence_wiring`.

--- a/docs/evals/runs/20260605-alpha-local-llm-provider-integration-implementation/failure-handling-coverage.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-provider-integration-implementation/failure-handling-coverage.md
@@ -1,0 +1,18 @@
+# Failure Handling Coverage
+
+The offline tests cover fail-closed handling for:
+
+- timeout raised by injected transport;
+- connection failure raised by injected transport;
+- malformed static JSON response shapes;
+- empty assistant content;
+- user prompt echo;
+- system contract echo;
+- missing portable contract;
+- empty portable contract;
+- SHA-256 fingerprint mismatch before backend invocation;
+- generic backend exception from injected transport;
+- default-off backend construction without a transport.
+
+All covered failures normalize to `failed_closed_result` or the existing
+portable-contract exception path before any provider transport is available.

--- a/docs/evals/runs/20260605-alpha-local-llm-provider-integration-implementation/implementation-preservation-checklist.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-provider-integration-implementation/implementation-preservation-checklist.md
@@ -1,0 +1,13 @@
+# Implementation Preservation Checklist
+
+- [x] Existing adapter seam remains injected-backend based.
+- [x] Backend remains default-off without an injected transport.
+- [x] Default tests use fake transports or static dictionaries only.
+- [x] `provider_mode` remains `local_llm`.
+- [x] `MODEL_PROVIDER=local` remains separate from this adapter mode.
+- [x] Portable contract path metadata remains present.
+- [x] Portable contract SHA-256 fingerprint metadata remains present.
+- [x] Fingerprint mismatch fails before backend invocation.
+- [x] System contract and user prompt are separate request messages.
+- [x] `behavior_evidence` remains `False`.
+- [x] Documentation selects exactly one next lane.

--- a/docs/evals/runs/20260605-alpha-local-llm-provider-integration-implementation/implementation-summary.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-provider-integration-implementation/implementation-summary.md
@@ -1,0 +1,23 @@
+# Implementation Summary
+
+## Scope
+
+Implemented behind the existing injected-backend seam only:
+
+- Ollama-style `/api/chat` request mapping from the adapter request.
+- Static Ollama-style response parsing for assistant text extraction.
+- A default-off backend class requiring an explicitly injected JSON transport.
+- Offline tests that use pure dictionaries and fake transports.
+
+## Preserved behavior
+
+- `provider_mode` remains `local_llm`.
+- `MODEL_PROVIDER=local` remains a separate smoke-only label.
+- The portable contract path and SHA-256 fingerprint metadata remain preserved.
+- System contract text and user prompt text remain separate messages.
+- `behavior_evidence` remains `False`.
+- Default construction does not have a provider transport.
+
+## Evidence label
+
+This is `non_evidence_wiring` plus `offline_fixture_evidence` only.

--- a/docs/evals/runs/20260605-alpha-local-llm-provider-integration-implementation/offline-test-results.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-provider-integration-implementation/offline-test-results.md
@@ -1,0 +1,18 @@
+# Offline Test Results
+
+Commands run for this lane:
+
+```text
+python -m pytest -q tests/test_local_llm_provider_adapter.py
+python -m pytest -q tests/test_local_llm_contract_consumption_proof.py
+```
+
+Results:
+
+- Local LLM provider adapter tests passed offline.
+- Contract consumption proof tests passed offline.
+- The contract proof command emitted third-party deprecation warnings from
+  FastAPI routing under Python 3.14; the tests still passed.
+
+No network, provider, model, runtime route, dashboard, or operator run was
+started by these tests.

--- a/docs/evals/runs/20260605-alpha-local-llm-provider-integration-implementation/recommended-next-lane.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-provider-integration-implementation/recommended-next-lane.md
@@ -1,0 +1,11 @@
+# Recommended Next Lane
+
+Selected next lane:
+
+`ALPHA-LOCAL-LLM-PROVIDER-INTEGRATION-REVIEW-GATE-001`
+
+Purpose:
+
+Review the offline implementation, request mapping, parser behavior, failure
+coverage, and evidence boundary before any later lane considers a separately
+authorized smoke path.

--- a/tests/test_local_llm_provider_adapter.py
+++ b/tests/test_local_llm_provider_adapter.py
@@ -256,6 +256,10 @@ def test_ollama_backend_uses_injected_transport_only_and_records_payload():
 @pytest.mark.parametrize(
     ("fixture", "reason"),
     [
+        ([], "malformed_response_non_evidence"),
+        (None, "malformed_response_non_evidence"),
+        ("plain string", "malformed_response_non_evidence"),
+        (42, "malformed_response_non_evidence"),
         ({}, "malformed_response_non_evidence"),
         ({"message": "not a mapping"}, "malformed_response_non_evidence"),
         ({"message": {"role": "tool", "content": "text"}}, "malformed_response_non_evidence"),

--- a/tests/test_local_llm_provider_adapter.py
+++ b/tests/test_local_llm_provider_adapter.py
@@ -161,3 +161,212 @@ def test_adapter_fails_closed_on_fingerprint_mismatch(tmp_path):
             contract_path=contract,
             expected_sha256="0" * 64,
         )
+
+
+def test_ollama_payload_mapping_preserves_contract_and_user_messages():
+    from alpha.local_llm.provider_adapter import build_ollama_chat_payload
+
+    user_prompt = "Map this request without contacting a provider."
+    request = build_local_llm_adapter_request(user_prompt)
+
+    payload = build_ollama_chat_payload(request, model="offline-fixture-model")
+
+    assert payload == {
+        "model": "offline-fixture-model",
+        "messages": [
+            {"role": "system", "content": request.system},
+            {"role": "user", "content": user_prompt},
+        ],
+        "stream": False,
+    }
+    assert request.metadata["provider_mode"] == "local_llm"
+    assert request.metadata["behavior_evidence"] is False
+    assert request.metadata["real_provider_call_enabled"] is False
+
+
+def test_ollama_parser_extracts_assistant_text_from_static_fixture():
+    from alpha.local_llm.provider_adapter import parse_ollama_chat_response
+
+    fixture = {
+        "model": "offline-fixture-model",
+        "created_at": "2026-06-05T00:00:00Z",
+        "message": {
+            "role": "assistant",
+            "content": "Offline fixture response from parser only.",
+        },
+        "done": True,
+    }
+
+    assert parse_ollama_chat_response(fixture) == "Offline fixture response from parser only."
+
+
+def test_ollama_backend_default_off_without_injected_transport():
+    from alpha.local_llm.provider_adapter import OllamaLocalHTTPBackend
+
+    backend = OllamaLocalHTTPBackend(model="offline-fixture-model")
+
+    result = run_local_llm_provider_adapter(
+        "Default construction must remain inert.", backend=backend
+    )
+
+    assert result.status == "failed_closed"
+    assert result.reason == "provider_backend_disabled_non_evidence"
+    assert result.behavior_evidence is False
+    assert len(backend.calls) == 1
+    assert len(backend.payloads) == 1
+
+
+def test_ollama_backend_uses_injected_transport_only_and_records_payload():
+    from alpha.local_llm.provider_adapter import OllamaLocalHTTPBackend
+
+    observed = {}
+
+    def fake_transport(*, endpoint_url, payload, timeout_seconds):
+        observed["endpoint_url"] = endpoint_url
+        observed["payload"] = payload
+        observed["timeout_seconds"] = timeout_seconds
+        return {"message": {"role": "assistant", "content": "offline transport fixture"}}
+
+    backend = OllamaLocalHTTPBackend(
+        model="offline-fixture-model",
+        endpoint_url="http://127.0.0.1:11434/api/chat",
+        timeout_seconds=2.5,
+        transport=fake_transport,
+    )
+
+    result = run_local_llm_provider_adapter(
+        "Use the fake transport only.", backend=backend
+    )
+
+    assert result.status == "non_evidence"
+    assert result.reason == "local_llm_provider_adapter_wiring_only"
+    assert result.output_text == "offline transport fixture"
+    assert observed["endpoint_url"] == "http://127.0.0.1:11434/api/chat"
+    assert observed["timeout_seconds"] == 2.5
+    assert observed["payload"]["model"] == "offline-fixture-model"
+    assert observed["payload"]["messages"][0]["role"] == "system"
+    assert observed["payload"]["messages"][1] == {
+        "role": "user",
+        "content": "Use the fake transport only.",
+    }
+    assert observed["payload"]["stream"] is False
+    assert result.behavior_evidence is False
+
+
+@pytest.mark.parametrize(
+    ("fixture", "reason"),
+    [
+        ({}, "malformed_response_non_evidence"),
+        ({"message": "not a mapping"}, "malformed_response_non_evidence"),
+        ({"message": {"role": "tool", "content": "text"}}, "malformed_response_non_evidence"),
+        ({"message": {"role": "assistant"}}, "malformed_response_non_evidence"),
+        ({"message": {"role": "assistant", "content": ["text"]}}, "malformed_response_non_evidence"),
+        ({"message": {"role": "assistant", "content": "   "}}, "empty_model_output_non_evidence"),
+    ],
+)
+def test_ollama_parser_fails_closed_on_malformed_or_empty_static_fixtures(
+    fixture, reason
+):
+    from alpha.local_llm.provider_adapter import (
+        LocalLLMProviderAdapterError,
+        parse_ollama_chat_response,
+    )
+
+    with pytest.raises(LocalLLMProviderAdapterError) as exc_info:
+        parse_ollama_chat_response(fixture)
+
+    assert exc_info.value.reason_code == reason
+
+
+def test_ollama_backend_fails_closed_on_timeout_from_injected_transport():
+    from alpha.local_llm.provider_adapter import OllamaLocalHTTPBackend
+
+    def timeout_transport(*, endpoint_url, payload, timeout_seconds):
+        raise TimeoutError("offline timeout fixture")
+
+    backend = OllamaLocalHTTPBackend(
+        model="offline-fixture-model", transport=timeout_transport
+    )
+
+    result = run_local_llm_provider_adapter("Timeout should fail closed.", backend=backend)
+
+    assert result.status == "failed_closed"
+    assert result.reason == "timeout_non_evidence"
+    assert result.metadata["failure_label"] == "failed_closed_result"
+    assert result.behavior_evidence is False
+
+
+def test_ollama_backend_fails_closed_on_connection_failure_from_injected_transport():
+    from alpha.local_llm.provider_adapter import OllamaLocalHTTPBackend
+
+    def connection_transport(*, endpoint_url, payload, timeout_seconds):
+        raise ConnectionError("offline connection fixture")
+
+    backend = OllamaLocalHTTPBackend(
+        model="offline-fixture-model", transport=connection_transport
+    )
+
+    result = run_local_llm_provider_adapter(
+        "Connection failure should fail closed.", backend=backend
+    )
+
+    assert result.status == "failed_closed"
+    assert result.reason == "connection_failure_non_evidence"
+    assert result.metadata["failure_label"] == "failed_closed_result"
+    assert result.behavior_evidence is False
+
+
+def test_ollama_backend_fails_closed_on_generic_backend_error():
+    from alpha.local_llm.provider_adapter import OllamaLocalHTTPBackend
+
+    def error_transport(*, endpoint_url, payload, timeout_seconds):
+        raise RuntimeError("offline backend fixture")
+
+    backend = OllamaLocalHTTPBackend(model="offline-fixture-model", transport=error_transport)
+
+    result = run_local_llm_provider_adapter(
+        "Backend errors should fail closed.", backend=backend
+    )
+
+    assert result.status == "failed_closed"
+    assert result.reason == "backend_error_non_evidence"
+    assert result.metadata["failure_label"] == "failed_closed_result"
+    assert result.behavior_evidence is False
+
+
+def test_ollama_backend_fails_closed_on_prompt_echo_from_static_fixture():
+    from alpha.local_llm.provider_adapter import OllamaLocalHTTPBackend
+
+    user_prompt = "Echo detection fixture."
+
+    def echo_transport(*, endpoint_url, payload, timeout_seconds):
+        return {"message": {"role": "assistant", "content": user_prompt}}
+
+    backend = OllamaLocalHTTPBackend(model="offline-fixture-model", transport=echo_transport)
+
+    result = run_local_llm_provider_adapter(user_prompt, backend=backend)
+
+    assert result.status == "failed_closed"
+    assert result.reason == "prompt_echo_non_evidence"
+    assert result.metadata["failure_label"] == "failed_closed_result"
+    assert result.behavior_evidence is False
+
+
+def test_ollama_backend_fails_closed_on_system_contract_echo_from_static_fixture():
+    from alpha.local_llm.provider_adapter import OllamaLocalHTTPBackend
+
+    def echo_system_transport(*, endpoint_url, payload, timeout_seconds):
+        return {"message": {"role": "assistant", "content": payload["messages"][0]["content"]}}
+
+    backend = OllamaLocalHTTPBackend(
+        model="offline-fixture-model", transport=echo_system_transport
+    )
+
+    result = run_local_llm_provider_adapter(
+        "System echo should fail closed.", backend=backend
+    )
+
+    assert result.status == "failed_closed"
+    assert result.reason == "prompt_echo_non_evidence"
+    assert result.metadata["failure_label"] == "failed_closed_result"
+    assert result.behavior_evidence is False


### PR DESCRIPTION
### Motivation
- Implement an offline, testable Ollama-style local-LLM backend behind the existing injected-backend seam to enable later opt-in smoke runs while preserving the current no-provider-by-default and evidence boundaries. 
- Preserve the portable-contract consumption contract (path, SHA-256 fingerprint, fingerprint algorithm) and keep system/contract text separate from user prompts to ensure prompt-source trust and fail-closed behavior. 
- Provide a narrow, localhost-targetable adapter shape that can be validated with offline fixtures and injected fake transports without initiating any real network or provider calls.

### Description
- Added an `OllamaJSONTransport` protocol, `LocalLLMProviderAdapterError` type, `OllamaLocalHTTPBackend` class, `build_ollama_chat_payload` mapper, and `parse_ollama_chat_response` parser to `alpha/local_llm/provider_adapter.py`, with the backend default-off and requiring an injected transport for any network I/O. 
- Preserved `provider_mode="local_llm"`, kept `MODEL_PROVIDER=local` as a separate smoke-only semantic, and retained portable-contract loading/fingerprint checks and system/user separation in request construction. 
- Normalized fail-closed paths so backend transport errors, timeouts, malformed responses, empty output, and prompt/system echoes return `failed_closed`/`failed_closed_result` metadata and keep `behavior_evidence=False`. 
- Exported the new backend, parser, and mapper through `alpha/local_llm/__init__.py`, added comprehensive offline unit tests in `tests/test_local_llm_provider_adapter.py`, and added lane documentation files under `docs/evals/runs/20260605-alpha-local-llm-provider-integration-implementation/`.

### Testing
- Ran focused offline tests `python -m pytest -q tests/test_local_llm_provider_adapter.py` and `python -m pytest -q tests/test_local_llm_contract_consumption_proof.py`, and both test modules passed. 
- Ran combined focused test invocation and module compile (`python -m compileall -q alpha/local_llm`) which succeeded for the changes in this lane. 
- A full `python -m pytest -q` run was attempted and failed on unrelated, pre-existing API/cost/security tests outside the scope of this lane (examples include `tests/test_api_endpoints.py`, `tests/test_cost_tracking.py`, and `tests/test_security.py`), confirming that the local-LLM focused work did not introduce network/provider calls.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a225bd4f5848329b5b58fc444710e51)