### PR TITLE
docs(local-llm): scaffold smoke results import

### DIFF
--- a/docs/evals/runs/20260605-alpha-local-llm-smoke-results-import-scaffold/README.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-smoke-results-import-scaffold/README.md
@@ -1,0 +1,66 @@
+# Local LLM Smoke Results Import Scaffold
+
+Lane ID: `ALPHA-LOCAL-LLM-SMOKE-RESULTS-IMPORT-SCAFFOLD-001`
+
+Status: docs-only scaffold for a future sanitized local LLM smoke results import.
+
+## Purpose
+
+This directory defines the documents, field requirements, redaction rules, result classifications, reviewer checks, and preservation checks that a future import lane must use after a separately produced smoke execution evidence file exists.
+
+This is a scaffold only. No smoke evidence is imported in this PR, no result row is created, and no smoke outcome is inferred.
+
+## Source files reviewed
+
+- `docs/evals/runs/20260605-alpha-local-llm-endpoint-locality-hardening/`
+- `docs/evals/runs/20260605-alpha-local-llm-endpoint-locality-review-gate/`
+- `docs/evals/runs/20260605-alpha-local-llm-smoke-authorization-refresh/`
+- `docs/evals/runs/20260605-alpha-local-llm-smoke-test-packet/`
+- `alpha/local_llm/provider_adapter.py`
+- `tests/test_local_llm_provider_adapter.py`
+
+## Scaffold contents
+
+- `required-source-evidence.md` records the mandatory future evidence file and import-stop rule.
+- `sanitized-import-template.md` provides a placeholder-only sanitized import structure.
+- `smoke-result-log-template.md` provides a header-only log template with no result rows.
+- `redaction-log-template.md` defines redaction checks for future imports.
+- `import-reviewer-checklist.md` defines reviewer checks before any import is accepted.
+- `evidence-boundary.md` preserves the narrow evidence boundary and non-claims.
+- `scaffold-preservation-checklist.md` checks that this lane remains scaffold-only.
+- `recommended-next-lane.md` selects exactly one recommended next lane.
+
+## Required future source evidence
+
+A future import must be blocked unless `ALPHA-LOCAL-LLM-SMOKE-TEST-EXECUTION-001.md` exists and is available to the importer.
+
+If `ALPHA-LOCAL-LLM-SMOKE-TEST-EXECUTION-001.md` is missing, the import must stop.
+
+## Required future evidence fields
+
+A future source evidence file must include:
+
+- lane ID
+- prerequisite PR link
+- exact command executed
+- endpoint pattern
+- exact model name, if approved for repo disclosure
+- timeout seconds
+- start timestamp
+- end timestamp
+- stdout
+- stderr
+- exit code
+- raw artifact preservation notes
+- executed / skipped / blocked status
+- redaction notes
+- evidence boundary
+- non-claims
+
+## Result classifications
+
+Allowed classifications are: `not run`, `skipped`, `blocked`, `pass`, `fail`, `error`, `timeout`, `connection failure`, `endpoint locality rejection`, `malformed response`, `empty output`, `prompt echo`, and `system echo`.
+
+## Evidence boundary
+
+This lane is import-scaffold documentation only. It is not smoke execution evidence, local LLM behavior evidence, Ollama behavior evidence, hosted provider evidence, `/v1/solve` readiness evidence, dashboard preview readiness evidence, runtime readiness evidence, MVP validation, production readiness, Alpha quality evidence, Alpha superiority evidence, broad plain-provider inferiority evidence, Batch C readiness, benchmark success, exact billing evidence, or provider orchestration evidence.

--- a/docs/evals/runs/20260605-alpha-local-llm-smoke-results-import-scaffold/evidence-boundary.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-smoke-results-import-scaffold/evidence-boundary.md
@@ -1,0 +1,30 @@
+# Evidence Boundary
+
+Lane ID: `ALPHA-LOCAL-LLM-SMOKE-RESULTS-IMPORT-SCAFFOLD-001`
+
+This lane is import-scaffold documentation only.
+
+No smoke evidence is imported in this PR. No actual result row is created. No smoke outcome is inferred.
+
+It is not:
+
+- smoke execution evidence
+- local LLM behavior evidence
+- Ollama behavior evidence
+- hosted provider evidence
+- `/v1/solve` readiness evidence
+- dashboard preview readiness evidence
+- runtime readiness evidence
+- MVP validation
+- production readiness
+- Alpha quality evidence
+- Alpha superiority evidence
+- broad plain-provider inferiority evidence
+- Batch C readiness
+- benchmark success
+- exact billing evidence
+- provider orchestration evidence
+
+## Non-actions
+
+This lane does not run smoke, call Ollama, call a hosted provider, call a local model, make network calls, add provider keys, change runtime routing, change `/v1/solve`, change dashboard preview, change operator-test evidence, do Batch C work, import actual results, or make readiness, validation, superiority, benchmark, billing, provider-orchestration, production, or local-LLM-quality claims.

--- a/docs/evals/runs/20260605-alpha-local-llm-smoke-results-import-scaffold/import-reviewer-checklist.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-smoke-results-import-scaffold/import-reviewer-checklist.md
@@ -1,0 +1,42 @@
+# Import Reviewer Checklist
+
+Lane ID: `ALPHA-LOCAL-LLM-SMOKE-RESULTS-IMPORT-SCAFFOLD-001`
+
+This checklist is for a future reviewer. It is scaffold documentation only and does not import results.
+
+## Source evidence gate
+
+- [ ] `ALPHA-LOCAL-LLM-SMOKE-TEST-EXECUTION-001.md` exists.
+- [ ] If the evidence file is missing, import stopped.
+- [ ] Required fields are present.
+- [ ] The exact command is copied from source evidence, not inferred.
+- [ ] stdout, stderr, and exit code are copied from source evidence, not inferred.
+
+## Redaction review
+
+- [ ] No provider keys appear.
+- [ ] No secrets appear.
+- [ ] No credentials appear.
+- [ ] No private URLs appear.
+- [ ] No nonpublic endpoints appear.
+- [ ] No sensitive environment dumps appear.
+- [ ] Endpoint is sanitized to localhost or loopback pattern only.
+- [ ] Exact model name appears only if approved for repo disclosure.
+
+## Classification review
+
+- [ ] Classification is exactly one of the allowed classifications.
+- [ ] Classification is supported by source evidence.
+- [ ] No smoke outcome is inferred from missing evidence.
+
+## Claim boundary review
+
+- [ ] Evidence boundary remains narrow.
+- [ ] No readiness claim is introduced.
+- [ ] No validation claim is introduced.
+- [ ] No superiority claim is introduced.
+- [ ] No benchmark success claim is introduced.
+- [ ] No billing claim is introduced.
+- [ ] No provider-orchestration claim is introduced.
+- [ ] No production claim is introduced.
+- [ ] No local-LLM-quality claim is introduced.

--- a/docs/evals/runs/20260605-alpha-local-llm-smoke-results-import-scaffold/recommended-next-lane.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-smoke-results-import-scaffold/recommended-next-lane.md
@@ -1,0 +1,19 @@
+# Recommended Next Lane
+
+Lane ID: `ALPHA-LOCAL-LLM-SMOKE-RESULTS-IMPORT-SCAFFOLD-001`
+
+## Selected next lane
+
+`ALPHA-LOCAL-LLM-SMOKE-RESULTS-IMPORT-001`
+
+This is the only recommended next lane selected by this scaffold.
+
+## Required blocker before next lane
+
+`ALPHA-LOCAL-LLM-SMOKE-RESULTS-IMPORT-001` must not run until `ALPHA-LOCAL-LLM-SMOKE-TEST-EXECUTION-001.md` exists.
+
+If `ALPHA-LOCAL-LLM-SMOKE-TEST-EXECUTION-001.md` is missing, import must stop.
+
+## Continued boundary
+
+The next lane may import only sanitized results supported by the required future evidence file. It must not run smoke or infer a smoke outcome from missing evidence.

--- a/docs/evals/runs/20260605-alpha-local-llm-smoke-results-import-scaffold/redaction-log-template.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-smoke-results-import-scaffold/redaction-log-template.md
@@ -1,0 +1,34 @@
+# Redaction Log Template
+
+Lane ID: `ALPHA-LOCAL-LLM-SMOKE-RESULTS-IMPORT-SCAFFOLD-001`
+
+This template defines future redaction requirements. It is not evidence that any smoke command ran.
+
+## Required redaction rules
+
+A future import must ensure:
+
+- no provider keys
+- no secrets
+- no private URLs
+- no nonpublic endpoints
+- no sensitive environment dumps
+- endpoint sanitized to localhost or loopback pattern only
+
+## Future redaction checklist
+
+- Provider keys removed or confirmed absent: `[future importer to fill]`
+- Secrets removed or confirmed absent: `[future importer to fill]`
+- Credentials removed or confirmed absent: `[future importer to fill]`
+- Private URLs removed or confirmed absent: `[future importer to fill]`
+- Nonpublic endpoints removed or confirmed absent: `[future importer to fill]`
+- Sensitive environment dumps removed or confirmed absent: `[future importer to fill]`
+- Endpoint shown only as localhost or loopback pattern: `[future importer to fill]`
+- Exact model name disclosed only if approved for repo disclosure: `[future importer to fill]`
+- stdout sanitized: `[future importer to fill]`
+- stderr sanitized: `[future importer to fill]`
+- raw artifact preservation notes sanitized: `[future importer to fill]`
+
+## Redaction stop condition
+
+If the future importer cannot remove or safely summarize sensitive content, import must stop rather than partially importing the result.

--- a/docs/evals/runs/20260605-alpha-local-llm-smoke-results-import-scaffold/required-source-evidence.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-smoke-results-import-scaffold/required-source-evidence.md
@@ -1,0 +1,57 @@
+# Required Source Evidence
+
+Lane ID: `ALPHA-LOCAL-LLM-SMOKE-RESULTS-IMPORT-SCAFFOLD-001`
+
+This file defines the required future source evidence for a later sanitized local LLM smoke results import. It is a scaffold only and does not import smoke evidence.
+
+## Mandatory future evidence file
+
+The future import lane must require this evidence file:
+
+`ALPHA-LOCAL-LLM-SMOKE-TEST-EXECUTION-001.md`
+
+If `ALPHA-LOCAL-LLM-SMOKE-TEST-EXECUTION-001.md` is missing, import must stop.
+
+## Required fields
+
+The future evidence file must include all of the following fields before any import may proceed:
+
+- lane ID
+- prerequisite PR link
+- exact command executed
+- endpoint pattern
+- exact model name, if approved for repo disclosure
+- timeout seconds
+- start timestamp
+- end timestamp
+- stdout
+- stderr
+- exit code
+- raw artifact preservation notes
+- executed / skipped / blocked status
+- redaction notes
+- evidence boundary
+- non-claims
+
+## Required source checks
+
+Before import, the importer must confirm:
+
+- the evidence file is present;
+- the lane ID matches the smoke execution lane;
+- the prerequisite PR link is present;
+- the exact command is recorded rather than reconstructed;
+- stdout, stderr, and exit code are sourced from the execution artifact rather than inferred;
+- raw artifact preservation notes are present;
+- redaction notes are present;
+- evidence boundary and non-claims are present.
+
+## Import stop conditions
+
+Import must stop if any of the following is true:
+
+- `ALPHA-LOCAL-LLM-SMOKE-TEST-EXECUTION-001.md` is missing;
+- required fields are missing;
+- the endpoint cannot be sanitized to a localhost or loopback pattern;
+- provider keys, secrets, credentials, private URLs, nonpublic endpoints, or raw sensitive environment dumps are present and cannot be removed;
+- the source evidence asks the importer to make readiness, validation, superiority, benchmark, billing, provider-orchestration, production, or local-LLM-quality claims.

--- a/docs/evals/runs/20260605-alpha-local-llm-smoke-results-import-scaffold/sanitized-import-template.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-smoke-results-import-scaffold/sanitized-import-template.md
@@ -1,0 +1,51 @@
+# Sanitized Import Template
+
+Lane ID: `ALPHA-LOCAL-LLM-SMOKE-RESULTS-IMPORT-SCAFFOLD-001`
+
+This is a placeholder template for a future import. It is not a result import, contains no actual result row, and does not imply that smoke has run.
+
+## Source evidence gate
+
+- Required evidence file: `ALPHA-LOCAL-LLM-SMOKE-TEST-EXECUTION-001.md`
+- Evidence file present: `[future importer to fill]`
+- If evidence file is missing: stop import
+
+## Sanitized execution summary
+
+- Smoke execution lane ID: `[future importer to fill from source evidence]`
+- Prerequisite PR link: `[future importer to fill from source evidence]`
+- Exact command executed: `[future importer to fill from source evidence]`
+- Endpoint pattern: `[localhost or loopback pattern only]`
+- Exact model name: `[include only if approved for repo disclosure]`
+- Timeout seconds: `[future importer to fill from source evidence]`
+- Start timestamp: `[future importer to fill from source evidence]`
+- End timestamp: `[future importer to fill from source evidence]`
+- Exit code: `[future importer to fill from source evidence]`
+- Classification: `[one allowed classification from smoke-result-log-template.md]`
+- Executed / skipped / blocked status: `[future importer to fill from source evidence]`
+
+## Sanitized captured output
+
+### stdout
+
+`[future importer to paste sanitized stdout only]`
+
+### stderr
+
+`[future importer to paste sanitized stderr only]`
+
+## Raw artifact preservation notes
+
+`[future importer to summarize raw artifact preservation notes without exposing sensitive paths or content]`
+
+## Redaction notes
+
+`[future importer to summarize redactions performed]`
+
+## Evidence boundary
+
+`[future importer to restate the future smoke evidence boundary without expanding claims]`
+
+## Non-claims
+
+`[future importer to restate non-claims from source evidence]`

--- a/docs/evals/runs/20260605-alpha-local-llm-smoke-results-import-scaffold/scaffold-preservation-checklist.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-smoke-results-import-scaffold/scaffold-preservation-checklist.md
@@ -1,0 +1,25 @@
+# Scaffold Preservation Checklist
+
+Lane ID: `ALPHA-LOCAL-LLM-SMOKE-RESULTS-IMPORT-SCAFFOLD-001`
+
+Use this checklist to confirm this lane remains a docs-only scaffold.
+
+- [ ] Changes are limited to `docs/evals/runs/20260605-alpha-local-llm-smoke-results-import-scaffold/`.
+- [ ] No source code files are changed.
+- [ ] No test code files are changed.
+- [ ] No live Ollama calls are made.
+- [ ] No hosted provider calls are made.
+- [ ] No local model calls are made.
+- [ ] No network calls are made.
+- [ ] No provider keys are added.
+- [ ] No runtime routing changes are made.
+- [ ] No `/v1/solve` changes are made.
+- [ ] No dashboard preview changes are made.
+- [ ] No operator-test evidence changes are made.
+- [ ] No Batch C work is performed.
+- [ ] No smoke execution is performed.
+- [ ] No actual result import is performed.
+- [ ] No actual result row is created.
+- [ ] No smoke outcome is inferred.
+- [ ] Evidence boundary remains import-scaffold documentation only.
+- [ ] Exactly one recommended next lane is selected.

--- a/docs/evals/runs/20260605-alpha-local-llm-smoke-results-import-scaffold/smoke-result-log-template.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-smoke-results-import-scaffold/smoke-result-log-template.md
@@ -1,0 +1,26 @@
+# Smoke Result Log Template
+
+Lane ID: `ALPHA-LOCAL-LLM-SMOKE-RESULTS-IMPORT-SCAFFOLD-001`
+
+This is a header-only template. It intentionally contains no actual result row and does not infer any smoke outcome.
+
+## Allowed result classifications
+
+- `not run`
+- `skipped`
+- `blocked`
+- `pass`
+- `fail`
+- `error`
+- `timeout`
+- `connection failure`
+- `endpoint locality rejection`
+- `malformed response`
+- `empty output`
+- `prompt echo`
+- `system echo`
+
+## Future log columns
+
+| source evidence file | lane ID | prerequisite PR link | command recorded | endpoint pattern | model disclosed | timeout seconds | start timestamp | end timestamp | exit code | executed/skipped/blocked | classification | stdout sanitized | stderr sanitized | raw artifact notes present | redaction notes present | evidence boundary present | non-claims present |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |


### PR DESCRIPTION
### Motivation

- Add a docs-only scaffold to capture the required structure, redaction rules, and reviewer checks for a future sanitized local LLM smoke results import without importing any results.  
- Preserve a narrow evidence boundary and explicit stop conditions so future import lanes cannot proceed without operator-supplied execution evidence and explicit approval.  

### Description

- Add nine documentation files under `docs/evals/runs/20260605-alpha-local-llm-smoke-results-import-scaffold/` including `README.md`, `required-source-evidence.md`, `sanitized-import-template.md`, `smoke-result-log-template.md`, `redaction-log-template.md`, `import-reviewer-checklist.md`, `evidence-boundary.md`, `scaffold-preservation-checklist.md`, and `recommended-next-lane.md`.  
- Record that no smoke evidence is imported in this change, require the future evidence file `ALPHA-LOCAL-LLM-SMOKE-TEST-EXECUTION-001.md`, and state that import must stop if that file is missing.  
- Define required evidence fields (lane ID, prerequisite PR link, exact command executed, endpoint pattern, exact model name if allowed, timeout, timestamps, stdout/stderr, exit code, raw artifact notes, executed/skipped/blocked status, redaction notes, evidence boundary, and non-claims) and explicit redaction rules (no provider keys, secrets, private URLs, nonpublic endpoints, sensitive env dumps, and endpoint sanitized to localhost/loopback only).  
- Provide a header-only `smoke-result-log-template.md` with allowed result classifications and a reviewer checklist and preservation checklist that enforce that only docs under the scaffold path are changed and that no code, tests, network calls, or result imports occur.  

### Testing

- Verified changed paths are limited to `docs/evals/runs/20260605-alpha-local-llm-smoke-results-import-scaffold/` with `git diff --cached --name-only` and a path-restriction `awk` check that failed if any files were outside that directory.  
- Confirmed the `smoke-result-log-template.md` is header-only and contains no actual result rows using `awk` to count table rows and confirmed the header-only table.  
- Performed sensitive-content scans using `rg` for URLs and common key/secret patterns and confirmed no provider keys, secrets, private URLs, or credential assignments were introduced.  
- Confirmed exactly one selected next lane is present and that evidence-boundary phrases exist using `rg`, then staged and committed the changes with `git commit`, and all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22f204ff8c8329a45cd252de762a7c)