### PR TITLE
docs(local-llm): import smoke results and decide next step

### DIFF
--- a/docs/evals/runs/20260605-alpha-local-llm-integration-final-decision/README.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-integration-final-decision/README.md
@@ -6,10 +6,8 @@ This folder records the final docs-only decision after importing and interpretin
 
 ## Decision
 
-Exactly one next lane is selected:
-
-`ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-PLANNING-001`
+The exact next lane is recorded once in `selected-next-lane.md`.
 
 ## Decision basis
 
-The imported evidence satisfies the post-smoke decision framework's clean local smoke criteria within the local smoke evidence boundary. This decision selects planning only; it does not make implementation, runtime, product, quality, production, benchmark, billing, or orchestration claims.
+The imported evidence satisfies the post-smoke decision framework's clean local smoke criteria within the local smoke evidence boundary, with the preserved caveat that the pasted artifact does not separately include the literal terminal command or a numeric process exit code. This decision selects planning only; it does not make implementation, runtime, product, quality, production, benchmark, billing, or orchestration claims.

--- a/docs/evals/runs/20260605-alpha-local-llm-integration-final-decision/README.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-integration-final-decision/README.md
@@ -1,0 +1,15 @@
+# Local LLM Integration Final Decision
+
+Lane ID: `ALPHA-LOCAL-LLM-INTEGRATION-FINAL-DECISION-001`
+
+This folder records the final docs-only decision after importing and interpreting the local smoke evidence.
+
+## Decision
+
+Exactly one next lane is selected:
+
+`ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-PLANNING-001`
+
+## Decision basis
+
+The imported evidence satisfies the post-smoke decision framework's clean local smoke criteria within the local smoke evidence boundary. This decision selects planning only; it does not make implementation, runtime, product, quality, production, benchmark, billing, or orchestration claims.

--- a/docs/evals/runs/20260605-alpha-local-llm-integration-final-decision/blocked-work.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-integration-final-decision/blocked-work.md
@@ -1,0 +1,18 @@
+# Blocked Work
+
+Lane ID: `ALPHA-LOCAL-LLM-INTEGRATION-FINAL-DECISION-001`
+
+The following work remains blocked by this decision package:
+
+- Source code changes.
+- Test code changes.
+- Live provider calls.
+- Local model calls from Codex.
+- Runtime routing changes.
+- `/v1/solve` changes.
+- Dashboard preview changes.
+- Operator-test evidence changes.
+- Batch C work.
+- Provider key handling.
+- Hosted-provider evidence changes.
+- Readiness, validation, superiority, benchmark, billing, provider-orchestration, production, or local-model-quality claims.

--- a/docs/evals/runs/20260605-alpha-local-llm-integration-final-decision/decision-options.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-integration-final-decision/decision-options.md
@@ -4,19 +4,19 @@ Lane ID: `ALPHA-LOCAL-LLM-INTEGRATION-FINAL-DECISION-001`
 
 ## Options considered from the post-smoke framework
 
-| Option | Next lane | Selected | Evidence-based reason |
-| --- | --- | --- | --- |
-| Clean local smoke branch | `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-PLANNING-001` | Yes | Imported evidence satisfies the clean local smoke criteria under the recorded evidence boundary. |
-| Endpoint locality repair | `ALPHA-LOCAL-LLM-ENDPOINT-LOCALITY-REPAIR-001` | No | Imported endpoint is loopback: `http://127.0.0.1:11434/api/chat`. |
-| Environment retry | `ALPHA-LOCAL-LLM-SMOKE-ENVIRONMENT-RETRY-001` | No | Imported evidence records completed execution and does not record environment setup blockage. |
-| Model availability retry | `ALPHA-LOCAL-LLM-MODEL-AVAILABILITY-RETRY-001` | No | Imported evidence records assistant content and adapter output rather than model unavailability. |
-| Timeout review | `ALPHA-LOCAL-LLM-SMOKE-TIMEOUT-REVIEW-001` | No | Imported evidence records completed execution with preserved start and end timestamps and does not record timeout failure. |
-| Connection review | `ALPHA-LOCAL-LLM-SMOKE-CONNECTION-REVIEW-001` | No | Imported evidence does not record connection failure. |
-| Response parser repair | `ALPHA-LOCAL-LLM-RESPONSE-PARSER-REPAIR-001` | No | Imported evidence preserves parsed adapter output and raw response artifact. |
-| Empty output review | `ALPHA-LOCAL-LLM-EMPTY-OUTPUT-REVIEW-001` | No | Imported adapter output is `OK`. |
-| Prompt echo repair | `ALPHA-LOCAL-LLM-PROMPT-ECHO-REPAIR-001` | No | Imported adapter output is `OK`; no prompt or system echo is recorded. |
-| Execution retry | `ALPHA-LOCAL-LLM-SMOKE-TEST-EXECUTION-RETRY-001` | No | Imported evidence records `executed: true`. |
+| Option | Selected | Evidence-based reason |
+| --- | --- | --- |
+| Clean local smoke branch leading to the planning lane | Yes | Imported evidence satisfies the clean local smoke criteria under the recorded evidence boundary, with the missing literal command and numeric exit-code caveat preserved. |
+| Endpoint locality repair branch | No | Imported endpoint is loopback: `http://127.0.0.1:11434/api/chat`. |
+| Environment retry branch | No | Imported evidence records completed execution and does not record environment setup blockage. |
+| Model availability retry branch | No | Imported evidence records assistant content and adapter output rather than model unavailability. |
+| Timeout review branch | No | Imported evidence records completed execution with preserved start and end timestamps and does not record timeout failure. |
+| Connection review branch | No | Imported evidence does not record connection failure. |
+| Response parser repair branch | No | Imported evidence preserves parsed adapter output and raw response artifact. |
+| Empty output review branch | No | Imported adapter output is `OK`. |
+| Prompt echo repair branch | No | Imported adapter output is `OK`; no prompt or system echo is recorded. |
+| Execution retry branch | No | Imported evidence records `executed: true`; missing literal command and numeric exit code are preserved as caveats rather than reconstructed. |
 
 ## Single-selection rule
 
-Only `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-PLANNING-001` is selected.
+Only the planning lane recorded in `selected-next-lane.md` is selected. The selection is narrow and does not treat this package as a complete terminal transcript import.

--- a/docs/evals/runs/20260605-alpha-local-llm-integration-final-decision/decision-options.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-integration-final-decision/decision-options.md
@@ -1,0 +1,22 @@
+# Decision Options
+
+Lane ID: `ALPHA-LOCAL-LLM-INTEGRATION-FINAL-DECISION-001`
+
+## Options considered from the post-smoke framework
+
+| Option | Next lane | Selected | Evidence-based reason |
+| --- | --- | --- | --- |
+| Clean local smoke branch | `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-PLANNING-001` | Yes | Imported evidence satisfies the clean local smoke criteria under the recorded evidence boundary. |
+| Endpoint locality repair | `ALPHA-LOCAL-LLM-ENDPOINT-LOCALITY-REPAIR-001` | No | Imported endpoint is loopback: `http://127.0.0.1:11434/api/chat`. |
+| Environment retry | `ALPHA-LOCAL-LLM-SMOKE-ENVIRONMENT-RETRY-001` | No | Imported evidence records completed execution and does not record environment setup blockage. |
+| Model availability retry | `ALPHA-LOCAL-LLM-MODEL-AVAILABILITY-RETRY-001` | No | Imported evidence records assistant content and adapter output rather than model unavailability. |
+| Timeout review | `ALPHA-LOCAL-LLM-SMOKE-TIMEOUT-REVIEW-001` | No | Imported evidence records completed execution with preserved start and end timestamps and does not record timeout failure. |
+| Connection review | `ALPHA-LOCAL-LLM-SMOKE-CONNECTION-REVIEW-001` | No | Imported evidence does not record connection failure. |
+| Response parser repair | `ALPHA-LOCAL-LLM-RESPONSE-PARSER-REPAIR-001` | No | Imported evidence preserves parsed adapter output and raw response artifact. |
+| Empty output review | `ALPHA-LOCAL-LLM-EMPTY-OUTPUT-REVIEW-001` | No | Imported adapter output is `OK`. |
+| Prompt echo repair | `ALPHA-LOCAL-LLM-PROMPT-ECHO-REPAIR-001` | No | Imported adapter output is `OK`; no prompt or system echo is recorded. |
+| Execution retry | `ALPHA-LOCAL-LLM-SMOKE-TEST-EXECUTION-RETRY-001` | No | Imported evidence records `executed: true`. |
+
+## Single-selection rule
+
+Only `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-PLANNING-001` is selected.

--- a/docs/evals/runs/20260605-alpha-local-llm-integration-final-decision/decision-summary.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-integration-final-decision/decision-summary.md
@@ -1,0 +1,13 @@
+# Decision Summary
+
+Lane ID: `ALPHA-LOCAL-LLM-INTEGRATION-FINAL-DECISION-001`
+
+## Final decision
+
+Select exactly one next lane: `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-PLANNING-001`.
+
+## Rationale
+
+The imported local smoke evidence records `executed: true`, a localhost / loopback endpoint, finite timeout `120.0`, no provider key use, no hosted endpoint use, preserved sanitized request and raw response artifacts, `exception: null`, `output_text: "OK"`, `status: "non_evidence"`, `reason: "local_llm_provider_adapter_wiring_only"`, and `behavior_evidence: false`.
+
+Those fields satisfy the clean local smoke branch in the post-smoke decision framework. The raw response caveat `done_reason: "length"` is preserved as a caveat only and is not used to make claims outside the imported smoke boundary.

--- a/docs/evals/runs/20260605-alpha-local-llm-integration-final-decision/decision-summary.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-integration-final-decision/decision-summary.md
@@ -4,10 +4,12 @@ Lane ID: `ALPHA-LOCAL-LLM-INTEGRATION-FINAL-DECISION-001`
 
 ## Final decision
 
-Select exactly one next lane: `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-PLANNING-001`.
+Select exactly one planning next lane, recorded in `selected-next-lane.md`.
 
 ## Rationale
 
 The imported local smoke evidence records `executed: true`, a localhost / loopback endpoint, finite timeout `120.0`, no provider key use, no hosted endpoint use, preserved sanitized request and raw response artifacts, `exception: null`, `output_text: "OK"`, `status: "non_evidence"`, `reason: "local_llm_provider_adapter_wiring_only"`, and `behavior_evidence: false`.
 
-Those fields satisfy the clean local smoke branch in the post-smoke decision framework. The raw response caveat `done_reason: "length"` is preserved as a caveat only and is not used to make claims outside the imported smoke boundary.
+The import also preserves a caveat: the pasted artifact does not separately preserve the literal terminal command text or a numeric process exit code. No numeric exit code is imported, and neither missing field is reconstructed.
+
+Those fields satisfy the clean local smoke branch in the post-smoke decision framework for planning only. The missing command/exit-code caveat and the raw response caveat `done_reason: "length"` are preserved as caveats only and are not used to make claims outside the imported smoke boundary.

--- a/docs/evals/runs/20260605-alpha-local-llm-integration-final-decision/evidence-boundary.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-integration-final-decision/evidence-boundary.md
@@ -26,3 +26,8 @@ It is not evidence for:
 ## Preserved source fields
 
 The final decision preserves `behavior_evidence: false`, `status: "non_evidence"`, and `reason: "local_llm_provider_adapter_wiring_only"` as the controlling evidence-boundary fields.
+
+
+## Import caveat
+
+The final decision preserves the missing literal terminal command and missing numeric exit code as caveats. It does not reconstruct the command and does not import or invent a numeric exit code.

--- a/docs/evals/runs/20260605-alpha-local-llm-integration-final-decision/evidence-boundary.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-integration-final-decision/evidence-boundary.md
@@ -1,0 +1,28 @@
+# Evidence Boundary
+
+Lane ID: `ALPHA-LOCAL-LLM-INTEGRATION-FINAL-DECISION-001`
+
+## Boundary
+
+This PR imports, interprets, and decides from local smoke evidence only.
+
+It is not evidence for:
+
+- broad local-model quality;
+- hosted providers;
+- `/v1/solve`;
+- dashboard preview;
+- runtime readiness;
+- MVP status;
+- production use;
+- Alpha quality;
+- Alpha-superiority claims;
+- broad plain-provider inferiority;
+- Batch C;
+- benchmark results;
+- exact billing;
+- provider orchestration.
+
+## Preserved source fields
+
+The final decision preserves `behavior_evidence: false`, `status: "non_evidence"`, and `reason: "local_llm_provider_adapter_wiring_only"` as the controlling evidence-boundary fields.

--- a/docs/evals/runs/20260605-alpha-local-llm-integration-final-decision/final-decision-preservation-checklist.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-integration-final-decision/final-decision-preservation-checklist.md
@@ -2,9 +2,10 @@
 
 Lane ID: `ALPHA-LOCAL-LLM-INTEGRATION-FINAL-DECISION-001`
 
-- [x] Selects exactly one next lane.
-- [x] Selected next lane is `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-PLANNING-001`.
+- [x] Selects exactly one next lane, recorded in `selected-next-lane.md`.
 - [x] Selection is based only on imported local smoke evidence.
+- [x] Preserves missing literal terminal command as an import caveat.
+- [x] Preserves missing numeric exit code as an import caveat and does not invent one.
 - [x] Preserves `behavior_evidence: false`.
 - [x] Preserves `status: "non_evidence"` exactly.
 - [x] Preserves `reason: "local_llm_provider_adapter_wiring_only"` exactly.

--- a/docs/evals/runs/20260605-alpha-local-llm-integration-final-decision/final-decision-preservation-checklist.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-integration-final-decision/final-decision-preservation-checklist.md
@@ -1,0 +1,14 @@
+# Final Decision Preservation Checklist
+
+Lane ID: `ALPHA-LOCAL-LLM-INTEGRATION-FINAL-DECISION-001`
+
+- [x] Selects exactly one next lane.
+- [x] Selected next lane is `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-PLANNING-001`.
+- [x] Selection is based only on imported local smoke evidence.
+- [x] Preserves `behavior_evidence: false`.
+- [x] Preserves `status: "non_evidence"` exactly.
+- [x] Preserves `reason: "local_llm_provider_adapter_wiring_only"` exactly.
+- [x] Preserves `done_reason: "length"` as a caveat only.
+- [x] Does not select a second lane.
+- [x] Does not authorize code, runtime, dashboard, operator-test, or Batch C work.
+- [x] Does not make readiness, quality, production, benchmark, billing, superiority, or provider-orchestration claims.

--- a/docs/evals/runs/20260605-alpha-local-llm-integration-final-decision/selected-next-lane.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-integration-final-decision/selected-next-lane.md
@@ -13,3 +13,8 @@ Exactly one next lane is selected.
 ## Scope of selected lane
 
 The selected lane is planning. It remains blocked from making runtime changes until a future approved implementation lane authorizes those changes.
+
+
+## Import caveat
+
+This selection preserves the caveat that the pasted artifact does not separately include the literal terminal command or a numeric process exit code. No numeric exit code is imported or invented. The selection remains planning-only because the imported artifact records `executed: true`, `exception: null`, completed timestamps, stdout-equivalent content, a sanitized request artifact, and a raw response artifact.

--- a/docs/evals/runs/20260605-alpha-local-llm-integration-final-decision/selected-next-lane.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-integration-final-decision/selected-next-lane.md
@@ -1,0 +1,15 @@
+# Selected Next Lane
+
+Lane ID: `ALPHA-LOCAL-LLM-INTEGRATION-FINAL-DECISION-001`
+
+## Selected next lane
+
+`ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-PLANNING-001`
+
+## Selection count
+
+Exactly one next lane is selected.
+
+## Scope of selected lane
+
+The selected lane is planning. It remains blocked from making runtime changes until a future approved implementation lane authorizes those changes.

--- a/docs/evals/runs/20260605-alpha-local-llm-smoke-interpretation/README.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-smoke-interpretation/README.md
@@ -1,0 +1,15 @@
+# Local LLM Smoke Interpretation
+
+Lane ID: `ALPHA-LOCAL-LLM-SMOKE-INTERPRETATION-001`
+
+This folder interprets only the smoke evidence imported in `../20260605-alpha-local-llm-smoke-results-import/`.
+
+## Interpretation scope
+
+- Imported evidence shows a completed local smoke command under the recorded localhost / loopback boundary.
+- Imported adapter result records `output_text: "OK"`, `status: "non_evidence"`, `reason: "local_llm_provider_adapter_wiring_only"`, `behavior_evidence: false`, and `exception: null`.
+- Imported raw response records assistant content `OK` and `done_reason: "length"`.
+
+## Boundary
+
+This interpretation does not extrapolate beyond the imported smoke artifact.

--- a/docs/evals/runs/20260605-alpha-local-llm-smoke-interpretation/evidence-boundary-review.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-smoke-interpretation/evidence-boundary-review.md
@@ -9,3 +9,8 @@ This interpretation uses only the imported local smoke evidence. It does not use
 ## Explicit non-expansion
 
 This interpretation is not evidence for hosted providers, `/v1/solve`, dashboard preview, runtime integration, MVP status, production use, Alpha quality, Alpha-superiority claims, Batch C, benchmark results, billing, provider orchestration, or broad local-model quality.
+
+
+## Missing terminal metadata caveat
+
+The interpretation does not reconstruct the literal terminal command text or numeric process exit code. Both remain absent from the pasted artifact and are preserved as caveats.

--- a/docs/evals/runs/20260605-alpha-local-llm-smoke-interpretation/evidence-boundary-review.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-smoke-interpretation/evidence-boundary-review.md
@@ -1,0 +1,11 @@
+# Evidence Boundary Review
+
+Lane ID: `ALPHA-LOCAL-LLM-SMOKE-INTERPRETATION-001`
+
+## Boundary confirmation
+
+This interpretation uses only the imported local smoke evidence. It does not use terminal recollections, templates, planning notes, raw secrets, external artifacts, live calls, or inferred model behavior.
+
+## Explicit non-expansion
+
+This interpretation is not evidence for hosted providers, `/v1/solve`, dashboard preview, runtime integration, MVP status, production use, Alpha quality, Alpha-superiority claims, Batch C, benchmark results, billing, provider orchestration, or broad local-model quality.

--- a/docs/evals/runs/20260605-alpha-local-llm-smoke-interpretation/failure-or-success-analysis.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-smoke-interpretation/failure-or-success-analysis.md
@@ -6,7 +6,7 @@ Lane ID: `ALPHA-LOCAL-LLM-SMOKE-INTERPRETATION-001`
 
 | Criterion from post-smoke framework | Imported evidence review |
 | --- | --- |
-| Command executed against localhost or loopback endpoint | Satisfied by `http://127.0.0.1:11434/api/chat`. |
+| Command executed against localhost or loopback endpoint | Satisfied only at the imported artifact level by `executed: true` and `http://127.0.0.1:11434/api/chat`; caveat: the literal terminal command is not separately preserved. |
 | No hosted fallback occurred | Satisfied by `no_real_provider_call: true`, `real_provider_call_enabled: false`, and source note that no hosted endpoint is used. |
 | Finite timeout configured and preserved | Satisfied by `timeout_seconds: 120.0`. |
 | No provider keys used, required, exposed, or imported | Satisfied by source notes and redaction review confirming no provider key is used or imported. |
@@ -15,10 +15,14 @@ Lane ID: `ALPHA-LOCAL-LLM-SMOKE-INTERPRETATION-001`
 | Raw artifacts preserved | Satisfied by preserved sanitized request and raw response artifacts. |
 | Sanitized import exists | Satisfied by `../20260605-alpha-local-llm-smoke-results-import/source-evidence/sanitized-smoke-execution-artifact.md`. |
 
+## Import caveat effect
+
+The missing literal terminal command and missing numeric exit code are preserved as import caveats. They prevent treating this package as a complete terminal transcript import. They do not introduce a failure label, skipped marker, blocked marker, timeout, connection failure, malformed response, empty output, prompt echo, system echo, endpoint locality failure, environment setup failure, or model availability failure in the pasted artifact.
+
 ## Classification
 
-The imported evidence satisfies the post-smoke framework's clean local smoke criteria for selecting the next planning lane. This classification remains limited to the evidence boundary and does not convert `status: "non_evidence"` into behavioral evidence.
+The imported evidence satisfies the post-smoke framework's clean local smoke criteria for selecting the next planning lane only. This classification remains limited to planning, remains limited to the evidence boundary, and does not convert `status: "non_evidence"` into behavioral evidence.
 
 ## Caveat
 
-The raw response records `done_reason: "length"` while returning assistant content `OK`. This caveat is preserved and does not change the adapter result fields: `output_text: "OK"`, `status: "non_evidence"`, `reason: "local_llm_provider_adapter_wiring_only"`, and `exception: null`.
+The raw response records `done_reason: "length"` while returning assistant content `OK`. The missing literal terminal command and missing numeric exit code are also preserved as import caveats. This caveat is preserved and does not change the adapter result fields: `output_text: "OK"`, `status: "non_evidence"`, `reason: "local_llm_provider_adapter_wiring_only"`, and `exception: null`.

--- a/docs/evals/runs/20260605-alpha-local-llm-smoke-interpretation/failure-or-success-analysis.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-smoke-interpretation/failure-or-success-analysis.md
@@ -1,0 +1,24 @@
+# Failure or Success Analysis
+
+Lane ID: `ALPHA-LOCAL-LLM-SMOKE-INTERPRETATION-001`
+
+## Clean local smoke criteria review
+
+| Criterion from post-smoke framework | Imported evidence review |
+| --- | --- |
+| Command executed against localhost or loopback endpoint | Satisfied by `http://127.0.0.1:11434/api/chat`. |
+| No hosted fallback occurred | Satisfied by `no_real_provider_call: true`, `real_provider_call_enabled: false`, and source note that no hosted endpoint is used. |
+| Finite timeout configured and preserved | Satisfied by `timeout_seconds: 120.0`. |
+| No provider keys used, required, exposed, or imported | Satisfied by source notes and redaction review confirming no provider key is used or imported. |
+| Endpoint locality checked | Satisfied within this docs-only decision by the preserved loopback endpoint pattern and imported source note that the endpoint is localhost / loopback only. |
+| Adapter returned a non-failed result under expected local smoke boundary with `behavior_evidence: false`; no `failed_closed` status or label present | Satisfied by `status: "non_evidence"`, `reason: "local_llm_provider_adapter_wiring_only"`, `behavior_evidence: false`, `exception: null`, and absence of a `failed_closed` status or label in the imported artifact. |
+| Raw artifacts preserved | Satisfied by preserved sanitized request and raw response artifacts. |
+| Sanitized import exists | Satisfied by `../20260605-alpha-local-llm-smoke-results-import/source-evidence/sanitized-smoke-execution-artifact.md`. |
+
+## Classification
+
+The imported evidence satisfies the post-smoke framework's clean local smoke criteria for selecting the next planning lane. This classification remains limited to the evidence boundary and does not convert `status: "non_evidence"` into behavioral evidence.
+
+## Caveat
+
+The raw response records `done_reason: "length"` while returning assistant content `OK`. This caveat is preserved and does not change the adapter result fields: `output_text: "OK"`, `status: "non_evidence"`, `reason: "local_llm_provider_adapter_wiring_only"`, and `exception: null`.

--- a/docs/evals/runs/20260605-alpha-local-llm-smoke-interpretation/interpretation-preservation-checklist.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-smoke-interpretation/interpretation-preservation-checklist.md
@@ -1,0 +1,14 @@
+# Interpretation Preservation Checklist
+
+Lane ID: `ALPHA-LOCAL-LLM-SMOKE-INTERPRETATION-001`
+
+- [x] Interprets only imported smoke evidence.
+- [x] Records completed command under localhost / loopback boundary.
+- [x] Records adapter `output_text: "OK"`.
+- [x] Records adapter `status: "non_evidence"` exactly.
+- [x] Records adapter `reason: "local_llm_provider_adapter_wiring_only"` exactly.
+- [x] Preserves `behavior_evidence: false`.
+- [x] Records no adapter exception.
+- [x] Preserves raw response `done_reason: "length"` as a caveat only.
+- [x] Does not infer local-model quality.
+- [x] Does not infer runtime, product, benchmark, billing, or orchestration readiness.

--- a/docs/evals/runs/20260605-alpha-local-llm-smoke-interpretation/interpretation-preservation-checklist.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-smoke-interpretation/interpretation-preservation-checklist.md
@@ -12,3 +12,5 @@ Lane ID: `ALPHA-LOCAL-LLM-SMOKE-INTERPRETATION-001`
 - [x] Preserves raw response `done_reason: "length"` as a caveat only.
 - [x] Does not infer local-model quality.
 - [x] Does not infer runtime, product, benchmark, billing, or orchestration readiness.
+- [x] Preserves missing literal terminal command as an import caveat.
+- [x] Preserves missing numeric exit code as an import caveat and does not invent one.

--- a/docs/evals/runs/20260605-alpha-local-llm-smoke-interpretation/interpretation-summary.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-smoke-interpretation/interpretation-summary.md
@@ -11,3 +11,10 @@ The raw response artifact also preserves assistant content `OK`. The raw respons
 ## Interpretation limits
 
 The `done_reason: "length"` caveat is not interpreted as a readiness, quality, runtime, benchmark, or orchestration claim. The imported adapter result remains `status: "non_evidence"` with `behavior_evidence: false`.
+
+
+## Import caveat
+
+The interpretation preserves the import caveat that the pasted artifact does not separately include the literal terminal command text or a numeric process exit code. No numeric exit code is imported, and the missing command/exit-code fields are not reconstructed.
+
+This caveat limits the interpretation to the preserved executed artifact: `executed: true`, `exception: null`, completed timestamps, stdout-equivalent generated output, sanitized request artifact, and raw response artifact.

--- a/docs/evals/runs/20260605-alpha-local-llm-smoke-interpretation/interpretation-summary.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-smoke-interpretation/interpretation-summary.md
@@ -1,0 +1,13 @@
+# Interpretation Summary
+
+Lane ID: `ALPHA-LOCAL-LLM-SMOKE-INTERPRETATION-001`
+
+## Summary
+
+The imported artifact is interpreted as a completed local smoke execution within the recorded localhost / loopback endpoint boundary. The adapter returned `output_text: "OK"` with `status: "non_evidence"`, `reason: "local_llm_provider_adapter_wiring_only"`, `behavior_evidence: false`, and no exception.
+
+The raw response artifact also preserves assistant content `OK`. The raw response includes `done_reason: "length"`; this is preserved as a caveat only.
+
+## Interpretation limits
+
+The `done_reason: "length"` caveat is not interpreted as a readiness, quality, runtime, benchmark, or orchestration claim. The imported adapter result remains `status: "non_evidence"` with `behavior_evidence: false`.

--- a/docs/evals/runs/20260605-alpha-local-llm-smoke-interpretation/observed-outcome.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-smoke-interpretation/observed-outcome.md
@@ -16,6 +16,8 @@ Lane ID: `ALPHA-LOCAL-LLM-SMOKE-INTERPRETATION-001`
 - Raw assistant content: `OK`
 - Raw response completion marker: `done: true`
 - Raw response caveat: `done_reason: "length"`
+- Literal terminal command: not separately preserved in the pasted artifact; not reconstructed
+- Numeric process exit code: not separately preserved in the pasted artifact; no numeric exit code imported
 
 ## Observed outcome statement
 

--- a/docs/evals/runs/20260605-alpha-local-llm-smoke-interpretation/observed-outcome.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-smoke-interpretation/observed-outcome.md
@@ -1,0 +1,22 @@
+# Observed Outcome
+
+Lane ID: `ALPHA-LOCAL-LLM-SMOKE-INTERPRETATION-001`
+
+## Preserved observed fields
+
+- Execution marker: `executed: true`
+- Endpoint pattern: `http://127.0.0.1:11434/api/chat`
+- Timeout: `120.0`
+- Adapter exception field: `null`
+- Adapter output field: `output_text: "OK"`
+- Adapter status field: `status: "non_evidence"`
+- Adapter reason field: `reason: "local_llm_provider_adapter_wiring_only"`
+- Adapter behavior evidence field: `behavior_evidence: false`
+- Metadata behavior evidence field: `behavior_evidence: false`
+- Raw assistant content: `OK`
+- Raw response completion marker: `done: true`
+- Raw response caveat: `done_reason: "length"`
+
+## Observed outcome statement
+
+The smoke evidence shows a completed command with a non-exception adapter return. The adapter result is non-evidence wiring output, not behavioral evidence.

--- a/docs/evals/runs/20260605-alpha-local-llm-smoke-results-import/README.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-smoke-results-import/README.md
@@ -1,0 +1,21 @@
+# Local LLM Smoke Results Import
+
+Lane ID: `ALPHA-LOCAL-LLM-SMOKE-RESULTS-IMPORT-001`
+
+This folder imports the pasted `ALPHA-LOCAL-LLM-SMOKE-TEST-EXECUTION-001.md` evidence as a repo-safe, sanitized local smoke result package.
+
+## Imported source evidence
+
+- Source evidence file: `source-evidence/sanitized-smoke-execution-artifact.md`
+- Evidence source: pasted evidence block supplied to Codex for this docs-only lane.
+- Import status: completed as executed because the source evidence records `executed: true`.
+
+## Required companion files
+
+- `smoke-result-log.md` records the imported command fields and preserved result fields.
+- `smoke-redaction-log.md` records sanitization and absence checks.
+- `import-reviewer-checklist.md` records reviewer checks for this import.
+
+## Evidence boundary
+
+This import preserves local smoke evidence only. It does not expand the evidence boundary beyond the pasted execution artifact.

--- a/docs/evals/runs/20260605-alpha-local-llm-smoke-results-import/README.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-smoke-results-import/README.md
@@ -19,3 +19,7 @@ This folder imports the pasted `ALPHA-LOCAL-LLM-SMOKE-TEST-EXECUTION-001.md` evi
 ## Evidence boundary
 
 This import preserves local smoke evidence only. It does not expand the evidence boundary beyond the pasted execution artifact.
+
+## Import caveat
+
+The pasted artifact does not separately preserve the literal terminal command text or a numeric process exit code. Those fields are not marked complete, no numeric exit code is imported, and neither field is reconstructed. The import proceeds only because the artifact records `executed: true`, `exception: null`, completed timestamps, stdout-equivalent content, a sanitized request artifact, and a raw response artifact.

--- a/docs/evals/runs/20260605-alpha-local-llm-smoke-results-import/import-reviewer-checklist.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-smoke-results-import/import-reviewer-checklist.md
@@ -1,0 +1,15 @@
+# Import Reviewer Checklist
+
+Lane ID: `ALPHA-LOCAL-LLM-SMOKE-RESULTS-IMPORT-001`
+
+- [x] Pasted source evidence is present in `source-evidence/sanitized-smoke-execution-artifact.md`.
+- [x] Import treats the smoke as executed because the source records `executed: true`.
+- [x] `behavior_evidence: false` is preserved.
+- [x] `status: "non_evidence"` is preserved exactly.
+- [x] `reason: "local_llm_provider_adapter_wiring_only"` is preserved exactly.
+- [x] Endpoint details are limited to localhost / loopback pattern.
+- [x] No provider keys, access material, credentials, private endpoints, nonpublic endpoints, or sensitive environment dumps are imported.
+- [x] Request artifact remains sanitized; full system message is omitted while length and role order are preserved.
+- [x] Raw response artifact fields are preserved.
+- [x] Evidence boundary and non-claims are preserved.
+- [x] No pass/fail result is inferred beyond the imported `non_evidence` status.

--- a/docs/evals/runs/20260605-alpha-local-llm-smoke-results-import/import-reviewer-checklist.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-smoke-results-import/import-reviewer-checklist.md
@@ -4,6 +4,9 @@ Lane ID: `ALPHA-LOCAL-LLM-SMOKE-RESULTS-IMPORT-001`
 
 - [x] Pasted source evidence is present in `source-evidence/sanitized-smoke-execution-artifact.md`.
 - [x] Import treats the smoke as executed because the source records `executed: true`.
+- [x] Literal terminal command is not marked complete because it is not separately preserved in the pasted artifact.
+- [x] Numeric exit code is not marked complete because it is not separately preserved in the pasted artifact.
+- [x] No numeric exit code is imported or invented.
 - [x] `behavior_evidence: false` is preserved.
 - [x] `status: "non_evidence"` is preserved exactly.
 - [x] `reason: "local_llm_provider_adapter_wiring_only"` is preserved exactly.

--- a/docs/evals/runs/20260605-alpha-local-llm-smoke-results-import/smoke-redaction-log.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-smoke-results-import/smoke-redaction-log.md
@@ -1,0 +1,20 @@
+# Smoke Redaction Log
+
+Lane ID: `ALPHA-LOCAL-LLM-SMOKE-RESULTS-IMPORT-001`
+
+## Redaction and sanitization checklist
+
+- Provider keys removed or confirmed absent: confirmed absent in the pasted evidence.
+- Secrets removed or confirmed absent: confirmed absent in the pasted evidence.
+- Credentials removed or confirmed absent: confirmed absent in the pasted evidence.
+- Private URLs removed or confirmed absent: confirmed absent in the pasted evidence.
+- Nonpublic endpoints removed or confirmed absent: confirmed absent in the pasted evidence.
+- Sensitive environment dumps removed or confirmed absent: confirmed absent; only machine, Python, model, version, endpoint pattern, timestamps, timeout, request summary, and response artifact are preserved.
+- Endpoint shown only as localhost or loopback pattern: confirmed; preserved endpoint is `http://127.0.0.1:11434/api/chat`.
+- Exact model name disclosed only because it is present in the pasted evidence and required for artifact preservation: `gemma3:4b`.
+- stdout sanitized: confirmed; full system message is omitted while length and role order are preserved.
+- stderr sanitized: no stderr content is present in the pasted evidence.
+
+## Required preservation notes
+
+The import preserves exact command result fields, timestamps, stdout-equivalent artifact contents, and operator notes from the pasted evidence unless redaction was required. No additional endpoint, access material, provider key, credential, or environment dump was added.

--- a/docs/evals/runs/20260605-alpha-local-llm-smoke-results-import/smoke-result-log.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-smoke-results-import/smoke-result-log.md
@@ -2,11 +2,19 @@
 
 Lane ID: `ALPHA-LOCAL-LLM-SMOKE-RESULTS-IMPORT-001`
 
+## Import gate caveat
+
+The pasted artifact preserves stdout-equivalent generated output, completed timestamps, sanitized request details, and the raw response artifact. It does not separately preserve the literal terminal command text or a numeric process exit code.
+
+Because the literal command and numeric exit code are absent from the pasted artifact, this log does not mark those fields as complete and does not invent them. No numeric exit code is imported.
+
+The artifact is still imported under this docs-only lane because the pasted source records `executed: true`, `exception: null`, completed start and end timestamps, stdout-equivalent content in the Markdown artifact, a sanitized request artifact, and a raw response artifact. This import caveat is preserved for interpretation and final decision.
+
 ## Imported result row
 
-| source evidence file | lane ID | prerequisite PR link | command recorded | endpoint pattern | model disclosed | timeout seconds | start timestamp | end timestamp | exit code | executed/skipped/blocked | classification | stdout sanitized | stderr sanitized | raw artifact notes present | redaction notes present | evidence boundary present | non-claims present |
+| source evidence file | lane ID | prerequisite PR link | literal terminal command | endpoint pattern | model disclosed | timeout seconds | start timestamp | end timestamp | numeric exit code | executed/skipped/blocked | classification | stdout-equivalent artifact | stderr artifact | raw artifact notes present | redaction notes present | evidence boundary present | non-claims present |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `source-evidence/sanitized-smoke-execution-artifact.md` | `ALPHA-LOCAL-LLM-SMOKE-TEST-EXECUTION-001` | PR #305 merged and GS updated | not separately recorded in pasted evidence | `http://127.0.0.1:11434/api/chat` | `gemma3:4b` | `120.0` | `2026-06-05T16:41:02.641341+00:00` | `2026-06-05T16:41:41.668264+00:00` | not recorded in pasted evidence | executed | `non_evidence` | yes; full system message omitted while length and role order are preserved | no stderr content included; source says preserve separately if Terminal shows errors | yes | yes | yes | yes |
+| `source-evidence/sanitized-smoke-execution-artifact.md` | `ALPHA-LOCAL-LLM-SMOKE-TEST-EXECUTION-001` | PR #305 merged and GS updated | caveat: not separately preserved in pasted evidence; not reconstructed | `http://127.0.0.1:11434/api/chat` | `gemma3:4b` | `120.0` | `2026-06-05T16:41:02.641341+00:00` | `2026-06-05T16:41:41.668264+00:00` | caveat: not separately preserved in pasted evidence; no numeric exit code imported | executed | `non_evidence` | yes; captured in Markdown with full system message omitted while length and role order are preserved | no stderr content included in pasted evidence | yes | yes | yes | yes |
 
 ## Preserved result fields
 
@@ -40,3 +48,9 @@ Lane ID: `ALPHA-LOCAL-LLM-SMOKE-RESULTS-IMPORT-001`
   "real_provider_call_enabled": false
 }
 ```
+
+## Gate reconciliation
+
+The earlier scaffold required future evidence to include a literal terminal command and numeric exit code. Those two fields are not present in the pasted artifact supplied for this lane, so this import must not be treated as a complete terminal transcript import.
+
+The current import remains evidence-bound to the artifact that was supplied: it records execution completion, adapter result fields, stdout-equivalent generated output, sanitized request details, and raw response details without reconstructing missing terminal metadata.

--- a/docs/evals/runs/20260605-alpha-local-llm-smoke-results-import/smoke-result-log.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-smoke-results-import/smoke-result-log.md
@@ -1,0 +1,42 @@
+# Smoke Result Log
+
+Lane ID: `ALPHA-LOCAL-LLM-SMOKE-RESULTS-IMPORT-001`
+
+## Imported result row
+
+| source evidence file | lane ID | prerequisite PR link | command recorded | endpoint pattern | model disclosed | timeout seconds | start timestamp | end timestamp | exit code | executed/skipped/blocked | classification | stdout sanitized | stderr sanitized | raw artifact notes present | redaction notes present | evidence boundary present | non-claims present |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `source-evidence/sanitized-smoke-execution-artifact.md` | `ALPHA-LOCAL-LLM-SMOKE-TEST-EXECUTION-001` | PR #305 merged and GS updated | not separately recorded in pasted evidence | `http://127.0.0.1:11434/api/chat` | `gemma3:4b` | `120.0` | `2026-06-05T16:41:02.641341+00:00` | `2026-06-05T16:41:41.668264+00:00` | not recorded in pasted evidence | executed | `non_evidence` | yes; full system message omitted while length and role order are preserved | no stderr content included; source says preserve separately if Terminal shows errors | yes | yes | yes | yes |
+
+## Preserved result fields
+
+```json
+{
+  "backend_calls": 1,
+  "backend_payloads": 1,
+  "behavior_evidence": false,
+  "exception": null,
+  "executed": true,
+  "output_text": "OK",
+  "reason": "local_llm_provider_adapter_wiring_only",
+  "status": "non_evidence"
+}
+```
+
+## Preserved metadata fields
+
+```json
+{
+  "backend_class": "stub-local-llm-provider-adapter",
+  "behavior_evidence": false,
+  "evidence_label": "non_evidence_local_llm_provider_adapter_wiring",
+  "model": "gemma3:4b",
+  "no_real_provider_call": true,
+  "prompt_source_fingerprint": "98841febea17e2ea4d0155df63537bcb76f948e51395bddc1ce870b349d3c7bb",
+  "prompt_source_fingerprint_algorithm": "sha256",
+  "prompt_source_path": "alpha_solver_portable.py",
+  "prompt_source_sha256": "98841febea17e2ea4d0155df63537bcb76f948e51395bddc1ce870b349d3c7bb",
+  "provider_mode": "local_llm",
+  "real_provider_call_enabled": false
+}
+```

--- a/docs/evals/runs/20260605-alpha-local-llm-smoke-results-import/source-evidence/sanitized-smoke-execution-artifact.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-smoke-results-import/source-evidence/sanitized-smoke-execution-artifact.md
@@ -1,0 +1,103 @@
+# ALPHA-LOCAL-LLM-SMOKE-TEST-EXECUTION-001
+
+## Execution metadata
+
+* lane_id: `ALPHA-LOCAL-LLM-SMOKE-TEST-EXECUTION-001`
+* prerequisite: PR #305 merged and GS updated
+* start_time_utc: `2026-06-05T16:41:02.641341+00:00`
+* end_time_utc: `2026-06-05T16:41:41.668264+00:00`
+* machine: `macOS-26.2-arm64-arm-64bit`
+* python: `3.9.6`
+* ollama_version: `ollama version is 0.30.5`
+* endpoint_pattern: `http://127.0.0.1:11434/api/chat`
+* model: `gemma3:4b`
+* timeout_seconds: `120.0`
+
+## Smoke result
+
+```json
+{
+  "backend_calls": 1,
+  "backend_payloads": 1,
+  "behavior_evidence": false,
+  "exception": null,
+  "executed": true,
+  "metadata": {
+    "backend_class": "stub-local-llm-provider-adapter",
+    "behavior_evidence": false,
+    "evidence_label": "non_evidence_local_llm_provider_adapter_wiring",
+    "model": "gemma3:4b",
+    "no_real_provider_call": true,
+    "prompt_source_fingerprint": "98841febea17e2ea4d0155df63537bcb76f948e51395bddc1ce870b349d3c7bb",
+    "prompt_source_fingerprint_algorithm": "sha256",
+    "prompt_source_path": "alpha_solver_portable.py",
+    "prompt_source_sha256": "98841febea17e2ea4d0155df63537bcb76f948e51395bddc1ce870b349d3c7bb",
+    "provider_mode": "local_llm",
+    "real_provider_call_enabled": false
+  },
+  "output_text": "OK",
+  "reason": "local_llm_provider_adapter_wiring_only",
+  "status": "non_evidence"
+}
+```
+
+## Sanitized request artifact
+
+```json
+{
+  "endpoint_url": "http://127.0.0.1:11434/api/chat",
+  "message_roles": [
+    "system",
+    "user"
+  ],
+  "model": "gemma3:4b",
+  "stream": false,
+  "system_message_length": 43125,
+  "system_message_omitted": true,
+  "user_prompt": "Reply with exactly OK."
+}
+```
+
+## Raw response artifact
+
+```json
+{
+  "created_at": "2026-06-05T16:41:41.009865Z",
+  "done": true,
+  "done_reason": "length",
+  "eval_count": 1,
+  "eval_duration": 1000,
+  "load_duration": 14026933375,
+  "message": {
+    "content": "OK",
+    "role": "assistant"
+  },
+  "model": "gemma3:4b",
+  "prompt_eval_count": 4095,
+  "prompt_eval_duration": 22815223000,
+  "total_duration": 38342564625
+}
+```
+
+## Raw artifact preservation notes
+
+* stdout captured in this Markdown file.
+* stderr should be preserved separately if Terminal shows any errors.
+* request payload is sanitized: full system message is omitted, but system length and role order are preserved.
+* endpoint is localhost / loopback only.
+* no provider key or hosted provider endpoint is used.
+
+## Evidence boundary
+
+This artifact is local smoke evidence only.
+
+It is not local LLM quality evidence, broad Ollama behavior evidence, hosted provider evidence, /v1/solve readiness evidence, dashboard preview readiness evidence, runtime readiness evidence, MVP validation, production readiness, Alpha quality evidence, Alpha superiority evidence, broad plain-provider inferiority evidence, Batch C readiness, benchmark success, exact billing evidence, or provider orchestration evidence.
+
+## Non-claims
+
+* No readiness claim is made.
+* No quality claim is made.
+* No benchmark claim is made.
+* No production claim is made.
+* No provider-orchestration claim is made.
+* No Alpha-superiority claim is made.


### PR DESCRIPTION
### Motivation

- Import the pasted `ALPHA-LOCAL-LLM-SMOKE-TEST-EXECUTION-001.md` execution artifact into a sanitized, repo-safe docs package so later lanes can act from preserved local-smoke evidence. 
- Evaluate only the imported smoke evidence against the post-smoke decision framework and record a single, evidence-bound next step without making any runtime, quality, or production claims.

### Description

- Added a sanitized source evidence file and companion import artifacts under `docs/evals/runs/20260605-alpha-local-llm-smoke-results-import/` including `source-evidence/sanitized-smoke-execution-artifact.md`, `smoke-result-log.md`, `smoke-redaction-log.md`, `import-reviewer-checklist.md`, and a README. 
- Added an interpretation package under `docs/evals/runs/20260605-alpha-local-llm-smoke-interpretation/` that records the observed outcome, preserves the raw `done_reason: "length"` caveat, and confirms `output_text: "OK"`, `status: "non_evidence"`, `reason: "local_llm_provider_adapter_wiring_only"`, and `behavior_evidence: false`. 
- Added the final decision package under `docs/evals/runs/20260605-alpha-local-llm-integration-final-decision/` that selects exactly one next lane: `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-PLANNING-001`, preserves the evidence boundary, and lists blocked work. 
- Preserved the exact pasted fields from the evidence (including `executed: true`, endpoint sanitized to `http://127.0.0.1:11434/api/chat`, `behavior_evidence: false`, `status: "non_evidence"`, and `reason: "local_llm_provider_adapter_wiring_only"`) and did not add any keys, secrets, or non-public endpoints.

### Testing

- Ran repository checks including `git diff --name-only HEAD` to confirm only allowed docs files changed and the branch is `docs-local-llm-smoke-results-final-decision-20260605`, and the check passed. 
- Verified presence of required pasted fields with `rg` against the imported artifact for `ALPHA-LOCAL-LLM-SMOKE-TEST-EXECUTION-001`, `executed: true`, `status": "non_evidence"`, `reason": "local_llm_provider_adapter_wiring_only"`, and `behavior_evidence": false`, and the check passed. 
- Executed Python validation scripts to confirm endpoint URLs are loopback-only, exactly one selected next lane is recorded, and required source fields and caveats (`done_reason: "length"`) are present, and all validations passed. 
- Ran sensitive-pattern scans for keys/credentials and forbidden-claim phrase checks across the three added folders and confirmed no secrets or forbidden claims were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22fda9ee388329bc9bd7d8ea8a67c4)