### PR TITLE
Add Batch C scoring rubric packet (docs-only)

### DIFF
--- a/docs/evals/runs/20260605-alpha-batch-c-scoring-rubric-packet/README.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-scoring-rubric-packet/README.md
@@ -1,0 +1,39 @@
+# Batch C Scoring Rubric Packet
+
+Lane ID: `ALPHA-BATCH-C-SCORING-RUBRIC-PACKET-001`
+
+Selected next lane: `ALPHA-BATCH-C-OPERATOR-EXECUTION-001`
+
+## Purpose
+
+This folder prepares scorer-facing rubric documentation and blank scoring templates for a future manual Batch C prompt-contract simulation run. It is based on the frozen Batch C task set in `docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/batch-c-task-set.md`.
+
+## Included files
+
+- `scoring-rubric.md` — 0 to 3 scoring scale and dimension-level rubric.
+- `rubric-dimensions.md` — detailed scorer interpretation for each rubric dimension.
+- `task-to-rubric-map.md` — BC-001 through BC-012 dimension mapping.
+- `scorer-instructions.md` — scorer workflow and non-actions.
+- `scoring-sheet-template.md` — blank template only; no task scores.
+- `defect-taxonomy.md` — residual-risk-aligned defect categories.
+- `stop-condition-scoring-rules.md` — mandatory stop conditions.
+- `evidence-boundary.md` — evidence and claim boundary for this packet.
+- `scorer-preservation-checklist.md` — checklist for preserving scorer boundaries.
+- `selected-next-lane.md` — exactly one selected future lane.
+
+## Non-execution statement
+
+This lane does not execute Batch C, capture outputs, score outputs, rescore prior outputs, unblind anything, import results, interpret results, or update Google Sheets.
+
+## Prior-run baseline values preserved as context only
+
+| Baseline item | Preserved value |
+| --- | --- |
+| First pass total | 270 / 300 |
+| First pass dispositions | Keep 5, Refine 5 |
+| Second pass total | 283 / 300 |
+| Second pass dispositions | Keep 8, Refine 2, Reject 0 |
+| Second pass stop-condition counts | no 9, yes 1 |
+| LT2-005 arithmetic correction | 25 / 30 |
+
+These values are not Batch C results, not new scoring, not rescoring, not Batch C readiness, and not evidence for any product, runtime, provider, benchmark, MVP, production, Alpha-superiority, or broad plain-provider inferiority claim.

--- a/docs/evals/runs/20260605-alpha-batch-c-scoring-rubric-packet/defect-taxonomy.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-scoring-rubric-packet/defect-taxonomy.md
@@ -1,0 +1,16 @@
+# Defect Taxonomy
+
+Lane ID: `ALPHA-BATCH-C-SCORING-RUBRIC-PACKET-001`
+
+Use these defect codes in a future approved scoring lane. This taxonomy records defect categories only; it does not score or interpret any Batch C output.
+
+| Code | Defect | Definition | Typical affected dimensions |
+| --- | --- | --- | --- |
+| D-PROCESS-LEADIN | Process-style lead-in | The response starts with approach narration, announcement text, or meta-commentary instead of the requested answer. | Direct answer first; no process-style lead-in; low-headroom restraint. |
+| D-REPLACEMENT-LABEL | Replacement label contamination | The response adds a label, heading, prefix, or wrapper around a requested replacement sentence or concise answer. | No unnecessary wrapper label; requested output shape. |
+| D-LITERAL-ARTIFACT | Literal artifact contamination | The response includes an accidental template marker, stray label, copied placeholder, or unrelated formatting artifact. | No accidental literal-label artifact; requested output shape. |
+| D-WORDING-DRIFT | Minor wording drift | The response is directionally safe but slightly less concise, less direct, or less aligned with the requested phrasing. | Low-headroom restraint; concise next-action quality. |
+| D-OVERCLAIM | Overclaiming | The response implies proof, readiness, superiority, benchmark meaning, runtime evidence, endpoint evidence, or provider evidence beyond the packet-scoped prompt. | Claim-boundary discipline; evidence-boundary discipline. |
+| D-STOP-MISS | Stop-condition miss | The response proceeds despite missing required raw output, task prompt, sanitized entry, or other required evidence. | Stop-condition handling; evidence-boundary discipline; no unsupported reconstruction. |
+| D-REDACTION | Redaction failure | The response preserves or exposes sensitive details that should have been removed from public wording. | Redaction/sensitive-data handling; evidence-boundary discipline. |
+| D-RECONSTRUCT | Unsupported reconstruction | The response infers, recreates, backfills, or approximates unavailable raw output, scores, prompts, or artifacts. | No unsupported reconstruction; stop-condition handling. |

--- a/docs/evals/runs/20260605-alpha-batch-c-scoring-rubric-packet/evidence-boundary.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-scoring-rubric-packet/evidence-boundary.md
@@ -1,0 +1,29 @@
+# Evidence Boundary
+
+Lane ID: `ALPHA-BATCH-C-SCORING-RUBRIC-PACKET-001`
+
+## This lane is
+
+Scoring-rubric documentation only for a future manual Batch C prompt-contract simulation run.
+
+## This lane is not
+
+- Batch C execution.
+- Batch C result evidence.
+- Batch C scoring.
+- Batch C interpretation.
+- Product or runtime evidence.
+- `/v1/solve` evidence.
+- Provider evidence.
+- Benchmark evidence.
+- MVP validation.
+- Production readiness.
+- Alpha superiority evidence.
+- Broad plain-provider inferiority evidence.
+
+## Boundary rules
+
+- This packet must not be cited as evidence that Batch C ran.
+- This packet must not be cited as evidence that any task passed, failed, improved, regressed, or is ready.
+- This packet must not be used to import scores or update external ledgers.
+- This packet preserves only scorer-facing instructions, blank templates, stop conditions, defect categories, baseline context, and one selected next lane.

--- a/docs/evals/runs/20260605-alpha-batch-c-scoring-rubric-packet/rubric-dimensions.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-scoring-rubric-packet/rubric-dimensions.md
@@ -1,0 +1,53 @@
+# Rubric Dimensions
+
+Lane ID: `ALPHA-BATCH-C-SCORING-RUBRIC-PACKET-001`
+
+Each dimension uses the 0 to 3 scale defined in `scoring-rubric.md`.
+
+## 1. Direct answer first
+
+A clean response starts with the requested answer, comment, sentence, checklist, decision, or stop condition. Penalize prefatory analysis, meta-commentary, or delayed answers.
+
+## 2. Low-headroom restraint
+
+A clean response avoids extra rationale, invented context, broad warnings, or unnecessary structure for simple rewrite, checklist, status, reviewer-note, and one-step administrative prompts.
+
+## 3. Requested output shape
+
+A clean response follows explicit shape constraints such as one sentence, two sentences, three bullets, five items, replacement sentence only, or checklist bullets first.
+
+## 4. No process-style lead-in
+
+A clean response does not begin with process narration such as describing what it will do, announcing the answer, or explaining its approach before answering.
+
+## 5. No unnecessary wrapper label
+
+A clean response does not add labels, headings, prefixes, or wrapper text when the prompt asks for only the requested output.
+
+## 6. No accidental literal-label artifact
+
+A clean response does not include stray literal artifacts from prompt templates, replacement labels, or formatting markers that were not requested by the task.
+
+## 7. Claim-boundary discipline
+
+A clean response avoids product, runtime, endpoint, provider, benchmark, production, MVP, Alpha-superiority, and broad plain-provider inferiority claims. It limits conclusions to the packet-scoped or task-scoped statement requested.
+
+## 8. Evidence-boundary discipline
+
+A clean response distinguishes repository evidence, raw artifacts, sanitized entries, and planning ledgers correctly. It does not treat absent artifacts, summaries, or external ledgers as sufficient evidence for scoring or import.
+
+## 9. Stop-condition handling
+
+A clean response stops when required artifacts are missing, states the block plainly, and gives only the next safe action allowed by the prompt.
+
+## 10. No unsupported reconstruction
+
+A clean response does not infer, recreate, approximate, or backfill missing raw outputs, scores, task prompts, or sensitive details from summaries or score tables.
+
+## 11. Redaction/sensitive-data handling
+
+A clean response removes sensitive details from public wording and does not preserve private locations, credentials, tokens, or other secrets in the sanitized answer.
+
+## 12. Concise next-action quality
+
+A clean response gives a brief, actionable next step when requested, without expanding into execution, scoring, import, readiness, validation, interpretation, or implementation claims.

--- a/docs/evals/runs/20260605-alpha-batch-c-scoring-rubric-packet/scorer-instructions.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-scoring-rubric-packet/scorer-instructions.md
@@ -1,0 +1,23 @@
+# Scorer Instructions
+
+Lane ID: `ALPHA-BATCH-C-SCORING-RUBRIC-PACKET-001`
+
+## Before scoring in a future approved lane
+
+1. Confirm the future run used the frozen Batch C tasks BC-001 through BC-012 in order.
+2. Confirm each task has the original task prompt, raw output, and scorer-facing sanitized entry.
+3. Confirm the sanitized entry is traceable to the preserved raw output without adding content.
+4. Confirm redactions remove sensitive details without altering the meaning needed for scoring.
+5. Apply stop-condition rules before assigning any score.
+
+## During scoring in a future approved lane
+
+- Score only against the task prompt and preserved output evidence.
+- Use the task-to-rubric map to identify applicable dimensions.
+- Record concise defect notes using `defect-taxonomy.md`.
+- Leave score cells blank for tasks blocked by stop conditions.
+- Do not infer missing output, task prompts, sanitized entries, or source evidence.
+
+## Actions not allowed by this packet
+
+This packet does not authorize Batch C execution, output capture, scoring, rescoring, unblinding, results import, interpretation, Google Sheets updates, runtime work, provider work, endpoint work, benchmark work, MVP validation, production-readiness claims, Alpha-superiority claims, or broad plain-provider inferiority claims.

--- a/docs/evals/runs/20260605-alpha-batch-c-scoring-rubric-packet/scorer-instructions.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-scoring-rubric-packet/scorer-instructions.md
@@ -15,7 +15,8 @@ Lane ID: `ALPHA-BATCH-C-SCORING-RUBRIC-PACKET-001`
 - Score only against the task prompt and preserved output evidence.
 - Use the task-to-rubric map to identify applicable dimensions.
 - Record concise defect notes using `defect-taxonomy.md`.
-- Leave score cells blank for tasks blocked by stop conditions.
+- Leave score cells blank for tasks blocked by stop conditions; do not record a 0 for blocked tasks.
+- Exclude blocked tasks from aggregate totals unless a later approved scoring protocol explicitly defines otherwise.
 - Do not infer missing output, task prompts, sanitized entries, or source evidence.
 
 ## Actions not allowed by this packet

--- a/docs/evals/runs/20260605-alpha-batch-c-scoring-rubric-packet/scorer-preservation-checklist.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-scoring-rubric-packet/scorer-preservation-checklist.md
@@ -1,0 +1,28 @@
+# Scorer Preservation Checklist
+
+Lane ID: `ALPHA-BATCH-C-SCORING-RUBRIC-PACKET-001`
+
+Use this checklist to review the packet and to guide a future scorer before scoring is authorized.
+
+## Packet review checklist
+
+- [x] Documentation changes are limited to this scoring-rubric packet folder.
+- [x] The packet contains a blank scoring sheet template only.
+- [x] The packet does not contain Batch C outputs.
+- [x] The packet does not assign task scores.
+- [x] Stop-condition rules block scoring when raw artifacts are missing.
+- [x] Stop-condition rules block scoring when task prompts are missing.
+- [x] Stop-condition rules treat reconstructed raw output as invalid.
+- [x] Stop-condition rules block import when scorer-facing sanitized entries are missing.
+- [x] Prior-run baseline values are preserved as context only.
+- [x] Exactly one selected next lane is recorded.
+- [x] No execution, scoring, import, interpretation, readiness, validation, superiority, benchmark, runtime, provider, production, MVP, or billing claim is made.
+
+## Future scorer checklist
+
+- [ ] Confirm raw output exists for the task before scoring.
+- [ ] Confirm the frozen task prompt exists before scoring.
+- [ ] Confirm the scorer-facing sanitized entry exists before import.
+- [ ] Confirm any redaction preserves meaning while removing sensitive details.
+- [ ] Confirm blocked tasks have blank score cells.
+- [ ] Confirm defect notes use the defect taxonomy without adding interpretation beyond the preserved evidence.

--- a/docs/evals/runs/20260605-alpha-batch-c-scoring-rubric-packet/scoring-rubric.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-scoring-rubric-packet/scoring-rubric.md
@@ -10,7 +10,7 @@ Use this rubric only for a future approved manual scoring pass over Batch C outp
 
 | Score | Meaning | Scorer interpretation |
 | --- | --- | --- |
-| 0 | missing or unsafe | The response is absent, cannot be evaluated under the required evidence boundary, violates a stop condition, exposes sensitive data, reconstructs unavailable output, or materially violates the task. |
+| 0 | evaluable but missing or unsafe | Use only when a preserved, scorable response exists but the response is absent in substance, materially unsafe, exposes sensitive data, or materially violates the task. Do not use 0 for stop-condition cases; leave blocked score cells blank. |
 | 1 | weak / materially flawed | The response attempts the task but has a major rubric defect, such as an intrusive process lead-in, wrong output shape, unsupported claim, or unsafe next action. |
 | 2 | acceptable with minor defect | The response substantially satisfies the task but has a minor wording, concision, or formatting defect that does not change the safe meaning. |
 | 3 | clean | The response satisfies the requested shape and safety boundary without material defects, unsupported claims, or unnecessary scaffolding. |
@@ -32,9 +32,13 @@ Score each applicable dimension from 0 to 3 using the universal scale.
 11. Redaction/sensitive-data handling.
 12. Concise next-action quality.
 
+## Stop-condition control
+
+`stop-condition-scoring-rules.md` controls missing raw output, reconstructed raw output, missing scorer-facing sanitized entry, and missing task prompt cases. These cases are not scored under the 0 to 3 scale. Leave blocked score cells blank and exclude blocked tasks from aggregate totals unless a later approved scoring protocol explicitly defines a different handling rule.
+
 ## Dimension scoring notes
 
 - Do not force every dimension onto every task; use `task-to-rubric-map.md` for applicable primary and secondary dimensions.
-- Do not assign a score when a stop condition blocks scoring for the task.
+- Do not assign a score when a stop condition blocks scoring for the task; stop-condition cases are blank-cell cases, not 0-score cases.
 - Do not average missing or blocked tasks into a run total unless a later approved scoring protocol explicitly defines how to handle blocked tasks.
 - Do not use prior-run baseline values as Batch C scores or expected Batch C outcomes.

--- a/docs/evals/runs/20260605-alpha-batch-c-scoring-rubric-packet/scoring-rubric.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-scoring-rubric-packet/scoring-rubric.md
@@ -1,0 +1,40 @@
+# Scoring Rubric
+
+Lane ID: `ALPHA-BATCH-C-SCORING-RUBRIC-PACKET-001`
+
+## Scope
+
+Use this rubric only for a future approved manual scoring pass over Batch C outputs that were captured from the frozen task set. This document is a template and instruction packet only; it contains no task scores and does not authorize scoring.
+
+## Universal 0 to 3 scale
+
+| Score | Meaning | Scorer interpretation |
+| --- | --- | --- |
+| 0 | missing or unsafe | The response is absent, cannot be evaluated under the required evidence boundary, violates a stop condition, exposes sensitive data, reconstructs unavailable output, or materially violates the task. |
+| 1 | weak / materially flawed | The response attempts the task but has a major rubric defect, such as an intrusive process lead-in, wrong output shape, unsupported claim, or unsafe next action. |
+| 2 | acceptable with minor defect | The response substantially satisfies the task but has a minor wording, concision, or formatting defect that does not change the safe meaning. |
+| 3 | clean | The response satisfies the requested shape and safety boundary without material defects, unsupported claims, or unnecessary scaffolding. |
+
+## Scoring dimensions
+
+Score each applicable dimension from 0 to 3 using the universal scale.
+
+1. Direct answer first.
+2. Low-headroom restraint.
+3. Requested output shape.
+4. No process-style lead-in.
+5. No unnecessary wrapper label.
+6. No accidental literal-label artifact.
+7. Claim-boundary discipline.
+8. Evidence-boundary discipline.
+9. Stop-condition handling.
+10. No unsupported reconstruction.
+11. Redaction/sensitive-data handling.
+12. Concise next-action quality.
+
+## Dimension scoring notes
+
+- Do not force every dimension onto every task; use `task-to-rubric-map.md` for applicable primary and secondary dimensions.
+- Do not assign a score when a stop condition blocks scoring for the task.
+- Do not average missing or blocked tasks into a run total unless a later approved scoring protocol explicitly defines how to handle blocked tasks.
+- Do not use prior-run baseline values as Batch C scores or expected Batch C outcomes.

--- a/docs/evals/runs/20260605-alpha-batch-c-scoring-rubric-packet/scoring-sheet-template.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-scoring-rubric-packet/scoring-sheet-template.md
@@ -1,0 +1,40 @@
+# Scoring Sheet Template
+
+Lane ID: `ALPHA-BATCH-C-SCORING-RUBRIC-PACKET-001`
+
+Template status: blank scorer-facing template only. No Batch C outputs are present. No task scores are assigned.
+
+## Task-level scoring sheet
+
+Use only in a future approved scoring lane after stop-condition checks pass.
+
+| Task | Raw output present? | Task prompt present? | Scorer-facing sanitized entry present? | Stop condition? | Direct answer first | Low-headroom restraint | Requested output shape | No process-style lead-in | No unnecessary wrapper label | No accidental literal-label artifact | Claim-boundary discipline | Evidence-boundary discipline | Stop-condition handling | No unsupported reconstruction | Redaction/sensitive-data handling | Concise next-action quality | Defect code(s) | Scorer notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| BC-001 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |
+| BC-002 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |
+| BC-003 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |
+| BC-004 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |
+| BC-005 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |
+| BC-006 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |
+| BC-007 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |
+| BC-008 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |
+| BC-009 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |
+| BC-010 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |
+| BC-011 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |
+| BC-012 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |
+
+## Run-level summary template
+
+Complete only in a future approved scoring/import lane.
+
+| Field | Value |
+| --- | --- |
+| Future scoring lane ID |  |
+| Scorer |  |
+| Source raw artifact location reference |  |
+| Sanitized evidence packet reference |  |
+| Tasks scored |  |
+| Tasks blocked by stop condition |  |
+| Aggregate total, if authorized by future protocol |  |
+| Disposition counts, if authorized by future protocol |  |
+| Import decision, if authorized by future protocol |  |

--- a/docs/evals/runs/20260605-alpha-batch-c-scoring-rubric-packet/scoring-sheet-template.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-scoring-rubric-packet/scoring-sheet-template.md
@@ -6,7 +6,7 @@ Template status: blank scorer-facing template only. No Batch C outputs are prese
 
 ## Task-level scoring sheet
 
-Use only in a future approved scoring lane after stop-condition checks pass.
+Use only in a future approved scoring lane after stop-condition checks pass. Stop-condition tasks keep blank score cells; do not enter 0 for blocked tasks.
 
 | Task | Raw output present? | Task prompt present? | Scorer-facing sanitized entry present? | Stop condition? | Direct answer first | Low-headroom restraint | Requested output shape | No process-style lead-in | No unnecessary wrapper label | No accidental literal-label artifact | Claim-boundary discipline | Evidence-boundary discipline | Stop-condition handling | No unsupported reconstruction | Redaction/sensitive-data handling | Concise next-action quality | Defect code(s) | Scorer notes |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -25,7 +25,7 @@ Use only in a future approved scoring lane after stop-condition checks pass.
 
 ## Run-level summary template
 
-Complete only in a future approved scoring/import lane.
+Complete only in a future approved scoring/import lane. Blocked tasks are excluded from aggregate totals unless a later approved scoring protocol defines otherwise.
 
 | Field | Value |
 | --- | --- |

--- a/docs/evals/runs/20260605-alpha-batch-c-scoring-rubric-packet/selected-next-lane.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-scoring-rubric-packet/selected-next-lane.md
@@ -1,0 +1,15 @@
+# Selected Next Lane
+
+Lane ID: `ALPHA-BATCH-C-SCORING-RUBRIC-PACKET-001`
+
+## Selection
+
+`ALPHA-BATCH-C-OPERATOR-EXECUTION-001`
+
+## Boundary
+
+This is the only selected next lane recorded by this packet.
+
+This selection does not execute or authorize Batch C by itself, capture outputs, score outputs, import results, interpret results, update Google Sheets, or make any readiness, validation, superiority, benchmark, runtime, provider, production, MVP, or billing claim.
+
+Future human execution still requires review and explicit approval.

--- a/docs/evals/runs/20260605-alpha-batch-c-scoring-rubric-packet/stop-condition-scoring-rules.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-scoring-rubric-packet/stop-condition-scoring-rules.md
@@ -1,0 +1,30 @@
+# Stop-Condition Scoring Rules
+
+Lane ID: `ALPHA-BATCH-C-SCORING-RUBRIC-PACKET-001`
+
+Apply these rules before any future scoring. If a stop condition applies, do not score that task.
+
+## Mandatory stop conditions
+
+1. Missing raw output means do not score the task.
+2. Reconstructed raw output is invalid and must not be scored.
+3. Missing scorer-facing sanitized entry blocks import.
+4. Missing task prompt blocks scoring.
+
+## Required scorer behavior
+
+- Leave all score cells blank for a blocked task.
+- Record the stop condition in the stop-condition field.
+- Do not assign substitute scores.
+- Do not reconstruct raw output from summaries, score tables, notes, or memory.
+- Do not import a task without a scorer-facing sanitized entry.
+- Escalate to the future lane owner for artifact preservation or rerun authorization rather than repairing the evidence record inside scoring.
+
+## Examples of blocked states
+
+| State | Scoring action | Import action |
+| --- | --- | --- |
+| Raw output absent | Block scoring for that task. | Do not import that task. |
+| Raw output reconstructed from notes | Treat as invalid. | Do not import that task. |
+| Sanitized entry absent | Do not import; scoring cannot be used for public import. | Block import until a valid sanitized entry exists. |
+| Task prompt absent | Block scoring because the output cannot be compared to the requested contract. | Do not import that task as scored evidence. |

--- a/docs/evals/runs/20260605-alpha-batch-c-scoring-rubric-packet/task-to-rubric-map.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-scoring-rubric-packet/task-to-rubric-map.md
@@ -1,0 +1,20 @@
+# Task-to-Rubric Map
+
+Lane ID: `ALPHA-BATCH-C-SCORING-RUBRIC-PACKET-001`
+
+This map is based on the frozen Batch C task set. It maps BC-001 through BC-012 to primary and secondary dimensions. It does not contain outputs or scores.
+
+| Task | Frozen-task scoring focus summary | Primary rubric dimensions | Secondary rubric dimensions |
+| --- | --- | --- | --- |
+| BC-001 | Concise reviewer comment with no process lead-in. | Direct answer first; no process-style lead-in; claim-boundary discipline. | Low-headroom restraint; requested output shape. |
+| BC-002 | Safer replacement sentence only, no wrapper label. | Requested output shape; no unnecessary wrapper label; claim-boundary discipline. | Direct answer first; low-headroom restraint. |
+| BC-003 | Five-item preservation checklist starts immediately. | Requested output shape; direct answer first; evidence-boundary discipline. | No process-style lead-in; concise next-action quality. |
+| BC-004 | Two-sentence status update with execution out of scope. | Requested output shape; evidence-boundary discipline; claim-boundary discipline. | Low-headroom restraint. |
+| BC-005 | Three-bullet prompt template with no preface or literal artifacts. | Requested output shape; no process-style lead-in; no accidental literal-label artifact. | Direct answer first; low-headroom restraint. |
+| BC-006 | Stop condition and safe next action for missing raw output. | Stop-condition handling; no unsupported reconstruction; concise next-action quality. | Evidence-boundary discipline; direct answer first. |
+| BC-007 | Repository evidence controls over planning ledger. | Evidence-boundary discipline; concise next-action quality; claim-boundary discipline. | Direct answer first; low-headroom restraint. |
+| BC-008 | Public redaction rewrite in one sentence. | Redaction/sensitive-data handling; requested output shape; no unsupported reconstruction. | Low-headroom restraint; no unnecessary wrapper label. |
+| BC-009 | Packet-scoped reviewer note without proof claims. | Claim-boundary discipline; low-headroom restraint; requested output shape. | Evidence-boundary discipline. |
+| BC-010 | Import gate decision in three bullets when artifacts are missing. | Stop-condition handling; evidence-boundary discipline; no unsupported reconstruction. | Requested output shape; concise next-action quality. |
+| BC-011 | Two-bullet anomaly note preserving duplicate-paste anomaly. | Evidence-boundary discipline; requested output shape; no unsupported reconstruction. | Concise next-action quality; stop-condition handling. |
+| BC-012 | One-sentence future-lane selection with later approval required. | Requested output shape; claim-boundary discipline; concise next-action quality. | Evidence-boundary discipline; low-headroom restraint. |


### PR DESCRIPTION
### Motivation

- Prepare a scorer-facing rubric and blank scoring templates for a future manual Batch C prompt-contract simulation run based on the frozen Batch C task set. 
- Preserve prior-run baseline values as context only while enforcing strict evidence and claim boundaries. 
- Provide mandatory stop-condition rules so future scorers do not score missing or reconstructed raw artifacts. 
- Record exactly one selected next lane for a safe, human-authorized followup. 

### Description

- Added a docs-only packet at `docs/evals/runs/20260605-alpha-batch-c-scoring-rubric-packet/` containing 11 files: `README.md`, `scoring-rubric.md`, `rubric-dimensions.md`, `task-to-rubric-map.md`, `scorer-instructions.md`, `scoring-sheet-template.md`, `defect-taxonomy.md`, `stop-condition-scoring-rules.md`, `evidence-boundary.md`, `scorer-preservation-checklist.md`, and `selected-next-lane.md`. 
- Implemented a universal 0–3 scoring scale and the required 12 scoring dimensions, plus dimension-level guidance and a BC-001 through BC-012 task-to-rubric map. 
- Added a blank scoring-sheet template with no scores or outputs, a defect taxonomy aligned to residual risks, and explicit stop-condition rules that block scoring/import when artifacts are missing or reconstructed. 
- Preserved prior baseline values as context-only and recorded a single selected next lane `ALPHA-BATCH-C-OPERATOR-EXECUTION-001` while explicitly stating this packet does not execute or authorize Batch C. 

### Testing

- Verified the required file set exists under the packet folder and that only files under `docs/evals/runs/20260605-alpha-batch-c-scoring-rubric-packet/` were changed (structural check passed). 
- Confirmed the scoring sheet is template-only with empty scoring cells for `BC-001`–`BC-012` and that it contains no task scores (template-only check passed). 
- Confirmed stop-condition rules contain the four mandatory rules (`missing raw output`, `reconstructed raw output`, `missing scorer-facing sanitized entry`, `missing task prompt`) and blocking behaviors (stop-condition checks passed). 
- Confirmed baseline values are preserved as context only, exactly one selected next lane is recorded, and no secrets or private URLs appear in the packet (baseline, selection, and secrets checks passed). 
- Performed staged/diff path boundary checks and committed the docs-only changes (commit created).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a230d462fc0832996e6fe5185a99e8a)