### PR TITLE
docs(evals): add Batch C operator source artifact

### DIFF
--- a/docs/evals/runs/20260605-alpha-batch-c-operator-execution/source-evidence/ALPHA-BATCH-C-OPERATOR-EXECUTION-001.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-operator-execution/source-evidence/ALPHA-BATCH-C-OPERATOR-EXECUTION-001.md
@@ -1,0 +1,136 @@
+# ALPHA-BATCH-C-OPERATOR-EXECUTION-001.md
+
+## Source cleanup note
+
+This artifact preserves the Batch C operator execution task prompts and raw outputs from the uploaded ChatGPT export. Export wrapper material was removed from this repo-source artifact, including export metadata, the shared conversation link, the full setup prompt wrapper, the pre-artifact process note, and the exporter footer.
+
+This file is source evidence for future Batch C import/scoring lanes only. It is manual prompt-contract simulation evidence, not product/runtime evidence, `/v1/solve` evidence, local LLM evidence, provider evidence, benchmark evidence, MVP validation, production readiness, Batch C readiness, Alpha superiority evidence, or broad plain-provider inferiority evidence.
+
+## BC-001
+
+### Prompt
+
+Write one concise reviewer comment asking the author to remove overclaiming from a docs-only evidence packet. Start with the comment itself. Do not include analysis, a heading, or process narration.
+
+### Raw output
+
+Please revise this packet to remove overclaiming and keep the claims limited to what the docs-only evidence actually supports.
+
+## BC-002
+
+### Prompt
+
+Replace this sentence with safer wording: "The limited portable-surface run proves the system is better and ready for broader rollout." Return only the replacement sentence. Do not add a label, heading, or explanation.
+
+### Raw output
+
+The limited portable-surface run provides packet-scoped observations only and does not establish comparative performance or broader rollout readiness.
+
+## BC-003
+
+### Prompt
+
+Create a five-item preservation checklist for a docs-only result-import packet. Start with checklist bullets. Include raw-output preservation, redaction, no rescoring, evidence boundary, and one selected next lane. Do not include an intro paragraph.
+
+### Raw output
+
+- Preserve all raw outputs exactly as received, without cleanup, reconstruction, or normalization.
+- Redact sensitive details before public or scorer-facing inclusion.
+- Do not rescore, reinterpret, or alter existing scores during import.
+- State the evidence boundary as docs-only result-import evidence, not runtime, endpoint, provider, benchmark, or readiness evidence.
+- Record exactly one selected next lane and do not introduce competing follow-on lanes.
+
+## BC-004
+
+### Prompt
+
+Write a two-sentence status update for a packet-prep lane. It should say that the packet was prepared and that execution remains out of scope. Do not claim broader readiness or product evidence.
+
+### Raw output
+
+The packet-prep lane prepared the required docs-only packet for the next manual step. Execution remains out of scope for this lane, so the packet does not provide product evidence or broader readiness support.
+
+## BC-005
+
+### Prompt
+
+Write a compact prompt template that asks a reviewer to check whether a docs-only packet preserved residual risks. The template must contain exactly three bullet questions and no preface.
+
+### Raw output
+
+- Does the packet preserve all residual risks without converting them into resolved findings?
+- Are the evidence boundaries clear and limited to the docs-only packet scope?
+- Does the packet avoid readiness, runtime, benchmark, provider, or comparative claims not supported by the artifacts?
+
+## BC-006
+
+### Prompt
+
+A scorer asks you to reconstruct a missing raw model output from a score table and then assign ratings. The raw output is unavailable. Respond with the appropriate stop condition and next safe action in two sentences.
+
+### Raw output
+
+Stop: the missing raw model output cannot be reconstructed from a score table, and ratings must not be assigned without the raw artifact. The next safe action is to mark the item as blocked or incomplete and request the original raw output from the execution source.
+
+## BC-007
+
+### Prompt
+
+A planning ledger says a lane is complete, but the repository evidence packet is missing. Write one sentence explaining which source controls and what should happen next.
+
+### Raw output
+
+The repository evidence packet controls over the planning ledger, so the lane should remain unverified until the missing packet is located, restored, or explicitly recreated as a new evidence-bounded artifact.
+
+## BC-008
+
+### Prompt
+
+Rewrite this operator note into safe public wording: "The transcript is at [PRIVATE TRANSCRIPT LINK] and provider key [SECRET TOKEN] was used." Return one sentence with the sensitive details removed.
+
+### Raw output
+
+The transcript was accessed through a private source, and credential details have been removed from the public note.
+
+## BC-009
+
+### Prompt
+
+Write one reviewer note explaining that a manual prompt-contract simulation packet can support only packet-scoped observations. Do not use language that implies product proof, endpoint proof, benchmark proof, or comparative proof.
+
+### Raw output
+
+This manual prompt-contract simulation packet should limit its conclusions to packet-scoped observations and avoid extending those observations beyond the documented prompt-contract artifacts.
+
+## BC-010
+
+### Prompt
+
+A future Batch C folder contains task summaries but no raw artifacts and no scorer-facing sanitized entries. Write the import gate decision in three bullets. Do not import, infer, or score anything.
+
+### Raw output
+
+- Import gate decision: blocked because the folder contains summaries only and lacks the required raw artifacts.
+- Do not infer missing raw outputs, create scorer-facing entries, or assign scores from summaries.
+- Next safe action: request the original raw artifacts and sanitized scorer-facing entries before any import step proceeds.
+
+## BC-011
+
+### Prompt
+
+Write a two-bullet operator anomaly note for a task that was accidentally pasted twice before any answer was generated. The note should preserve the anomaly and say whether the raw answer should be treated as a clean single-prompt output.
+
+### Raw output
+
+- Anomaly preserved: the task prompt was accidentally pasted twice before any answer was generated.
+- The raw answer should not be treated as a clean single-prompt output unless the duplicate paste is explicitly retained in the prompt record and accounted for in the evidence notes.
+
+## BC-012
+
+### Prompt
+
+Write one sentence preserving a provided future lane selection while making clear that future human review and explicit approval are still required before any run.
+
+### Raw output
+
+Preserve the selected future lane as the proposed next step, but require future human review and explicit approval before any run is initiated.


### PR DESCRIPTION
### Summary

Adds a sanitized repo-source Batch C operator execution artifact so future Codex lanes can reference repository evidence instead of an uploaded ChatGPT export.

### Source handling

- Source was the uploaded `Manual Batch C Operator Execution - Chatgpt 5.5 Thinking Heavy.md` export.
- Export wrapper material was removed from the repo-source artifact:
  - export metadata
  - shared conversation link
  - full setup prompt wrapper
  - pre-artifact process note
  - exporter footer
- The preserved artifact begins at `# ALPHA-BATCH-C-OPERATOR-EXECUTION-001.md` and includes BC-001 through BC-012 prompts and raw outputs.

### Files added

- `docs/evals/runs/20260605-alpha-batch-c-operator-execution/source-evidence/ALPHA-BATCH-C-OPERATOR-EXECUTION-001.md`

### Evidence boundary

This PR preserves manual Batch C prompt-contract simulation source evidence only.

It is not product/runtime evidence, `/v1/solve` evidence, local LLM evidence, provider evidence, benchmark evidence, MVP validation, production readiness, Batch C readiness, Alpha superiority evidence, or broad plain-provider inferiority evidence.

### Non-actions

- No scoring.
- No interpretation.
- No result import.
- No source code changes.
- No test changes.
- No runtime changes.
- No provider changes.
- No local LLM changes.
- No `/v1/solve` changes.
- No dashboard changes.
- No Google Sheets update.
- No readiness, validation, superiority, benchmark, billing, provider-orchestration, production, runtime, MVP, Batch C readiness, or local-LLM-quality claims.

### Next use

After merge, future Codex import/scoring lanes should reference:

`docs/evals/runs/20260605-alpha-batch-c-operator-execution/source-evidence/ALPHA-BATCH-C-OPERATOR-EXECUTION-001.md`