### PR TITLE
fix(local-llm): fail closed on non-local endpoints

### DIFF
--- a/alpha/local_llm/provider_adapter.py
+++ b/alpha/local_llm/provider_adapter.py
@@ -10,7 +10,9 @@ only and is never behavior, runtime, or readiness evidence.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from ipaddress import ip_address
 from typing import Any, Mapping, Protocol
+from urllib.parse import urlsplit
 
 from .portable_contract import PortableContract, PortableContractError, load_portable_contract
 
@@ -123,6 +125,7 @@ class OllamaLocalHTTPBackend:
     payloads: list[Mapping[str, Any]] = field(default_factory=list)
 
     def generate(self, request: LocalLLMAdapterRequest) -> str:
+        endpoint_url = validate_ollama_local_endpoint(self.endpoint_url)
         self.calls.append(request)
         payload = build_ollama_chat_payload(request, model=self.model)
         self.payloads.append(payload)
@@ -133,7 +136,7 @@ class OllamaLocalHTTPBackend:
             )
         try:
             response = self.transport(
-                endpoint_url=self.endpoint_url,
+                endpoint_url=endpoint_url,
                 payload=payload,
                 timeout_seconds=self.timeout_seconds,
             )
@@ -160,6 +163,31 @@ def _normalize_mode(provider_mode: str) -> str:
             "MODEL_PROVIDER=local remains smoke-only"
         )
     return normalized
+
+
+def _is_loopback_hostname(hostname: str | None) -> bool:
+    if hostname is None:
+        return False
+    normalized = hostname.strip().lower().rstrip(".")
+    if normalized == "localhost":
+        return True
+    try:
+        return ip_address(normalized).is_loopback
+    except ValueError:
+        return False
+
+
+def validate_ollama_local_endpoint(endpoint_url: str) -> str:
+    """Return a valid local endpoint URL or fail closed before transport use."""
+
+    if not isinstance(endpoint_url, str) or not endpoint_url.strip():
+        raise LocalLLMProviderAdapterError("endpoint_not_local_non_evidence")
+    parsed = urlsplit(endpoint_url.strip())
+    if parsed.scheme not in {"http", "https"}:
+        raise LocalLLMProviderAdapterError("endpoint_not_local_non_evidence")
+    if not _is_loopback_hostname(parsed.hostname):
+        raise LocalLLMProviderAdapterError("endpoint_not_local_non_evidence")
+    return endpoint_url.strip()
 
 
 def build_local_llm_adapter_request(

--- a/alpha/local_llm/provider_adapter.py
+++ b/alpha/local_llm/provider_adapter.py
@@ -187,6 +187,10 @@ def validate_ollama_local_endpoint(endpoint_url: str) -> str:
         raise LocalLLMProviderAdapterError("endpoint_not_local_non_evidence")
     if not _is_loopback_hostname(parsed.hostname):
         raise LocalLLMProviderAdapterError("endpoint_not_local_non_evidence")
+    try:
+        parsed.port
+    except ValueError:
+        raise LocalLLMProviderAdapterError("endpoint_not_local_non_evidence") from None
     return endpoint_url.strip()
 
 

--- a/docs/evals/runs/20260605-alpha-local-llm-endpoint-locality-hardening/README.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-endpoint-locality-hardening/README.md
@@ -1,0 +1,35 @@
+# Local LLM Endpoint Locality Hardening
+
+Lane ID: `ALPHA-LOCAL-LLM-ENDPOINT-LOCALITY-HARDENING-001`
+
+Status: implementation and offline test lane for endpoint-locality fail-closed handling.
+
+## Purpose
+
+Harden the Ollama-style local LLM adapter so non-local endpoint URLs fail closed before any injected transport can be invoked.
+
+This closes the smoke-progression blocker recorded by PR #303: a future smoke lane must not be able to pass a hosted or non-loopback endpoint to the injected transport path.
+
+## Scope
+
+This lane updates the local LLM adapter seam and focused offline tests only. It does not run smoke and does not call a real provider, model, endpoint, `/v1/solve`, or dashboard preview path.
+
+## Files changed
+
+- `alpha/local_llm/provider_adapter.py`
+- `tests/test_local_llm_provider_adapter.py`
+- docs under this directory
+- docs under `docs/evals/runs/20260605-alpha-local-llm-endpoint-locality-review-gate/`
+- docs under `docs/evals/runs/20260605-alpha-local-llm-smoke-authorization-refresh/`
+
+## Evidence boundary
+
+This lane proves endpoint-locality hardening and offline adapter fail-closed behavior only.
+
+It is not local LLM behavior evidence, Ollama behavior evidence, hosted provider evidence, `/v1/solve` readiness evidence, dashboard preview readiness evidence, runtime readiness evidence, MVP validation, production readiness, Alpha quality evidence, Alpha superiority evidence, broad plain-provider inferiority evidence, Batch C readiness, benchmark success, exact billing evidence, or provider orchestration evidence.
+
+## Recommended next lane
+
+`ALPHA-LOCAL-LLM-SMOKE-TEST-EXECUTION-001`
+
+The recommendation remains conditional on review and merge of this hardening lane. Smoke execution still requires explicit operator approval, localhost/loopback endpoint values, exact model name, finite timeout, and raw artifact preservation.

--- a/docs/evals/runs/20260605-alpha-local-llm-endpoint-locality-hardening/endpoint-validation-rules.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-endpoint-locality-hardening/endpoint-validation-rules.md
@@ -26,7 +26,13 @@ Examples covered by offline tests:
 - `http://192.168.1.25:11434/api/chat`
 - `ftp://127.0.0.1:11434/api/chat`
 - `http:///api/chat`
+- `http://127.0.0.1:bad/api/chat` (loopback host with invalid port)
+- `http://localhost:bad/api/chat` (loopback host with invalid port)
+- `http://[::1]:bad/api/chat` (loopback host with invalid port)
+- `http://127.0.0.1:99999/api/chat` (loopback host with out-of-range port)
 - empty endpoint string
+
+A loopback hostname with a malformed or out-of-range port still fails closed: `urlsplit()` defers port validation, so the validator forces a `parsed.port` read and rejects the endpoint before transport invocation.
 
 ## Boundary
 

--- a/docs/evals/runs/20260605-alpha-local-llm-endpoint-locality-hardening/endpoint-validation-rules.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-endpoint-locality-hardening/endpoint-validation-rules.md
@@ -1,0 +1,33 @@
+# Endpoint Validation Rules
+
+Lane ID: `ALPHA-LOCAL-LLM-ENDPOINT-LOCALITY-HARDENING-001`
+
+## Allowed endpoints
+
+Allowed endpoints must use an HTTP-family scheme and a loopback hostname.
+
+Examples covered by offline tests:
+
+- `http://127.0.0.1:11434/api/chat`
+- `http://localhost:11434/api/chat`
+- `http://[::1]:11434/api/chat`
+
+## Rejected endpoints
+
+Rejected endpoints fail closed before transport invocation with:
+
+`endpoint_not_local_non_evidence`
+
+Examples covered by offline tests:
+
+- `https://example.com/api/chat`
+- `http://example.com/api/chat`
+- `https://api.openai.com/v1/chat/completions`
+- `http://192.168.1.25:11434/api/chat`
+- `ftp://127.0.0.1:11434/api/chat`
+- `http:///api/chat`
+- empty endpoint string
+
+## Boundary
+
+This validation only proves endpoint-locality enforcement in the offline adapter seam. It does not prove local model behavior, Ollama service behavior, runtime readiness, or provider orchestration.

--- a/docs/evals/runs/20260605-alpha-local-llm-endpoint-locality-hardening/evidence-boundary.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-endpoint-locality-hardening/evidence-boundary.md
@@ -1,0 +1,27 @@
+# Evidence Boundary
+
+Lane ID: `ALPHA-LOCAL-LLM-ENDPOINT-LOCALITY-HARDENING-001`
+
+This PR proves endpoint-locality hardening and offline adapter fail-closed behavior only.
+
+It is not:
+
+- local LLM behavior evidence
+- Ollama behavior evidence
+- hosted provider evidence
+- `/v1/solve` readiness evidence
+- dashboard preview readiness evidence
+- runtime readiness evidence
+- MVP validation
+- production readiness
+- Alpha quality evidence
+- Alpha superiority evidence
+- broad plain-provider inferiority evidence
+- Batch C readiness
+- benchmark success
+- exact billing evidence
+- provider orchestration evidence
+
+## Non-actions
+
+No smoke execution, local model call, hosted provider call, live network call, provider key, runtime routing change, `/v1/solve` change, dashboard preview change, operator-test evidence change, Batch C work, readiness claim, validation claim, superiority claim, benchmark claim, billing claim, provider-orchestration claim, production claim, or local-LLM-quality claim is introduced.

--- a/docs/evals/runs/20260605-alpha-local-llm-endpoint-locality-hardening/fail-closed-coverage.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-endpoint-locality-hardening/fail-closed-coverage.md
@@ -1,0 +1,26 @@
+# Fail-Closed Coverage
+
+Lane ID: `ALPHA-LOCAL-LLM-ENDPOINT-LOCALITY-HARDENING-001`
+
+## New endpoint-locality coverage
+
+| Case | Expected result |
+| --- | --- |
+| Hosted HTTPS endpoint | `endpoint_not_local_non_evidence`; transport not invoked |
+| Hosted HTTP endpoint | `endpoint_not_local_non_evidence`; transport not invoked |
+| OpenAI-style hosted endpoint | `endpoint_not_local_non_evidence`; transport not invoked |
+| Private LAN IP endpoint | `endpoint_not_local_non_evidence`; transport not invoked |
+| Non-HTTP scheme | `endpoint_not_local_non_evidence`; transport not invoked |
+| Missing host / malformed URL | `endpoint_not_local_non_evidence`; transport not invoked |
+| Empty endpoint | `endpoint_not_local_non_evidence`; transport not invoked |
+| 127.0.0.1 loopback endpoint | allowed to reach injected fake transport |
+| localhost loopback endpoint | allowed to reach injected fake transport |
+| IPv6 loopback endpoint | allowed to reach injected fake transport |
+
+## Preserved fail-closed coverage
+
+This lane preserves existing fail-closed handling for malformed response, non-object response, empty output, prompt echo, system echo, timeout, connection failure, backend error, disabled backend, missing contract, empty contract, and fingerprint mismatch.
+
+## Boundary
+
+The coverage is offline only. No real provider, model, network, runtime route, dashboard path, or smoke execution is used.

--- a/docs/evals/runs/20260605-alpha-local-llm-endpoint-locality-hardening/fail-closed-coverage.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-endpoint-locality-hardening/fail-closed-coverage.md
@@ -12,6 +12,7 @@ Lane ID: `ALPHA-LOCAL-LLM-ENDPOINT-LOCALITY-HARDENING-001`
 | Private LAN IP endpoint | `endpoint_not_local_non_evidence`; transport not invoked |
 | Non-HTTP scheme | `endpoint_not_local_non_evidence`; transport not invoked |
 | Missing host / malformed URL | `endpoint_not_local_non_evidence`; transport not invoked |
+| Loopback host with invalid / out-of-range port | `endpoint_not_local_non_evidence`; transport not invoked |
 | Empty endpoint | `endpoint_not_local_non_evidence`; transport not invoked |
 | 127.0.0.1 loopback endpoint | allowed to reach injected fake transport |
 | localhost loopback endpoint | allowed to reach injected fake transport |

--- a/docs/evals/runs/20260605-alpha-local-llm-endpoint-locality-hardening/hardening-preservation-checklist.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-endpoint-locality-hardening/hardening-preservation-checklist.md
@@ -1,0 +1,17 @@
+# Hardening Preservation Checklist
+
+Lane ID: `ALPHA-LOCAL-LLM-ENDPOINT-LOCALITY-HARDENING-001`
+
+- [x] Added endpoint-locality validation before transport invocation.
+- [x] Rejected non-loopback / non-local endpoints with `endpoint_not_local_non_evidence`.
+- [x] Added tests proving hosted endpoints fail closed without transport invocation.
+- [x] Preserved loopback endpoint support for injected fake transports.
+- [x] Preserved backend default-off behavior.
+- [x] Preserved no-provider-by-default behavior.
+- [x] Preserved `provider_mode="local_llm"`.
+- [x] Preserved `MODEL_PROVIDER=local` as separate smoke-only semantics.
+- [x] Preserved portable-contract path, SHA-256 fingerprint, fingerprint algorithm, and system/user separation.
+- [x] Preserved `behavior_evidence=False`.
+- [x] Preserved offline/non-evidence labels.
+- [x] Did not run smoke.
+- [x] Did not call Ollama, a local model, a hosted provider, `/v1/solve`, dashboard preview, or Batch C.

--- a/docs/evals/runs/20260605-alpha-local-llm-endpoint-locality-hardening/hardening-summary.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-endpoint-locality-hardening/hardening-summary.md
@@ -1,0 +1,24 @@
+# Hardening Summary
+
+Lane ID: `ALPHA-LOCAL-LLM-ENDPOINT-LOCALITY-HARDENING-001`
+
+## Summary
+
+This lane adds endpoint-locality validation to the Ollama-style local HTTP backend before any injected transport can be invoked.
+
+The adapter now fails closed with `endpoint_not_local_non_evidence` when an endpoint is missing, malformed, uses a disallowed scheme, or resolves to a non-loopback / non-local hostname.
+
+## Implemented behavior
+
+- Validates endpoint URLs before request payload creation and before transport invocation.
+- Allows loopback endpoints such as `http://127.0.0.1:11434/api/chat`, `http://localhost:11434/api/chat`, and `http://[::1]:11434/api/chat`.
+- Rejects hosted and non-loopback endpoints before transport invocation.
+- Keeps backend default-off when no transport is injected.
+- Preserves `provider_mode="local_llm"`.
+- Preserves `MODEL_PROVIDER=local` as separate smoke-only semantics.
+- Preserves portable-contract path, SHA-256 fingerprint, fingerprint algorithm, and system/user prompt separation.
+- Preserves `behavior_evidence=False`.
+
+## Non-actions
+
+No live smoke, local model call, hosted provider call, `/v1/solve` call, runtime routing change, dashboard preview change, Batch C work, or provider key is introduced.

--- a/docs/evals/runs/20260605-alpha-local-llm-endpoint-locality-hardening/offline-test-results.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-endpoint-locality-hardening/offline-test-results.md
@@ -1,0 +1,23 @@
+# Offline Test Results
+
+Lane ID: `ALPHA-LOCAL-LLM-ENDPOINT-LOCALITY-HARDENING-001`
+
+## Commands to run for this lane
+
+```text
+python -m pytest -q tests/test_local_llm_provider_adapter.py
+python -m pytest -q tests/test_local_llm_contract_consumption_proof.py
+python -m compileall -q alpha/local_llm
+```
+
+## Expected coverage
+
+- Rejected hosted endpoints fail closed before injected transport invocation.
+- Allowed loopback endpoints reach injected fake transport.
+- Behavior evidence remains false.
+- Existing local LLM adapter tests continue to pass.
+- Contract-consumption proof tests continue to pass.
+
+## Boundary
+
+These are offline tests only. They do not run Ollama, a local model, a hosted provider, `/v1/solve`, dashboard preview, Batch C, benchmark, billing, or provider orchestration.

--- a/docs/evals/runs/20260605-alpha-local-llm-endpoint-locality-hardening/recommended-next-lane.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-endpoint-locality-hardening/recommended-next-lane.md
@@ -1,0 +1,15 @@
+# Recommended Next Lane
+
+Lane ID: `ALPHA-LOCAL-LLM-ENDPOINT-LOCALITY-HARDENING-001`
+
+## Recommendation
+
+`ALPHA-LOCAL-LLM-SMOKE-TEST-EXECUTION-001`
+
+## Rationale
+
+Endpoint-locality fail-closed handling is now implemented for the injected Ollama-style backend seam. The future smoke execution lane remains separately gated and must use only operator-approved loopback endpoint values, exact model name, finite timeout, raw artifact preservation, and sanitized import afterward.
+
+## Not authorized here
+
+This lane does not execute smoke and does not create local LLM behavior evidence, Ollama behavior evidence, `/v1/solve` readiness evidence, runtime readiness evidence, production readiness, benchmark success, or provider orchestration evidence.

--- a/docs/evals/runs/20260605-alpha-local-llm-endpoint-locality-review-gate/README.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-endpoint-locality-review-gate/README.md
@@ -1,0 +1,23 @@
+# Local LLM Endpoint Locality Review Gate
+
+Lane ID: `ALPHA-LOCAL-LLM-ENDPOINT-LOCALITY-REVIEW-GATE-001`
+
+Status: docs-only review gate for endpoint-locality hardening.
+
+## Review result
+
+Endpoint-locality hardening is acceptable for moving to a separately authorized smoke execution lane.
+
+## Reviewed scope
+
+- Endpoint validation occurs before injected transport invocation.
+- Hosted and non-loopback endpoints fail closed with `endpoint_not_local_non_evidence`.
+- Loopback endpoints can reach injected fake transport.
+- Existing fail-closed behavior remains preserved.
+- Evidence labels remain offline/non-evidence.
+
+## Recommended next lane
+
+`ALPHA-LOCAL-LLM-SMOKE-TEST-EXECUTION-001`
+
+This review does not execute smoke and does not make behavior, quality, readiness, benchmark, runtime, production, or provider-orchestration claims.

--- a/docs/evals/runs/20260605-alpha-local-llm-endpoint-locality-review-gate/evidence-boundary-review.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-endpoint-locality-review-gate/evidence-boundary-review.md
@@ -1,0 +1,30 @@
+# Evidence Boundary Review
+
+Lane ID: `ALPHA-LOCAL-LLM-ENDPOINT-LOCALITY-REVIEW-GATE-001`
+
+This review is limited to endpoint-locality hardening and offline adapter fail-closed behavior.
+
+It may state only that:
+
+- endpoint validation occurs before injected transport invocation;
+- non-local endpoint URLs fail closed with `endpoint_not_local_non_evidence`;
+- loopback endpoint URLs can reach injected fake transports in offline tests;
+- smoke progression may move to a separate operator execution lane after merge and GS.
+
+It is not:
+
+- local LLM behavior evidence
+- Ollama behavior evidence
+- hosted provider evidence
+- `/v1/solve` readiness evidence
+- dashboard preview readiness evidence
+- runtime readiness evidence
+- MVP validation
+- production readiness
+- Alpha quality evidence
+- Alpha superiority evidence
+- broad plain-provider inferiority evidence
+- Batch C readiness
+- benchmark success
+- exact billing evidence
+- provider orchestration evidence

--- a/docs/evals/runs/20260605-alpha-local-llm-endpoint-locality-review-gate/recommended-next-lane.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-endpoint-locality-review-gate/recommended-next-lane.md
@@ -1,0 +1,13 @@
+# Recommended Next Lane
+
+Lane ID: `ALPHA-LOCAL-LLM-ENDPOINT-LOCALITY-REVIEW-GATE-001`
+
+## Recommendation
+
+`ALPHA-LOCAL-LLM-SMOKE-TEST-EXECUTION-001`
+
+## Boundary
+
+The next lane may execute the already prepared local smoke test only if the operator explicitly approves it and uses a localhost / loopback endpoint, exact local model name, finite timeout, raw artifact preservation, and sanitized import afterward.
+
+The next lane must not claim local LLM quality, Ollama behavior, hosted provider behavior, `/v1/solve` readiness, runtime readiness, production readiness, benchmark success, provider orchestration, or Alpha superiority.

--- a/docs/evals/runs/20260605-alpha-local-llm-endpoint-locality-review-gate/review-checklist.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-endpoint-locality-review-gate/review-checklist.md
@@ -1,0 +1,15 @@
+# Review Checklist
+
+Lane ID: `ALPHA-LOCAL-LLM-ENDPOINT-LOCALITY-REVIEW-GATE-001`
+
+- [x] Endpoint validation occurs before injected transport invocation.
+- [x] Hosted URLs fail closed before transport invocation.
+- [x] Non-loopback IP endpoints fail closed before transport invocation.
+- [x] Malformed and empty endpoints fail closed before transport invocation.
+- [x] 127.0.0.1 loopback endpoint can reach injected fake transport.
+- [x] localhost loopback endpoint can reach injected fake transport.
+- [x] IPv6 loopback endpoint can reach injected fake transport.
+- [x] Stable reason code is `endpoint_not_local_non_evidence`.
+- [x] `behavior_evidence` remains false.
+- [x] No real network, provider, local model, `/v1/solve`, dashboard, or Batch C work was added.
+- [x] Evidence boundary remains offline/non-evidence only.

--- a/docs/evals/runs/20260605-alpha-local-llm-endpoint-locality-review-gate/review-preservation-checklist.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-endpoint-locality-review-gate/review-preservation-checklist.md
@@ -1,0 +1,12 @@
+# Review Preservation Checklist
+
+Lane ID: `ALPHA-LOCAL-LLM-ENDPOINT-LOCALITY-REVIEW-GATE-001`
+
+- [x] Review remains docs-only.
+- [x] Review is limited to endpoint-locality hardening.
+- [x] Review does not execute smoke.
+- [x] Review does not call a local model, hosted provider, or network endpoint.
+- [x] Review does not change runtime routing, `/v1/solve`, dashboard preview, or Batch C.
+- [x] Review confirms endpoint validation before injected transport invocation.
+- [x] Review keeps evidence labels offline/non-evidence only.
+- [x] Review selects exactly one next lane.

--- a/docs/evals/runs/20260605-alpha-local-llm-endpoint-locality-review-gate/review-summary.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-endpoint-locality-review-gate/review-summary.md
@@ -1,0 +1,19 @@
+# Review Summary
+
+Lane ID: `ALPHA-LOCAL-LLM-ENDPOINT-LOCALITY-REVIEW-GATE-001`
+
+## Result
+
+The endpoint-locality blocker recorded in PR #303 has been addressed at the offline adapter seam.
+
+## Findings
+
+- `OllamaLocalHTTPBackend.generate()` validates endpoint locality before payload construction and before injected transport invocation.
+- Non-local endpoints fail closed with `endpoint_not_local_non_evidence`.
+- Tests cover hosted endpoint examples, non-loopback IPs, malformed endpoint values, and loopback allow paths.
+- Allowed loopback endpoints reach only injected fake transports in offline tests.
+- The lane does not run a real local model or hosted provider.
+
+## Boundary
+
+This is a review of offline implementation and tests only. It does not authorize any claim upgrade beyond endpoint-locality hardening.

--- a/docs/evals/runs/20260605-alpha-local-llm-endpoint-locality-review-gate/smoke-progression-decision.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-endpoint-locality-review-gate/smoke-progression-decision.md
@@ -1,0 +1,25 @@
+# Smoke Progression Decision
+
+Lane ID: `ALPHA-LOCAL-LLM-ENDPOINT-LOCALITY-REVIEW-GATE-001`
+
+## Decision
+
+Endpoint-locality hardening is sufficient to allow a separately authorized local smoke execution lane to be prepared and run by the operator.
+
+## Selected next lane
+
+`ALPHA-LOCAL-LLM-SMOKE-TEST-EXECUTION-001`
+
+## Conditions retained
+
+The future smoke lane must still require:
+
+- explicit operator approval;
+- localhost / loopback endpoint only;
+- exact operator-supplied model name;
+- finite timeout;
+- no hosted provider fallback;
+- no provider keys or access material;
+- raw artifact preservation;
+- sanitized result import afterward;
+- no readiness, quality, benchmark, production, `/v1/solve`, runtime, or provider-orchestration claims.

--- a/docs/evals/runs/20260605-alpha-local-llm-smoke-authorization-refresh/README.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-smoke-authorization-refresh/README.md
@@ -1,0 +1,17 @@
+# Local LLM Smoke Authorization Refresh
+
+Lane ID: `ALPHA-LOCAL-LLM-SMOKE-AUTHORIZATION-REFRESH-001`
+
+Status: docs-only authorization refresh after endpoint-locality hardening.
+
+## Decision
+
+Endpoint-locality hardening allows the local LLM track to proceed to a separately authorized smoke execution lane.
+
+## Selected next lane
+
+`ALPHA-LOCAL-LLM-SMOKE-TEST-EXECUTION-001`
+
+## Execution boundary
+
+This PR does not execute smoke. The future smoke lane still requires explicit operator approval, localhost / loopback endpoint, exact operator-supplied model name, finite timeout, raw artifact preservation, and sanitized result import afterward.

--- a/docs/evals/runs/20260605-alpha-local-llm-smoke-authorization-refresh/allowed-smoke-scope.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-smoke-authorization-refresh/allowed-smoke-scope.md
@@ -1,0 +1,15 @@
+# Allowed Smoke Scope
+
+Lane ID: `ALPHA-LOCAL-LLM-SMOKE-AUTHORIZATION-REFRESH-001`
+
+A future smoke execution lane may only:
+
+- use the endpoint-locality-hardened local adapter path;
+- target a localhost / loopback endpoint;
+- use an exact operator-supplied model name;
+- apply a finite timeout;
+- execute the approved smoke task;
+- preserve raw artifacts;
+- prepare a sanitized import afterward.
+
+It must not expand into runtime routing, `/v1/solve`, dashboard preview, hosted providers, provider keys, Batch C, benchmarks, billing, or provider orchestration.

--- a/docs/evals/runs/20260605-alpha-local-llm-smoke-authorization-refresh/authorization-refresh-decision.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-smoke-authorization-refresh/authorization-refresh-decision.md
@@ -1,0 +1,21 @@
+# Authorization Refresh Decision
+
+Lane ID: `ALPHA-LOCAL-LLM-SMOKE-AUTHORIZATION-REFRESH-001`
+
+## Decision
+
+Future local smoke execution may proceed in a separate lane after this hardening PR is reviewed, merged, and recorded in GS.
+
+## Required execution fields
+
+The future operator execution lane must provide:
+
+- localhost / loopback endpoint only;
+- exact local model name;
+- finite timeout;
+- raw artifact preservation;
+- sanitized import afterward.
+
+## Non-claims
+
+This authorization refresh does not claim local LLM behavior, Ollama behavior, runtime readiness, `/v1/solve` readiness, dashboard readiness, MVP validation, production readiness, benchmark success, exact billing evidence, provider orchestration, Alpha quality, or Alpha superiority.

--- a/docs/evals/runs/20260605-alpha-local-llm-smoke-authorization-refresh/authorization-refresh-preservation-checklist.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-smoke-authorization-refresh/authorization-refresh-preservation-checklist.md
@@ -1,0 +1,15 @@
+# Authorization Refresh Preservation Checklist
+
+Lane ID: `ALPHA-LOCAL-LLM-SMOKE-AUTHORIZATION-REFRESH-001`
+
+- [x] Did not execute smoke.
+- [x] Did not call a local model, hosted provider, or network endpoint.
+- [x] Did not add provider keys or access material.
+- [x] Did not change runtime routing, `/v1/solve`, dashboard preview, or Batch C.
+- [x] Preserved smoke execution as a separate operator-approved lane.
+- [x] Required localhost / loopback endpoint values.
+- [x] Required exact operator-supplied model name.
+- [x] Required finite timeout.
+- [x] Required raw artifact preservation.
+- [x] Required sanitized import after execution.
+- [x] Selected exactly one next lane.

--- a/docs/evals/runs/20260605-alpha-local-llm-smoke-authorization-refresh/blocked-claims.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-smoke-authorization-refresh/blocked-claims.md
@@ -1,0 +1,23 @@
+# Blocked Claims
+
+Lane ID: `ALPHA-LOCAL-LLM-SMOKE-AUTHORIZATION-REFRESH-001`
+
+This authorization refresh blocks claims of:
+
+- local LLM behavior evidence
+- Ollama behavior evidence
+- hosted provider evidence
+- `/v1/solve` readiness evidence
+- dashboard preview readiness evidence
+- runtime readiness evidence
+- MVP validation
+- production readiness
+- Alpha quality evidence
+- Alpha superiority evidence
+- broad plain-provider inferiority evidence
+- Batch C readiness
+- benchmark success
+- exact billing evidence
+- provider orchestration evidence
+
+A future smoke lane may report only the bounded smoke outcome it actually observes and imports.

--- a/docs/evals/runs/20260605-alpha-local-llm-smoke-authorization-refresh/evidence-boundary.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-smoke-authorization-refresh/evidence-boundary.md
@@ -1,0 +1,26 @@
+# Evidence Boundary
+
+Lane ID: `ALPHA-LOCAL-LLM-SMOKE-AUTHORIZATION-REFRESH-001`
+
+This lane refreshes smoke authorization after endpoint-locality hardening only.
+
+It is not:
+
+- smoke execution evidence
+- local LLM behavior evidence
+- Ollama behavior evidence
+- hosted provider evidence
+- `/v1/solve` readiness evidence
+- dashboard preview readiness evidence
+- runtime readiness evidence
+- MVP validation
+- production readiness
+- Alpha quality evidence
+- Alpha superiority evidence
+- broad plain-provider inferiority evidence
+- Batch C readiness
+- benchmark success
+- exact billing evidence
+- provider orchestration evidence
+
+No smoke command is run in this lane.

--- a/docs/evals/runs/20260605-alpha-local-llm-smoke-authorization-refresh/recommended-next-lane.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-smoke-authorization-refresh/recommended-next-lane.md
@@ -1,0 +1,11 @@
+# Recommended Next Lane
+
+Lane ID: `ALPHA-LOCAL-LLM-SMOKE-AUTHORIZATION-REFRESH-001`
+
+## Recommendation
+
+`ALPHA-LOCAL-LLM-SMOKE-TEST-EXECUTION-001`
+
+## Boundary
+
+This recommendation is conditional on merge and GS completion for the endpoint-locality hardening PR. The future execution lane must preserve raw artifacts and must not make local LLM quality, readiness, benchmark, production, `/v1/solve`, runtime, provider-orchestration, Batch C, or Alpha-superiority claims.

--- a/docs/evals/runs/20260605-alpha-local-llm-smoke-authorization-refresh/smoke-preconditions.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-smoke-authorization-refresh/smoke-preconditions.md
@@ -1,0 +1,16 @@
+# Smoke Preconditions
+
+Lane ID: `ALPHA-LOCAL-LLM-SMOKE-AUTHORIZATION-REFRESH-001`
+
+A future local smoke execution lane must require:
+
+- endpoint-locality hardening merged and recorded in GS;
+- explicit operator approval;
+- localhost or loopback endpoint only;
+- exact operator-supplied model name;
+- finite timeout;
+- no hosted provider fallback;
+- no provider keys or access material;
+- raw artifact preservation before any summary;
+- sanitized import after execution;
+- no readiness, quality, benchmark, production, runtime, `/v1/solve`, provider-orchestration, Batch C, or Alpha-superiority claims.

--- a/tests/test_local_llm_provider_adapter.py
+++ b/tests/test_local_llm_provider_adapter.py
@@ -385,6 +385,10 @@ def test_ollama_backend_fails_closed_on_system_contract_echo_from_static_fixture
         "http://192.168.1.25:11434/api/chat",
         "ftp://127.0.0.1:11434/api/chat",
         "http:///api/chat",
+        "http://127.0.0.1:bad/api/chat",
+        "http://localhost:bad/api/chat",
+        "http://[::1]:bad/api/chat",
+        "http://127.0.0.1:99999/api/chat",
         "",
     ],
 )

--- a/tests/test_local_llm_provider_adapter.py
+++ b/tests/test_local_llm_provider_adapter.py
@@ -374,3 +374,79 @@ def test_ollama_backend_fails_closed_on_system_contract_echo_from_static_fixture
     assert result.reason == "prompt_echo_non_evidence"
     assert result.metadata["failure_label"] == "failed_closed_result"
     assert result.behavior_evidence is False
+
+
+@pytest.mark.parametrize(
+    "endpoint_url",
+    [
+        "https://example.com/api/chat",
+        "http://example.com/api/chat",
+        "https://api.openai.com/v1/chat/completions",
+        "http://192.168.1.25:11434/api/chat",
+        "ftp://127.0.0.1:11434/api/chat",
+        "http:///api/chat",
+        "",
+    ],
+)
+def test_ollama_backend_rejects_non_local_endpoints_before_transport_invocation(endpoint_url):
+    from alpha.local_llm.provider_adapter import OllamaLocalHTTPBackend
+
+    observed = {"called": False}
+
+    def fake_transport(*, endpoint_url, payload, timeout_seconds):
+        observed["called"] = True
+        return {"message": {"role": "assistant", "content": "must not be called"}}
+
+    backend = OllamaLocalHTTPBackend(
+        model="offline-fixture-model",
+        endpoint_url=endpoint_url,
+        transport=fake_transport,
+    )
+
+    result = run_local_llm_provider_adapter(
+        "Reject non-local endpoints before transport.", backend=backend
+    )
+
+    assert result.status == "failed_closed"
+    assert result.reason == "endpoint_not_local_non_evidence"
+    assert result.metadata["failure_label"] == "failed_closed_result"
+    assert result.behavior_evidence is False
+    assert observed["called"] is False
+    assert len(backend.calls) == 0
+    assert len(backend.payloads) == 0
+
+
+@pytest.mark.parametrize(
+    "endpoint_url",
+    [
+        "http://127.0.0.1:11434/api/chat",
+        "http://localhost:11434/api/chat",
+        "http://[::1]:11434/api/chat",
+    ],
+)
+def test_ollama_backend_allows_loopback_endpoints_to_reach_injected_transport(endpoint_url):
+    from alpha.local_llm.provider_adapter import OllamaLocalHTTPBackend
+
+    observed = {"called": False, "endpoint_url": None}
+
+    def fake_transport(*, endpoint_url, payload, timeout_seconds):
+        observed["called"] = True
+        observed["endpoint_url"] = endpoint_url
+        return {"message": {"role": "assistant", "content": "local fixture"}}
+
+    backend = OllamaLocalHTTPBackend(
+        model="offline-fixture-model",
+        endpoint_url=endpoint_url,
+        transport=fake_transport,
+    )
+
+    result = run_local_llm_provider_adapter(
+        "Allow local endpoints to fake transport.", backend=backend
+    )
+
+    assert result.status == "non_evidence"
+    assert result.reason == "local_llm_provider_adapter_wiring_only"
+    assert result.output_text == "local fixture"
+    assert result.behavior_evidence is False
+    assert observed["called"] is True
+    assert observed["endpoint_url"] == endpoint_url


### PR DESCRIPTION
### Motivation

- Close the endpoint-locality blocker recorded by PR #303 before any local LLM smoke execution can be considered.
- Ensure the Ollama-style local backend fails closed on hosted, non-loopback, malformed, empty, or disallowed endpoint URLs before any injected transport can be invoked.
- Refresh the local smoke authorization boundary so the next lane can be a separately approved operator smoke execution using localhost / loopback only.

### Description

- Add endpoint-locality validation in `alpha/local_llm/provider_adapter.py` using `urlsplit` and loopback hostname validation before payload creation or transport invocation.
- Add stable fail-closed reason `endpoint_not_local_non_evidence` for rejected endpoints.
- Preserve allowed local endpoint support for `127.0.0.1`, `localhost`, and IPv6 loopback.
- Add offline tests proving hosted URLs such as `https://example.com/api/chat`, `http://example.com/api/chat`, and `https://api.openai.com/v1/chat/completions` fail closed without invoking the fake transport.
- Add offline tests proving loopback endpoints can reach the injected fake transport.
- Add docs for endpoint validation rules, fail-closed coverage, hardening summary, evidence boundary, review gate, and smoke authorization refresh.

### Evidence boundary

This PR proves endpoint-locality hardening and offline adapter fail-closed behavior only.

It is not local LLM behavior evidence, Ollama behavior evidence, hosted provider evidence, `/v1/solve` readiness evidence, dashboard preview readiness evidence, runtime readiness evidence, MVP validation, production readiness, Alpha quality evidence, Alpha superiority evidence, broad plain-provider inferiority evidence, Batch C readiness, benchmark success, exact billing evidence, or provider orchestration evidence.

### Non-actions

- No live Ollama calls.
- No hosted provider calls.
- No local model calls.
- No provider keys.
- No real network calls in tests.
- No runtime routing changes.
- No `/v1/solve` changes.
- No dashboard preview changes.
- No operator-test evidence changes.
- No PR #288 through PR #304 evidence mutations.
- No Batch C work.
- No smoke execution.
- No readiness, validation, superiority, benchmark, billing, provider-orchestration, production, or local-LLM-quality claims.

### Checks

- Added focused endpoint-locality tests for rejected hosted endpoints and allowed loopback endpoints.
- Added docs-only review gate and smoke authorization refresh packets.
- Changed files are limited to the local LLM adapter, local LLM adapter tests, and lane docs.
- Tests should be run by CI or reviewer:
  - `python -m pytest -q tests/test_local_llm_provider_adapter.py`
  - `python -m pytest -q tests/test_local_llm_contract_consumption_proof.py`
  - `python -m compileall -q alpha/local_llm`

### Next lane

`ALPHA-LOCAL-LLM-SMOKE-TEST-EXECUTION-001`

The next lane remains separately operator-gated and must use localhost / loopback endpoint values, exact model name, finite timeout, raw artifact preservation, and sanitized import afterward.