### PR TITLE
feat(local-llm): add optional runtime integration path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,13 @@ MODEL_PROVIDER=local
 # GOOGLE_API_KEY=placeholder-google-api-key
 DEBUG=false
 PROD=false
+
+# Optional local LLM runtime path (default-off): keep commented unless an
+# approved local-runtime lane explicitly opts in. This mode requires localhost /
+# loopback, an exact local model name, a finite timeout, and no provider keys.
+# It is not exposed through /v1/solve or dashboard preview by this implementation.
+# MODEL_PROVIDER=local_llm
+# ALPHA_LOCAL_LLM_ENABLED=true
+# ALPHA_LOCAL_LLM_ENDPOINT=http://127.0.0.1:11434/api/chat
+# ALPHA_LOCAL_LLM_MODEL=llama3.2:1b-local-fixture
+# ALPHA_LOCAL_LLM_TIMEOUT_SECONDS=10

--- a/alpha/local_llm/provider_adapter.py
+++ b/alpha/local_llm/provider_adapter.py
@@ -10,16 +10,32 @@ only and is never behavior, runtime, or readiness evidence.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import json
 from ipaddress import ip_address
+from math import isfinite
+import os
 from typing import Any, Mapping, Protocol
 from urllib.parse import urlsplit
+from urllib.request import Request as URLRequest, urlopen
 
 from .portable_contract import PortableContract, PortableContractError, load_portable_contract
 
 _LOCAL_LLM_ADAPTER_MODE = "local_llm"
 _ADAPTER_BACKEND_CLASS = "stub-local-llm-provider-adapter"
+_OLLAMA_BACKEND_CLASS = "ollama-local-http-runtime"
 _ADAPTER_EVIDENCE_LABEL = "non_evidence_local_llm_provider_adapter_wiring"
 _DISABLED_MODEL_LABEL = "local-llm-disabled-unconfigured"
+_LOCAL_LLM_ENABLED_ENV = "ALPHA_LOCAL_LLM_ENABLED"
+_LOCAL_LLM_ENDPOINT_ENV = "ALPHA_LOCAL_LLM_ENDPOINT"
+_LOCAL_LLM_MODEL_ENV = "ALPHA_LOCAL_LLM_MODEL"
+_LOCAL_LLM_TIMEOUT_ENV = "ALPHA_LOCAL_LLM_TIMEOUT_SECONDS"
+_FORBIDDEN_PROVIDER_KEY_ENVS = (
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GOOGLE_API_KEY",
+    "GEMINI_API_KEY",
+    "DEEPSEEK_API_KEY",
+)
 
 
 @dataclass(frozen=True)
@@ -92,6 +108,80 @@ class LocalLLMProviderAdapterError(PortableContractError):
         self.reason_code = reason_code
 
 
+def _truthy(value: str | None) -> bool:
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _require_exact_model_name(model: str) -> str:
+    if not isinstance(model, str) or not model.strip():
+        raise LocalLLMProviderAdapterError("missing_model_non_evidence")
+    if model != model.strip():
+        raise LocalLLMProviderAdapterError("invalid_model_non_evidence")
+    return model
+
+
+def _require_finite_timeout_seconds(timeout_seconds: float) -> float:
+    try:
+        value = float(timeout_seconds)
+    except (TypeError, ValueError):
+        raise LocalLLMProviderAdapterError("invalid_timeout_non_evidence") from None
+    if not isfinite(value) or value <= 0:
+        raise LocalLLMProviderAdapterError("invalid_timeout_non_evidence")
+    return value
+
+
+def _present_provider_keys(env: Mapping[str, str]) -> tuple[str, ...]:
+    return tuple(key for key in _FORBIDDEN_PROVIDER_KEY_ENVS if str(env.get(key, "")).strip())
+
+
+@dataclass(frozen=True)
+class LocalLLMRuntimeConfig:
+    """Explicit, default-off local LLM runtime configuration.
+
+    This config is not consumed by ``/v1/solve`` or dashboard preview. It exists
+    for approved local-runtime call sites and tests only, requires positive
+    operator opt-in, rejects provider keys, and validates localhost/loopback plus
+    finite timeout before any transport can be invoked.
+    """
+
+    endpoint_url: str
+    model: str
+    timeout_seconds: float
+    enabled: bool = True
+    provider_mode: str = _LOCAL_LLM_ADAPTER_MODE
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str] | None = None) -> "LocalLLMRuntimeConfig":
+        source = os.environ if env is None else env
+        if not _truthy(source.get(_LOCAL_LLM_ENABLED_ENV)):
+            raise LocalLLMProviderAdapterError("local_llm_disabled_non_evidence")
+        present_keys = _present_provider_keys(source)
+        if present_keys:
+            raise LocalLLMProviderAdapterError("provider_keys_forbidden_non_evidence")
+        endpoint_url = validate_ollama_local_endpoint(str(source.get(_LOCAL_LLM_ENDPOINT_ENV, "")))
+        model = _require_exact_model_name(str(source.get(_LOCAL_LLM_MODEL_ENV, "")))
+        timeout_seconds = _require_finite_timeout_seconds(source.get(_LOCAL_LLM_TIMEOUT_ENV, ""))
+        return cls(
+            endpoint_url=endpoint_url,
+            model=model,
+            timeout_seconds=timeout_seconds,
+        )
+
+    def build_backend(
+        self, transport: OllamaJSONTransport | None = None
+    ) -> "OllamaLocalHTTPBackend":
+        if not self.enabled:
+            raise LocalLLMProviderAdapterError("local_llm_disabled_non_evidence")
+        if self.provider_mode != _LOCAL_LLM_ADAPTER_MODE:
+            raise LocalLLMProviderAdapterError("provider_mode_mismatch_non_evidence")
+        return OllamaLocalHTTPBackend(
+            model=self.model,
+            endpoint_url=self.endpoint_url,
+            timeout_seconds=self.timeout_seconds,
+            transport=transport,
+        )
+
+
 @dataclass
 class StubLocalLLMProviderBackend:
     """Offline stub backend that records requests and performs no I/O."""
@@ -124,10 +214,31 @@ class OllamaLocalHTTPBackend:
     calls: list[LocalLLMAdapterRequest] = field(default_factory=list)
     payloads: list[Mapping[str, Any]] = field(default_factory=list)
 
+    def runtime_metadata(self) -> Mapping[str, Any]:
+        endpoint_url = validate_ollama_local_endpoint(self.endpoint_url)
+        parsed = urlsplit(endpoint_url)
+        return {
+            "provider_mode": _LOCAL_LLM_ADAPTER_MODE,
+            "backend_class": _OLLAMA_BACKEND_CLASS,
+            "local_backend": "ollama_chat",
+            "local_model": self.model,
+            "model": self.model,
+            "endpoint_is_loopback": True,
+            "endpoint_host_label": "localhost"
+            if (parsed.hostname or "").lower().rstrip(".") == "localhost"
+            else "loopback",
+            "timeout_seconds": _require_finite_timeout_seconds(self.timeout_seconds),
+            "no_provider_keys_required": True,
+            "no_hosted_fallback": True,
+            "behavior_evidence": False,
+        }
+
     def generate(self, request: LocalLLMAdapterRequest) -> str:
         endpoint_url = validate_ollama_local_endpoint(self.endpoint_url)
+        timeout_seconds = _require_finite_timeout_seconds(self.timeout_seconds)
+        model = _require_exact_model_name(self.model)
         self.calls.append(request)
-        payload = build_ollama_chat_payload(request, model=self.model)
+        payload = build_ollama_chat_payload(request, model=model)
         self.payloads.append(payload)
         if self.transport is None:
             raise LocalLLMProviderAdapterError(
@@ -138,7 +249,7 @@ class OllamaLocalHTTPBackend:
             response = self.transport(
                 endpoint_url=endpoint_url,
                 payload=payload,
-                timeout_seconds=self.timeout_seconds,
+                timeout_seconds=timeout_seconds,
             )
         except TimeoutError as exc:
             raise LocalLLMProviderAdapterError("timeout_non_evidence", str(exc)) from exc
@@ -183,7 +294,9 @@ def validate_ollama_local_endpoint(endpoint_url: str) -> str:
     if not isinstance(endpoint_url, str) or not endpoint_url.strip():
         raise LocalLLMProviderAdapterError("endpoint_not_local_non_evidence")
     parsed = urlsplit(endpoint_url.strip())
-    if parsed.scheme not in {"http", "https"}:
+    if parsed.scheme != "http":
+        raise LocalLLMProviderAdapterError("endpoint_not_local_non_evidence")
+    if parsed.username is not None or parsed.password is not None:
         raise LocalLLMProviderAdapterError("endpoint_not_local_non_evidence")
     if not _is_loopback_hostname(parsed.hostname):
         raise LocalLLMProviderAdapterError("endpoint_not_local_non_evidence")
@@ -253,8 +366,7 @@ def build_ollama_chat_payload(
 
     if request.provider_mode != _LOCAL_LLM_ADAPTER_MODE:
         raise LocalLLMProviderAdapterError("provider_mode_mismatch_non_evidence")
-    if not model.strip():
-        raise LocalLLMProviderAdapterError("missing_model_non_evidence")
+    model = _require_exact_model_name(model)
     payload: dict[str, Any] = {
         "model": model,
         "messages": [
@@ -286,9 +398,13 @@ def parse_ollama_chat_response(response: Any) -> str:
     return content
 
 
-def _is_prompt_echo(output_text: str, request: LocalLLMAdapterRequest) -> bool:
+def _echo_reason(output_text: str, request: LocalLLMAdapterRequest) -> str | None:
     stripped = output_text.strip()
-    return stripped in {request.user_prompt.strip(), request.system.strip()}
+    if stripped == request.user_prompt.strip():
+        return "prompt_echo_non_evidence"
+    if stripped == request.system.strip():
+        return "system_echo_non_evidence"
+    return None
 
 
 def run_local_llm_provider_adapter(
@@ -317,6 +433,9 @@ def run_local_llm_provider_adapter(
     )
     result_metadata = {**request.metadata, "behavior_evidence": False}
     try:
+        runtime_metadata = getattr(backend, "runtime_metadata", None)
+        if callable(runtime_metadata):
+            result_metadata = {**result_metadata, **runtime_metadata(), "behavior_evidence": False}
         output_text = backend.generate(request)
     except Exception as exc:  # injected-backend-only failure normalization
         reason = getattr(exc, "reason_code", f"adapter_error:{exc.__class__.__name__}")
@@ -336,12 +455,13 @@ def run_local_llm_provider_adapter(
             reason="empty_model_output_non_evidence",
             metadata={**result_metadata, "failure_label": "failed_closed_result"},
         )
-    if _is_prompt_echo(output_text, request):
+    echo_reason = _echo_reason(output_text, request)
+    if echo_reason is not None:
         return LocalLLMAdapterResult(
             request=request,
             output_text=output_text,
             status="failed_closed",
-            reason="prompt_echo_non_evidence",
+            reason=echo_reason,
             metadata={**result_metadata, "failure_label": "failed_closed_result"},
         )
 
@@ -351,4 +471,64 @@ def run_local_llm_provider_adapter(
         status="non_evidence",
         reason="local_llm_provider_adapter_wiring_only",
         metadata=result_metadata,
+    )
+
+
+def urllib_ollama_json_transport(
+    *,
+    endpoint_url: str,
+    payload: Mapping[str, Any],
+    timeout_seconds: float,
+) -> Mapping[str, Any]:
+    """POST JSON to a pre-validated local Ollama endpoint.
+
+    The caller must pass a URL through ``validate_ollama_local_endpoint`` and a
+    finite timeout before this transport executes. The helper uses only the
+    supplied endpoint and contains no hosted-provider fallback.
+    """
+
+    endpoint_url = validate_ollama_local_endpoint(endpoint_url)
+    timeout_seconds = _require_finite_timeout_seconds(timeout_seconds)
+    data = json.dumps(dict(payload)).encode("utf-8")
+    request = URLRequest(
+        endpoint_url,
+        data=data,
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+        method="POST",
+    )
+    with urlopen(request, timeout=timeout_seconds) as response:  # nosec B310 - loopback URL only
+        decoded = json.loads(response.read().decode("utf-8"))
+    if not isinstance(decoded, Mapping):
+        raise LocalLLMProviderAdapterError("malformed_response_non_evidence")
+    return decoded
+
+
+def run_configured_local_llm_runtime(
+    user_prompt: str,
+    *,
+    config: LocalLLMRuntimeConfig | None = None,
+    env: Mapping[str, str] | None = None,
+    transport: OllamaJSONTransport | None = None,
+    contract: PortableContract | None = None,
+    contract_path: str | None = None,
+    expected_sha256: str | None = None,
+) -> LocalLLMAdapterResult:
+    """Run the optional local LLM runtime path after explicit safe config.
+
+    This is intentionally not wired to ``/v1/solve`` or dashboard preview. With
+    no explicit config/env opt-in it fails before transport construction. With no
+    supplied transport, it uses the loopback-only urllib transport. Tests should
+    inject transports and must not make network calls.
+    """
+
+    runtime_config = config or LocalLLMRuntimeConfig.from_env(env)
+    backend = runtime_config.build_backend(transport or urllib_ollama_json_transport)
+    return run_local_llm_provider_adapter(
+        user_prompt,
+        backend=backend,
+        contract=contract,
+        contract_path=contract_path,
+        expected_sha256=expected_sha256,
+        provider_mode=_LOCAL_LLM_ADAPTER_MODE,
+        model=runtime_config.model,
     )

--- a/alpha/local_llm/provider_adapter.py
+++ b/alpha/local_llm/provider_adapter.py
@@ -16,7 +16,8 @@ from math import isfinite
 import os
 from typing import Any, Mapping, Protocol
 from urllib.parse import urlsplit
-from urllib.request import Request as URLRequest, urlopen
+from urllib.error import HTTPError
+from urllib.request import HTTPRedirectHandler, Request as URLRequest, build_opener
 
 from .portable_contract import PortableContract, PortableContractError, load_portable_contract
 
@@ -106,6 +107,22 @@ class LocalLLMProviderAdapterError(PortableContractError):
     def __init__(self, reason_code: str, detail: str | None = None):
         super().__init__(detail or reason_code)
         self.reason_code = reason_code
+
+
+_REDIRECT_STATUS_CODES = frozenset({301, 302, 303, 307, 308})
+
+
+class _FailClosedRedirectHandler(HTTPRedirectHandler):
+    """urllib redirect handler that refuses every redirect target."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[no-untyped-def]
+        return None
+
+
+def _local_no_redirect_opener():
+    """Build an opener for local runtime calls that never follows redirects."""
+
+    return build_opener(_FailClosedRedirectHandler)
 
 
 def _truthy(value: str | None) -> bool:
@@ -496,8 +513,16 @@ def urllib_ollama_json_transport(
         headers={"Content-Type": "application/json", "Accept": "application/json"},
         method="POST",
     )
-    with urlopen(request, timeout=timeout_seconds) as response:  # nosec B310 - loopback URL only
-        decoded = json.loads(response.read().decode("utf-8"))
+    try:
+        with _local_no_redirect_opener().open(request, timeout=timeout_seconds) as response:
+            decoded = json.loads(response.read().decode("utf-8"))
+    except HTTPError as exc:
+        if exc.code in _REDIRECT_STATUS_CODES:
+            raise LocalLLMProviderAdapterError(
+                "endpoint_redirect_non_evidence",
+                "Local LLM endpoint redirects are disabled",
+            ) from exc
+        raise
     if not isinstance(decoded, Mapping):
         raise LocalLLMProviderAdapterError("malformed_response_non_evidence")
     return decoded

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-implementation/README.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-implementation/README.md
@@ -1,0 +1,19 @@
+# Local LLM Runtime Integration Implementation
+
+Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-IMPLEMENTATION-001`
+
+This package records the narrow implementation lane for the optional local LLM runtime path authorized by `.specs/LOCAL-LLM-RUNTIME-INTEGRATION-001.md`.
+
+## Status
+
+- Local LLM runtime mode remains optional and default-off.
+- Explicit operator opt-in is required through `MODEL_PROVIDER=local_llm` plus `ALPHA_LOCAL_LLM_ENABLED=true` and complete local runtime configuration.
+- Only localhost / loopback `http` endpoints are accepted.
+- Exact model name and finite positive timeout are required.
+- Provider keys are rejected for local LLM runtime mode.
+- `/v1/solve` and dashboard preview remain blocked from local LLM runtime mode.
+- Tests use injected transports only and make no real local model or hosted provider calls.
+
+## Evidence boundary
+
+This package proves implementation shape and offline/unit-test behavior only. It is not local model quality evidence, hosted provider evidence, runtime smoke evidence, `/v1/solve` readiness, dashboard preview readiness, MVP validation, production readiness, benchmark evidence, provider orchestration evidence, or Alpha superiority evidence.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-implementation/evidence-boundary.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-implementation/evidence-boundary.md
@@ -1,0 +1,18 @@
+# Evidence Boundary
+
+This PR may prove implementation and offline/unit test behavior only.
+
+It is not:
+
+- local model quality evidence;
+- hosted provider evidence;
+- `/v1/solve` readiness;
+- dashboard preview readiness;
+- MVP validation;
+- production readiness;
+- benchmark evidence;
+- provider orchestration evidence;
+- Alpha superiority evidence;
+- runtime smoke evidence.
+
+No hosted provider calls, real local model calls, provider keys, dashboard exposure, or `/v1/solve` local LLM exposure are included.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-implementation/fail-closed-coverage.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-implementation/fail-closed-coverage.md
@@ -7,6 +7,7 @@ Offline tests cover fail-closed behavior for:
 - invalid, missing, non-finite, zero, or negative timeout;
 - forbidden provider keys;
 - non-local endpoint;
+- endpoint redirect before any redirected request is made;
 - malformed / ambiguous endpoint;
 - unsupported `https` or userinfo-bearing endpoint;
 - connection failure;

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-implementation/fail-closed-coverage.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-implementation/fail-closed-coverage.md
@@ -1,0 +1,21 @@
+# Fail-Closed Coverage
+
+Offline tests cover fail-closed behavior for:
+
+- default-off / missing explicit opt-in;
+- missing or non-exact model name;
+- invalid, missing, non-finite, zero, or negative timeout;
+- forbidden provider keys;
+- non-local endpoint;
+- malformed / ambiguous endpoint;
+- unsupported `https` or userinfo-bearing endpoint;
+- connection failure;
+- timeout;
+- generic backend failure;
+- malformed response;
+- empty output;
+- prompt echo;
+- system echo;
+- no hosted-provider fallback after local failure.
+
+All failure outcomes preserve `behavior_evidence=false` and do not present failed or echoed output as successful behavior.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-implementation/file-change-boundary.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-implementation/file-change-boundary.md
@@ -1,0 +1,25 @@
+# File Change Boundary
+
+Allowed implementation files changed:
+
+- `alpha/local_llm/provider_adapter.py`
+- `scripts/check_env.py`
+- `service/config/validators.py`
+- `.env.example`
+- `tests/test_local_llm_provider_adapter.py`
+- `tests/test_local_llm_runtime_integration.py`
+- `tests/test_config_validation.py`
+
+Allowed documentation added under this package:
+
+- `README.md`
+- `implementation-summary.md`
+- `file-change-boundary.md`
+- `runtime-config-summary.md`
+- `fail-closed-coverage.md`
+- `test-results.md`
+- `evidence-boundary.md`
+- `implementation-preservation-checklist.md`
+- `selected-next-lane.md`
+
+No backlog workbooks were modified. No dashboard or `/v1/solve` exposure was added.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-implementation/implementation-preservation-checklist.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-implementation/implementation-preservation-checklist.md
@@ -5,6 +5,7 @@
 - [x] Local LLM runtime mode remains optional and default-off.
 - [x] Explicit operator opt-in is required.
 - [x] Only localhost / loopback endpoints are accepted.
+- [x] HTTP redirects are disabled and treated as local fail-closed non-evidence outcomes.
 - [x] Exact local model name is required.
 - [x] Finite timeout is required.
 - [x] Provider keys are rejected for local LLM runtime mode.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-implementation/implementation-preservation-checklist.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-implementation/implementation-preservation-checklist.md
@@ -1,0 +1,17 @@
+# Implementation Preservation Checklist
+
+- [x] Canonical spec `.specs/LOCAL-LLM-RUNTIME-INTEGRATION-001.md` was inspected.
+- [x] `.specs/INDEX.md` includes the canonical spec.
+- [x] Local LLM runtime mode remains optional and default-off.
+- [x] Explicit operator opt-in is required.
+- [x] Only localhost / loopback endpoints are accepted.
+- [x] Exact local model name is required.
+- [x] Finite timeout is required.
+- [x] Provider keys are rejected for local LLM runtime mode.
+- [x] No hosted-provider fallback is implemented.
+- [x] Provenance distinguishes local LLM runtime output from hosted output.
+- [x] `behavior_evidence=false` is preserved.
+- [x] Existing default runtime behavior remains unchanged when local LLM mode is not configured.
+- [x] `/v1/solve` remains blocked from local LLM runtime mode.
+- [x] Dashboard preview remains blocked from local LLM runtime mode.
+- [x] Tests use mocked/injected transports only.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-implementation/implementation-summary.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-implementation/implementation-summary.md
@@ -6,7 +6,7 @@ Implemented behavior:
 
 - `LocalLLMRuntimeConfig.from_env()` validates explicit operator opt-in and required runtime configuration.
 - `OllamaLocalHTTPBackend` validates endpoint locality, exact model name, and finite timeout before invoking any transport.
-- A loopback-only `urllib_ollama_json_transport()` exists for approved future local runtime use.
+- A loopback-only `urllib_ollama_json_transport()` exists for approved future local runtime use and uses a fail-closed no-redirect opener.
 - `run_configured_local_llm_runtime()` wires validated config to the adapter without hosted-provider fallback.
 - Provenance metadata distinguishes local LLM runtime output from hosted provider output and preserves `behavior_evidence=false`.
 

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-implementation/implementation-summary.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-implementation/implementation-summary.md
@@ -1,0 +1,13 @@
+# Implementation Summary
+
+The implementation adds a small optional runtime configuration and transport seam around the existing local LLM provider adapter.
+
+Implemented behavior:
+
+- `LocalLLMRuntimeConfig.from_env()` validates explicit operator opt-in and required runtime configuration.
+- `OllamaLocalHTTPBackend` validates endpoint locality, exact model name, and finite timeout before invoking any transport.
+- A loopback-only `urllib_ollama_json_transport()` exists for approved future local runtime use.
+- `run_configured_local_llm_runtime()` wires validated config to the adapter without hosted-provider fallback.
+- Provenance metadata distinguishes local LLM runtime output from hosted provider output and preserves `behavior_evidence=false`.
+
+The implementation does not wire local LLM runtime mode into `/v1/solve` or dashboard preview.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-implementation/runtime-config-summary.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-implementation/runtime-config-summary.md
@@ -1,0 +1,21 @@
+# Runtime Configuration Summary
+
+Local LLM runtime mode is default-off.
+
+Required explicit opt-in configuration:
+
+- `MODEL_PROVIDER=local_llm`
+- `ALPHA_LOCAL_LLM_ENABLED=true`
+- `ALPHA_LOCAL_LLM_ENDPOINT=http://127.0.0.1:11434/api/chat` or another accepted localhost / loopback `http` endpoint
+- `ALPHA_LOCAL_LLM_MODEL=<exact-local-model-name>`
+- `ALPHA_LOCAL_LLM_TIMEOUT_SECONDS=<finite-positive-number>`
+
+Forbidden for local LLM runtime mode:
+
+- `OPENAI_API_KEY`
+- `ANTHROPIC_API_KEY`
+- `GOOGLE_API_KEY`
+- `GEMINI_API_KEY`
+- `DEEPSEEK_API_KEY`
+
+`MODEL_PROVIDER=local` remains the existing offline/local solver default and is not treated as local LLM runtime opt-in.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-implementation/selected-next-lane.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-implementation/selected-next-lane.md
@@ -1,0 +1,7 @@
+# Selected Next Lane
+
+Exactly one next lane is selected:
+
+`ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-REVIEW-GATE-001`
+
+The next lane should review implementation safety, evidence boundaries, and offline test coverage before any future runtime smoke lane is considered.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-implementation/test-results.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-implementation/test-results.md
@@ -1,0 +1,13 @@
+# Test Results
+
+Checks run in this implementation lane:
+
+- `python -m pytest -q tests/test_local_llm_runtime_integration.py tests/test_local_llm_provider_adapter.py` — passed.
+- `python -m pytest -q tests/test_config_validation.py tests/config/test_loader.py` — passed.
+- `python -m pytest -q tests/test_api_endpoints.py::test_solve_local_mode_ignores_provider_factory tests/test_api_endpoints.py::test_solve_expert_route_local_mode_preserves_local_response tests/ui/test_expert_preview.py::test_local_provider_expert_preview_ignores_route_context` — passed with upstream deprecation warnings.
+- `python -m pytest -q tests/providers/test_openai_provider.py tests/providers/test_provider_contract.py tests/providers/test_provider_accounting.py tests/providers/test_provider_telemetry.py` — passed.
+- `python -m ruff check alpha/local_llm/provider_adapter.py scripts/check_env.py service/config/validators.py tests/test_local_llm_runtime_integration.py tests/test_local_llm_provider_adapter.py tests/test_config_validation.py` — passed.
+- `python -m py_compile alpha/local_llm/provider_adapter.py scripts/check_env.py service/config/validators.py` — passed.
+- `python -m pytest -q` — failed in pre-existing unrelated areas after the focused checks passed: `tests/test_api_endpoints.py::test_solve_openai_provider_errors_return_safe_responses[...]` expected `gpt-5` but observed `gpt-5-mini`; `tests/test_cost_tracking.py::test_cost_tracking`; and `tests/test_security.py::test_a3_1_prompt_subset_passes_solve_input_validation`.
+
+These checks use offline fakes and injected transports only. They do not call a hosted provider or a real local model.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-implementation/test-results.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-integration-implementation/test-results.md
@@ -2,6 +2,7 @@
 
 Checks run in this implementation lane:
 
+- `python -m pytest -q tests/test_local_llm_runtime_integration.py` — passed, including redirect fail-closed coverage for 301, 302, 303, 307, and 308.
 - `python -m pytest -q tests/test_local_llm_runtime_integration.py tests/test_local_llm_provider_adapter.py` — passed.
 - `python -m pytest -q tests/test_config_validation.py tests/config/test_loader.py` — passed.
 - `python -m pytest -q tests/test_api_endpoints.py::test_solve_local_mode_ignores_provider_factory tests/test_api_endpoints.py::test_solve_expert_route_local_mode_preserves_local_response tests/ui/test_expert_preview.py::test_local_provider_expert_preview_ignores_route_context` — passed with upstream deprecation warnings.

--- a/scripts/check_env.py
+++ b/scripts/check_env.py
@@ -7,12 +7,23 @@ basic invariants hold. No secret values are ever printed.
 from __future__ import annotations
 
 import os
+from pathlib import Path
 import sys
 from typing import List
 
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
 SECRET_KEYS = ("KEY", "TOKEN", "SECRET")
-ALLOWED_PROVIDERS = {"local", "none", "openai", "anthropic", "gemini", "google"}
+ALLOWED_PROVIDERS = {"local", "local_llm", "none", "openai", "anthropic", "gemini", "google"}
 _NO_KEY_PROVIDERS = {"local", "none"}
+_LOCAL_LLM_PROVIDER_KEYS = (
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GOOGLE_API_KEY",
+    "GEMINI_API_KEY",
+    "DEEPSEEK_API_KEY",
+)
 
 
 def _is_truthy(value: str | None) -> bool:
@@ -39,6 +50,31 @@ def _missing(var: str) -> bool:
     return value is None or not value.strip()
 
 
+def _validate_local_llm_env() -> List[str]:
+    errors: List[str] = []
+    if not _is_truthy(os.getenv("ALPHA_LOCAL_LLM_ENABLED")):
+        errors.append("ALPHA_LOCAL_LLM_ENABLED must be true for MODEL_PROVIDER=local_llm")
+    for var in (
+        "ALPHA_LOCAL_LLM_ENDPOINT",
+        "ALPHA_LOCAL_LLM_MODEL",
+        "ALPHA_LOCAL_LLM_TIMEOUT_SECONDS",
+    ):
+        if _missing(var):
+            errors.append(var)
+    for var in _LOCAL_LLM_PROVIDER_KEYS:
+        if not _missing(var):
+            errors.append(f"{var} must be unset for MODEL_PROVIDER=local_llm")
+    if not errors:
+        try:
+            from alpha.local_llm.provider_adapter import LocalLLMRuntimeConfig
+
+            LocalLLMRuntimeConfig.from_env()
+        except Exception as exc:
+            reason = getattr(exc, "reason_code", exc.__class__.__name__)
+            errors.append(f"local_llm configuration failed closed: {reason}")
+    return errors
+
+
 def main() -> int:
     missing: List[str] = []
     provider_raw = os.getenv("MODEL_PROVIDER", "")
@@ -59,7 +95,9 @@ def main() -> int:
         )
         return 1
 
-    if provider and provider not in _NO_KEY_PROVIDERS:
+    if provider == "local_llm":
+        missing.extend(_validate_local_llm_env())
+    elif provider and provider not in _NO_KEY_PROVIDERS:
         for var in _required_keys_for_provider(provider):
             if _missing(var):
                 missing.append(var)

--- a/service/config/validators.py
+++ b/service/config/validators.py
@@ -7,7 +7,7 @@ from typing import Any, Mapping
 # User-facing provider values mirror scripts/check_env.py. Accepting a
 # provider here validates configuration shape only; it does not imply that
 # remote LLM API execution is implemented.
-USER_FACING_PROVIDERS = {"local", "none", "openai", "anthropic", "gemini", "google"}
+USER_FACING_PROVIDERS = {"local", "local_llm", "none", "openai", "anthropic", "gemini", "google"}
 
 # Internal/test-only provider retained for config-loader tests and local harnesses.
 # Do not document this as a user-facing remote provider.

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -167,7 +167,7 @@ def test_check_env_unknown_provider_lists_allowed_values():
     assert result.returncode != 0
     assert "Unknown MODEL_PROVIDER" in result.stdout
     assert "Allowed values" in result.stdout
-    for provider in ("local", "none", "openai", "anthropic", "gemini", "google"):
+    for provider in ("local", "local_llm", "none", "openai", "anthropic", "gemini", "google"):
         assert provider in result.stdout
 
 
@@ -175,3 +175,55 @@ def test_redaction(caplog):
     with caplog.at_level("DEBUG"):
         load_config(env={"MODEL_PROVIDER": "openai", "OPENAI_API_KEY": "secret"})
     assert "secret" not in caplog.text
+
+
+def test_check_env_local_llm_requires_explicit_runtime_config_without_provider_keys():
+    result = _run_check_env({"MODEL_PROVIDER": "local_llm"})
+    assert result.returncode != 0
+    assert "ALPHA_LOCAL_LLM_ENABLED" in result.stdout
+    assert "ALPHA_LOCAL_LLM_ENDPOINT" in result.stdout
+    assert "ALPHA_LOCAL_LLM_MODEL" in result.stdout
+    assert "ALPHA_LOCAL_LLM_TIMEOUT_SECONDS" in result.stdout
+
+
+def test_check_env_local_llm_accepts_loopback_without_provider_keys():
+    result = _run_check_env(
+        {
+            "MODEL_PROVIDER": "local_llm",
+            "ALPHA_LOCAL_LLM_ENABLED": "true",
+            "ALPHA_LOCAL_LLM_ENDPOINT": "http://127.0.0.1:11434/api/chat",
+            "ALPHA_LOCAL_LLM_MODEL": "llama3.2:1b-local-fixture",
+            "ALPHA_LOCAL_LLM_TIMEOUT_SECONDS": "2.5",
+        }
+    )
+    assert result.returncode == 0
+    assert "Environment looks good" in result.stdout
+
+
+def test_check_env_local_llm_rejects_provider_keys():
+    result = _run_check_env(
+        {
+            "MODEL_PROVIDER": "local_llm",
+            "ALPHA_LOCAL_LLM_ENABLED": "true",
+            "ALPHA_LOCAL_LLM_ENDPOINT": "http://127.0.0.1:11434/api/chat",
+            "ALPHA_LOCAL_LLM_MODEL": "llama3.2:1b-local-fixture",
+            "ALPHA_LOCAL_LLM_TIMEOUT_SECONDS": "2.5",
+            "OPENAI_API_KEY": "sk-not-used",
+        }
+    )
+    assert result.returncode != 0
+    assert "OPENAI_API_KEY must be unset" in result.stdout
+
+
+def test_check_env_local_llm_rejects_remote_endpoint():
+    result = _run_check_env(
+        {
+            "MODEL_PROVIDER": "local_llm",
+            "ALPHA_LOCAL_LLM_ENABLED": "true",
+            "ALPHA_LOCAL_LLM_ENDPOINT": "http://example.com/api/chat",
+            "ALPHA_LOCAL_LLM_MODEL": "llama3.2:1b-local-fixture",
+            "ALPHA_LOCAL_LLM_TIMEOUT_SECONDS": "2.5",
+        }
+    )
+    assert result.returncode != 0
+    assert "endpoint_not_local_non_evidence" in result.stdout

--- a/tests/test_local_llm_provider_adapter.py
+++ b/tests/test_local_llm_provider_adapter.py
@@ -371,7 +371,7 @@ def test_ollama_backend_fails_closed_on_system_contract_echo_from_static_fixture
     )
 
     assert result.status == "failed_closed"
-    assert result.reason == "prompt_echo_non_evidence"
+    assert result.reason == "system_echo_non_evidence"
     assert result.metadata["failure_label"] == "failed_closed_result"
     assert result.behavior_evidence is False
 

--- a/tests/test_local_llm_runtime_integration.py
+++ b/tests/test_local_llm_runtime_integration.py
@@ -202,3 +202,60 @@ def test_backend_missing_model_fails_closed_before_transport_invocation():
     assert result.status == "failed_closed"
     assert result.reason == "missing_model_non_evidence"
     assert observed["called"] is False
+
+@pytest.mark.parametrize("status_code", [301, 302, 303, 307, 308])
+def test_urllib_transport_redirects_fail_closed_without_following_non_local_target(
+    monkeypatch, status_code
+):
+    from urllib.error import HTTPError
+
+    from alpha.local_llm import provider_adapter
+
+    observed_urls: list[str] = []
+
+    class FakeNoRedirectOpener:
+        def open(self, request, timeout):
+            observed_urls.append(request.full_url)
+            raise HTTPError(
+                request.full_url,
+                status_code,
+                "redirect fixture",
+                {"Location": "https://api.openai.com/v1/chat/completions"},
+                None,
+            )
+
+    monkeypatch.setattr(
+        provider_adapter,
+        "_local_no_redirect_opener",
+        lambda: FakeNoRedirectOpener(),
+    )
+
+    result = run_configured_local_llm_runtime(
+        "Redirects must fail closed without following Location.",
+        env=_valid_env(),
+    )
+
+    assert result.status == "failed_closed"
+    assert result.reason == "endpoint_redirect_non_evidence"
+    assert result.metadata["behavior_evidence"] is False
+    assert result.metadata["no_hosted_fallback"] is True
+    assert observed_urls == ["http://127.0.0.1:11434/api/chat"]
+    assert "https://api.openai.com/v1/chat/completions" not in observed_urls
+
+
+@pytest.mark.parametrize("status_code", [301, 302, 303, 307, 308])
+def test_fail_closed_redirect_handler_never_constructs_redirect_request(status_code):
+    from alpha.local_llm.provider_adapter import _FailClosedRedirectHandler
+
+    handler = _FailClosedRedirectHandler()
+
+    redirected = handler.redirect_request(
+        None,
+        None,
+        status_code,
+        "redirect fixture",
+        {"Location": "https://example.com/not-local"},
+        "https://example.com/not-local",
+    )
+
+    assert redirected is None

--- a/tests/test_local_llm_runtime_integration.py
+++ b/tests/test_local_llm_runtime_integration.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import pytest
+
+from alpha.local_llm.provider_adapter import (
+    LocalLLMProviderAdapterError,
+    LocalLLMRuntimeConfig,
+    OllamaLocalHTTPBackend,
+    run_configured_local_llm_runtime,
+    run_local_llm_provider_adapter,
+)
+
+
+def _valid_env(**overrides: str) -> dict[str, str]:
+    env = {
+        "ALPHA_LOCAL_LLM_ENABLED": "true",
+        "ALPHA_LOCAL_LLM_ENDPOINT": "http://127.0.0.1:11434/api/chat",
+        "ALPHA_LOCAL_LLM_MODEL": "llama3.2:1b-local-fixture",
+        "ALPHA_LOCAL_LLM_TIMEOUT_SECONDS": "2.5",
+    }
+    env.update(overrides)
+    return env
+
+
+def test_runtime_config_is_default_off_and_does_not_invoke_transport():
+    observed = {"called": False}
+
+    def fake_transport(*, endpoint_url, payload, timeout_seconds):
+        observed["called"] = True
+        return {"message": {"role": "assistant", "content": "must not run"}}
+
+    with pytest.raises(LocalLLMProviderAdapterError) as exc:
+        run_configured_local_llm_runtime(
+            "Default-off runtime must fail before transport.",
+            env={},
+            transport=fake_transport,
+        )
+
+    assert exc.value.reason_code == "local_llm_disabled_non_evidence"
+    assert observed["called"] is False
+
+
+def test_runtime_config_requires_exact_model_name():
+    with pytest.raises(LocalLLMProviderAdapterError) as exc:
+        LocalLLMRuntimeConfig.from_env(_valid_env(ALPHA_LOCAL_LLM_MODEL=""))
+    assert exc.value.reason_code == "missing_model_non_evidence"
+
+    with pytest.raises(LocalLLMProviderAdapterError) as exc:
+        LocalLLMRuntimeConfig.from_env(
+            _valid_env(ALPHA_LOCAL_LLM_MODEL=" llama3.2:1b-local-fixture ")
+        )
+    assert exc.value.reason_code == "invalid_model_non_evidence"
+
+
+def test_runtime_config_requires_finite_positive_timeout():
+    for timeout in ("", "0", "-1", "nan", "inf", "not-a-number"):
+        with pytest.raises(LocalLLMProviderAdapterError) as exc:
+            LocalLLMRuntimeConfig.from_env(
+                _valid_env(ALPHA_LOCAL_LLM_TIMEOUT_SECONDS=timeout)
+            )
+        assert exc.value.reason_code == "invalid_timeout_non_evidence"
+
+
+def test_runtime_config_requires_no_provider_keys():
+    with pytest.raises(LocalLLMProviderAdapterError) as exc:
+        LocalLLMRuntimeConfig.from_env(_valid_env(OPENAI_API_KEY="sk-not-used"))
+
+    assert exc.value.reason_code == "provider_keys_forbidden_non_evidence"
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "http://127.0.0.1:11434/api/chat",
+        "http://localhost:11434/api/chat",
+        "http://[::1]:11434/api/chat",
+    ],
+)
+def test_runtime_config_accepts_loopback_endpoint_and_records_provenance(endpoint):
+    observed = {}
+
+    def fake_transport(*, endpoint_url, payload, timeout_seconds):
+        observed["endpoint_url"] = endpoint_url
+        observed["payload"] = payload
+        observed["timeout_seconds"] = timeout_seconds
+        return {"message": {"role": "assistant", "content": "local runtime fixture"}}
+
+    result = run_configured_local_llm_runtime(
+        "Run through fake local runtime transport.",
+        env=_valid_env(ALPHA_LOCAL_LLM_ENDPOINT=endpoint),
+        transport=fake_transport,
+    )
+
+    assert result.status == "non_evidence"
+    assert result.output_text == "local runtime fixture"
+    assert result.behavior_evidence is False
+    assert result.metadata["provider_mode"] == "local_llm"
+    assert result.metadata["backend_class"] == "ollama-local-http-runtime"
+    assert result.metadata["local_backend"] == "ollama_chat"
+    assert result.metadata["local_model"] == "llama3.2:1b-local-fixture"
+    assert result.metadata["endpoint_is_loopback"] is True
+    assert result.metadata["timeout_seconds"] == 2.5
+    assert result.metadata["no_provider_keys_required"] is True
+    assert result.metadata["no_hosted_fallback"] is True
+    assert observed["endpoint_url"] == endpoint
+    assert observed["payload"]["model"] == "llama3.2:1b-local-fixture"
+    assert observed["timeout_seconds"] == 2.5
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "https://127.0.0.1:11434/api/chat",
+        "http://user:pass@127.0.0.1:11434/api/chat",
+        "http://example.com/api/chat",
+        "http://192.168.1.25:11434/api/chat",
+        "http:///api/chat",
+    ],
+)
+def test_runtime_config_rejects_non_local_or_ambiguous_endpoints(endpoint):
+    with pytest.raises(LocalLLMProviderAdapterError) as exc:
+        LocalLLMRuntimeConfig.from_env(_valid_env(ALPHA_LOCAL_LLM_ENDPOINT=endpoint))
+
+    assert exc.value.reason_code == "endpoint_not_local_non_evidence"
+
+
+def test_runtime_path_does_not_silently_fall_back_to_hosted_provider_on_failure():
+    observed = {"calls": 0}
+
+    def connection_failure(*, endpoint_url, payload, timeout_seconds):
+        observed["calls"] += 1
+        raise ConnectionError("offline local connection fixture")
+
+    result = run_configured_local_llm_runtime(
+        "Connection failure must remain a local failure.",
+        env=_valid_env(),
+        transport=connection_failure,
+    )
+
+    assert observed["calls"] == 1
+    assert result.status == "failed_closed"
+    assert result.reason == "connection_failure_non_evidence"
+    assert result.output_text == ""
+    assert result.metadata["no_hosted_fallback"] is True
+    assert result.metadata["behavior_evidence"] is False
+
+
+def test_runtime_backend_fails_closed_on_system_echo_with_specific_reason():
+    def echo_system_transport(*, endpoint_url, payload, timeout_seconds):
+        return {"message": {"role": "assistant", "content": payload["messages"][0]["content"]}}
+
+    result = run_configured_local_llm_runtime(
+        "System echo must not be successful behavior.",
+        env=_valid_env(),
+        transport=echo_system_transport,
+    )
+
+    assert result.status == "failed_closed"
+    assert result.reason == "system_echo_non_evidence"
+    assert result.metadata["behavior_evidence"] is False
+
+
+def test_backend_invalid_timeout_fails_closed_before_transport_invocation():
+    observed = {"called": False}
+
+    def fake_transport(*, endpoint_url, payload, timeout_seconds):
+        observed["called"] = True
+        return {"message": {"role": "assistant", "content": "must not run"}}
+
+    backend = OllamaLocalHTTPBackend(
+        model="llama3.2:1b-local-fixture",
+        timeout_seconds=float("inf"),
+        transport=fake_transport,
+    )
+
+    result = run_local_llm_provider_adapter(
+        "Invalid runtime timeout fails closed.",
+        backend=backend,
+        model="llama3.2:1b-local-fixture",
+    )
+
+    assert result.status == "failed_closed"
+    assert result.reason == "invalid_timeout_non_evidence"
+    assert observed["called"] is False
+
+
+def test_backend_missing_model_fails_closed_before_transport_invocation():
+    observed = {"called": False}
+
+    def fake_transport(*, endpoint_url, payload, timeout_seconds):
+        observed["called"] = True
+        return {"message": {"role": "assistant", "content": "must not run"}}
+
+    backend = OllamaLocalHTTPBackend(model="", transport=fake_transport)
+
+    result = run_local_llm_provider_adapter(
+        "Missing model fails closed.",
+        backend=backend,
+        model="llama3.2:1b-local-fixture",
+    )
+
+    assert result.status == "failed_closed"
+    assert result.reason == "missing_model_non_evidence"
+    assert observed["called"] is False


### PR DESCRIPTION
### Motivation

- Implement a minimal, safe, optional local LLM runtime integration per the canonical spec `.specs/LOCAL-LLM-RUNTIME-INTEGRATION-001.md`, preserving default behavior and strict safety gates. 
- Provide an explicit operator-opt-in path that accepts only localhost/loopback `http` endpoints, requires an exact local model name and finite timeout, forbids provider keys, and fails closed on errors.

### Description

- Add an explicit runtime config and runtime entrypoint: `LocalLLMRuntimeConfig` and `run_configured_local_llm_runtime()` to validate opt-in, reject provider keys, require exact model name, and require finite positive timeout before transport use (`alpha/local_llm/provider_adapter.py`).
- Harden the Ollama-style backend (`OllamaLocalHTTPBackend`) to validate endpoint locality (loopback/localhost only), disallow userinfo, require `http` scheme, validate model and timeout, and emit local-runtime provenance metadata (provider_mode, backend_class, local_model, loopback confirmation, timeout, `behavior_evidence=false`).
- Add a loopback-only `urllib_ollama_json_transport` seam (default-off) and keep network execution opt-in via injected transports; tests inject fake transports only.
- Wire environment validation: extend `scripts/check_env.py` and `service/config/validators.py` to recognize `MODEL_PROVIDER=local_llm` and require `ALPHA_LOCAL_LLM_*` fields while rejecting provider keys for this mode.
- Preserve default-off behavior: `.env.example` keeps `MODEL_PROVIDER=local` as the safe default and documents the optional local-llm config commented out.
- Documentation: add the docs/evals package under `docs/evals/runs/20260605-alpha-local-llm-runtime-integration-implementation/` with README, implementation-summary, file-change-boundary, runtime-config-summary, fail-closed-coverage, test-results, evidence-boundary, implementation-preservation-checklist, and selected-next-lane.

### Testing

- Focused unit tests executed and results:
  - `pytest -q tests/test_local_llm_runtime_integration.py tests/test_local_llm_provider_adapter.py` — passed (focused local-LLM adapter/runtime tests).
  - `pytest -q tests/test_config_validation.py tests/config/test_loader.py` — passed (env/config validation including `local_llm` cases).
  - `pytest -q tests/test_api_endpoints.py::test_solve_local_mode_ignores_provider_factory tests/test_api_endpoints.py::test_solve_expert_route_local_mode_preserves_local_response tests/ui/test_expert_preview.py::test_local_provider_expert_preview_ignores_route_context` — passed (sanity checks that existing local/default behavior unchanged).
  - Provider helper tests (`tests/providers/*`) and static checks (`ruff`, `py_compile`) — passed.
- Full test-suite run (`python -m pytest -q`) completed but failed in unrelated, pre-existing test areas (not introduced by this PR): three provider/expectation and cost-tracking/security tests; these failures are orthogonal to the local-LLM changes and recorded in `docs/evals/.../test-results.md`.
- All local-LLM changes use injected fakes only; no real provider calls or local-model network calls were made during tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23211f22b08329a16e78e4a39403b1)