### PR TITLE
docs: add local LLM runtime safety-gate scaffold

### DIFF
--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-safety-gate-scaffold/README.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-safety-gate-scaffold/README.md
@@ -1,0 +1,27 @@
+# Alpha Local LLM Runtime Safety-Gate Scaffold
+
+Lane: `ALPHA-LOCAL-LLM-RUNTIME-SAFETY-GATE-SCAFFOLD-001`
+
+Status: docs-only scaffold; local LLM runtime integration is not implemented here.
+
+## Purpose
+
+This directory defines safety-gate scaffolding only for any future local LLM runtime integration implementation. It records guardrails that later implementation work must satisfy before any runtime-readiness claim can be made.
+
+This lane does not implement local LLM runtime routing, does not edit source code, does not edit tests, does not run a model, does not call Ollama, does not call hosted providers, and does not make network calls.
+
+## Contents
+
+- `safety-gate-summary.md`
+- `local-only-endpoint-guardrails.md`
+- `default-off-and-opt-in-requirements.md`
+- `fallback-policy-constraints.md`
+- `timeout-and-fail-closed-requirements.md`
+- `runtime-smoke-gate.md`
+- `implementation-review-checklist.md`
+- `evidence-boundary.md`
+- `selected-next-lane.md`
+
+## Non-implementation rule
+
+Future local LLM runtime integration remains blocked until a later explicitly authorized implementation lane updates the relevant spec and code. This scaffold does not authorize runtime routing, `/v1/solve` exposure, dashboard preview exposure, provider orchestration, model calls, hosted fallback, billing behavior, readiness claims, validation claims, benchmark claims, production claims, MVP claims, or Alpha superiority claims.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-safety-gate-scaffold/default-off-and-opt-in-requirements.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-safety-gate-scaffold/default-off-and-opt-in-requirements.md
@@ -1,0 +1,23 @@
+# Default-Off and Opt-In Requirements
+
+This is a scaffold only. Local LLM runtime integration is not implemented here.
+
+## Default-off rule
+
+Local LLM runtime use must be default-off. No request path may use a local LLM runtime unless a later implementation lane explicitly defines and implements operator opt-in configuration.
+
+## Explicit configuration rule
+
+A future implementation must require explicit local LLM configuration before any local runtime call is attempted. Silent enablement, implicit auto-discovery, opportunistic routing, and environment-dependent activation are prohibited unless a later lane separately authorizes them.
+
+## No exposure by default
+
+Until explicitly authorized by a later lane:
+
+- `/v1/solve` must not be exposed to local LLM mode;
+- dashboard preview must not be exposed to local LLM mode;
+- hosted-provider routing must not silently switch into or out of local LLM mode.
+
+## Evidence model preservation
+
+`behavior_evidence=false` must remain preserved for local LLM runtime outputs until a later lane explicitly changes the evidence model.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-safety-gate-scaffold/evidence-boundary.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-safety-gate-scaffold/evidence-boundary.md
@@ -1,0 +1,29 @@
+# Evidence Boundary
+
+This lane is runtime safety-gate scaffold only.
+
+It is not:
+
+- local LLM runtime integration;
+- runtime evidence;
+- local model quality evidence;
+- hosted provider evidence;
+- `/v1/solve` readiness;
+- dashboard preview readiness;
+- MVP validation;
+- production readiness;
+- benchmark evidence;
+- provider orchestration evidence;
+- Alpha superiority evidence.
+
+## Claim boundary
+
+This scaffold must not be used for readiness, validation, superiority, benchmark, production, MVP, runtime, billing, or provider-orchestration claims.
+
+## Smoke boundary
+
+This lane does not run a model, does not call Ollama, does not call hosted providers, does not make network calls, and does not import runtime evidence.
+
+## Evidence-model boundary
+
+`behavior_evidence=false` must remain preserved until a later lane explicitly changes the evidence model.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-safety-gate-scaffold/fallback-policy-constraints.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-safety-gate-scaffold/fallback-policy-constraints.md
@@ -1,0 +1,20 @@
+# Fallback Policy Constraints
+
+This is a scaffold only. Local LLM runtime integration is not implemented here.
+
+## No hosted fallback without authorization
+
+A future local LLM runtime implementation must not fall back to a hosted provider unless a later lane separately authorizes that behavior. Local LLM failures must not be masked by hosted-provider output.
+
+## Required fallback review questions
+
+Future implementation review must confirm that:
+
+- routing does not silently switch to a hosted provider;
+- hosted provider keys are not required for local LLM mode;
+- local LLM mode does not use hosted-provider billing, telemetry, or orchestration paths;
+- failure outcomes are visible as local LLM failures rather than transformed into hosted-provider successes.
+
+## Fail-closed fallback handling
+
+For local LLM mode, connection failures, timeouts, malformed responses, empty outputs, prompt echoes, and system echoes must fail closed rather than triggering hosted fallback.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-safety-gate-scaffold/implementation-review-checklist.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-safety-gate-scaffold/implementation-review-checklist.md
@@ -1,0 +1,37 @@
+# Implementation Review Checklist
+
+This is a scaffold only. Local LLM runtime integration is not implemented here.
+
+A future implementation review must verify each item below before merge.
+
+## Routing and exposure
+
+- [ ] Local LLM runtime use is default-off unless explicitly configured.
+- [ ] Routing does not silently switch to a hosted provider.
+- [ ] `/v1/solve` is not exposed to local LLM mode until explicitly authorized.
+- [ ] Dashboard preview is not exposed to local LLM mode until explicitly authorized.
+- [ ] Local LLM mode requires no provider keys.
+
+## Endpoint and timeout controls
+
+- [ ] Local LLM mode accepts only localhost or loopback endpoints.
+- [ ] Non-local endpoints fail closed.
+- [ ] Malformed endpoints fail closed.
+- [ ] Runtime calls use finite timeout values.
+- [ ] Connection failures fail closed.
+- [ ] Timeouts fail closed.
+
+## Response and evidence controls
+
+- [ ] Malformed responses fail closed.
+- [ ] Empty outputs fail closed.
+- [ ] Prompt echoes fail closed.
+- [ ] System echoes fail closed.
+- [ ] `behavior_evidence=false` remains preserved until a later lane explicitly changes the evidence model.
+- [ ] Observability distinguishes local LLM from hosted providers.
+- [ ] Raw artifacts are preserved for runtime smoke.
+
+## Claim controls
+
+- [ ] Runtime smoke was completed before any runtime-readiness claim.
+- [ ] The implementation does not claim MVP validation, production readiness, benchmark evidence, provider-orchestration evidence, Alpha superiority evidence, `/v1/solve` readiness, or dashboard preview readiness unless separately authorized.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-safety-gate-scaffold/local-only-endpoint-guardrails.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-safety-gate-scaffold/local-only-endpoint-guardrails.md
@@ -1,0 +1,24 @@
+# Local-Only Endpoint Guardrails
+
+This is a scaffold only. Local LLM runtime integration is not implemented here.
+
+## Required endpoint locality
+
+Any future local LLM runtime implementation must accept only localhost or loopback endpoints for local LLM mode. The acceptable endpoint boundary must be limited to local machine targets such as `localhost`, `127.0.0.1`, and `::1`, subject to a future implementation spec defining exact parsing rules.
+
+## Fail-closed endpoint handling
+
+A future implementation must fail closed for:
+
+- non-local endpoint;
+- malformed endpoint;
+- endpoint values that cannot be parsed deterministically;
+- endpoint values that could be interpreted as hosted, remote, or network provider targets.
+
+## Provider-key separation
+
+Local LLM mode must require no hosted-provider keys, no local-provider keys, and no provider credential fallback path. If a provider key is required for a path, that path must not be treated as local LLM mode.
+
+## No readiness claim
+
+These guardrails are requirements for future work only. They are not runtime evidence and do not prove endpoint-locality enforcement in code.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-safety-gate-scaffold/runtime-smoke-gate.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-safety-gate-scaffold/runtime-smoke-gate.md
@@ -1,0 +1,23 @@
+# Runtime Smoke Gate
+
+This is a scaffold only. Local LLM runtime integration is not implemented here.
+
+## Smoke-before-readiness rule
+
+Runtime smoke is required before any local LLM runtime-readiness claim. A future implementation cannot claim runtime readiness based on this scaffold.
+
+## Minimum future smoke expectations
+
+A future runtime smoke lane must preserve raw artifacts and must check, at minimum, that:
+
+- local LLM mode was explicitly configured;
+- the endpoint was localhost or loopback only;
+- no hosted provider fallback occurred;
+- no provider keys were required for local LLM mode;
+- finite timeout behavior was exercised or verified;
+- malformed, empty, prompt-echo, and system-echo response handling was evaluated according to the authorized smoke plan;
+- `behavior_evidence=false` remained preserved unless a later lane explicitly changed the evidence model.
+
+## No smoke in this lane
+
+This lane does not run a model, does not call Ollama, does not call hosted providers, does not make network calls, and does not create runtime evidence.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-safety-gate-scaffold/safety-gate-summary.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-safety-gate-scaffold/safety-gate-summary.md
@@ -1,0 +1,24 @@
+# Safety-Gate Summary
+
+This is a scaffold only. Local LLM runtime integration is not implemented here.
+
+Any future local LLM runtime integration implementation must satisfy the safety gates below before it can be described as runtime-ready.
+
+## Required gates
+
+1. Local LLM runtime use must remain default-off unless explicitly configured by the operator.
+2. Local LLM mode must require a localhost or loopback endpoint only.
+3. Local LLM mode must require no provider keys.
+4. Hosted provider fallback is prohibited unless separately authorized by a later lane.
+5. Runtime calls must use a finite timeout.
+6. Runtime handling must fail closed for endpoint, connection, timeout, response, and echo failures.
+7. Runtime smoke must run before any runtime-readiness claim.
+8. `behavior_evidence=false` must remain preserved until a later lane explicitly changes the evidence model.
+9. `/v1/solve` must not be exposed to local LLM mode until explicitly authorized.
+10. Dashboard preview must not be exposed to local LLM mode until explicitly authorized.
+11. Observability must distinguish local LLM from hosted providers.
+12. Raw artifacts must be preserved for runtime smoke.
+
+## Blocked by this scaffold
+
+This scaffold does not permit source changes, test changes, runtime changes, provider changes, `/v1/solve` changes, dashboard changes, local model calls, hosted provider calls, network calls, provider keys, or any readiness, validation, superiority, benchmark, production, MVP, runtime, billing, or provider-orchestration claim.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-safety-gate-scaffold/selected-next-lane.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-safety-gate-scaffold/selected-next-lane.md
@@ -1,0 +1,13 @@
+# Selected Next Lane
+
+Exactly one selected next lane is recorded:
+
+`ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-SPEC-001`
+
+## Conditionality
+
+This selected next lane is conditional on the separately running runtime-planning PR also selecting or permitting spec work. This scaffold does not override the runtime-planning PR.
+
+## Non-expansion rule
+
+The selected next lane must remain spec work unless a later explicit authorization permits implementation. It must not become runtime implementation, local model execution, hosted provider execution, `/v1/solve` exposure, dashboard preview exposure, provider orchestration, benchmark work, MVP validation, production readiness, runtime readiness, billing claims, or Alpha superiority claims.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-safety-gate-scaffold/timeout-and-fail-closed-requirements.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-safety-gate-scaffold/timeout-and-fail-closed-requirements.md
@@ -1,0 +1,28 @@
+# Timeout and Fail-Closed Requirements
+
+This is a scaffold only. Local LLM runtime integration is not implemented here.
+
+## Finite timeout requirement
+
+Any future local LLM runtime call must use a finite timeout. Unbounded calls are prohibited.
+
+## Required fail-closed cases
+
+A future implementation must fail closed for all of the following local LLM mode cases:
+
+- non-local endpoint;
+- malformed endpoint;
+- connection failure;
+- timeout;
+- malformed response;
+- empty output;
+- prompt echo;
+- system echo.
+
+## Fail-closed meaning
+
+Fail-closed means the runtime must stop the local LLM path, surface a bounded error outcome, avoid hosted-provider fallback unless separately authorized, and avoid presenting the output as successful behavior evidence.
+
+## Evidence model preservation
+
+`behavior_evidence=false` must remain preserved for affected local LLM outcomes until a later lane explicitly changes the evidence model.


### PR DESCRIPTION
### Motivation

- Provide a docs-only safety-gate scaffold to record mandatory guardrails for any future local LLM runtime integration. 
- Make explicit that this lane does not implement runtime routing, model execution, provider calls, or any source/test/runtime changes. 
- Preserve a narrow evidence boundary and a single recommended next lane so future implementation work remains gated and auditable.

### Description

- Added a docs-only scaffold under `docs/evals/runs/20260605-alpha-local-llm-runtime-safety-gate-scaffold/` consisting of `README.md`, `safety-gate-summary.md`, `local-only-endpoint-guardrails.md`, `default-off-and-opt-in-requirements.md`, `fallback-policy-constraints.md`, `timeout-and-fail-closed-requirements.md`, `runtime-smoke-gate.md`, `implementation-review-checklist.md`, `evidence-boundary.md`, and `selected-next-lane.md`. 
- The scaffold requires local LLM runtime to be default-off, accept only localhost/loopback endpoints, require no provider keys, prohibit hosted-provider fallback unless explicitly authorized, mandate finite timeouts, and require fail-closed behavior for endpoint/connection/timeout/response/echo failures. 
- It records that `behavior_evidence=false` must be preserved until a later lane explicitly changes the evidence model and that `/v1/solve` and dashboard preview must not be exposed to local LLM mode without explicit authorization. 
- The scaffold records exactly one conditional selected next lane: `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-SPEC-001`, and explicitly blocks any implementation, network, provider, source, or test changes in this lane.

### Testing

- Confirmed only scaffold docs were staged with `git diff --cached --name-only` and path-confinement awk check, which passed. 
- Verified no source/test/runtime/provider/dashboard paths were staged with an awk path check, which passed. 
- Checked exactly one occurrence of the selected next lane with a Python count assertion on `selected-next-lane.md`, which passed. 
- Ran `rg` evidence-boundary checks to confirm narrow/no-call/evidence-model language and committed changes with `git commit`, which succeeded (commit `522810c`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a230d362c548329bfa27fd24f68a60b)