### PR TITLE
docs(evals): decide second-pass next step and preflight Batch C packet

### DIFF
--- a/docs/evals/runs/20260605-alpha-batch-c-packet-prep-decision/README.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-packet-prep-decision/README.md
@@ -1,0 +1,38 @@
+# Batch C Packet-Prep Decision
+
+Lane ID: `ALPHA-BATCH-C-PACKET-PREP-DECISION-001`
+
+Status: completed as a docs-only packet-prep decision.
+
+## Purpose
+
+This packet decides the final next lane after the portable-surface readiness review.
+
+## Source files reviewed
+
+- `docs/evals/runs/20260605-alpha-limited-operator-test-second-pass-results-import/`
+- `docs/evals/runs/20260605-alpha-limited-operator-test-second-pass-interpretation/`
+- `docs/evals/runs/20260604-alpha-limited-operator-test-prompt-contract-simulation-results-import-clean/`
+- `docs/evals/runs/20260604-alpha-limited-operator-test-interpretation/`
+- `docs/evals/runs/20260604-alpha-portable-contract-followup-refinement/`
+- `docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision/`
+- `alpha_solver_portable.py`
+- `tests/test_alpha_minimal_behavior_contract.py`
+- `docs/evals/runs/20260605-alpha-limited-operator-test-second-pass-post-results-decision/`
+- `docs/evals/runs/20260605-alpha-portable-surface-readiness-review/`
+
+## Packet files
+
+- `packet-prep-decision.md`
+- `packet-prep-allowed-scope.md`
+- `packet-prep-blockers.md`
+- `required-inputs-for-frozen-packet.md`
+- `evidence-boundary.md`
+- `selected-next-lane.md`
+- `packet-decision-preservation-checklist.md`
+
+## Final selected next lane
+
+`ALPHA-BATCH-C-FROZEN-PACKET-PREP-001`
+
+This PR does not create that lane or the frozen packet.

--- a/docs/evals/runs/20260605-alpha-batch-c-packet-prep-decision/evidence-boundary.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-packet-prep-decision/evidence-boundary.md
@@ -1,0 +1,24 @@
+# Evidence Boundary
+
+Lane ID: `ALPHA-BATCH-C-PACKET-PREP-DECISION-001`
+
+## Boundary statement
+
+This packet is a portable-contract manual simulation decision packet only.
+
+## Evidence used
+
+- Imported first-pass and second-pass mechanical totals.
+- First-pass and second-pass interpretation packets.
+- Portable-contract follow-up refinement packet.
+- Second-pass post-results decision packet.
+- Portable-surface readiness review packet.
+- Inspect-only review of portable contract and focused test artifacts.
+
+## Evidence not used
+
+This packet does not use product/runtime evidence, endpoint evidence, local model evidence, provider evidence, benchmark evidence, MVP proof, production approval, Batch C execution approval, Alpha comparative proof, broad plain-provider comparison proof, unredacted transcript content, operator maps, assignment maps, or planning-ledger status changes.
+
+## Boundary-preserving conclusion
+
+The packet supports selecting a future frozen-packet-prep lane only. It does not create the packet and does not authorize execution.

--- a/docs/evals/runs/20260605-alpha-batch-c-packet-prep-decision/packet-decision-preservation-checklist.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-packet-prep-decision/packet-decision-preservation-checklist.md
@@ -1,0 +1,18 @@
+# Packet Decision Preservation Checklist
+
+Lane ID: `ALPHA-BATCH-C-PACKET-PREP-DECISION-001`
+
+- [x] Decided exactly one final next lane.
+- [x] Selected `ALPHA-BATCH-C-FROZEN-PACKET-PREP-001`.
+- [x] Did not create the selected next lane.
+- [x] Did not create a frozen Batch C packet.
+- [x] Preserved first-pass total as 270 / 300.
+- [x] Preserved first-pass dispositions as Keep 5 and Refine 5.
+- [x] Preserved second-pass total as 283 / 300.
+- [x] Preserved second-pass dispositions as Keep 8, Refine 2, Reject 0.
+- [x] Preserved second-pass stop-condition counts as no 9 and yes 1.
+- [x] Preserved LT2-005 corrected arithmetic as 25 / 30.
+- [x] Did not rescore.
+- [x] Did not infer missing evidence.
+- [x] Kept execution blocked.
+- [x] Kept the evidence boundary narrow.

--- a/docs/evals/runs/20260605-alpha-batch-c-packet-prep-decision/packet-prep-allowed-scope.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-packet-prep-decision/packet-prep-allowed-scope.md
@@ -1,0 +1,18 @@
+# Packet-Prep Allowed Scope
+
+Lane ID: `ALPHA-BATCH-C-PACKET-PREP-DECISION-001`
+
+## Allowed future scope for `ALPHA-BATCH-C-FROZEN-PACKET-PREP-001`
+
+A future frozen-packet-prep lane may:
+
+- assemble a frozen Batch C packet from already preserved documentation evidence;
+- copy preserved totals without rescoring;
+- list residual risks from LT2-001, LT2-005, and LT2-009;
+- state that execution remains blocked;
+- include a narrow non-claims section;
+- identify required approvals or inputs before execution can be considered in a later lane.
+
+## Not allowed in this PR
+
+This PR does not create the frozen packet, execute Batch C, call endpoints, call providers, call local models, edit ratings, rescore tasks, update planning ledgers, or modify prior evidence packets.

--- a/docs/evals/runs/20260605-alpha-batch-c-packet-prep-decision/packet-prep-blockers.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-packet-prep-decision/packet-prep-blockers.md
@@ -1,0 +1,23 @@
+# Packet-Prep Blockers
+
+Lane ID: `ALPHA-BATCH-C-PACKET-PREP-DECISION-001`
+
+## Blocker assessment
+
+| item | blocks frozen packet preparation? | reason |
+| --- | --- | --- |
+| LT2-001 process-style lead-in | No | It is a preserved residual defect that can be disclosed in the frozen packet. |
+| LT2-005 process-style lead-in | No | It is a preserved residual defect that can be disclosed in the frozen packet. |
+| LT2-009 wording drift | No | It requires conservative claim wording, not another packet-prep blocker. |
+| Missing execution evidence | No for packet preparation; yes for execution | The future packet may preserve that execution remains blocked. |
+
+## Work still blocked
+
+- Batch C execution
+- endpoint use
+- provider calls
+- local model calls
+- source or test changes
+- planning-ledger updates
+- rating edits or rescoring
+- prior evidence-packet edits

--- a/docs/evals/runs/20260605-alpha-batch-c-packet-prep-decision/packet-prep-decision.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-packet-prep-decision/packet-prep-decision.md
@@ -1,0 +1,32 @@
+# Packet-Prep Decision
+
+Lane ID: `ALPHA-BATCH-C-PACKET-PREP-DECISION-001`
+
+## Decision question
+
+Do the residual second-pass defects block preparing a frozen Batch C packet?
+
+## Decision
+
+No. The residual process-style lead-ins and the minor wording drift do not block preparing a frozen Batch C packet in a separately authorized lane, as long as the frozen packet preserves the evidence boundary, records the residual risks, and keeps execution blocked.
+
+## Final selected next lane
+
+`ALPHA-BATCH-C-FROZEN-PACKET-PREP-001`
+
+This is the only final selected next lane in the joint PR packet.
+
+## Alternative not selected
+
+`ALPHA-PORTABLE-CONTRACT-MICRO-REFINEMENT-PROCESS-LEADINS-001` is not selected now because the remaining process-style lead-ins are bounded packet risks rather than packet-preparation blockers.
+
+## Preserved totals
+
+| item | preserved value |
+| --- | --- |
+| First-pass grand mechanical rating sum | 270 / 300 |
+| First-pass dispositions | Keep: 5; Refine: 5 |
+| Second-pass grand mechanical rating sum | 283 / 300 |
+| Second-pass dispositions | Keep: 8; Refine: 2; Reject: 0 |
+| Second-pass stop-condition status | no: 9; yes: 1 |
+| LT2-005 corrected arithmetic total | 25 / 30 |

--- a/docs/evals/runs/20260605-alpha-batch-c-packet-prep-decision/required-inputs-for-frozen-packet.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-packet-prep-decision/required-inputs-for-frozen-packet.md
@@ -1,0 +1,16 @@
+# Required Inputs for Frozen Packet
+
+Lane ID: `ALPHA-BATCH-C-PACKET-PREP-DECISION-001`
+
+A future `ALPHA-BATCH-C-FROZEN-PACKET-PREP-001` lane should include these inputs without changing their values:
+
+- First-pass manual simulation total: 270 / 300.
+- First-pass dispositions: Keep 5 and Refine 5.
+- Second-pass manual simulation total: 283 / 300.
+- Second-pass dispositions: Keep 8, Refine 2, Reject 0.
+- Second-pass stop-condition status counts: no 9 and yes 1.
+- LT2-005 arithmetic correction: 25 / 30.
+- Residual defects: LT2-001 process-style lead-in, LT2-005 process-style lead-in, and LT2-009 minor wording drift.
+- Improved patterns: reduced accidental `standard:` artifacts, reduced unnecessary `Replacement:` labels, and correct LT2-006 stop-condition handling.
+- Explicit execution block.
+- Explicit evidence-boundary and non-claims language.

--- a/docs/evals/runs/20260605-alpha-batch-c-packet-prep-decision/selected-next-lane.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-packet-prep-decision/selected-next-lane.md
@@ -1,0 +1,17 @@
+# Selected Next Lane
+
+Lane ID: `ALPHA-BATCH-C-PACKET-PREP-DECISION-001`
+
+## Final selected next lane
+
+`ALPHA-BATCH-C-FROZEN-PACKET-PREP-001`
+
+This is the only final selected next lane in this joint PR packet.
+
+## Lane not created here
+
+The selected lane is not created in this PR. No frozen Batch C packet is created here.
+
+## Scope guard
+
+The selected lane is packet-preparation work only. Batch C execution remains blocked unless a later separately authorized lane changes that scope.

--- a/docs/evals/runs/20260605-alpha-limited-operator-test-second-pass-post-results-decision/README.md
+++ b/docs/evals/runs/20260605-alpha-limited-operator-test-second-pass-post-results-decision/README.md
@@ -1,0 +1,40 @@
+# Second-Pass Post-Results Decision
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-SECOND-PASS-POST-RESULTS-DECISION-001`
+
+Status: completed as an evidence-bounded manual simulation decision packet.
+
+## Purpose
+
+This packet decides the next lane after the second-pass manual prompt-contract simulation results import and interpretation.
+
+## Source files reviewed
+
+- `docs/evals/runs/20260605-alpha-limited-operator-test-second-pass-results-import/`
+- `docs/evals/runs/20260605-alpha-limited-operator-test-second-pass-interpretation/`
+- `docs/evals/runs/20260604-alpha-limited-operator-test-prompt-contract-simulation-results-import-clean/`
+- `docs/evals/runs/20260604-alpha-limited-operator-test-interpretation/`
+- `docs/evals/runs/20260604-alpha-portable-contract-followup-refinement/`
+- `docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision/`
+- `alpha_solver_portable.py`
+- `tests/test_alpha_minimal_behavior_contract.py`
+
+## Packet files
+
+- `decision-summary.md`
+- `decision-options.md`
+- `selected-next-lane.md`
+- `residual-defects.md`
+- `blocked-work.md`
+- `evidence-boundary.md`
+- `decision-preservation-checklist.md`
+
+## Boundary
+
+This packet does not provide product/runtime evidence, endpoint evidence, local model evidence, provider evidence, benchmark evidence, MVP proof, production approval, Batch C execution approval, Alpha comparative proof, or broad plain-provider comparison proof.
+
+## Outcome
+
+Selected next lane: `ALPHA-PORTABLE-SURFACE-READINESS-REVIEW-001`.
+
+That readiness-review lane is documented as completed in this joint PR packet.

--- a/docs/evals/runs/20260605-alpha-limited-operator-test-second-pass-post-results-decision/blocked-work.md
+++ b/docs/evals/runs/20260605-alpha-limited-operator-test-second-pass-post-results-decision/blocked-work.md
@@ -1,0 +1,20 @@
+# Blocked Work
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-SECOND-PASS-POST-RESULTS-DECISION-001`
+
+The following work remains blocked by this packet:
+
+- source code changes
+- test code changes
+- runtime, routing, model, API, or provider-file changes
+- endpoint use
+- provider calls
+- local model calls
+- Batch C execution
+- frozen Batch C packet creation
+- planning-ledger updates
+- rating edits
+- rescoring
+- result imports
+- edits to prior evidence packets
+- product, production, benchmark, MVP, comparative, endpoint, provider, local model, or Batch C execution claims

--- a/docs/evals/runs/20260605-alpha-limited-operator-test-second-pass-post-results-decision/decision-options.md
+++ b/docs/evals/runs/20260605-alpha-limited-operator-test-second-pass-post-results-decision/decision-options.md
@@ -1,0 +1,31 @@
+# Decision Options
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-SECOND-PASS-POST-RESULTS-DECISION-001`
+
+## Option A: portable-surface readiness review for packet preparation
+
+Status: selected.
+
+Rationale: this option is bounded to a review of whether the portable surface is ready to prepare a Batch C packet. It uses the preserved first-pass and second-pass manual simulation evidence without changing ratings or claiming execution approval.
+
+## Option B: micro-refinement for process-style lead-ins
+
+Status: not selected for this post-results decision.
+
+Rationale: process-style lead-ins remain on LT2-001 and LT2-005, but the second-pass packet records eight Keep dispositions, zero Reject dispositions, improved answer-shape patterns, and correct stop-condition handling. The next safest step is to review whether these residual defects block packet preparation before creating another refinement lane.
+
+## Option C: prepare a frozen Batch C packet immediately
+
+Status: not selected here.
+
+Rationale: this post-results packet is not the packet-prep decision. A separate readiness-review and packet-prep decision must preserve the evidence boundary before any frozen packet-prep lane is selected.
+
+## Option D: start Batch C execution
+
+Status: blocked and not selected.
+
+Rationale: execution is outside this packet. The evidence is manual prompt-contract simulation evidence only.
+
+## Exactly one selected post-results lane
+
+`ALPHA-PORTABLE-SURFACE-READINESS-REVIEW-001`

--- a/docs/evals/runs/20260605-alpha-limited-operator-test-second-pass-post-results-decision/decision-preservation-checklist.md
+++ b/docs/evals/runs/20260605-alpha-limited-operator-test-second-pass-post-results-decision/decision-preservation-checklist.md
@@ -1,0 +1,15 @@
+# Decision Preservation Checklist
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-SECOND-PASS-POST-RESULTS-DECISION-001`
+
+- [x] Preserved first-pass total as 270 / 300.
+- [x] Preserved first-pass dispositions as Keep 5 and Refine 5.
+- [x] Preserved second-pass total as 283 / 300.
+- [x] Preserved second-pass dispositions as Keep 8, Refine 2, Reject 0.
+- [x] Preserved second-pass stop-condition counts as no 9 and yes 1.
+- [x] Preserved LT2-005 corrected arithmetic as 25 / 30.
+- [x] Did not rescore.
+- [x] Did not infer missing evidence.
+- [x] Selected exactly one post-results next lane.
+- [x] Kept Batch C execution blocked.
+- [x] Kept the evidence boundary narrow.

--- a/docs/evals/runs/20260605-alpha-limited-operator-test-second-pass-post-results-decision/decision-summary.md
+++ b/docs/evals/runs/20260605-alpha-limited-operator-test-second-pass-post-results-decision/decision-summary.md
@@ -1,0 +1,36 @@
+# Decision Summary
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-SECOND-PASS-POST-RESULTS-DECISION-001`
+
+## Decision
+
+Selected next lane:
+
+`ALPHA-PORTABLE-SURFACE-READINESS-REVIEW-001`
+
+This packet selects exactly one post-results next lane. The selected lane is completed in this same joint documentation PR under `docs/evals/runs/20260605-alpha-portable-surface-readiness-review/`.
+
+## Why this lane is selected
+
+The first-pass manual simulation produced 270 / 300 with five Keep dispositions and five Refine dispositions. The first-pass decision selected a narrow portable-contract follow-up refinement.
+
+The second-pass manual simulation then produced 283 / 300 with eight Keep dispositions, two Refine dispositions, and zero Reject dispositions. The second-pass interpretation reports reduced accidental `standard:` artifacts, reduced unnecessary `Replacement:` labels, and correct stop-condition handling on LT2-006.
+
+The remaining defects are limited to two visible process-style lead-ins and one minor claim-boundary wording drift. Those observations support a readiness review for packet preparation only, not execution or broader claims.
+
+## Preserved imported results
+
+These values are copied from the imported result packets and interpretation packets. They are not rescored.
+
+| item | preserved value |
+| --- | --- |
+| First-pass grand mechanical rating sum | 270 / 300 |
+| First-pass dispositions | Keep: 5; Refine: 5 |
+| Second-pass grand mechanical rating sum | 283 / 300 |
+| Second-pass dispositions | Keep: 8; Refine: 2; Reject: 0 |
+| Second-pass stop-condition status | no: 9; yes: 1 |
+| LT2-005 corrected arithmetic total | 25 / 30 |
+
+## What this decision does not do
+
+This decision does not edit ratings, rescore tasks, infer missing evidence, change source code, change tests, use endpoints, call providers, call local models, update planning ledgers, start Batch C, create a frozen Batch C packet, or make broad claims.

--- a/docs/evals/runs/20260605-alpha-limited-operator-test-second-pass-post-results-decision/evidence-boundary.md
+++ b/docs/evals/runs/20260605-alpha-limited-operator-test-second-pass-post-results-decision/evidence-boundary.md
@@ -1,0 +1,19 @@
+# Evidence Boundary
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-SECOND-PASS-POST-RESULTS-DECISION-001`
+
+## Boundary statement
+
+This decision is based on portable-contract manual simulation evidence only.
+
+## Evidence used
+
+The decision uses the imported first-pass and second-pass mechanical totals, the interpretation packets, the portable-contract follow-up refinement packet, and inspect-only review of the portable contract and focused test file.
+
+## Evidence not used
+
+This packet does not use product/runtime evidence, endpoint evidence, local model evidence, provider evidence, benchmark evidence, MVP proof, production approval, Batch C execution approval, Alpha comparative proof, broad plain-provider comparison proof, unredacted transcript content, operator maps, assignment maps, or planning-ledger status changes.
+
+## Boundary-preserving conclusion
+
+Within this boundary, the evidence supports only a documentation readiness review for Batch C packet preparation. It does not support execution approval or broader claims.

--- a/docs/evals/runs/20260605-alpha-limited-operator-test-second-pass-post-results-decision/residual-defects.md
+++ b/docs/evals/runs/20260605-alpha-limited-operator-test-second-pass-post-results-decision/residual-defects.md
@@ -1,0 +1,23 @@
+# Residual Defects
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-SECOND-PASS-POST-RESULTS-DECISION-001`
+
+## Preserved second-pass residual defects
+
+The residual defects are copied from the second-pass interpretation and are not rescored.
+
+| task | preserved defect |
+| --- | --- |
+| LT2-001 | Visible process-style lead-in before the requested reviewer comment. |
+| LT2-005 | Visible process-style lead-in before the requested compact prompt template. |
+| LT2-009 | Minor claim-boundary wording drift around comparative-evidence wording. |
+
+## Preserved improved patterns
+
+- Accidental `standard:` artifacts were reduced in the second pass.
+- Unnecessary `Replacement:` labels were reduced in the second pass.
+- LT2-006 correctly handled missing raw artifact reconstruction as a stop condition.
+
+## Decision impact
+
+The residual defects are real and preserved. They are treated as inputs to the portable-surface readiness review, not as grounds for rescoring or changing imported totals.

--- a/docs/evals/runs/20260605-alpha-limited-operator-test-second-pass-post-results-decision/selected-next-lane.md
+++ b/docs/evals/runs/20260605-alpha-limited-operator-test-second-pass-post-results-decision/selected-next-lane.md
@@ -1,0 +1,15 @@
+# Selected Next Lane
+
+Lane ID: `ALPHA-LIMITED-OPERATOR-TEST-SECOND-PASS-POST-RESULTS-DECISION-001`
+
+## Selected lane
+
+`ALPHA-PORTABLE-SURFACE-READINESS-REVIEW-001`
+
+## Completion note
+
+The selected readiness-review lane is completed in this same joint PR packet. It is represented by `docs/evals/runs/20260605-alpha-portable-surface-readiness-review/`.
+
+## Scope of selection
+
+This selection only authorizes and records a documentation review of portable-surface readiness for Batch C packet preparation. It does not authorize Batch C execution, endpoint use, provider calls, local model calls, source changes, test changes, result imports, rating edits, or planning-ledger updates.

--- a/docs/evals/runs/20260605-alpha-portable-surface-readiness-review/README.md
+++ b/docs/evals/runs/20260605-alpha-portable-surface-readiness-review/README.md
@@ -1,0 +1,34 @@
+# Portable-Surface Readiness Review
+
+Lane ID: `ALPHA-PORTABLE-SURFACE-READINESS-REVIEW-001`
+
+Status: completed as a docs-only readiness review for Batch C packet preparation.
+
+## Purpose
+
+This packet reviews whether the portable surface is ready for Batch C packet-preparation work only.
+
+## Source files reviewed
+
+- `docs/evals/runs/20260605-alpha-limited-operator-test-second-pass-results-import/`
+- `docs/evals/runs/20260605-alpha-limited-operator-test-second-pass-interpretation/`
+- `docs/evals/runs/20260604-alpha-limited-operator-test-prompt-contract-simulation-results-import-clean/`
+- `docs/evals/runs/20260604-alpha-limited-operator-test-interpretation/`
+- `docs/evals/runs/20260604-alpha-portable-contract-followup-refinement/`
+- `docs/evals/runs/20260604-alpha-limited-operator-test-post-results-decision/`
+- `alpha_solver_portable.py`
+- `tests/test_alpha_minimal_behavior_contract.py`
+
+## Packet files
+
+- `readiness-review-summary.md`
+- `positive-signals.md`
+- `residual-risks.md`
+- `readiness-scope-boundary.md`
+- `batch-c-preconditions.md`
+- `selected-next-lane.md`
+- `readiness-preservation-checklist.md`
+
+## Review result
+
+The portable surface is ready for Batch C packet-preparation decision work only. Batch C execution remains blocked.

--- a/docs/evals/runs/20260605-alpha-portable-surface-readiness-review/batch-c-preconditions.md
+++ b/docs/evals/runs/20260605-alpha-portable-surface-readiness-review/batch-c-preconditions.md
@@ -1,0 +1,23 @@
+# Batch C Preconditions
+
+Lane ID: `ALPHA-PORTABLE-SURFACE-READINESS-REVIEW-001`
+
+## Preconditions satisfied for packet preparation
+
+- First-pass imported total preserved: 270 / 300.
+- First-pass dispositions preserved: Keep 5 and Refine 5.
+- Second-pass imported total preserved: 283 / 300.
+- Second-pass dispositions preserved: Keep 8, Refine 2, Reject 0.
+- Second-pass stop-condition counts preserved: no 9 and yes 1.
+- LT2-005 corrected arithmetic preserved: 25 / 30.
+- Remaining defects are identified and bounded.
+- Batch C execution remains blocked.
+- Frozen packet creation is left to a separately authorized next lane.
+
+## Preconditions not satisfied for execution
+
+- No execution authorization is provided by this packet.
+- No endpoint evidence is introduced.
+- No provider evidence is introduced.
+- No local model evidence is introduced.
+- No benchmark evidence is introduced.

--- a/docs/evals/runs/20260605-alpha-portable-surface-readiness-review/positive-signals.md
+++ b/docs/evals/runs/20260605-alpha-portable-surface-readiness-review/positive-signals.md
@@ -1,0 +1,18 @@
+# Positive Signals
+
+Lane ID: `ALPHA-PORTABLE-SURFACE-READINESS-REVIEW-001`
+
+## Preserved positive signals
+
+- The second-pass total improved from 270 / 300 to 283 / 300.
+- Dispositions shifted from Keep 5 and Refine 5 to Keep 8, Refine 2, and Reject 0.
+- Accidental `standard:` artifacts were reduced in the second pass.
+- Unnecessary `Replacement:` labels were reduced in the second pass.
+- LT2-006 correctly treated missing raw artifact reconstruction as a stop condition.
+- Evidence-boundary, no-invention, and stop-condition dimensions were preserved at 30 / 30 in the second-pass mechanical totals.
+- The portable contract contains explicit output-format contamination guard language and compact low-headroom guidance.
+- The focused minimal-behavior contract tests inspect claim boundaries, stop-condition examples, output-format suppression examples, and non-runtime boundary wording.
+
+## Review impact
+
+These signals are enough to proceed to a packet-prep decision lane. They are not execution evidence.

--- a/docs/evals/runs/20260605-alpha-portable-surface-readiness-review/readiness-preservation-checklist.md
+++ b/docs/evals/runs/20260605-alpha-portable-surface-readiness-review/readiness-preservation-checklist.md
@@ -1,0 +1,15 @@
+# Readiness Preservation Checklist
+
+Lane ID: `ALPHA-PORTABLE-SURFACE-READINESS-REVIEW-001`
+
+- [x] Reviewed readiness only for Batch C packet preparation.
+- [x] Did not claim execution approval.
+- [x] Did not claim product/runtime approval.
+- [x] Did not claim endpoint approval.
+- [x] Did not claim provider or local model results.
+- [x] Did not claim benchmark evidence.
+- [x] Did not claim Alpha comparative proof.
+- [x] Preserved all imported ratings and totals exactly.
+- [x] Did not rescore.
+- [x] Did not infer missing evidence.
+- [x] Selected exactly one next decision lane.

--- a/docs/evals/runs/20260605-alpha-portable-surface-readiness-review/readiness-review-summary.md
+++ b/docs/evals/runs/20260605-alpha-portable-surface-readiness-review/readiness-review-summary.md
@@ -1,0 +1,25 @@
+# Readiness Review Summary
+
+Lane ID: `ALPHA-PORTABLE-SURFACE-READINESS-REVIEW-001`
+
+## Review question
+
+Is the portable surface ready only for Batch C packet preparation?
+
+## Review result
+
+Yes, for packet-preparation decision work only. The residual process-style lead-ins and minor wording drift do not block preparing a frozen packet in a separately authorized lane, provided that the frozen packet preserves these residual risks and keeps execution blocked.
+
+## Evidence considered
+
+- First-pass manual simulation: 270 / 300; Keep 5; Refine 5.
+- First-pass post-results decision: selected portable-contract follow-up refinement.
+- Portable-contract follow-up refinement: targeted output-format contamination and preserved boundary wording.
+- Second-pass manual simulation: 283 / 300; Keep 8; Refine 2; Reject 0.
+- Second-pass stop-condition status: no 9; yes 1.
+- LT2-005 arithmetic correction: 25 / 30.
+- Inspect-only review of `alpha_solver_portable.py` and `tests/test_alpha_minimal_behavior_contract.py` for the portable prompt-contract surface and focused preservation tests.
+
+## Interpretation limit
+
+The review result is limited to packet-preparation readiness. It is not an execution approval and does not establish broader system claims.

--- a/docs/evals/runs/20260605-alpha-portable-surface-readiness-review/readiness-scope-boundary.md
+++ b/docs/evals/runs/20260605-alpha-portable-surface-readiness-review/readiness-scope-boundary.md
@@ -1,0 +1,29 @@
+# Readiness Scope Boundary
+
+Lane ID: `ALPHA-PORTABLE-SURFACE-READINESS-REVIEW-001`
+
+## In scope
+
+- Review of manual prompt-contract simulation evidence.
+- Review of the portable prompt-contract surface.
+- Review of focused minimal-behavior contract tests as repository artifacts.
+- Decision on whether Batch C packet-preparation decision work may proceed.
+
+## Out of scope
+
+- source code changes
+- test code changes
+- runtime execution
+- endpoint use
+- provider calls
+- local model calls
+- Batch C execution
+- frozen Batch C packet creation
+- planning-ledger updates
+- rating edits or rescoring
+- edits to prior evidence packets
+- broad product, production, MVP, benchmark, endpoint, provider, local model, comparative, or Batch C execution claims
+
+## Boundary conclusion
+
+The review supports packet-preparation decision work only.

--- a/docs/evals/runs/20260605-alpha-portable-surface-readiness-review/residual-risks.md
+++ b/docs/evals/runs/20260605-alpha-portable-surface-readiness-review/residual-risks.md
@@ -1,0 +1,15 @@
+# Residual Risks
+
+Lane ID: `ALPHA-PORTABLE-SURFACE-READINESS-REVIEW-001`
+
+## Preserved residual risks
+
+| risk | source-limited description | packet-prep impact |
+| --- | --- | --- |
+| Process-style lead-ins | LT2-001 and LT2-005 included visible lead-in text before the requested artifact. | Must be preserved as a residual risk in any frozen packet. Does not block packet preparation. |
+| Minor claim-boundary wording drift | LT2-009 included minor comparative-evidence wording drift. | Must be kept out of stronger claims in any frozen packet. Does not block packet preparation. |
+| Evidence type limit | Manual simulation evidence is not runtime or benchmark evidence. | Any packet must label evidence type narrowly and keep execution blocked. |
+
+## Risk conclusion
+
+The risks require explicit packet constraints, but they do not require another micro-refinement before packet preparation.

--- a/docs/evals/runs/20260605-alpha-portable-surface-readiness-review/selected-next-lane.md
+++ b/docs/evals/runs/20260605-alpha-portable-surface-readiness-review/selected-next-lane.md
@@ -1,0 +1,15 @@
+# Selected Next Lane
+
+Lane ID: `ALPHA-PORTABLE-SURFACE-READINESS-REVIEW-001`
+
+## Selected lane
+
+`ALPHA-BATCH-C-PACKET-PREP-DECISION-001`
+
+## Completion note
+
+The selected packet-prep decision lane is completed in this same joint PR packet under `docs/evals/runs/20260605-alpha-batch-c-packet-prep-decision/`.
+
+## Scope of selection
+
+This selection authorizes only a documentation decision about whether to prepare a frozen Batch C packet in a future lane. It does not create that packet and does not authorize execution.


### PR DESCRIPTION
### Motivation

- Record a bounded post-results decision after the second-pass manual prompt-contract simulation to determine the single next lane. 
- Assess whether the portable prompt-contract surface is ready only for Batch C packet-preparation decision work and document that determination. 
- Decide whether residual second-pass defects block preparing a frozen Batch C packet while preserving evidence boundaries and blocking execution. 

### Description

- Add docs-only decision packets under `docs/evals/runs/20260605-alpha-limited-operator-test-second-pass-post-results-decision/`, `docs/evals/runs/20260605-alpha-portable-surface-readiness-review/`, and `docs/evals/runs/20260605-alpha-batch-c-packet-prep-decision/` with the required files (`README.md` plus the specified decision, summary, boundary, checklist, and selected-next-lane artifacts). 
- Selected and recorded one post-results next lane: `ALPHA-PORTABLE-SURFACE-READINESS-REVIEW-001`, completed that readiness review in this joint PR, then ran the packet-prep decision which selects `ALPHA-BATCH-C-FROZEN-PACKET-PREP-001` as the single final next lane without creating the lane or a frozen packet. 
- Preserved mechanical totals and imported ratings exactly (first-pass `270 / 300`, first-pass dispositions `Keep 5, Refine 5`; second-pass `283 / 300`, dispositions `Keep 8, Refine 2, Reject 0`; stop-condition counts `no 9 / yes 1`; `LT2-005 = 25 / 30`). 
- Maintain the narrow evidence boundary and blocked-work list: no source/test/runtime/provider/local-model changes, no rescoring, no frozen-packet creation, and no Batch C execution approval. 

### Testing

- Ran `python -m pytest -q tests/test_alpha_minimal_behavior_contract.py` and the test suite passed. 
- Confirmed changed files are only under the three allowed folders with `git diff --name-only HEAD` and an allowed-path check. 
- Searched changed files for forbidden claim phrases with `rg` and `git diff`-based checks and found none in staged changes. 
- Verified preserved totals and final selected next-lane occurrences via content searches and an automated required-file presence check, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2265fbd78483298fdb0b6bc2360a47)