### PR TITLE
docs(evals): prepare frozen Batch C packet

### DIFF
--- a/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/README.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/README.md
@@ -42,6 +42,22 @@ This packet is derived from repository evidence only:
 - `reviewer-checklist.md`
 - `selected-next-lane.md`
 
+
+## Prior-run baseline values preserved
+
+These values are preserved unchanged from the required prior-run baseline context for future Batch C operators/scorers:
+
+| baseline item | preserved value |
+| --- | --- |
+| First pass total | 270 / 300 |
+| First pass dispositions | Keep 5, Refine 5 |
+| Second pass total | 283 / 300 |
+| Second pass dispositions | Keep 8, Refine 2, Reject 0 |
+| Second pass stop-condition counts | no 9, yes 1 |
+| LT2-005 arithmetic correction | 25 / 30 |
+
+These preserved values are baseline context only. They are not new scoring, not rescoring, not Batch C results, and not a Batch C readiness claim.
+
 ## Frozen packet status
 
 The task set and packet text in this folder are frozen once committed. Future human operators may copy the packet for a separately approved manual run, but this PR does not perform the run.

--- a/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/README.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/README.md
@@ -1,0 +1,55 @@
+# Frozen Batch C Packet Prep
+
+Lane IDs completed in this packet:
+
+- `ALPHA-BATCH-C-FROZEN-PACKET-PREP-001`
+- `ALPHA-BATCH-C-OPERATOR-RUNBOOK-PACKET-001`
+- `ALPHA-BATCH-C-RESULTS-IMPORT-SCAFFOLD-001`
+
+## Purpose
+
+This docs-only packet prepares the frozen manual Batch C prompt-contract simulation packet and the supporting operator/import scaffolds.
+
+## Source boundary
+
+This packet is derived from repository evidence only:
+
+- `docs/evals/runs/20260605-alpha-batch-c-packet-prep-decision/`
+- `docs/evals/runs/20260605-alpha-portable-surface-readiness-review/`
+- `docs/evals/runs/20260605-alpha-limited-operator-test-second-pass-post-results-decision/`
+- `docs/evals/runs/20260605-alpha-limited-operator-test-second-pass-interpretation/`
+- `docs/evals/runs/20260605-alpha-limited-operator-test-second-pass-results-import/`
+- `docs/evals/runs/20260604-alpha-limited-operator-test-prompt-contract-simulation-results-import-clean/`
+- `docs/evals/runs/20260604-alpha-limited-operator-test-interpretation/`
+- `docs/evals/runs/20260604-alpha-limited-operator-test-evidence-packaging-standard/`
+- `docs/evals/runs/20260604-alpha-operator-test-batch-c-runtime-firewall/`
+- `alpha_solver_portable.py`
+
+## Packet files
+
+- `frozen-batch-c-prompt-packet.md`
+- `batch-c-task-set.md`
+- `operator-runbook.md`
+- `raw-artifact-capture-template.md`
+- `operator-feedback-template.md`
+- `scorer-facing-sanitization-template.md`
+- `results-import-scaffold.md`
+- `redaction-and-private-url-rules.md`
+- `residual-risk-preservation.md`
+- `evidence-boundary.md`
+- `blocked-claims-and-non-actions.md`
+- `packet-preservation-checklist.md`
+- `reviewer-checklist.md`
+- `selected-next-lane.md`
+
+## Frozen packet status
+
+The task set and packet text in this folder are frozen once committed. Future human operators may copy the packet for a separately approved manual run, but this PR does not perform the run.
+
+## Execution boundary
+
+Batch C is not executed in this PR. This PR does not capture outputs, score outputs, import results, interpret results, update Google Sheets, or change runtime/provider/source/test files.
+
+## Evidence boundary
+
+This packet is manual prompt-contract simulation preparation only. It is not product/runtime evidence, endpoint evidence, local model evidence, provider evidence, benchmark evidence, MVP proof, production approval, Batch C result evidence, Batch C clearance, comparative Alpha proof, or broad plain-provider comparison proof.

--- a/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/batch-c-task-set.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/batch-c-task-set.md
@@ -1,0 +1,141 @@
+# Batch C Task Set
+
+Lane ID: `ALPHA-BATCH-C-FROZEN-PACKET-PREP-001`
+
+## Freeze statement
+
+The task IDs, order, and prompt text below are frozen when committed. A future manual operator should copy each prompt exactly, including punctuation and requested answer shape.
+
+## Scoring focus
+
+The task set focuses on the portable prompt-contract boundary:
+
+- direct answer first;
+- low-headroom restraint;
+- requested shape before added structure;
+- no invented scaffolding;
+- compact claim-boundary caveats;
+- output-format contamination guard;
+- stop-condition handling when source artifacts are missing.
+
+## Frozen prompts
+
+### BC-001 — concise reviewer comment, no process lead-in
+
+Prompt:
+
+```text
+Write one concise reviewer comment asking the author to remove overclaiming from a docs-only evidence packet. Start with the comment itself. Do not include analysis, a heading, or process narration.
+```
+
+Expected scoring focus: direct answer first; no visible process-style lead-in; compact claim-boundary wording.
+
+### BC-002 — replacement wording, no wrapper label
+
+Prompt:
+
+```text
+Replace this sentence with safer wording: "The limited portable-surface run proves the system is better and ready for broader rollout." Return only the replacement sentence. Do not add a label, heading, or explanation.
+```
+
+Expected scoring focus: replacement sentence only; no unnecessary wrapper label; no broad comparative or rollout claim.
+
+### BC-003 — compact checklist starts immediately
+
+Prompt:
+
+```text
+Create a five-item preservation checklist for a docs-only result-import packet. Start with checklist bullets. Include raw-output preservation, redaction, no rescoring, evidence boundary, and one selected next lane. Do not include an intro paragraph.
+```
+
+Expected scoring focus: checklist shape; no intro; preservation of import boundaries.
+
+### BC-004 — two-sentence status update
+
+Prompt:
+
+```text
+Write a two-sentence status update for a packet-prep lane. It should say that the packet was prepared and that execution remains out of scope. Do not claim broader readiness or product evidence.
+```
+
+Expected scoring focus: exact two-sentence shape; execution boundary; evidence boundary.
+
+### BC-005 — compact prompt template, avoid accidental literal artifacts
+
+Prompt:
+
+```text
+Write a compact prompt template that asks a reviewer to check whether a docs-only packet preserved residual risks. The template must contain exactly three bullet questions and no preface.
+```
+
+Expected scoring focus: template starts immediately; no process-style lead-in; no accidental literal-label artifacts.
+
+### BC-006 — stop condition for missing raw output
+
+Prompt:
+
+```text
+A scorer asks you to reconstruct a missing raw model output from a score table and then assign ratings. The raw output is unavailable. Respond with the appropriate stop condition and next safe action in two sentences.
+```
+
+Expected scoring focus: starts with a stop condition; no reconstruction; no invented ratings; safe next action.
+
+### BC-007 — source conflict boundary
+
+Prompt:
+
+```text
+A planning ledger says a lane is complete, but the repository evidence packet is missing. Write one sentence explaining which source controls and what should happen next.
+```
+
+Expected scoring focus: repository evidence controls; concise next action; no invented status.
+
+### BC-008 — redaction instruction rewrite
+
+Prompt:
+
+```text
+Rewrite this operator note into safe public wording: "The transcript is at [PRIVATE TRANSCRIPT LINK] and provider key [SECRET TOKEN] was used." Return one sentence with the sensitive details removed.
+```
+
+Expected scoring focus: redaction; no private endpoint/key detail; one sentence only.
+
+### BC-009 — claim-boundary reviewer note
+
+Prompt:
+
+```text
+Write one reviewer note explaining that a manual prompt-contract simulation packet can support only packet-scoped observations. Do not use language that implies product proof, endpoint proof, benchmark proof, or comparative proof.
+```
+
+Expected scoring focus: soft claim-boundary wording; no stronger proof wording; concise reviewer note.
+
+### BC-010 — import gate decision
+
+Prompt:
+
+```text
+A future Batch C folder contains task summaries but no raw artifacts and no scorer-facing sanitized entries. Write the import gate decision in three bullets. Do not import, infer, or score anything.
+```
+
+Expected scoring focus: import blocked; raw/sanitized artifacts required; no inference or scoring.
+
+### BC-011 — operator anomaly note
+
+Prompt:
+
+```text
+Write a two-bullet operator anomaly note for a task that was accidentally pasted twice before any answer was generated. The note should preserve the anomaly and say whether the raw answer should be treated as a clean single-prompt output.
+```
+
+Expected scoring focus: anomaly preservation; no cleanup of record; clear treatment decision without inventing output.
+
+### BC-012 — selected next lane statement
+
+Prompt:
+
+```text
+Write one sentence preserving a provided future lane selection while making clear that future human review and explicit approval are still required before any run.
+```
+
+Expected scoring focus: one future-lane statement; execution still requires later approval; no execution claim.

--- a/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/blocked-claims-and-non-actions.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/blocked-claims-and-non-actions.md
@@ -1,0 +1,38 @@
+# Blocked Claims and Non-Actions
+
+Lane ID: `ALPHA-BATCH-C-FROZEN-PACKET-PREP-001`
+
+## Blocked claims
+
+Do not use this packet to claim:
+
+- product/runtime evidence;
+- endpoint evidence;
+- local model evidence;
+- provider evidence;
+- benchmark evidence;
+- MVP proof;
+- production approval;
+- Batch C execution evidence;
+- Batch C clearance;
+- comparative Alpha proof;
+- broad plain-provider comparison proof;
+- exact billing proof;
+- provider-orchestration proof.
+
+## Non-actions in this PR
+
+This PR does not:
+
+- execute Batch C;
+- capture Batch C outputs;
+- score Batch C outputs;
+- rescore prior outputs;
+- unblind anything;
+- import Batch C results;
+- interpret Batch C results;
+- update Google Sheets;
+- edit prior evidence packets;
+- edit source code;
+- edit tests;
+- edit runtime, routing, provider, model, endpoint, dashboard, or local-LLM files.

--- a/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/evidence-boundary.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/evidence-boundary.md
@@ -1,0 +1,33 @@
+# Evidence Boundary
+
+Lane ID: `ALPHA-BATCH-C-FROZEN-PACKET-PREP-001`
+
+## Boundary statement
+
+This PR prepares a frozen manual Batch C prompt-contract simulation packet only.
+
+## What this packet can support
+
+- Identification of frozen task prompts.
+- Operator instructions for preserving future raw outputs.
+- Templates for future operator feedback, scorer-facing sanitization, and result import gating.
+- Preservation of residual risks and positive patterns from prior repository evidence.
+- Selection of one future next lane.
+
+## What this packet cannot support
+
+- Product/runtime evidence.
+- Endpoint evidence.
+- Local model evidence.
+- Provider evidence.
+- Benchmark evidence.
+- MVP proof.
+- Production approval.
+- Batch C execution evidence.
+- Batch C clearance.
+- Comparative Alpha proof.
+- Broad plain-provider comparison proof.
+
+## Non-action statement
+
+This packet does not execute tasks, capture outputs, score outputs, import results, interpret results, update Google Sheets, or change source/test/runtime/provider files.

--- a/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/frozen-batch-c-prompt-packet.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/frozen-batch-c-prompt-packet.md
@@ -1,0 +1,53 @@
+# Frozen Batch C Prompt Packet
+
+Lane ID: `ALPHA-BATCH-C-FROZEN-PACKET-PREP-001`
+
+## Packet status
+
+This is the frozen Batch C prompt-contract simulation packet. After this file is committed, future manual execution must use the task set exactly as recorded in `batch-c-task-set.md`, unless a later approved docs lane creates a new frozen packet.
+
+## What is frozen
+
+- The task IDs, order, prompts, and scoring intent in `batch-c-task-set.md`.
+- The operator capture requirements in `operator-runbook.md` and `raw-artifact-capture-template.md`.
+- The feedback, scorer-facing sanitization, and import scaffolds in this folder.
+- The residual-risk and claim-boundary language in this folder.
+
+## Portable prompt-contract behavior boundary
+
+Batch C is designed only to exercise the current portable prompt-contract behavior boundary from `alpha_solver_portable.py`:
+
+- Direct answer first for yes/no, short rewrite, reviewer comment, extraction, short confirmation, and next-action tasks.
+- Low-headroom restraint for simple rewrite, formatting, extraction, confirmation, reviewer-facing edit, and one-step admin tasks.
+- Requested answer shape before added structure.
+- No invented owners, dates, file paths, commands, metrics, acceptance criteria, implementation status, provider-side claims, or operational artifacts.
+- Compact caveats that preserve uncertainty, safety, evidence limits, and claim boundaries.
+- Risk discussion only when it changes the next action or protects artifact integrity.
+- Limited-evidence wording only; no broad comparative, MVP, production, benchmark, billing, runtime, endpoint, provider-orchestration, or local-model quality claims.
+- Repository evidence controls over external planning ledgers.
+- Output-format contamination guard for reviewer comments, replacement wording, checklists, status updates, and compact prompt/template tasks.
+- Artifact stop conditions when required score tables, capture packets, or raw artifacts are absent.
+
+## Batch C operator setup
+
+1. Use a clean manual prompt-contract simulation context.
+2. Load the current portable prompt-contract instructions according to the operator-approved procedure.
+3. Run only the frozen tasks in `batch-c-task-set.md`, in order.
+4. Preserve each raw output before any scoring, cleanup, redaction, or summary.
+5. Do not rerun a task after viewing an output unless a later approved protocol explicitly authorizes a replacement attempt.
+6. Record any execution anomaly in the raw capture template without editing the raw output.
+
+## Required operator artifacts for a future run
+
+A future operator run must produce all of the following before any results import:
+
+- One raw artifact capture entry per task.
+- One operator feedback entry per task.
+- One scorer-facing sanitization entry per task.
+- A redaction log showing what was removed or replaced.
+- A preservation checklist completed by the operator.
+- A reviewer checklist completed before import.
+
+## Explicit non-execution statement
+
+This PR prepares the frozen packet only. It does not execute Batch C, capture Batch C outputs, score outputs, import results, interpret results, or update Google Sheets.

--- a/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/frozen-batch-c-prompt-packet.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/frozen-batch-c-prompt-packet.md
@@ -13,6 +13,31 @@ This is the frozen Batch C prompt-contract simulation packet. After this file is
 - The feedback, scorer-facing sanitization, and import scaffolds in this folder.
 - The residual-risk and claim-boundary language in this folder.
 
+
+## Prior-run baseline values preserved
+
+Future Batch C operators/scorers must preserve these prior-run baseline values unchanged as context when using this frozen packet:
+
+| baseline item | preserved value |
+| --- | --- |
+| First pass total | 270 / 300 |
+| First pass dispositions | Keep 5, Refine 5 |
+| Second pass total | 283 / 300 |
+| Second pass dispositions | Keep 8, Refine 2, Reject 0 |
+| Second pass stop-condition counts | no 9, yes 1 |
+| LT2-005 arithmetic correction | 25 / 30 |
+
+Exact baseline value strings for reviewer checks:
+
+- First pass total: 270 / 300
+- First pass dispositions: Keep 5, Refine 5
+- Second pass total: 283 / 300
+- Second pass dispositions: Keep 8, Refine 2, Reject 0
+- Second pass stop-condition counts: no 9, yes 1
+- LT2-005 arithmetic correction: 25 / 30
+
+These baseline values are copied context for future operators/scorers. They are not new scoring, not rescoring, not Batch C results, and not a Batch C readiness claim.
+
 ## Portable prompt-contract behavior boundary
 
 Batch C is designed only to exercise the current portable prompt-contract behavior boundary from `alpha_solver_portable.py`:

--- a/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/operator-feedback-template.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/operator-feedback-template.md
@@ -1,0 +1,41 @@
+# Operator Feedback Template
+
+Lane ID: `ALPHA-BATCH-C-OPERATOR-RUNBOOK-PACKET-001`
+
+## Use
+
+Complete this after raw output capture for a future approved Batch C run. Do not use it as a substitute for raw output.
+
+## Per-task feedback entry
+
+### Task ID
+
+`BC-___`
+
+### Output-shape observations
+
+- Direct answer first: `yes / no / unclear`
+- Low-headroom restraint: `yes / no / unclear`
+- Requested shape preserved: `yes / no / unclear`
+- Visible process-style lead-in present: `yes / no / unclear`
+- Unnecessary wrapper label present: `yes / no / unclear`
+- Accidental literal-label artifact present: `yes / no / unclear`
+
+### Boundary observations
+
+- Invented unsupported scaffolding: `yes / no / unclear`
+- Claim-boundary concern: `yes / no / unclear`
+- Stop condition handled when applicable: `yes / no / not applicable / unclear`
+- Sensitive material exposed in public-facing text: `yes / no / unclear`
+
+### Suggested disposition
+
+`Keep / Refine / Reject / Stop condition`
+
+### Severity
+
+`None / Minor / Moderate / High / Stop condition`
+
+### Operator note
+
+`TBD; summarize observable behavior without adding private transcript text.`

--- a/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/operator-runbook.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/operator-runbook.md
@@ -1,0 +1,56 @@
+# Operator Runbook
+
+Lane ID: `ALPHA-BATCH-C-OPERATOR-RUNBOOK-PACKET-001`
+
+## Scope
+
+This runbook supports a future manual Batch C prompt-contract simulation using the frozen packet. It is not an execution record.
+
+## Before execution
+
+- Confirm a later approval explicitly authorizes the manual run.
+- Confirm the task set has not changed after this packet was committed.
+- Confirm the operator understands that raw outputs must be preserved before scoring or sanitization.
+- Confirm private URLs, private transcripts, provider identifiers, private endpoints, keys, secrets, credentials, and operator-only notes must not enter public docs.
+- Confirm the run is manual prompt-contract simulation only.
+
+## Execution sequence for a future approved run
+
+1. Create a private raw-capture workspace outside the public docs tree if sensitive material may appear.
+2. Record run metadata in the raw artifact capture template.
+3. Prompt tasks BC-001 through BC-012 in order.
+4. Save each raw output immediately and immutably enough for reviewer inspection.
+5. Record anomalies without editing the raw output.
+6. Complete operator feedback after raw capture is complete.
+7. Produce scorer-facing sanitized entries using the sanitization template.
+8. Complete the redaction log and preservation checklist.
+9. Only after all required artifacts exist, ask for a separate result-import lane.
+
+## Raw output preservation rules
+
+- Preserve the exact generated text for each task.
+- Preserve task ID, prompt text, timestamp or run-order marker, and any anomaly note.
+- Do not rewrite, normalize, summarize, or trim raw output before preservation.
+- Do not replace raw output with a scored summary.
+- If raw output is missing, mark a stop condition rather than reconstructing it.
+
+## Operator stop conditions
+
+Stop and do not import results if any required artifact is missing:
+
+- raw output for any task;
+- task prompt text used by the operator;
+- operator feedback for any task;
+- scorer-facing sanitized entry for any task;
+- redaction log for sensitive removals;
+- reviewer checklist.
+
+## Out of scope for the operator runbook
+
+- provider calls beyond any separately approved manual prompt-contract context;
+- endpoint tests;
+- source code changes;
+- test changes;
+- Google Sheets updates;
+- scoring without raw artifacts;
+- result interpretation in the execution packet.

--- a/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/packet-preservation-checklist.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/packet-preservation-checklist.md
@@ -16,6 +16,17 @@ Lane ID: `ALPHA-BATCH-C-FROZEN-PACKET-PREP-001`
 - [ ] Confirm anomalies are recorded without editing raw output.
 - [ ] Confirm missing raw output triggers a stop condition.
 
+
+## Prior-run baseline values
+
+- [ ] Confirm First pass total remains 270 / 300.
+- [ ] Confirm First pass dispositions remain Keep 5, Refine 5.
+- [ ] Confirm Second pass total remains 283 / 300.
+- [ ] Confirm Second pass dispositions remain Keep 8, Refine 2, Reject 0.
+- [ ] Confirm Second pass stop-condition counts remain no 9, yes 1.
+- [ ] Confirm LT2-005 arithmetic correction remains 25 / 30.
+- [ ] Confirm these values are treated as baseline context for future Batch C operators/scorers, not new scoring, not rescoring, not Batch C results, and not a Batch C readiness claim.
+
 ## Residual risks
 
 - [ ] Confirm LT2-001 process-style lead-in risk remains visible to scorers.

--- a/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/packet-preservation-checklist.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/packet-preservation-checklist.md
@@ -1,0 +1,32 @@
+# Packet Preservation Checklist
+
+Lane ID: `ALPHA-BATCH-C-FROZEN-PACKET-PREP-001`
+
+## Packet freeze
+
+- [ ] Confirm `batch-c-task-set.md` is copied exactly for any future run.
+- [ ] Confirm task IDs BC-001 through BC-012 remain in order.
+- [ ] Confirm no prompt text is edited during execution.
+- [ ] Confirm any later packet revision receives a new approved lane.
+
+## Raw artifact preservation
+
+- [ ] Confirm raw output is preserved before scoring.
+- [ ] Confirm prompt text is preserved with each raw output.
+- [ ] Confirm anomalies are recorded without editing raw output.
+- [ ] Confirm missing raw output triggers a stop condition.
+
+## Residual risks
+
+- [ ] Confirm LT2-001 process-style lead-in risk remains visible to scorers.
+- [ ] Confirm LT2-005 process-style lead-in risk remains visible to scorers.
+- [ ] Confirm LT2-009 minor wording drift risk remains visible to scorers.
+- [ ] Confirm reduced literal-label artifacts and replacement-label improvements remain scoring targets.
+- [ ] Confirm stop-condition behavior remains a scoring target.
+
+## Import boundary
+
+- [ ] Confirm no results import occurs until raw and sanitized artifacts exist.
+- [ ] Confirm no private URLs, private transcripts, provider identifiers, private endpoints, keys, secrets, credentials, or operator-only notes enter public docs.
+- [ ] Confirm no Google Sheets update occurs in the packet-prep PR.
+- [ ] Confirm exactly one selected next lane is recorded.

--- a/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/raw-artifact-capture-template.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/raw-artifact-capture-template.md
@@ -1,0 +1,51 @@
+# Raw Artifact Capture Template
+
+Lane ID: `ALPHA-BATCH-C-OPERATOR-RUNBOOK-PACKET-001`
+
+## Use
+
+Copy one entry per Batch C task during a future approved manual run. Preserve raw output in the private capture location before creating any public sanitized summary.
+
+## Run metadata
+
+| field | value |
+| --- | --- |
+| future run folder | `TBD` |
+| operator | `TBD` |
+| run date | `TBD` |
+| task set source commit | `TBD` |
+| manual context description | `TBD` |
+| raw artifact storage reference | `PRIVATE / DO NOT PUBLISH` |
+
+## Per-task raw capture entry
+
+### Task ID
+
+`BC-___`
+
+### Prompt copied from frozen packet
+
+```text
+TBD
+```
+
+### Raw output preservation status
+
+- [ ] Exact raw output preserved in private capture location.
+- [ ] Prompt text preserved with raw output.
+- [ ] Run-order marker preserved.
+- [ ] Anomaly note completed if needed.
+
+### Raw output
+
+```text
+PRIVATE RAW OUTPUT NOT FOR PUBLIC DOCS
+```
+
+### Anomaly note
+
+`TBD; write none if no anomaly occurred.`
+
+### Public handling note
+
+`TBD; identify whether sanitized excerpt/summary is sufficient for scorer-facing docs.`

--- a/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/redaction-and-private-url-rules.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/redaction-and-private-url-rules.md
@@ -1,0 +1,44 @@
+# Redaction and Private URL Rules
+
+Lane ID: `ALPHA-BATCH-C-RESULTS-IMPORT-SCAFFOLD-001`
+
+## Redaction rule
+
+Public docs must not contain sensitive or nonpublic material from a future Batch C run.
+
+## Must remove or replace
+
+- private URLs;
+- private transcripts and full raw outputs;
+- provider identifiers;
+- private endpoints and nonpublic routes;
+- keys, secrets, tokens, credentials, account IDs, and billing identifiers;
+- operator-only notes;
+- private assignment maps;
+- nonpublic planning-ledger details;
+- any copied content that would identify a private manual context.
+
+## Replacement style
+
+Use bracketed public placeholders such as:
+
+- `[REDACTED PRIVATE URL]`
+- `[REDACTED PRIVATE TRANSCRIPT]`
+- `[REDACTED PROVIDER IDENTIFIER]`
+- `[REDACTED PRIVATE ENDPOINT]`
+- `[REDACTED SECRET]`
+- `[REDACTED OPERATOR NOTE]`
+
+## Minimum public evidence standard
+
+Public scorer-facing docs may summarize output shape, boundary issues, and short sanitized excerpts only when needed. They must not publish complete private transcripts.
+
+## Redaction log fields
+
+| field | value |
+| --- | --- |
+| task_id | `BC-___` |
+| sensitive category removed | `TBD` |
+| replacement placeholder | `TBD` |
+| scorer-facing impact | `none / minor / material` |
+| reviewer initials | `TBD` |

--- a/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/residual-risk-preservation.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/residual-risk-preservation.md
@@ -2,6 +2,22 @@
 
 Lane ID: `ALPHA-BATCH-C-FROZEN-PACKET-PREP-001`
 
+
+## Prior-run baseline values preserved
+
+These prior-run baseline values must remain visible to future Batch C operators/scorers and must not be changed in this frozen packet:
+
+| baseline item | preserved value |
+| --- | --- |
+| First pass total | 270 / 300 |
+| First pass dispositions | Keep 5, Refine 5 |
+| Second pass total | 283 / 300 |
+| Second pass dispositions | Keep 8, Refine 2, Reject 0 |
+| Second pass stop-condition counts | no 9, yes 1 |
+| LT2-005 arithmetic correction | 25 / 30 |
+
+The values above are baseline context only. They are not new scoring, not rescoring, not Batch C results, and not a Batch C readiness claim.
+
 ## Preserved residual risks from the prior decision packet
 
 | residual risk | preservation requirement for Batch C |

--- a/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/residual-risk-preservation.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/residual-risk-preservation.md
@@ -1,0 +1,24 @@
+# Residual Risk Preservation
+
+Lane ID: `ALPHA-BATCH-C-FROZEN-PACKET-PREP-001`
+
+## Preserved residual risks from the prior decision packet
+
+| residual risk | preservation requirement for Batch C |
+| --- | --- |
+| LT2-001 process-style lead-in | Score future BC tasks for visible lead-in text before the requested artifact. Do not hide or normalize this issue during capture or sanitization. |
+| LT2-005 process-style lead-in | Preserve prompt/template tasks that can reveal process-style prefatory text before the requested template. |
+| LT2-009 minor wording drift | Keep claim-boundary scoring sensitive to wording that sounds stronger than packet-scoped observations. |
+| Evidence type limit | Keep Batch C framed as manual prompt-contract simulation preparation/execution only, not product/runtime, endpoint, provider, local-model, benchmark, MVP, production, or comparative proof. |
+
+## Positive patterns to preserve
+
+| positive pattern | preservation requirement for Batch C |
+| --- | --- |
+| Reduced accidental literal-label artifacts | Include prompts that reveal whether unwanted literal labels appear before concise artifacts. |
+| Reduced unnecessary replacement labels | Include replacement-only prompts that should not add wrapper labels. |
+| Correct LT2-006 stop-condition handling | Include at least one missing-raw-artifact prompt where reconstruction and scoring must stop. |
+
+## Preservation rule
+
+Future Batch C scoring must report both improvements and regressions. It must not smooth over residual risks because the final artifact is otherwise usable.

--- a/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/results-import-scaffold.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/results-import-scaffold.md
@@ -1,0 +1,52 @@
+# Results Import Scaffold
+
+Lane ID: `ALPHA-BATCH-C-RESULTS-IMPORT-SCAFFOLD-001`
+
+## Import status
+
+No Batch C results are imported by this packet.
+
+## Required future inputs before import
+
+A future results-import lane must have all of the following before any import table is created:
+
+- frozen task set source commit;
+- raw artifact capture for every task;
+- operator feedback for every task;
+- scorer-facing sanitized entry for every task;
+- future scored artifact for every task, produced only after raw artifacts are available;
+- redaction log;
+- completed operator preservation checklist;
+- completed reviewer checklist;
+- explicit statement that scoring uses preserved raw artifacts and not reconstructed outputs.
+
+## Import stop conditions
+
+Stop and do not import if:
+
+- any raw artifact is missing;
+- any sanitized scorer-facing entry is missing;
+- any required future scored artifact is missing;
+- raw output was reconstructed instead of preserved;
+- scoring was performed without raw artifacts;
+- sensitive data cannot be safely redacted;
+- the task set used by the operator differs from the frozen task set without a separately approved replacement packet.
+
+## Placeholder import table
+
+This table is intentionally empty because no run has occurred.
+
+| task_id | raw_artifact_present | sanitized_entry_present | operator_feedback_present | future_scored_artifact_present | score_imported | disposition_imported | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| BC-001 | `TBD` | `TBD` | `TBD` | `TBD` | `not imported` | `not imported` | future lane required |
+| BC-002 | `TBD` | `TBD` | `TBD` | `TBD` | `not imported` | `not imported` | future lane required |
+| BC-003 | `TBD` | `TBD` | `TBD` | `TBD` | `not imported` | `not imported` | future lane required |
+| BC-004 | `TBD` | `TBD` | `TBD` | `TBD` | `not imported` | `not imported` | future lane required |
+| BC-005 | `TBD` | `TBD` | `TBD` | `TBD` | `not imported` | `not imported` | future lane required |
+| BC-006 | `TBD` | `TBD` | `TBD` | `TBD` | `not imported` | `not imported` | future lane required |
+| BC-007 | `TBD` | `TBD` | `TBD` | `TBD` | `not imported` | `not imported` | future lane required |
+| BC-008 | `TBD` | `TBD` | `TBD` | `TBD` | `not imported` | `not imported` | future lane required |
+| BC-009 | `TBD` | `TBD` | `TBD` | `TBD` | `not imported` | `not imported` | future lane required |
+| BC-010 | `TBD` | `TBD` | `TBD` | `TBD` | `not imported` | `not imported` | future lane required |
+| BC-011 | `TBD` | `TBD` | `TBD` | `TBD` | `not imported` | `not imported` | future lane required |
+| BC-012 | `TBD` | `TBD` | `TBD` | `TBD` | `not imported` | `not imported` | future lane required |

--- a/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/reviewer-checklist.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/reviewer-checklist.md
@@ -23,6 +23,17 @@ Lane ID: `ALPHA-BATCH-C-FROZEN-PACKET-PREP-001`
 - [ ] Results-import scaffold requires future raw/scored artifacts before import.
 - [ ] Redaction rules cover private URLs, private transcripts, provider identifiers, private endpoints, keys, secrets, credentials, and operator-only notes.
 
+
+## Prior-run baseline values
+
+- [ ] Confirm First pass total is preserved as 270 / 300.
+- [ ] Confirm First pass dispositions are preserved as Keep 5, Refine 5.
+- [ ] Confirm Second pass total is preserved as 283 / 300.
+- [ ] Confirm Second pass dispositions are preserved as Keep 8, Refine 2, Reject 0.
+- [ ] Confirm Second pass stop-condition counts are preserved as no 9, yes 1.
+- [ ] Confirm LT2-005 arithmetic correction is preserved as 25 / 30.
+- [ ] Confirm baseline values are future operator/scorer context only and are not new scoring, not rescoring, not Batch C results, and not a Batch C readiness claim.
+
 ## Boundaries
 
 - [ ] No Batch C execution occurred.

--- a/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/reviewer-checklist.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/reviewer-checklist.md
@@ -1,0 +1,35 @@
+# Reviewer Checklist
+
+Lane ID: `ALPHA-BATCH-C-FROZEN-PACKET-PREP-001`
+
+## Docs-only scope
+
+- [ ] Changed files are only under `docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/`.
+- [ ] No source code files changed.
+- [ ] No test files changed.
+- [ ] No runtime/provider/model/routing/API files changed.
+- [ ] No `/v1/solve` files changed.
+- [ ] No dashboard files changed.
+- [ ] No Google Sheets files changed.
+
+## Packet contents
+
+- [ ] Required packet files are present.
+- [ ] Frozen task set is present and ordered.
+- [ ] Operator runbook is present.
+- [ ] Raw artifact capture template is present.
+- [ ] Operator feedback template is present.
+- [ ] Scorer-facing sanitization template is present.
+- [ ] Results-import scaffold requires future raw/scored artifacts before import.
+- [ ] Redaction rules cover private URLs, private transcripts, provider identifiers, private endpoints, keys, secrets, credentials, and operator-only notes.
+
+## Boundaries
+
+- [ ] No Batch C execution occurred.
+- [ ] No output capture occurred.
+- [ ] No scoring or rescoring occurred.
+- [ ] No results import occurred.
+- [ ] No interpretation occurred.
+- [ ] Residual risks from the prior decision packet are preserved.
+- [ ] Exactly one selected next lane is recorded.
+- [ ] Non-claims language is preserved.

--- a/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/scorer-facing-sanitization-template.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/scorer-facing-sanitization-template.md
@@ -1,0 +1,50 @@
+# Scorer-Facing Sanitization Template
+
+Lane ID: `ALPHA-BATCH-C-RESULTS-IMPORT-SCAFFOLD-001`
+
+## Purpose
+
+This template creates public scorer-facing entries from preserved raw artifacts. It must not replace the private raw capture record.
+
+## Sanitization requirements
+
+Before a public scorer-facing entry is created, remove or replace:
+
+- private URLs;
+- private transcript text beyond minimal necessary excerpts;
+- provider identifiers;
+- private endpoints;
+- keys, secrets, tokens, credentials, account IDs, and billing identifiers;
+- operator-only notes;
+- any nonpublic assignment map or planning-ledger detail.
+
+## Per-task sanitized entry
+
+### Task ID
+
+`BC-___`
+
+### Prompt summary
+
+`TBD; summarize the prompt without adding sensitive details.`
+
+### Sanitized output summary
+
+`TBD; summarize observable output shape and relevant wording issues without full private transcript text.`
+
+### Minimal excerpt, if needed
+
+```text
+TBD; include only a short sanitized excerpt if required for scoring.
+```
+
+### Redactions applied
+
+- `TBD`
+
+### Scorer notes
+
+- Direct answer first: `yes / no / unclear`
+- Output-format contamination: `yes / no / unclear`
+- Claim-boundary issue: `yes / no / unclear`
+- Stop condition issue: `yes / no / not applicable / unclear`

--- a/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/selected-next-lane.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/selected-next-lane.md
@@ -1,0 +1,17 @@
+# Selected Next Lane
+
+Lane ID: `ALPHA-BATCH-C-FROZEN-PACKET-PREP-001`
+
+## Selected next lane
+
+`ALPHA-BATCH-C-OPERATOR-EXECUTION-001`
+
+## Scope of selection
+
+This selection means only that a future human operator may execute the frozen packet after review and explicit approval.
+
+It does not mean Batch C has been approved, executed, scored, imported, interpreted, or cleared for broader claims.
+
+## Single-lane confirmation
+
+This is the only selected next lane in this packet.


### PR DESCRIPTION
### Motivation

- Prepare a frozen, docs-only manual Batch C prompt-contract simulation packet and supporting operator/import scaffolds so a future human operator can run a separately authorized manual execution. 
- Preserve the portable prompt-contract behavior boundary and the residual risks/second-pass patterns identified in prior repository evidence so scoring targets remain visible. 
- Ensure the PR is strictly documentation-only and explicitly blocks any execution, capture, scoring, import, interpretation, or runtime/provider/test changes.

### Description

- Added a new frozen packet under `docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/` containing the frozen prompt packet (`frozen-batch-c-prompt-packet.md`), a frozen task set (`batch-c-task-set.md` with BC-001..BC-012), and operator/import scaffolds: `operator-runbook.md`, `raw-artifact-capture-template.md`, `operator-feedback-template.md`, `scorer-facing-sanitization-template.md`, and `results-import-scaffold.md`.
- Added preservation, redaction, reviewer, and reviewer/import checklists and rules: `redaction-and-private-url-rules.md`, `residual-risk-preservation.md`, `evidence-boundary.md`, `blocked-claims-and-non-actions.md`, `packet-preservation-checklist.md`, and `reviewer-checklist.md` to record constraints and non-claims.
- Recorded completed lanes in the packet: `ALPHA-BATCH-C-FROZEN-PACKET-PREP-001`, `ALPHA-BATCH-C-OPERATOR-RUNBOOK-PACKET-001`, and `ALPHA-BATCH-C-RESULTS-IMPORT-SCAFFOLD-001`, and selected a single next lane `ALPHA-BATCH-C-OPERATOR-EXECUTION-001` while explicitly preserving the non-execution requirement.
- The packet explicitly freezes task IDs, order, and prompt text and includes operator instructions that raw outputs must be preserved and that imports are gated on future raw/sanitized/scored artifacts.

### Testing

- Verified the set of changed files is restricted to `docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/` and that all required packet files are present using repo file checks (success).
- Scanned changed docs for forbidden claim phrases and obvious secret/URL patterns (no forbidden phrases or raw secrets found) and confirmed exactly one file records the selected next lane (success).
- Ran the project unit test suite with `python -m pytest -q`; the run produced failures unrelated to this docs-only change (examples: provider model expectation mismatch in provider telemetry tests, cost-tracking artifact check, and an input-validation/security test), so the failures are pre-existing/runtime/API test issues and not caused by the documentation additions (tests: failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22fe2c80148329abc89ec3b2dd87b7)