### PR TITLE
docs: add local LLM runtime integration spec (hybrid strategy)

### DIFF
--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -32,6 +32,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `EVAL-DIFFERENTIATION-RUN-001.md` | EVAL-DIFFERENTIATION-RUN-001 · Controlled Alpha-vs-Plain Run Scaffold |
 | `HIGHER-HEADROOM-EVAL-001.md` | HIGHER-HEADROOM-EVAL-001 · Higher-Headroom Alpha-vs-Plain Prompt Set |
 | `FINOPS-BUDGET-001.md` | FINOPS-BUDGET-001 · Budget Guardrails |
+| `LOCAL-LLM-RUNTIME-INTEGRATION-001.md` | LOCAL-LLM-RUNTIME-INTEGRATION-001 · Local LLM Runtime Integration Implementation Contract |
 | `MCP-001.md` | CODE SPEC — MCP-001 · MCP Registry Loader & Wiring (MCP) |
 | `MCP-002.md` | CODE SPEC — MCP-002 · Router decision rule (MCP) |
 | `MCP-003.md` | CODE SPEC — MCP-003 · MCP OAuth/Secrets scaffold (auth surface) (MCP) |

--- a/.specs/LOCAL-LLM-RUNTIME-INTEGRATION-001.md
+++ b/.specs/LOCAL-LLM-RUNTIME-INTEGRATION-001.md
@@ -1,0 +1,119 @@
+# LOCAL-LLM-RUNTIME-INTEGRATION-001 · Local LLM Runtime Integration Implementation Contract
+
+## Purpose
+
+This spec is the canonical implementation contract for a future local LLM runtime integration lane. The supporting lane record lives under `docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/`.
+
+This spec preserves local LLM as an optional backend path. It does not make local model setup required for existing operation, and it does not authorize implementation in this spec-registration lane.
+
+## Selected backend strategy
+
+Selected backend strategy: `hybrid`.
+
+Hybrid means hosted and local provider modes may exist as separately selected modes. It does not mean automatic fallback, hidden provider orchestration, provider racing, opportunistic routing, or substituting hosted output for local LLM failure.
+
+The future implementation must require explicit provider selection. Silent hosted-provider fallback from local LLM mode is prohibited.
+
+## Local LLM enablement contract
+
+A future implementation must satisfy all of the following:
+
+1. Local LLM mode is optional and default-off.
+2. Explicit operator opt-in is required before local LLM mode can be used.
+3. Local LLM mode must accept only localhost or loopback endpoints.
+4. Local LLM mode must require no provider keys.
+5. Local LLM calls must use a finite timeout.
+6. Hosted output must not be labeled as local LLM output.
+7. Local LLM output must preserve `behavior_evidence=false` unless a later spec explicitly changes the evidence model.
+
+## Endpoint contract
+
+Local LLM mode may use only local machine endpoints. The future implementation must accept only endpoints that parse deterministically as localhost or loopback, such as:
+
+- `localhost`
+- `127.0.0.1`
+- `::1`
+
+The implementation must reject remote, hosted, LAN, private-network, malformed, ambiguous, unsupported-scheme, missing-host, and userinfo-bearing endpoint values for local LLM mode.
+
+## Fail-closed contract
+
+A future implementation must fail closed for all of the following local LLM mode cases:
+
+- non-local endpoint;
+- malformed endpoint;
+- connection failure;
+- timeout;
+- malformed response;
+- empty output;
+- prompt echo;
+- system echo.
+
+Fail-closed means the local LLM path stops with a bounded local failure outcome, no hosted-provider call is made unless a later spec separately authorizes explicit fallback, failed or echoed output is not presented as successful behavior, and `behavior_evidence=false` is preserved.
+
+## Fallback contract
+
+No silent hosted-provider fallback is allowed from local LLM mode.
+
+If a later spec authorizes fallback, that later spec must define operator opt-in, fallback trigger conditions, hosted-provider credential requirements, provenance labels, and tests proving fallback is explicit rather than silent. Until then, local failures must remain visible as local failures.
+
+## Observability and provenance contract
+
+A future implementation must distinguish local LLM output from hosted provider output in observability and provenance. Local records must include enough metadata to identify:
+
+- local provider mode;
+- local backend or adapter identifier;
+- configured local model identifier;
+- localhost or loopback endpoint confirmation without exposing unnecessary raw endpoint detail;
+- timeout value used;
+- status and deterministic reason label;
+- `behavior_evidence=false`.
+
+Hosted output must not be labeled as local LLM output.
+
+## Blocked surfaces for this implementation phase
+
+The following surfaces remain blocked from local LLM mode unless a later spec explicitly authorizes them:
+
+- `/v1/solve`;
+- dashboard preview.
+
+This spec does not authorize changes to provider orchestration, billing or hosted-provider credential paths, broad routing, MCP, SAFE-OUT, budget guard, determinism, replay, or SolverEnvelope behavior.
+
+## Future implementation boundary
+
+Future implementation must remain narrow and avoid broad refactors. The expected implementation boundary is limited to:
+
+- `alpha/local_llm/provider_adapter.py` for local endpoint, timeout, transport, parser, fail-closed, and provenance refinements;
+- the narrow runtime configuration module or entrypoint code needed for explicit provider selection, if inspection proves it is required;
+- the narrow runtime call site needed to invoke the local LLM backend, if inspection proves it is required;
+- focused tests for this contract.
+
+## Required future tests
+
+A future implementation must include focused tests proving:
+
+1. local LLM mode is default-off;
+2. explicit operator opt-in is required;
+3. local LLM mode requires no provider keys;
+4. localhost and loopback endpoints are accepted;
+5. non-local endpoints fail closed;
+6. malformed endpoints fail closed;
+7. invalid timeout values fail closed;
+8. connection failure fails closed;
+9. timeout fails closed;
+10. malformed response fails closed;
+11. empty output fails closed;
+12. prompt echo fails closed;
+13. system echo fails closed;
+14. hosted-provider fallback does not occur from local LLM mode;
+15. observability labels local LLM output separately from hosted provider output;
+16. `behavior_evidence=false` is preserved.
+
+## Runtime smoke requirement
+
+Future runtime smoke is required before any runtime-readiness claim. That smoke must preserve artifacts sufficient to confirm explicit local provider selection, localhost or loopback endpoint use, finite timeout, no provider keys, no hosted-provider fallback, status/reason labels, and `behavior_evidence=false` preservation.
+
+## Evidence boundary
+
+This spec is an implementation contract only. It is not implementation, runtime evidence, local model quality evidence, hosted provider evidence, `/v1/solve` readiness, dashboard preview readiness, MVP validation, production readiness, benchmark evidence, provider orchestration evidence, or Alpha superiority evidence.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/README.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/README.md
@@ -2,12 +2,13 @@
 
 Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-SPEC-001`
 
-This docs-only package converts prior local LLM planning and safety-gate scaffold material into a concrete specification for a later implementation lane.
+This docs-only package records the evaluation/specification lane and supporting material for the canonical implementation contract in `.specs/LOCAL-LLM-RUNTIME-INTEGRATION-001.md`.
 
 ## Package status
 
 - Scope: specification only.
 - Allowed file area: `docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/`.
+- Canonical implementation contract: `.specs/LOCAL-LLM-RUNTIME-INTEGRATION-001.md`.
 - Source changes: none authorized here.
 - Test changes: none authorized here.
 - Provider, `/v1/solve`, dashboard, and runtime behavior changes: none authorized here.
@@ -43,6 +44,10 @@ This package is derived from the following existing repository materials:
 13. `evidence-boundary.md`
 14. `spec-preservation-checklist.md`
 15. `selected-next-lane.md`
+
+## Canonical contract
+
+Future implementation lanes must reference `.specs/LOCAL-LLM-RUNTIME-INTEGRATION-001.md` as the canonical contract. This docs/evals package remains the lane record and supporting package.
 
 ## Selected backend strategy
 

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/README.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/README.md
@@ -1,0 +1,51 @@
+# Local LLM Runtime Integration Specification Package
+
+Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-SPEC-001`
+
+This docs-only package converts prior local LLM planning and safety-gate scaffold material into a concrete specification for a later implementation lane.
+
+## Package status
+
+- Scope: specification only.
+- Allowed file area: `docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/`.
+- Source changes: none authorized here.
+- Test changes: none authorized here.
+- Provider, `/v1/solve`, dashboard, and runtime behavior changes: none authorized here.
+- Local model calls, hosted provider calls, network calls, and provider keys: prohibited for this lane.
+
+## Source-of-truth inputs
+
+This package is derived from the following existing repository materials:
+
+- `docs/evals/runs/20260605-alpha-local-llm-smoke-results-import/`
+- `docs/evals/runs/20260605-alpha-local-llm-smoke-interpretation/`
+- `docs/evals/runs/20260605-alpha-local-llm-integration-final-decision/`
+- `docs/evals/runs/20260605-alpha-local-llm-runtime-integration-planning/`
+- `docs/evals/runs/20260605-alpha-local-llm-runtime-safety-gate-scaffold/`
+- `alpha/local_llm/provider_adapter.py`
+- `tests/test_local_llm_provider_adapter.py`
+- `alpha_solver_portable.py`
+
+## Required documents
+
+1. `README.md`
+2. `spec-summary.md`
+3. `backend-strategy-decision.md`
+4. `provider-selection-contract.md`
+5. `runtime-configuration-contract.md`
+6. `local-endpoint-contract.md`
+7. `request-response-contract.md`
+8. `timeout-and-error-contract.md`
+9. `fallback-policy-contract.md`
+10. `observability-and-provenance-contract.md`
+11. `implementation-file-boundary.md`
+12. `test-and-smoke-plan.md`
+13. `evidence-boundary.md`
+14. `spec-preservation-checklist.md`
+15. `selected-next-lane.md`
+
+## Selected backend strategy
+
+The selected strategy for future implementation planning is `hybrid`.
+
+Hybrid means the existing hosted path remains a separate explicit option and local LLM is introduced only as an optional, default-off, operator-selected backend. Hybrid in this package does not authorize silent fallback, provider orchestration, hosted-provider substitution, or any runtime readiness claim.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/backend-strategy-decision.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/backend-strategy-decision.md
@@ -1,0 +1,31 @@
+# Backend Strategy Decision
+
+Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-SPEC-001`
+
+## Decision
+
+Exactly one backend strategy is selected for the future implementation lane:
+
+- Selected: `hybrid`
+- Not selected: `hosted-only`
+- Not selected: `local-only`
+
+## Meaning of hybrid in this specification
+
+Hybrid means the product may expose separately configured hosted and local backend modes, but the provider for a request or run must be selected explicitly by operator configuration. Hybrid does not mean automatic fallback, opportunistic routing, provider racing, hidden orchestration, or substituting hosted output for a local LLM failure.
+
+## Why hosted-only is not selected
+
+Hosted-only would end local runtime integration planning. That would be simpler operationally, but it would not satisfy the selected planning direction to preserve local LLM as an optional backend path.
+
+## Why local-only is not selected
+
+Local-only would require local model setup for the affected LLM-backed path and would make local machine configuration too central. This conflicts with the requirement to preserve local LLM as optional and not make it the required MVP path.
+
+## Why hybrid is selected
+
+Hybrid is the smallest path that preserves existing hosted operation as a distinct option while allowing a future implementation lane to add default-off local LLM mode. The implementation must keep provider selection explicit and observable.
+
+## Fallback rule attached to this decision
+
+Because hybrid is selected, the future implementation must require explicit provider selection and must prohibit silent fallback. If fallback is ever separately authorized by a later lane, the fallback must be explicit, operator-approved, request-visible, and labeled in provenance as hosted-provider fallback rather than local LLM output.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/evidence-boundary.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/evidence-boundary.md
@@ -6,7 +6,7 @@ Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-SPEC-001`
 
 This PR is a runtime integration specification only.
 
-It records a selected backend strategy, contracts, implementation boundaries, and future test/smoke requirements for the selected next lane.
+It records the docs/evals lane record and supporting package for the canonical implementation contract in `.specs/LOCAL-LLM-RUNTIME-INTEGRATION-001.md`, including selected strategy, boundaries, and future test/smoke requirements for the selected next lane.
 
 ## What this PR is not
 

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/evidence-boundary.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/evidence-boundary.md
@@ -1,0 +1,44 @@
+# Evidence Boundary
+
+Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-SPEC-001`
+
+## What this PR is
+
+This PR is a runtime integration specification only.
+
+It records a selected backend strategy, contracts, implementation boundaries, and future test/smoke requirements for the selected next lane.
+
+## What this PR is not
+
+This PR is not:
+
+- implementation;
+- runtime evidence;
+- local model quality evidence;
+- hosted provider evidence;
+- `/v1/solve` readiness;
+- dashboard preview readiness;
+- MVP validation;
+- production readiness;
+- benchmark evidence;
+- provider orchestration evidence;
+- Alpha superiority evidence.
+
+## Actions not performed
+
+This lane performs no:
+
+- source code changes;
+- test code changes;
+- runtime changes;
+- provider changes;
+- `/v1/solve` changes;
+- dashboard changes;
+- local model calls;
+- hosted provider calls;
+- network calls;
+- provider key use.
+
+## Evidence model preservation
+
+`behavior_evidence=false` remains preserved. A later lane must explicitly change the evidence model before any local LLM output can be treated differently.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/fallback-policy-contract.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/fallback-policy-contract.md
@@ -1,0 +1,27 @@
+# Fallback Policy Contract
+
+Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-SPEC-001`
+
+## Default fallback policy
+
+Hosted-provider fallback from local LLM mode is prohibited.
+
+## Hybrid-specific fallback requirement
+
+Because the selected backend strategy is `hybrid`, provider selection must be explicit. Hybrid must not be implemented as silent fallback from one provider class to another.
+
+## Local failure behavior
+
+When local LLM mode is selected and any local failure occurs, the failure must remain local and visible. Connection failures, timeouts, malformed responses, empty outputs, prompt echoes, and system echoes must not trigger hosted-provider output.
+
+## Future fallback authorization
+
+If a later lane authorizes fallback, that future authorization must define:
+
+- operator opt-in for fallback;
+- exact fallback trigger conditions;
+- hosted-provider key requirements for the fallback path;
+- provenance labels that identify fallback output as hosted output;
+- tests proving fallback is explicit and not silent.
+
+No such fallback is authorized by this specification package.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/implementation-file-boundary.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/implementation-file-boundary.md
@@ -1,0 +1,36 @@
+# Implementation File Boundary
+
+Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-SPEC-001`
+
+## Boundary purpose
+
+This document defines the minimal file-change boundary for the future implementation lane. It does not authorize changes in this docs-only lane.
+
+## Minimal future implementation boundary
+
+The future implementation lane should prefer the smallest file set needed to wire explicit local LLM mode while preserving default-off behavior. Expected candidate files are:
+
+- `alpha/local_llm/provider_adapter.py` for endpoint, timeout, transport, parser, fail-closed, and provenance refinements;
+- the narrow runtime configuration module or entrypoint code that selects provider mode, if needed after inspection;
+- the narrow runtime call site that invokes LLM-backed behavior, if needed after inspection;
+- focused tests covering the local LLM mode contract.
+
+## Files and surfaces that must remain blocked unless separately authorized
+
+The future implementation lane must not expose local LLM mode through the following surfaces unless that lane explicitly keeps them blocked or a later lane authorizes exposure:
+
+- `/v1/solve` behavior;
+- dashboard preview behavior;
+- provider orchestration code;
+- billing or hosted-provider credential paths;
+- broad MCP, routing, SAFE-OUT, budget guard, determinism, observability, replay, or SolverEnvelope behavior.
+
+## Implementation style constraints
+
+A future implementation should:
+
+- avoid broad refactors;
+- preserve existing portable contract semantics;
+- preserve `behavior_evidence=false`;
+- keep hosted provider behavior separate from local LLM behavior;
+- add only focused tests tied to this contract.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/implementation-file-boundary.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/implementation-file-boundary.md
@@ -4,11 +4,11 @@ Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-SPEC-001`
 
 ## Boundary purpose
 
-This document defines the minimal file-change boundary for the future implementation lane. It does not authorize changes in this docs-only lane.
+This document records the docs/evals supporting view of the minimal file-change boundary for the future implementation lane. The canonical implementation contract is `.specs/LOCAL-LLM-RUNTIME-INTEGRATION-001.md`. This document does not authorize changes in this docs-only lane.
 
 ## Minimal future implementation boundary
 
-The future implementation lane should prefer the smallest file set needed to wire explicit local LLM mode while preserving default-off behavior. Expected candidate files are:
+Future implementation lanes must reference `.specs/LOCAL-LLM-RUNTIME-INTEGRATION-001.md` as the canonical contract and should prefer the smallest file set needed to wire explicit local LLM mode while preserving default-off behavior. Expected candidate files are:
 
 - `alpha/local_llm/provider_adapter.py` for endpoint, timeout, transport, parser, fail-closed, and provenance refinements;
 - the narrow runtime configuration module or entrypoint code that selects provider mode, if needed after inspection;

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/local-endpoint-contract.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/local-endpoint-contract.md
@@ -1,0 +1,35 @@
+# Local Endpoint Contract
+
+Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-SPEC-001`
+
+## Allowed endpoint boundary
+
+Local LLM mode may call only localhost or loopback endpoints. The acceptable host boundary must be limited to local machine targets such as:
+
+- `localhost`
+- `127.0.0.1`
+- `::1`
+
+A future implementation may include additional loopback addresses only if they are parsed deterministically as loopback by standard IP parsing.
+
+## Required URL behavior
+
+A future implementation must parse the endpoint before use and must reject endpoints that are malformed, ambiguous, remote, hosted, or non-local.
+
+The implementation must fail closed for:
+
+- missing scheme;
+- unsupported scheme;
+- missing host;
+- malformed host;
+- non-local host;
+- userinfo-bearing URLs;
+- values that cannot be parsed deterministically.
+
+## Scheme requirement
+
+The future implementation should require `http` for loopback local service calls unless a later lane explicitly authorizes additional local-only schemes. Hosted `https` endpoints must not be accepted as local LLM endpoints.
+
+## No network expansion
+
+The endpoint contract does not authorize calls to LAN, private-network, public-network, hosted-provider, or proxy endpoints.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/observability-and-provenance-contract.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/observability-and-provenance-contract.md
@@ -1,0 +1,34 @@
+# Observability and Provenance Contract
+
+Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-SPEC-001`
+
+## Required distinction
+
+A future implementation must make local LLM output distinguishable from hosted provider output in logs, returned metadata, smoke artifacts, or equivalent provenance records.
+
+## Required local LLM metadata
+
+Local LLM records must include, at minimum:
+
+- provider mode identifying `local_llm`;
+- local backend class or equivalent adapter identifier;
+- configured local model identifier;
+- sanitized local endpoint category or localhost/loopback confirmation;
+- timeout value used;
+- status and reason label;
+- `behavior_evidence=false`.
+
+## Hosted output separation
+
+Hosted output must not be labeled as local LLM output. Local LLM failure must not be converted into hosted success unless a later lane separately authorizes and labels explicit fallback.
+
+## Raw and sanitized smoke artifacts
+
+Before any future runtime-readiness claim, a runtime smoke lane must preserve artifacts sufficient to confirm:
+
+- explicit local provider selection;
+- localhost/loopback endpoint use;
+- finite timeout;
+- absence of hosted-provider fallback;
+- status, reason, and `behavior_evidence=false` preservation;
+- raw local response shape, with secrets absent or redacted.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/provider-selection-contract.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/provider-selection-contract.md
@@ -1,0 +1,32 @@
+# Provider Selection Contract
+
+Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-SPEC-001`
+
+## Required provider modes
+
+A future implementation may define explicit provider mode values such as:
+
+- `hosted`
+- `local_llm`
+
+The exact names may be adjusted during implementation, but the semantics must remain explicit and auditable.
+
+## Default provider behavior
+
+Local LLM mode must be default-off. Absence of local LLM configuration must not enable local LLM behavior.
+
+## Explicit operator selection
+
+A future implementation must require explicit operator opt-in before local LLM mode is used. The implementation must not use auto-discovery, implicit local endpoint probing, environment-dependent activation, or opportunistic local routing.
+
+## Local LLM key policy
+
+Local LLM mode must require no hosted provider keys and no local provider keys. If a path requires provider credentials, that path must not be described as local LLM mode.
+
+## Hosted-provider separation
+
+Hosted provider operation must remain a separate selected mode. Hosted output must not be labeled as local LLM output.
+
+## No silent fallback
+
+When `local_llm` is selected and local handling fails closed, the failure must remain visible as a local LLM failure. The implementation must not silently route the same request to hosted providers.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/request-response-contract.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/request-response-contract.md
@@ -1,0 +1,33 @@
+# Request and Response Contract
+
+Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-SPEC-001`
+
+## Request construction
+
+A future implementation must preserve the existing adapter contract shape as the starting point for local LLM requests:
+
+- a system message derived from the portable contract;
+- a user message containing the operator/request prompt;
+- local provider metadata marking the path as local LLM;
+- `behavior_evidence=false`.
+
+## Local provider payload
+
+A future implementation may map the adapter request to a local service payload, such as a chat-style payload with:
+
+- model identifier;
+- ordered messages;
+- streaming disabled unless a later lane specifies streaming behavior;
+- finite timeout supplied by configuration.
+
+## Response parsing
+
+A future implementation must parse only the expected assistant-content field for the configured local service response. The parser must fail closed for missing, malformed, non-string, or empty assistant output.
+
+## Echo rejection
+
+The implementation must fail closed when local output is a prompt echo or system echo. Echo checks must compare against the request prompt and the system content sufficiently to prevent presenting echoed input as generated output.
+
+## Output classification
+
+Successful local adapter output remains non-evidence for this phase. It must not be promoted to behavior evidence, runtime readiness evidence, model quality evidence, MVP validation, benchmark evidence, production readiness, provider orchestration evidence, or Alpha superiority evidence.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/runtime-configuration-contract.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/runtime-configuration-contract.md
@@ -1,0 +1,38 @@
+# Runtime Configuration Contract
+
+Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-SPEC-001`
+
+## Configuration goals
+
+The future implementation must add the smallest configuration surface needed to run an explicitly selected local LLM backend without disturbing existing hosted paths.
+
+## Required local LLM configuration fields
+
+A future implementation must define configuration for:
+
+- provider mode, explicitly selecting `local_llm` or hosted mode;
+- local endpoint URL, constrained by `local-endpoint-contract.md`;
+- model identifier for the local service;
+- finite timeout in seconds;
+- enablement flag or equivalent explicit opt-in.
+
+## Default-off requirement
+
+Default configuration must not use local LLM mode. A missing, empty, malformed, or partial local LLM configuration must fail closed or leave local LLM disabled.
+
+## No provider keys
+
+Local LLM configuration must not require hosted provider API keys, hosted-provider credentials, billing credentials, or local-provider credentials.
+
+## Blocked surfaces for this implementation phase
+
+A future implementation under the selected next lane must keep local LLM mode blocked from:
+
+- `/v1/solve` exposure;
+- dashboard preview exposure.
+
+Those surfaces require separate explicit authorization in a later lane.
+
+## Evidence model preservation
+
+Configuration must not cause local LLM output to become behavior evidence. `behavior_evidence=false` must remain preserved unless a later lane explicitly changes the evidence model.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/selected-next-lane.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/selected-next-lane.md
@@ -10,7 +10,7 @@ Exactly one next lane is selected:
 
 ## Scope of selected next lane
 
-The selected next lane should implement the explicit, default-off, localhost-only hybrid local LLM mode described by this specification package, while preserving the blocked surfaces and evidence boundaries defined here.
+The selected next lane should implement the explicit, default-off, localhost-only hybrid local LLM mode described by the canonical contract `.specs/LOCAL-LLM-RUNTIME-INTEGRATION-001.md`, while using this docs/evals package as the lane record and supporting package and preserving the blocked surfaces and evidence boundaries defined here.
 
 ## Non-selections
 

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/selected-next-lane.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/selected-next-lane.md
@@ -1,0 +1,17 @@
+# Selected Next Lane
+
+Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-SPEC-001`
+
+## Selection
+
+Exactly one next lane is selected:
+
+`ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-IMPLEMENTATION-001`
+
+## Scope of selected next lane
+
+The selected next lane should implement the explicit, default-off, localhost-only hybrid local LLM mode described by this specification package, while preserving the blocked surfaces and evidence boundaries defined here.
+
+## Non-selections
+
+No other next lane is selected by this package.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/spec-preservation-checklist.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/spec-preservation-checklist.md
@@ -1,0 +1,49 @@
+# Spec Preservation Checklist
+
+Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-SPEC-001`
+
+## Scope checks
+
+- [x] Docs-only package created under `docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/`.
+- [x] No source code changes are authorized by this package.
+- [x] No test code changes are authorized by this package.
+- [x] No runtime implementation is included.
+- [x] No provider implementation is included.
+- [x] No `/v1/solve` or dashboard change is included.
+
+## Strategy checks
+
+- [x] Exactly one backend strategy is selected: `hybrid`.
+- [x] `hosted-only` is not selected.
+- [x] `local-only` is not selected.
+- [x] Hybrid requires explicit provider selection.
+- [x] Hybrid prohibits silent fallback.
+
+## Safety checks
+
+- [x] Local LLM runtime mode is default-off.
+- [x] Explicit operator opt-in is required.
+- [x] Localhost / loopback endpoint only is required.
+- [x] No provider keys are required for local LLM mode.
+- [x] Finite timeout is required.
+- [x] Fail-closed handling is required for non-local endpoint, malformed endpoint, connection failure, timeout, malformed response, empty output, prompt echo, and system echo.
+- [x] Hosted-provider fallback is prohibited unless separately authorized and explicitly labeled.
+- [x] Observability must distinguish local LLM output from hosted provider output.
+- [x] `behavior_evidence=false` remains preserved unless a later lane explicitly changes the evidence model.
+- [x] Runtime smoke is required before any future runtime-readiness claim.
+- [x] `/v1/solve` remains blocked from local LLM mode for this implementation phase.
+- [x] Dashboard preview remains blocked from local LLM mode for this implementation phase.
+
+## Evidence-boundary checks
+
+- [x] This package is not implementation evidence.
+- [x] This package is not runtime evidence.
+- [x] This package is not model quality evidence.
+- [x] This package is not hosted provider evidence.
+- [x] This package is not `/v1/solve` readiness.
+- [x] This package is not dashboard preview readiness.
+- [x] This package is not MVP validation, production readiness, benchmark evidence, provider orchestration evidence, or Alpha superiority evidence.
+
+## Next-lane check
+
+- [x] Exactly one next lane is selected: `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-IMPLEMENTATION-001`.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/spec-preservation-checklist.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/spec-preservation-checklist.md
@@ -5,6 +5,8 @@ Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-SPEC-001`
 ## Scope checks
 
 - [x] Docs-only package created under `docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/`.
+- [x] Canonical implementation contract registered at `.specs/LOCAL-LLM-RUNTIME-INTEGRATION-001.md`.
+- [x] Future implementation lanes must reference `.specs/LOCAL-LLM-RUNTIME-INTEGRATION-001.md` as the canonical contract.
 - [x] No source code changes are authorized by this package.
 - [x] No test code changes are authorized by this package.
 - [x] No runtime implementation is included.
@@ -43,6 +45,10 @@ Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-SPEC-001`
 - [x] This package is not `/v1/solve` readiness.
 - [x] This package is not dashboard preview readiness.
 - [x] This package is not MVP validation, production readiness, benchmark evidence, provider orchestration evidence, or Alpha superiority evidence.
+
+## Registry checks
+
+- [x] `.specs/INDEX.md` includes `LOCAL-LLM-RUNTIME-INTEGRATION-001.md`.
 
 ## Next-lane check
 

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/spec-summary.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/spec-summary.md
@@ -4,9 +4,9 @@ Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-SPEC-001`
 
 ## Purpose
 
-Define the minimum future implementation contract for adding local LLM as an optional MVP-compatible backend while keeping the required MVP path independent of local model availability.
+Summarize the supporting evaluation/specification lane for the canonical implementation contract in `.specs/LOCAL-LLM-RUNTIME-INTEGRATION-001.md`. The canonical spec defines the minimum future implementation contract for adding local LLM as an optional backend while keeping existing operation independent of local model availability.
 
-This package specifies boundaries only. It does not implement the local LLM runtime path, does not change tests, and does not call any model or provider.
+This docs/evals package specifies supporting boundaries only. Future implementation lanes must reference `.specs/LOCAL-LLM-RUNTIME-INTEGRATION-001.md` as the canonical contract. This lane does not implement the local LLM runtime path, does not change tests, and does not call any model or provider.
 
 ## Selected strategy
 

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/spec-summary.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/spec-summary.md
@@ -1,0 +1,39 @@
+# Specification Summary
+
+Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-SPEC-001`
+
+## Purpose
+
+Define the minimum future implementation contract for adding local LLM as an optional MVP-compatible backend while keeping the required MVP path independent of local model availability.
+
+This package specifies boundaries only. It does not implement the local LLM runtime path, does not change tests, and does not call any model or provider.
+
+## Selected strategy
+
+Selected backend strategy: `hybrid`.
+
+Rationale:
+
+- `hosted-only` would stop local runtime integration and would not preserve the optional local backend path requested by the planning lane.
+- `local-only` would make local setup too central for MVP compatibility and would prohibit hosted operation in affected paths.
+- `hybrid` preserves the smallest implementation path: existing hosted behavior can remain separately selectable, while local LLM can be added as an explicit, default-off option.
+
+## Non-negotiable safety requirements
+
+A future implementation must:
+
+1. keep local LLM mode default-off;
+2. require explicit operator opt-in;
+3. accept only localhost or loopback endpoints;
+4. require no provider keys for local LLM mode;
+5. use a finite timeout;
+6. fail closed for non-local endpoint, malformed endpoint, connection failure, timeout, malformed response, empty output, prompt echo, and system echo;
+7. prohibit hosted-provider fallback unless separately authorized and explicitly labeled;
+8. distinguish local LLM output from hosted provider output in observability and provenance fields;
+9. preserve `behavior_evidence=false` unless a later lane explicitly changes the evidence model;
+10. require runtime smoke before any future runtime-readiness claim;
+11. keep `/v1/solve` and dashboard preview blocked from local LLM mode for this implementation phase.
+
+## Evidence boundary
+
+This package is a runtime integration specification only. It is not implementation evidence, model quality evidence, hosted provider evidence, `/v1/solve` readiness evidence, dashboard readiness evidence, MVP validation, production readiness, benchmark evidence, provider orchestration evidence, or Alpha superiority evidence.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/test-and-smoke-plan.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/test-and-smoke-plan.md
@@ -1,0 +1,42 @@
+# Test and Smoke Plan
+
+Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-SPEC-001`
+
+This file defines required future tests and smoke checks. No tests are added by this lane.
+
+## Required offline tests for future implementation
+
+A future implementation must add or update focused tests proving:
+
+1. local LLM mode is default-off;
+2. explicit operator opt-in is required;
+3. local LLM mode requires no provider keys;
+4. localhost and loopback endpoints are accepted;
+5. non-local endpoints fail closed;
+6. malformed endpoints fail closed;
+7. invalid timeout values fail closed;
+8. connection failure fails closed;
+9. timeout fails closed;
+10. malformed response fails closed;
+11. empty output fails closed;
+12. prompt echo fails closed;
+13. system echo fails closed;
+14. hosted-provider fallback does not occur from local LLM mode;
+15. observability labels local LLM output separately from hosted provider output;
+16. `behavior_evidence=false` is preserved.
+
+## Required runtime smoke before future runtime-readiness claim
+
+Before any future runtime-readiness claim, a separate implementation or smoke lane must run a local LLM runtime smoke with:
+
+- explicit local LLM provider selection;
+- localhost or loopback endpoint;
+- finite timeout;
+- no provider keys;
+- raw and sanitized artifacts;
+- status and reason preservation;
+- proof that hosted-provider fallback did not occur.
+
+## Blocked smoke claims
+
+A smoke result may show only the bounded facts it records. It must not be treated as local model quality evidence, hosted provider evidence, `/v1/solve` readiness, dashboard readiness, MVP validation, production readiness, benchmark evidence, provider orchestration evidence, or Alpha superiority evidence.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/timeout-and-error-contract.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/timeout-and-error-contract.md
@@ -1,0 +1,36 @@
+# Timeout and Error Contract
+
+Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-SPEC-001`
+
+## Finite timeout
+
+Every future local LLM call must use a finite timeout. Unbounded requests are prohibited.
+
+The implementation must reject missing, non-numeric, zero, negative, infinite, or otherwise invalid timeout values for local LLM mode.
+
+## Required fail-closed cases
+
+A future implementation must fail closed for:
+
+1. non-local endpoint;
+2. malformed endpoint;
+3. connection failure;
+4. timeout;
+5. malformed response;
+6. empty output;
+7. prompt echo;
+8. system echo.
+
+## Fail-closed semantics
+
+Fail-closed means:
+
+- stop the local LLM path;
+- return or record a bounded local LLM failure outcome;
+- do not make a hosted-provider call unless separately authorized by a later lane;
+- do not present failed or echoed output as successful local behavior;
+- preserve `behavior_evidence=false`.
+
+## Error labels
+
+A future implementation must use deterministic reason labels that distinguish endpoint rejection, connection failure, timeout, malformed response, empty output, prompt echo, and system echo. Labels may be refined during implementation, but they must remain observable in tests and smoke artifacts.


### PR DESCRIPTION
### Motivation

- Capture and convert prior planning and safety-gate scaffold material into a concrete, docs-only specification package for a future implementation lane. 
- Preserve a narrow evidence boundary and prevent any runtime, source, test, provider, network, or model calls in this lane. 
- Choose a single backend strategy that preserves an optional local LLM path without making it required for MVP compatibility.

### Description

- Added a docs-only specification package under `docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/` containing 15 files that define contracts, boundary conditions, and the implementation-file surface for a future lane. 
- Selected exactly one backend strategy: `hybrid`, with an explicit-provider selection requirement and a prohibition on silent/fallback substitution to hosted providers. 
- Defined non-negotiable safety requirements including default-off local mode, operator opt-in, localhost/loopback-only endpoints, no provider keys for local mode, finite timeouts, and fail-closed behavior for endpoint/connection/timeout/response/echo failures, and preserved `behavior_evidence=false`. 
- Recorded the minimal future implementation file boundary and a required test-and-smoke plan and selected next lane `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-IMPLEMENTATION-001` for implementation work.

### Testing

- Ran path and content checks to confirm only files under `docs/evals/runs/20260605-alpha-local-llm-runtime-integration-spec/` were added and that the package contains the required 15 files, which all passed. 
- Executed automated assertions (small Python checks and pattern searches) to verify a single `hybrid` selection, a single selected next lane (`ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-IMPLEMENTATION-001`), and presence of narrow evidence-boundary language including `behavior_evidence=false`, which all succeeded. 
- Performed repository status validation to confirm a clean worktree and that no source/test/runtime/provider/dashboard files were changed, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a231545ed8c8329bbe50514e7afd5b5)