### PR TITLE
docs: add operator config & runtime-smoke runbook for optional local LLM runtime (docs-only)

### DIFF
--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-operator-config-runbook/README.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-operator-config-runbook/README.md
@@ -1,0 +1,61 @@
+# Local LLM Runtime Operator Configuration Runbook
+
+Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-OPERATOR-CONFIG-RUNBOOK-001`
+
+Status: docs-only operator preparation runbook for the optional local LLM runtime path.
+
+## Purpose
+
+This directory prepares operator-facing documentation for configuring and smoke-testing a future optional local LLM runtime path.
+
+This lane is documentation only. It does not implement runtime integration, does not execute smoke, does not call a local model, does not call a hosted provider, and does not import smoke results.
+
+Runtime implementation may be running separately under `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-IMPLEMENTATION-001`. This runbook does not prove that implementation exists, has merged, works, or is ready for runtime use.
+
+## Canonical contract
+
+The canonical implementation contract is `.specs/LOCAL-LLM-RUNTIME-INTEGRATION-001.md`.
+
+Operators must confirm the eventual implementation against that contract before using these templates as runtime instructions.
+
+## Historical local smoke context only
+
+Prior local smoke materials referenced these historical values:
+
+- endpoint pattern: `http://127.0.0.1:11434/api/chat`
+- model used in smoke: `gemma3:4b`
+- timeout used in smoke: `120`
+
+These values are historical context only. They are not automatic runtime configuration and must be confirmed against the future implementation before use.
+
+## Runbook contents
+
+- `operator-configuration-guide.md` records operator setup fields and default-off expectations.
+- `local-environment-precheck.md` provides future-use local precheck command templates; they were not executed in this lane.
+- `runtime-smoke-runbook.md` provides a future-use smoke sequence; it was not executed in this lane.
+- `artifact-capture-template.md` provides a placeholder artifact template for future runtime smoke.
+- `redaction-rules.md` defines redaction requirements for future artifacts.
+- `failure-troubleshooting-guide.md` lists implementation and runtime failure categories.
+- `evidence-boundary.md` preserves the narrow documentation-only boundary.
+- `runbook-preservation-checklist.md` records preservation checks for this docs-only lane.
+- `selected-next-lane.md` records exactly one selected next lane.
+
+## Operator setup fields
+
+Implementation-dependent fields remain `TBD` until the runtime implementation PR has merged and the final configuration interface is known.
+
+| Field | Status for this lane | Notes |
+| --- | --- | --- |
+| Local endpoint | `TBD` | Must be localhost or loopback only under the canonical contract. Historical context: `http://127.0.0.1:11434/api/chat`. |
+| Local model name | `TBD` | Must be confirmed against the future implementation. Historical context: `gemma3:4b`. |
+| Timeout seconds | `TBD` | Must be finite. Historical context: `120`. |
+| Explicit opt-in flag or setting | `TBD` | Local LLM mode must require explicit operator opt-in. |
+| Default-off behavior | Required | Local LLM mode must remain optional and default-off. |
+| Hosted fallback | Prohibited unless a later spec explicitly authorizes it | No silent hosted fallback is expected. |
+| Provider key requirement | None expected for local mode | Local LLM mode must not require hosted provider keys. |
+
+## Evidence boundary summary
+
+This PR is operator runbook documentation only.
+
+It is not runtime implementation, runtime smoke execution, runtime evidence, local model quality evidence, hosted provider evidence, `/v1/solve` readiness, dashboard preview readiness, MVP validation, production readiness, benchmark evidence, provider orchestration evidence, or Alpha superiority evidence.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-operator-config-runbook/artifact-capture-template.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-operator-config-runbook/artifact-capture-template.md
@@ -1,0 +1,62 @@
+# Artifact Capture Template
+
+Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-OPERATOR-CONFIG-RUNBOOK-001`
+
+This is a placeholder template for a future runtime smoke lane. It is not a smoke result and must not be filled with invented or imported results in this PR.
+
+Canonical contract: `.specs/LOCAL-LLM-RUNTIME-INTEGRATION-001.md`.
+
+## Future artifact metadata
+
+| Field | Value |
+| --- | --- |
+| Future smoke lane ID | `TBD` |
+| Implementation PR or commit | `TBD` |
+| Operator | `TBD-redacted-if-needed` |
+| Start timestamp | `TBD` |
+| End timestamp | `TBD` |
+| Exact command executed | `TBD-redacted` |
+| Working directory | `TBD-redacted-private-paths` |
+| Exit code | `TBD` |
+| Status classification | `TBD` |
+
+## Future runtime configuration capture
+
+| Field | Value |
+| --- | --- |
+| Local provider mode selected explicitly? | `TBD` |
+| Default-off behavior checked? | `TBD` |
+| Explicit opt-in field and value | `TBD` |
+| Local endpoint field | `TBD` |
+| Local endpoint value | `TBD-redacted-or-local-pattern` |
+| Endpoint locality confirmed? | `TBD` |
+| Local model field | `TBD` |
+| Local model name | `TBD` |
+| Timeout field | `TBD` |
+| Timeout seconds | `TBD` |
+| Provider key required? | `TBD-expected-no` |
+| Hosted fallback observed? | `TBD-expected-no` |
+| `behavior_evidence=false` preserved? | `TBD` |
+
+Historical context only: endpoint pattern `http://127.0.0.1:11434/api/chat`, model `gemma3:4b`, timeout `120`. Confirm against the implementation before use.
+
+## Future output capture
+
+```text
+STDOUT:
+TBD-redacted
+```
+
+```text
+STDERR:
+TBD-redacted
+```
+
+## Future operator notes
+
+- Redactions applied: `TBD`
+- Private paths removed: `TBD`
+- Provider keys or tokens present before redaction: `TBD-expected-no`
+- Nonpublic endpoint details removed: `TBD`
+- Evidence boundary acknowledged: `TBD`
+- No readiness, validation, superiority, benchmark, production, MVP, runtime, billing, provider-orchestration, or local-model-quality claim made: `TBD`

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-operator-config-runbook/evidence-boundary.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-operator-config-runbook/evidence-boundary.md
@@ -1,0 +1,40 @@
+# Evidence Boundary
+
+Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-OPERATOR-CONFIG-RUNBOOK-001`
+
+This PR is operator runbook documentation only.
+
+It does not implement runtime integration. It does not execute runtime smoke. It does not call a local model. It does not call hosted providers. It does not make network calls. It does not add provider keys. It does not import smoke results.
+
+Runtime implementation may be running separately under `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-IMPLEMENTATION-001`. This runbook does not prove that implementation exists, has merged, works, or is ready.
+
+Canonical contract: `.specs/LOCAL-LLM-RUNTIME-INTEGRATION-001.md`.
+
+It is not:
+
+- runtime implementation;
+- runtime smoke execution;
+- runtime evidence;
+- local model quality evidence;
+- hosted provider evidence;
+- `/v1/solve` readiness;
+- dashboard preview readiness;
+- MVP validation;
+- production readiness;
+- benchmark evidence;
+- provider orchestration evidence;
+- Alpha superiority evidence.
+
+## Forbidden claims preserved
+
+This lane makes no readiness, validation, superiority, benchmark, production, MVP, runtime, billing, provider-orchestration, provider-quality, hosted-provider, local-model-quality, `/v1/solve`, or dashboard-preview claim.
+
+## Historical values boundary
+
+Historical local smoke values are preserved only as context:
+
+- endpoint pattern: `http://127.0.0.1:11434/api/chat`
+- model used in smoke: `gemma3:4b`
+- timeout used in smoke: `120`
+
+These values are not automatic runtime configuration and must be confirmed against the future implementation.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-operator-config-runbook/failure-troubleshooting-guide.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-operator-config-runbook/failure-troubleshooting-guide.md
@@ -1,0 +1,79 @@
+# Failure Troubleshooting Guide
+
+Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-OPERATOR-CONFIG-RUNBOOK-001`
+
+This guide is docs-only preparation for future runtime smoke triage. It is not runtime evidence and does not prove any implementation behavior.
+
+Canonical contract: `.specs/LOCAL-LLM-RUNTIME-INTEGRATION-001.md`.
+
+## Failure categories
+
+### Implementation missing
+
+Use this category when the runtime implementation PR has not merged, the local provider mode cannot be selected, or the implementation-dependent fields are still unknown.
+
+Expected operator action: stop. Do not run smoke. Keep fields marked `TBD`.
+
+### Local service unavailable
+
+Use this category when the local runtime service is not installed, not started, not listening, or refuses local connections.
+
+Expected operator action: stop and record the bounded local failure in future artifacts. Do not fall back to hosted providers.
+
+### Model unavailable
+
+Use this category when the configured local model name is missing, misspelled, not loaded, or otherwise unavailable.
+
+Expected operator action: stop or record a local failure. Do not download or switch models unless the future smoke lane explicitly authorizes that operator action.
+
+### Endpoint not local
+
+Use this category when the endpoint is remote, hosted, LAN, private-network, malformed, ambiguous, unsupported, missing a host, includes userinfo, or does not parse as localhost or loopback.
+
+Expected operator action: stop. Local mode must accept only localhost or loopback endpoints.
+
+### Timeout
+
+Use this category when the local call exceeds the configured finite timeout or the timeout configuration is invalid, missing, or unbounded.
+
+Expected operator action: record timeout as a bounded local failure. Do not silently retry through a hosted provider.
+
+### Malformed response
+
+Use this category when the local runtime returns a response that cannot be parsed into the expected implementation-specific shape.
+
+Expected operator action: record malformed response as a local failure and preserve redacted artifacts.
+
+### Empty output
+
+Use this category when the local runtime returns no usable content.
+
+Expected operator action: record empty output as a local failure and do not label it successful behavior.
+
+### Prompt echo
+
+Use this category when the output appears to repeat the user prompt rather than produce an answer.
+
+Expected operator action: record prompt echo as a local failure under the canonical fail-closed expectation.
+
+### System echo
+
+Use this category when the output appears to expose or repeat system, developer, routing, or hidden instruction content.
+
+Expected operator action: record system echo as a local failure and preserve only redacted artifacts.
+
+### Hosted fallback detected
+
+Use this category when output, logs, metadata, billing traces, provider labels, or network behavior indicate a hosted provider was called or hosted output replaced the local failure.
+
+Expected operator action: stop. Silent hosted fallback from local mode is prohibited unless a later spec explicitly authorizes it.
+
+### Provider key unexpectedly required
+
+Use this category when local mode refuses to run unless a hosted provider key, token, or credential is present.
+
+Expected operator action: stop. Do not add provider keys. Record the issue as a configuration or implementation blocker.
+
+## Non-claim reminder
+
+Troubleshooting notes do not establish runtime readiness, local model quality, hosted provider evidence, `/v1/solve` readiness, dashboard preview readiness, MVP validation, production readiness, benchmark evidence, provider orchestration evidence, or Alpha superiority evidence.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-operator-config-runbook/failure-troubleshooting-guide.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-operator-config-runbook/failure-troubleshooting-guide.md
@@ -28,9 +28,9 @@ Expected operator action: stop or record a local failure. Do not download or swi
 
 ### Endpoint not local
 
-Use this category when the endpoint is remote, hosted, LAN, private-network, malformed, ambiguous, unsupported, missing a host, includes userinfo, or does not parse as localhost or loopback.
+Use this category when the endpoint is remote, hosted, LAN, private-network, malformed, ambiguous, unsupported, non-HTTP, missing a host, includes userinfo, has an invalid or out-of-range port, or does not parse deterministically as localhost or loopback.
 
-Expected operator action: stop. Local mode must accept only localhost or loopback endpoints.
+Expected operator action: stop. Local mode must accept only HTTP localhost or loopback endpoints with no username, password, or userinfo.
 
 ### Timeout
 

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-operator-config-runbook/local-environment-precheck.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-operator-config-runbook/local-environment-precheck.md
@@ -1,0 +1,89 @@
+# Local Environment Precheck
+
+Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-OPERATOR-CONFIG-RUNBOOK-001`
+
+This file is a future-use template only. The commands below were not executed in this lane. This lane does not call a local model, does not call a hosted provider, does not make network calls, and does not run smoke.
+
+Canonical contract: `.specs/LOCAL-LLM-RUNTIME-INTEGRATION-001.md`.
+
+## Future-use precheck goals
+
+A future operator may use implementation-specific prechecks to confirm:
+
+- a local service is installed and intentionally started;
+- the endpoint is localhost or loopback only;
+- the intended local model is available;
+- the timeout is finite;
+- local mode requires explicit opt-in;
+- local mode is default-off before opt-in;
+- no hosted provider key is required;
+- no hosted fallback occurs from local mode.
+
+## Implementation-dependent values
+
+| Value | Future value |
+| --- | --- |
+| Endpoint field | `TBD` |
+| Endpoint value | `TBD` |
+| Model field | `TBD` |
+| Model value | `TBD` |
+| Timeout field | `TBD` |
+| Timeout seconds | `TBD` |
+| Explicit opt-in field | `TBD` |
+| Explicit opt-in value | `TBD` |
+
+Historical context only: endpoint pattern `http://127.0.0.1:11434/api/chat`, model `gemma3:4b`, timeout `120`. These values are not automatic runtime config.
+
+## Future-use command templates, not executed here
+
+Replace placeholders only after the implementation has merged and the exact operator interface is known.
+
+```bash
+# Confirm the runtime implementation exposes the expected local LLM config fields.
+<TBD-alpha-command-or-doc-command> --help
+```
+
+```bash
+# Confirm the local service process is intentionally running.
+<TBD-local-runtime-status-command>
+```
+
+```bash
+# Confirm the selected local model is available without downloading during smoke.
+<TBD-local-runtime-model-list-command>
+```
+
+```bash
+# Confirm the endpoint is loopback or localhost before runtime smoke.
+python - <<'PY'
+from urllib.parse import urlparse
+endpoint = "TBD"
+parsed = urlparse(endpoint)
+print(parsed.scheme, parsed.hostname, parsed.port, parsed.path)
+assert parsed.hostname in {"localhost", "127.0.0.1", "::1"}
+PY
+```
+
+```bash
+# Confirm required provider-key variables are not needed for local mode.
+<TBD-alpha-local-mode-dry-config-command>
+```
+
+```bash
+# Confirm default-off behavior before explicit opt-in.
+<TBD-alpha-command> <TBD-minimal-input> --expect-local-mode-off
+```
+
+## Stop conditions for future operators
+
+Stop before runtime smoke if any of the following are true:
+
+- the runtime implementation has not merged;
+- the exact local configuration fields remain unknown;
+- the endpoint is not localhost or loopback;
+- the service is unavailable;
+- the model is unavailable;
+- the timeout is missing or unbounded;
+- a hosted provider key is required for local mode;
+- the system appears to silently fall back to a hosted provider;
+- redaction requirements cannot be satisfied.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-operator-config-runbook/local-environment-precheck.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-operator-config-runbook/local-environment-precheck.md
@@ -54,15 +54,56 @@ Replace placeholders only after the implementation has merged and the exact oper
 ```
 
 ```bash
-# Confirm the endpoint is loopback or localhost before runtime smoke.
+# Confirm the endpoint is an unambiguous HTTP localhost or loopback URL before runtime smoke.
 python - <<'PY'
-from urllib.parse import urlparse
+from ipaddress import ip_address
+from urllib.parse import urlsplit
+
 endpoint = "TBD"
-parsed = urlparse(endpoint)
-print(parsed.scheme, parsed.hostname, parsed.port, parsed.path)
-assert parsed.hostname in {"localhost", "127.0.0.1", "::1"}
+
+try:
+    parsed = urlsplit(endpoint)
+
+    if parsed.scheme != "http":
+        raise ValueError("local LLM endpoints must use the http scheme")
+
+    if not parsed.netloc or parsed.hostname is None:
+        raise ValueError("local LLM endpoint must include an unambiguous host")
+
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError("local LLM endpoint must not include username/password/userinfo")
+
+    # Accessing parsed.port forces urllib to reject invalid and out-of-range ports.
+    port = parsed.port
+    effective_port = port if port is not None else 80
+
+    hostname = parsed.hostname
+    is_allowed_name = hostname == "localhost"
+    try:
+        is_loopback_ip = ip_address(hostname).is_loopback
+    except ValueError:
+        is_loopback_ip = False
+
+    if not (is_allowed_name or is_loopback_ip):
+        raise ValueError("local LLM endpoint host must be localhost or a loopback IP")
+
+    if parsed.fragment:
+        raise ValueError("local LLM endpoint must not include a fragment")
+
+    print("accepted local endpoint", parsed.scheme, hostname, effective_port, parsed.path)
+except ValueError as exc:
+    raise SystemExit(f"rejected local LLM endpoint: {exc}")
 PY
 ```
+
+This template must reject malformed, ambiguous, non-HTTP, non-loopback, and userinfo-bearing endpoints before any future runtime smoke. Examples that must be rejected include:
+
+- `ftp://127.0.0.1:11434/api/chat` because the scheme is not `http`;
+- `https://127.0.0.1:11434/api/chat` because the scheme is not `http`;
+- `http://user:pass@127.0.0.1:11434/api/chat` because userinfo is present;
+- hosted URLs such as `http://api.example.com/api/chat`;
+- LAN or private-network URLs such as `http://192.168.1.10:11434/api/chat` or `http://10.0.0.5:11434/api/chat`;
+- invalid-port URLs such as `http://127.0.0.1:99999/api/chat` or `http://127.0.0.1:notaport/api/chat`.
 
 ```bash
 # Confirm required provider-key variables are not needed for local mode.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-operator-config-runbook/operator-configuration-guide.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-operator-config-runbook/operator-configuration-guide.md
@@ -1,0 +1,60 @@
+# Operator Configuration Guide
+
+Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-OPERATOR-CONFIG-RUNBOOK-001`
+
+This guide is docs-only preparation for a future optional local LLM runtime path. It does not implement configuration, prove configuration behavior, or authorize runtime use.
+
+Runtime implementation may be running separately under `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-IMPLEMENTATION-001`. Until that implementation is merged and reviewed, implementation-dependent field names, environment variables, CLI flags, config keys, and runtime behavior are `TBD`.
+
+Canonical contract: `.specs/LOCAL-LLM-RUNTIME-INTEGRATION-001.md`.
+
+## Required operator setup concepts
+
+| Setup concept | Implementation field | Required expectation |
+| --- | --- | --- |
+| Local endpoint | `TBD` | Must point only to localhost or loopback. Non-local endpoints must fail closed. |
+| Local model name | `TBD` | Must identify the local model selected by the operator. |
+| Timeout seconds | `TBD` | Must be finite and explicitly represented in runtime configuration or invocation. |
+| Explicit opt-in | `TBD` | Local LLM runtime mode must not activate unless the operator explicitly opts in. |
+| Default-off behavior | `TBD` | Local LLM mode must remain optional and disabled by default. |
+| Hosted fallback behavior | `TBD` | Silent hosted fallback from local mode is not expected and must not be assumed. |
+| Provider key requirement | `TBD` | Local mode must require no hosted provider key. |
+
+## Historical values preserved for context only
+
+Previous local smoke context used:
+
+- endpoint pattern: `http://127.0.0.1:11434/api/chat`
+- model used in smoke: `gemma3:4b`
+- timeout used in smoke: `120`
+
+These are not automatic runtime configuration values. They must be confirmed against the future implementation before any operator uses them.
+
+## Configuration expectations
+
+1. Start from the canonical contract in `.specs/LOCAL-LLM-RUNTIME-INTEGRATION-001.md`.
+2. Confirm that the implementation has a documented way to select local provider mode explicitly.
+3. Confirm that local provider mode is default-off before operator opt-in.
+4. Confirm the exact field names for endpoint, model name, timeout seconds, and opt-in.
+5. Confirm that no hosted provider key is required for local mode.
+6. Confirm that local failures remain local failures and are not silently replaced with hosted output.
+7. Confirm that observability or artifact metadata labels output as local only when it came from the local runtime path.
+
+## Example placeholder record
+
+Do not fill this record with real secrets, private paths, or unredacted endpoints.
+
+| Field | Future value |
+| --- | --- |
+| Implementation PR merged? | `TBD` |
+| Runtime config source reviewed? | `TBD` |
+| Local endpoint field name | `TBD` |
+| Local endpoint value | `TBD-localhost-or-loopback-only` |
+| Local model field name | `TBD` |
+| Local model value | `TBD` |
+| Timeout field name | `TBD` |
+| Timeout value | `TBD-finite-seconds` |
+| Explicit opt-in field name | `TBD` |
+| Explicit opt-in value | `TBD` |
+| Hosted fallback disabled or absent? | `TBD` |
+| Provider key required? | `TBD-expected-no` |

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-operator-config-runbook/redaction-rules.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-operator-config-runbook/redaction-rules.md
@@ -1,0 +1,56 @@
+# Redaction Rules
+
+Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-OPERATOR-CONFIG-RUNBOOK-001`
+
+These rules apply to future local LLM runtime smoke artifacts and operator notes. This lane does not capture runtime artifacts and does not import smoke results.
+
+Canonical contract: `.specs/LOCAL-LLM-RUNTIME-INTEGRATION-001.md`.
+
+## Redact before committing or sharing
+
+Redact or omit:
+
+- provider keys;
+- API tokens;
+- bearer tokens;
+- session cookies;
+- private URLs;
+- nonpublic endpoints;
+- local endpoints when they reveal sensitive hostnames, ports, paths, query strings, or user-specific deployment details;
+- private filesystem paths;
+- usernames in paths;
+- environment dumps;
+- shell histories;
+- process lists that include secrets or private paths;
+- full request or response payloads containing private prompts, private data, credentials, or tokens.
+
+## Local endpoint handling
+
+Loopback examples such as `localhost`, `127.0.0.1`, and `::1` may be referenced when they do not expose private deployment details.
+
+Historical endpoint pattern `http://127.0.0.1:11434/api/chat` is preserved as historical context only. It is not automatic runtime config and must be confirmed against the future implementation.
+
+If a future endpoint includes nonpublic hostnames, private paths, query strings, usernames, passwords, or deployment identifiers, replace it with a neutral pattern such as:
+
+```text
+http://127.0.0.1:<redacted-port>/<redacted-path>
+```
+
+## Environment handling
+
+Do not commit raw environment dumps. If environment state must be summarized, capture only the specific nonsecret field names needed to establish local mode configuration and replace values with redacted placeholders.
+
+Examples:
+
+```text
+LOCAL_LLM_ENDPOINT=<redacted-localhost-or-loopback-endpoint>
+LOCAL_LLM_MODEL=<redacted-or-approved-model-name>
+LOCAL_LLM_TIMEOUT_SECONDS=<finite-seconds>
+LOCAL_LLM_EXPLICIT_OPT_IN=<redacted-value>
+```
+
+Implementation-specific names remain `TBD` until the implementation has merged.
+
+## Provider-key expectation
+
+Local mode must not require hosted provider keys under the canonical contract. If a future smoke reveals a provider key requirement, stop and classify the issue as `provider key unexpectedly required` rather than adding keys to artifacts.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-operator-config-runbook/runbook-preservation-checklist.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-operator-config-runbook/runbook-preservation-checklist.md
@@ -1,0 +1,30 @@
+# Runbook Preservation Checklist
+
+Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-OPERATOR-CONFIG-RUNBOOK-001`
+
+- [x] Kept this lane docs-only.
+- [x] Added files only under `docs/evals/runs/20260605-alpha-local-llm-runtime-operator-config-runbook/`.
+- [x] Did not change source code.
+- [x] Did not change test code.
+- [x] Did not change runtime behavior.
+- [x] Did not change provider behavior.
+- [x] Did not change `/v1/solve`.
+- [x] Did not change dashboard files.
+- [x] Did not call a local model.
+- [x] Did not call hosted providers.
+- [x] Did not make network calls.
+- [x] Did not add or use provider keys.
+- [x] Did not execute smoke.
+- [x] Did not import smoke results.
+- [x] Referenced `.specs/LOCAL-LLM-RUNTIME-INTEGRATION-001.md` as the canonical contract.
+- [x] Stated runtime implementation may be running separately and this runbook does not prove implementation.
+- [x] Marked implementation-dependent fields as `TBD`.
+- [x] Preserved historical endpoint, model, and timeout values as context only.
+- [x] Stated historical values are not automatic runtime config and must be confirmed against the future implementation.
+- [x] Included future-use precheck command templates and labeled them not executed in this lane.
+- [x] Included an artifact capture template for future runtime smoke.
+- [x] Included redaction rules for local endpoints, private paths, provider keys, tokens, private URLs, nonpublic endpoints, and environment dumps.
+- [x] Included troubleshooting categories for implementation missing, local service unavailable, model unavailable, endpoint not local, timeout, malformed response, empty output, prompt echo, system echo, hosted fallback detected, and provider key unexpectedly required.
+- [x] Preserved narrow evidence-boundary language.
+- [x] Recorded exactly one selected next lane.
+- [x] Made no readiness, validation, superiority, benchmark, production, MVP, runtime, billing, provider-orchestration, provider-quality, hosted-provider, local-model-quality, `/v1/solve`, or dashboard-preview claim.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-operator-config-runbook/runtime-smoke-runbook.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-operator-config-runbook/runtime-smoke-runbook.md
@@ -1,0 +1,61 @@
+# Runtime Smoke Runbook
+
+Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-OPERATOR-CONFIG-RUNBOOK-001`
+
+This runbook is a future-use template only. No runtime smoke was executed in this lane. No local model was called. No hosted provider was called. No smoke result is imported.
+
+Canonical contract: `.specs/LOCAL-LLM-RUNTIME-INTEGRATION-001.md`.
+
+## Preconditions for a future smoke lane
+
+A future operator must confirm all of the following before execution:
+
+1. The local LLM runtime implementation PR has merged and is reviewed against `.specs/LOCAL-LLM-RUNTIME-INTEGRATION-001.md`.
+2. The exact runtime configuration fields are documented.
+3. Local LLM mode is default-off and requires explicit opt-in.
+4. The endpoint is localhost or loopback only.
+5. The local model name is intentionally selected and available.
+6. The timeout is finite.
+7. No hosted provider key is required for local mode.
+8. No silent hosted fallback is enabled.
+9. Artifact redaction rules are understood before capture.
+
+## Historical context only
+
+Previous local smoke context used endpoint pattern `http://127.0.0.1:11434/api/chat`, model `gemma3:4b`, and timeout `120`.
+
+Those values are not automatic runtime configuration. Confirm all values against the future implementation before any smoke execution.
+
+## Future smoke sequence template
+
+1. Record implementation commit or PR reference.
+2. Record exact config fields and values after redaction review.
+3. Confirm local mode remains default-off without explicit opt-in.
+4. Confirm explicit opt-in activates only local mode.
+5. Confirm endpoint locality before execution.
+6. Confirm local model availability.
+7. Execute one bounded runtime smoke command using a finite timeout.
+8. Capture stdout, stderr, exit code, start timestamp, end timestamp, and sanitized metadata.
+9. Confirm `behavior_evidence=false` is preserved if applicable to the implemented artifact shape.
+10. Confirm no hosted provider call occurred and no hosted output was substituted.
+11. Classify the outcome without making readiness, quality, superiority, benchmark, production, MVP, provider-orchestration, or billing claims.
+
+## Future command placeholder
+
+Do not execute this placeholder in this lane.
+
+```bash
+<TBD-alpha-runtime-command> \
+  --provider <TBD-local-provider-mode> \
+  --local-endpoint <TBD-localhost-or-loopback-endpoint> \
+  --local-model <TBD-local-model-name> \
+  --timeout-seconds <TBD-finite-timeout> \
+  --explicit-local-opt-in <TBD-value> \
+  <TBD-smoke-input>
+```
+
+## Acceptance scope for future smoke
+
+A future smoke may only support a narrow claim that the implemented local runtime path was invoked under the recorded configuration and produced the recorded bounded outcome.
+
+A future smoke must not be interpreted as local model quality evidence, hosted provider evidence, `/v1/solve` readiness, dashboard preview readiness, MVP validation, production readiness, benchmark evidence, provider orchestration evidence, or Alpha superiority evidence.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-operator-config-runbook/selected-next-lane.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-operator-config-runbook/selected-next-lane.md
@@ -1,0 +1,7 @@
+# Selected Next Lane
+
+Selected next lane: `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-REVIEW-GATE-001`
+
+This is the only selected next lane recorded by this docs-only runbook.
+
+The selected lane should review any future local LLM runtime integration against `.specs/LOCAL-LLM-RUNTIME-INTEGRATION-001.md` before smoke execution, evidence import, readiness claims, or broader runtime progression.


### PR DESCRIPTION
### Motivation

- Provide operator-facing, docs-only runbook and templates to prepare for a future optional local LLM runtime path while preserving a narrow evidence boundary. 
- Capture operator setup guidance, precheck and smoke templates, artifact capture and redaction guidance, failure categories, and preservation checks without performing any runtime or provider actions. 

### Description

- Added a new docs-only runbook directory `docs/evals/runs/20260605-alpha-local-llm-runtime-operator-config-runbook/` containing the required files: `README.md`, `operator-configuration-guide.md`, `local-environment-precheck.md`, `runtime-smoke-runbook.md`, `artifact-capture-template.md`, `redaction-rules.md`, `failure-troubleshooting-guide.md`, `evidence-boundary.md`, `runbook-preservation-checklist.md`, and `selected-next-lane.md`.
- All files explicitly reference the canonical contract `.specs/LOCAL-LLM-RUNTIME-INTEGRATION-001.md`, mark implementation-dependent fields as `TBD`, and preserve historical local-smoke values (endpoint `http://127.0.0.1:11434/api/chat`, model `gemma3:4b`, timeout `120`) as context only. 
- Included future-use command templates for local prechecks and a bounded runtime-smoke sequence that are clearly labeled as not executed, and provided an artifact-capture template plus explicit redaction rules for secrets, private paths, nonpublic endpoints, and environment dumps. 
- Recorded the evidence boundary (docs-only) and selected exactly one next lane: `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-REVIEW-GATE-001` while preserving a checklist that no source/test/runtime/provider/dashboard files were changed and no runtime/provider calls or smoke imports occurred. 

### Testing

- Ran repository and preservation checks including `git diff HEAD~1 --name-only` to confirm only files under `docs/evals/runs/20260605-alpha-local-llm-runtime-operator-config-runbook/` were added, and this check passed. 
- Ran file/content checks using `rg` to confirm the presence of evidence-boundary language, `TBD` implementation-dependent markers, and the single selected next lane (`ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-REVIEW-GATE-001` and related pattern checks), and all checks passed. 
- Ran `git diff --cached --check`, `git diff --cached --name-only` and `test -z "$(git status --short)"` to ensure no unintended changes outside the docs directory and a clean working tree, and these checks passed. 
- All automated checks executed in this rollout succeeded and no runtime, provider, or network actions were performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a232124aa088329b57461bd9938e295)