### PR TITLE
docs(local-llm): prepare runtime smoke execution packet

### DIFF
--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-packet/README.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-packet/README.md
@@ -1,0 +1,56 @@
+# Alpha Local LLM Runtime Smoke Execution Packet
+
+Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-PACKET-001`
+
+This directory is a docs-only final manual runtime smoke execution packet for the optional local LLM runtime path. Runtime smoke is not executed in this PR. This packet is not runtime smoke evidence and must not be imported or cited as a completed local runtime result.
+
+Runtime smoke remains blocked until `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-REVIEW-GATE-001` explicitly authorizes smoke execution.
+
+## Source material
+
+- Canonical implementation contract: `.specs/LOCAL-LLM-RUNTIME-INTEGRATION-001.md`
+- Merged implementation surface: `alpha/local_llm/provider_adapter.py`
+- Environment examples and precheck behavior: `.env.example` and `scripts/check_env.py`
+- Provider config validation: `service/config/validators.py`
+- Prior implementation packet: `docs/evals/runs/20260605-alpha-local-llm-runtime-integration-implementation/`
+- Prior operator runbook: `docs/evals/runs/20260605-alpha-local-llm-runtime-operator-config-runbook/`
+- Prior smoke scaffold: `docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-packet-scaffold/`
+
+## Required packet files
+
+1. `README.md`
+2. `smoke-execution-packet-summary.md`
+3. `prerequisite-gates.md`
+4. `operator-runbook.md`
+5. `local-runtime-smoke-command.md`
+6. `raw-artifact-capture-template.md`
+7. `sanitized-artifact-template.md`
+8. `expected-result-fields.md`
+9. `failure-classification.md`
+10. `redaction-rules.md`
+11. `post-execution-import-instructions.md`
+12. `evidence-boundary.md`
+13. `smoke-packet-preservation-checklist.md`
+14. `selected-next-lane.md`
+
+## Implementation-aware configuration fields
+
+The packet uses the merged implementation fields below. Actual values must be confirmed by the operator at execution time.
+
+- `MODEL_PROVIDER=local_llm`
+- `ALPHA_LOCAL_LLM_ENABLED=true`
+- `ALPHA_LOCAL_LLM_ENDPOINT=<localhost-or-loopback-http-endpoint>`
+- `ALPHA_LOCAL_LLM_MODEL=<exact-local-model-name>`
+- `ALPHA_LOCAL_LLM_TIMEOUT_SECONDS=<finite-positive-number>`
+
+Historical operator-local examples only:
+
+- Endpoint pattern: `http://127.0.0.1:11434/api/chat`
+- Model: `gemma3:4b`
+- Timeout: `120`
+
+These examples are not automatic execution values.
+
+## Evidence boundary
+
+This PR prepares a manual runtime smoke execution packet only. It is not runtime smoke execution, runtime smoke evidence, local model quality evidence, hosted provider evidence, `/v1/solve` readiness, dashboard preview readiness, MVP validation, production readiness, benchmark evidence, provider orchestration evidence, or Alpha superiority evidence.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-packet/evidence-boundary.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-packet/evidence-boundary.md
@@ -1,0 +1,29 @@
+# Evidence Boundary
+
+Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-PACKET-001`
+
+This PR prepares a manual runtime smoke execution packet only.
+
+It is not:
+
+- runtime smoke execution;
+- runtime smoke evidence;
+- local model quality evidence;
+- hosted provider evidence;
+- `/v1/solve` readiness;
+- dashboard preview readiness;
+- MVP validation;
+- production readiness;
+- benchmark evidence;
+- provider orchestration evidence;
+- Alpha superiority evidence.
+
+## Explicit non-claims
+
+This packet does not claim readiness, validation, superiority, benchmark performance, production readiness, MVP readiness, runtime success, billing behavior, provider orchestration behavior, hosted-provider behavior, local-model quality, `/v1/solve` readiness, or dashboard-preview readiness.
+
+## Execution boundary
+
+No local model is called. No hosted provider is called. No network calls are made. No smoke is executed. No smoke result is imported.
+
+Runtime smoke remains blocked until `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-REVIEW-GATE-001` explicitly authorizes smoke.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-packet/expected-result-fields.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-packet/expected-result-fields.md
@@ -1,0 +1,56 @@
+# Expected Result Fields
+
+Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-PACKET-001`
+
+The future smoke should capture implementation-specific result fields emitted by `run_configured_local_llm_runtime()`.
+
+## Top-level result fields
+
+- `status`: expected `non_evidence` for a bounded non-failed result or `failed_closed` for a bounded failure.
+- `reason`: expected implementation reason code.
+- `behavior_evidence`: must remain `false`.
+- `output_text`: raw model output or empty string on failed-closed outcomes.
+- `metadata`: implementation metadata map.
+
+## Expected metadata fields
+
+The merged implementation currently supplies or preserves the following metadata fields for the local runtime path:
+
+- `provider_mode`: `local_llm`
+- `backend_class`: `ollama-local-http-runtime`
+- `local_backend`: `ollama_chat`
+- `local_model`: exact configured local model name
+- `model`: exact configured local model name
+- `endpoint_is_loopback`: `true`
+- `endpoint_host_label`: `localhost` or `loopback`
+- `timeout_seconds`: finite positive timeout
+- `no_provider_keys_required`: `true`
+- `no_hosted_fallback`: `true`
+- `behavior_evidence`: `false`
+- `failure_label`: `failed_closed_result` when a failure is normalized
+
+## Expected reason codes
+
+Known implementation reason codes include:
+
+- `local_llm_provider_adapter_wiring_only`
+- `local_llm_disabled_non_evidence`
+- `provider_keys_forbidden_non_evidence`
+- `endpoint_not_local_non_evidence`
+- `invalid_model_non_evidence`
+- `missing_model_non_evidence`
+- `invalid_timeout_non_evidence`
+- `provider_mode_mismatch_non_evidence`
+- `provider_backend_disabled_non_evidence`
+- `timeout_non_evidence`
+- `connection_failure_non_evidence`
+- `backend_error_non_evidence`
+- `endpoint_redirect_non_evidence`
+- `malformed_response_non_evidence`
+- `empty_model_output_non_evidence`
+- `prompt_echo_non_evidence`
+- `system_echo_non_evidence`
+
+## Blocked-if-absent rule
+
+If any required implementation config field is absent or cannot be mapped at execution time, stop before smoke and classify as `implementation missing` or `implementation config field absent`, rather than inventing a field name.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-packet/failure-classification.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-packet/failure-classification.md
@@ -1,0 +1,44 @@
+# Failure Classification
+
+Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-PACKET-001`
+
+Use one primary failure classification and optional secondary notes. Preserve raw artifacts for every attempted execution or pre-execution stop.
+
+## Stop conditions and classifications
+
+| Stop condition | Classification |
+| --- | --- |
+| Review gate missing or not approving smoke | `review gate missing or not approving smoke` |
+| Implementation missing | `implementation missing` |
+| Required implementation config field absent | `implementation config field absent` |
+| Local service unavailable | `local service unavailable` |
+| Model unavailable | `model unavailable` |
+| Endpoint not local | `endpoint not local` |
+| Endpoint redirects | `endpoint redirects` |
+| Invalid scheme | `invalid scheme` |
+| Userinfo-bearing endpoint | `userinfo-bearing endpoint` |
+| Invalid port | `invalid port` |
+| Timeout | `timeout` |
+| Malformed response | `malformed response` |
+| Empty output | `empty output` |
+| Prompt echo | `prompt echo` |
+| System echo | `system echo` |
+| Hosted fallback detected | `hosted fallback detected` |
+| Provider key unexpectedly required | `provider key unexpectedly required` |
+| Artifact capture cannot be preserved | `artifact capture cannot be preserved` |
+
+## Mapping to implementation reason codes
+
+- `endpoint_not_local_non_evidence` may map to endpoint not local, invalid scheme, userinfo-bearing endpoint, or invalid port depending on the raw validation context.
+- `endpoint_redirect_non_evidence` maps to endpoint redirects.
+- `timeout_non_evidence` maps to timeout.
+- `connection_failure_non_evidence` maps to local service unavailable unless service health artifacts prove a narrower cause.
+- `malformed_response_non_evidence` maps to malformed response.
+- `empty_model_output_non_evidence` maps to empty output.
+- `prompt_echo_non_evidence` maps to prompt echo.
+- `system_echo_non_evidence` maps to system echo.
+- `provider_keys_forbidden_non_evidence` maps to provider key unexpectedly required or forbidden-key-present depending on context.
+
+## Required language
+
+Classifications must not be converted into readiness, validation, superiority, benchmark, production, MVP, billing, provider-orchestration, hosted-provider, local-model-quality, `/v1/solve`, or dashboard-preview claims.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-packet/local-runtime-smoke-command.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-packet/local-runtime-smoke-command.md
@@ -1,0 +1,83 @@
+# Local Runtime Smoke Command
+
+Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-PACKET-001`
+
+Do not run these commands in this packet-preparation PR. They are future-use templates only and remain blocked until `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-REVIEW-GATE-001` explicitly authorizes smoke.
+
+## Environment precheck template
+
+This precheck validates configuration shape and must be captured with stdout, stderr, and exit code in the future execution lane. It does not prove runtime smoke.
+
+```bash
+MODEL_PROVIDER=local_llm \
+ALPHA_LOCAL_LLM_ENABLED=true \
+ALPHA_LOCAL_LLM_ENDPOINT="<operator-confirmed-localhost-or-loopback-http-endpoint>" \
+ALPHA_LOCAL_LLM_MODEL="<operator-confirmed-exact-local-model-name>" \
+ALPHA_LOCAL_LLM_TIMEOUT_SECONDS="<operator-confirmed-finite-positive-timeout>" \
+env -u OPENAI_API_KEY \
+    -u ANTHROPIC_API_KEY \
+    -u GOOGLE_API_KEY \
+    -u GEMINI_API_KEY \
+    -u DEEPSEEK_API_KEY \
+    python scripts/check_env.py
+```
+
+## Future runtime smoke command template
+
+This command uses the merged implementation surface `run_configured_local_llm_runtime()` and the default local `urllib_ollama_json_transport()` path. Running it will call the operator-confirmed local loopback endpoint; therefore it must not be executed until smoke is explicitly authorized.
+
+```bash
+MODEL_PROVIDER=local_llm \
+ALPHA_LOCAL_LLM_ENABLED=true \
+ALPHA_LOCAL_LLM_ENDPOINT="<operator-confirmed-localhost-or-loopback-http-endpoint>" \
+ALPHA_LOCAL_LLM_MODEL="<operator-confirmed-exact-local-model-name>" \
+ALPHA_LOCAL_LLM_TIMEOUT_SECONDS="<operator-confirmed-finite-positive-timeout>" \
+env -u OPENAI_API_KEY \
+    -u ANTHROPIC_API_KEY \
+    -u GOOGLE_API_KEY \
+    -u GEMINI_API_KEY \
+    -u DEEPSEEK_API_KEY \
+    python - <<'PY'
+import json
+import os
+import sys
+
+from alpha.local_llm.provider_adapter import run_configured_local_llm_runtime
+
+PROMPT = "Local runtime smoke: respond with one concise sentence that does not echo this prompt."
+
+result = run_configured_local_llm_runtime(PROMPT, env=os.environ)
+record = {
+    "status": result.status,
+    "reason": result.reason,
+    "behavior_evidence": result.behavior_evidence,
+    "output_text": result.output_text,
+    "metadata": dict(result.metadata),
+}
+print(json.dumps(record, sort_keys=True, indent=2))
+if result.status == "failed_closed":
+    sys.exit(2)
+sys.exit(0)
+PY
+```
+
+## Historical example values only
+
+The following values were prior operator-local examples only. The future operator must confirm actual values at execution time.
+
+```dotenv
+ALPHA_LOCAL_LLM_ENDPOINT=http://127.0.0.1:11434/api/chat
+ALPHA_LOCAL_LLM_MODEL=gemma3:4b
+ALPHA_LOCAL_LLM_TIMEOUT_SECONDS=120
+```
+
+## Command constraints
+
+- Use `MODEL_PROVIDER=local_llm`.
+- Use `ALPHA_LOCAL_LLM_ENABLED=true`.
+- Use only a localhost or loopback `http` endpoint.
+- Use the exact local model name.
+- Use a finite positive timeout.
+- Unset hosted provider keys for local mode.
+- Do not enable hosted fallback.
+- Preserve raw stdout, raw stderr, command, exit code, config summary, and sanitized result.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-packet/operator-runbook.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-packet/operator-runbook.md
@@ -1,0 +1,84 @@
+# Operator Runbook
+
+Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-PACKET-001`
+
+This runbook is for a future execution lane only. Do not execute it in this packet-preparation PR.
+
+## Step 0 — Confirm authorization
+
+Stop unless `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-REVIEW-GATE-001` explicitly authorizes smoke.
+
+## Step 1 — Confirm local-only configuration
+
+Record actual operator-confirmed values at execution time. Historical examples are provided only for context and must not be copied blindly.
+
+Required local setup fields:
+
+```dotenv
+MODEL_PROVIDER=local_llm
+ALPHA_LOCAL_LLM_ENABLED=true
+ALPHA_LOCAL_LLM_ENDPOINT=<localhost-or-loopback-http-endpoint>
+ALPHA_LOCAL_LLM_MODEL=<exact-local-model-name>
+ALPHA_LOCAL_LLM_TIMEOUT_SECONDS=<finite-positive-number>
+```
+
+Historical examples only:
+
+```dotenv
+ALPHA_LOCAL_LLM_ENDPOINT=http://127.0.0.1:11434/api/chat
+ALPHA_LOCAL_LLM_MODEL=gemma3:4b
+ALPHA_LOCAL_LLM_TIMEOUT_SECONDS=120
+```
+
+## Step 2 — Enforce local endpoint constraints
+
+The endpoint must satisfy all constraints:
+
+- scheme is `http`;
+- host is `localhost`, `127.0.0.1`, `::1`, or another deterministic loopback address accepted by the merged implementation;
+- no userinfo is present;
+- port parses as valid if provided;
+- endpoint does not redirect;
+- endpoint is not hosted, LAN, private-network, ambiguous, malformed, or unsupported-scheme.
+
+## Step 3 — Confirm credentials are absent
+
+Local mode requires no hosted provider keys. Confirm the following are absent or empty before execution:
+
+- `OPENAI_API_KEY`
+- `ANTHROPIC_API_KEY`
+- `GOOGLE_API_KEY`
+- `GEMINI_API_KEY`
+- `DEEPSEEK_API_KEY`
+
+If any key is present or unexpectedly required, stop and classify as `provider key unexpectedly required`.
+
+## Step 4 — Confirm local service and exact model
+
+Confirm the local service is intentionally started by the operator, reachable only on localhost or loopback, and has the exact model name available. Do not substitute a different model name after artifact capture starts; if the model is unavailable, stop and classify as `model unavailable`.
+
+## Step 5 — Capture raw command and config summary before execution
+
+Before executing the future command, capture:
+
+- full command;
+- working directory;
+- start timestamp;
+- redacted config summary;
+- exact endpoint host label (`localhost` or `loopback` only);
+- exact local model name;
+- finite timeout;
+- provider key absence confirmation;
+- no hosted fallback confirmation.
+
+## Step 6 — Execute exactly one bounded smoke command
+
+Use `local-runtime-smoke-command.md`. Execute one bounded smoke only after authorization. Preserve stdout, stderr, exit code, and the raw result object or failure object.
+
+## Step 7 — Classify and preserve
+
+Classify success or failure without making readiness, validation, superiority, benchmark, production, MVP, billing, provider-orchestration, hosted-provider, local-model-quality, `/v1/solve`, or dashboard-preview claims.
+
+## Step 8 — Import later, not here
+
+Results must be imported in a future docs-only import lane. Do not import smoke results in the execution-packet preparation lane.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-packet/post-execution-import-instructions.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-packet/post-execution-import-instructions.md
@@ -1,0 +1,31 @@
+# Post-Execution Import Instructions
+
+Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-PACKET-001`
+
+No smoke result is imported in this packet-preparation PR.
+
+## Future import lane requirement
+
+After authorized execution, results must be imported in a future docs-only import lane. The future import lane must:
+
+1. Reference `ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-001` as the execution lane.
+2. Reference this packet lane as source instructions.
+3. Reference the review gate artifact that explicitly authorized smoke.
+4. Preserve raw artifact references without overwriting raw artifacts.
+5. Include a sanitized result using `sanitized-artifact-template.md`.
+6. Include raw stdout, stderr, command, exit code, config summary, and sanitized result references.
+7. Preserve `behavior_evidence=false`.
+8. State whether the outcome was `non_evidence` or `failed_closed`.
+9. Avoid readiness, validation, superiority, benchmark, production, MVP, runtime, billing, provider-orchestration, hosted-provider, local-model-quality, `/v1/solve`, or dashboard-preview claims.
+
+## Import block conditions
+
+Do not import results if:
+
+- the review gate did not explicitly authorize smoke;
+- raw artifacts are missing;
+- command or exit code is missing;
+- stdout or stderr capture is missing;
+- config summary is missing;
+- sanitization cannot be performed safely;
+- hosted fallback or provider-key use is suspected and not clearly classified.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-packet/prerequisite-gates.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-packet/prerequisite-gates.md
@@ -1,0 +1,35 @@
+# Prerequisite Gates
+
+Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-PACKET-001`
+
+## Required before future execution
+
+The future operator must confirm all prerequisites before executing smoke:
+
+1. PR #315 is squashed, merged, closed, and recorded in GS.
+2. PR #316 is squashed, merged, closed, and recorded in GS.
+3. PR #318 is squashed, merged, closed, and recorded in GS.
+4. PR #319 is squashed, merged, closed, and recorded in GS.
+5. Canonical implementation spec exists at `.specs/LOCAL-LLM-RUNTIME-INTEGRATION-001.md`.
+6. The merged implementation surface exists in `alpha/local_llm/provider_adapter.py`.
+7. `scripts/check_env.py` recognizes `MODEL_PROVIDER=local_llm` and the required local runtime fields.
+8. `service/config/validators.py` recognizes `local_llm` as a user-facing provider value for configuration validation.
+9. `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-REVIEW-GATE-001` explicitly authorizes runtime smoke.
+
+## Hard block
+
+Runtime smoke remains blocked unless the review gate explicitly approves smoke. Do not infer authorization from implementation merge, docs merge, operator availability, or local service availability.
+
+## Gate record template
+
+```text
+Review gate lane:
+Review gate artifact path:
+Review gate status:
+Does the gate explicitly authorize runtime smoke? yes/no
+Gate reviewer or approver:
+Gate decision timestamp:
+Notes:
+```
+
+If the answer is not exactly `yes`, stop.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-packet/raw-artifact-capture-template.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-packet/raw-artifact-capture-template.md
@@ -1,0 +1,57 @@
+# Raw Artifact Capture Template
+
+Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-PACKET-001`
+
+Do not create runtime smoke artifacts in this packet-preparation PR. This template defines what a later authorized execution lane must preserve before sanitization.
+
+## Raw artifact fields
+
+```yaml
+lane: ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-001
+execution_packet_lane: ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-PACKET-001
+review_gate_lane: ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-REVIEW-GATE-001
+review_gate_authorized_smoke: <yes/no>
+operator: <operator-id-or-redacted-label>
+working_directory: <repo-root-or-redacted-path>
+start_timestamp_utc: <timestamp>
+end_timestamp_utc: <timestamp>
+command_path_or_shell: <raw-command-location>
+command_exact: |
+  <exact command executed>
+exit_code: <integer>
+raw_stdout_path: <path>
+raw_stderr_path: <path>
+raw_result_path: <path>
+config_summary_path: <path>
+sanitized_result_path: <path>
+endpoint_summary:
+  raw_endpoint_preserved: <yes/no; preserve securely, sanitize before import>
+  public_summary: <localhost-or-loopback-only>
+  endpoint_host_label: <localhost|loopback>
+  scheme: http
+  redirect_observed: <yes/no>
+local_model: <exact-local-model-name>
+timeout_seconds: <finite-positive-number>
+provider_mode: local_llm
+alpha_local_llm_enabled: true
+provider_keys_absent:
+  OPENAI_API_KEY: <confirmed-absent/empty>
+  ANTHROPIC_API_KEY: <confirmed-absent/empty>
+  GOOGLE_API_KEY: <confirmed-absent/empty>
+  GEMINI_API_KEY: <confirmed-absent/empty>
+  DEEPSEEK_API_KEY: <confirmed-absent/empty>
+no_hosted_fallback: <confirmed>
+status: <non_evidence|failed_closed|not_run>
+reason: <implementation-reason-or-stop-condition>
+behavior_evidence: false
+failure_classification: <if applicable>
+artifact_preservation_confirmed: <yes/no>
+```
+
+## Raw stdout and stderr preservation
+
+Preserve the raw `stdout` and `stderr` byte-for-byte in dedicated files. Do not overwrite raw artifacts with sanitized artifacts.
+
+## Raw artifact stop rule
+
+If raw command, stdout, stderr, exit code, config summary, or sanitized result cannot be preserved, stop and classify as `artifact capture cannot be preserved`.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-packet/redaction-rules.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-packet/redaction-rules.md
@@ -1,0 +1,36 @@
+# Redaction Rules
+
+Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-PACKET-001`
+
+Apply these rules before any sanitized artifact is imported in a future docs-only import lane.
+
+## Must redact
+
+- Provider keys, tokens, secrets, cookies, authorization headers, and credential-like values.
+- Values of `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `GEMINI_API_KEY`, and `DEEPSEEK_API_KEY` if accidentally present.
+- Full environment dumps.
+- Private filesystem paths unless needed for artifact provenance and approved for disclosure.
+- Nonpublic URLs and non-loopback endpoint details.
+- User names, home directories, shell history, terminal metadata, machine names, and unrelated local service details.
+- Prompt or output content that contains private, sensitive, or unrelated data.
+
+## Must preserve
+
+- `MODEL_PROVIDER=local_llm`.
+- `ALPHA_LOCAL_LLM_ENABLED=true`.
+- Endpoint locality summary: localhost or loopback only.
+- Exact local model name, unless the operator marks the model name sensitive; if redacted, preserve a stable redacted label and raw artifact reference.
+- Finite timeout value.
+- Confirmation that hosted provider keys were absent and not required.
+- Confirmation that hosted fallback was not used.
+- Raw stdout, stderr, command, exit code, config summary, and sanitized result references.
+- `behavior_evidence=false`.
+- `status` and `reason` values.
+
+## Endpoint redaction
+
+The public sanitized artifact may show `http://127.0.0.1:11434/api/chat` or `http://localhost:<port>/<path>` only when the endpoint is loopback/local and the operator approves that disclosure. Otherwise summarize as `loopback http endpoint` and preserve the exact value only in raw artifacts.
+
+## No provider keys for local mode
+
+Do not add provider keys to make local mode pass. If a provider key is required or used, stop and classify as `provider key unexpectedly required` or `hosted fallback detected` as applicable.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-packet/sanitized-artifact-template.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-packet/sanitized-artifact-template.md
@@ -1,0 +1,49 @@
+# Sanitized Artifact Template
+
+Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-PACKET-001`
+
+This template is for a future docs-only import lane after authorized execution. Do not import smoke results in this packet-preparation PR.
+
+```yaml
+lane: ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-001
+source_packet_lane: ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-PACKET-001
+review_gate_authorized_smoke: true
+execution_timestamp_utc: <timestamp>
+command_summary: <sanitized command summary>
+exit_code: <integer>
+provider_mode: local_llm
+alpha_local_llm_enabled: true
+endpoint_public_summary: <localhost|loopback http endpoint; no nonpublic host details beyond loopback>
+endpoint_is_loopback: true
+endpoint_host_label: <localhost|loopback>
+local_backend: ollama_chat
+backend_class: ollama-local-http-runtime
+local_model: <exact-local-model-name>
+timeout_seconds: <finite-positive-number>
+no_provider_keys_required: true
+provider_keys_absent_confirmed: true
+no_hosted_fallback: true
+status: <non_evidence|failed_closed>
+reason: <implementation reason code>
+behavior_evidence: false
+output_text_summary: <short sanitized summary or redacted if sensitive>
+raw_stdout_artifact: <raw artifact reference>
+raw_stderr_artifact: <raw artifact reference>
+raw_result_artifact: <raw artifact reference>
+failure_classification: <if applicable>
+non_claims:
+  - not runtime smoke evidence until imported by the future import lane
+  - not local model quality evidence
+  - not hosted provider evidence
+  - not /v1/solve readiness
+  - not dashboard preview readiness
+  - not MVP validation
+  - not production readiness
+  - not benchmark evidence
+  - not provider orchestration evidence
+  - not Alpha superiority evidence
+```
+
+## Sanitization requirement
+
+The sanitized artifact must preserve enough information to identify local-only execution and bounded outcome without exposing provider keys, private paths, private URLs, nonpublic endpoints, tokens, full environment dumps, or unrelated machine details.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-packet/selected-next-lane.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-packet/selected-next-lane.md
@@ -1,0 +1,9 @@
+# Selected Next Lane
+
+Selected next lane: `ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-001`
+
+This is the only selected next lane recorded by this execution packet.
+
+## Boundary
+
+The selected next lane is not authorized by this packet alone to run smoke. Runtime smoke remains blocked until `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-REVIEW-GATE-001` explicitly authorizes smoke.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-packet/smoke-execution-packet-summary.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-packet/smoke-execution-packet-summary.md
@@ -1,0 +1,56 @@
+# Smoke Execution Packet Summary
+
+Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-PACKET-001`
+
+## Purpose
+
+Prepare the exact future manual local runtime smoke execution packet for the optional local LLM runtime path, using the merged implementation and operator runbook as source material.
+
+## Non-execution statement
+
+Runtime smoke is not executed in this PR. No local model is called. No hosted provider is called. No network calls are made. No smoke result is imported.
+
+This packet is not runtime smoke evidence. It only records instructions, command templates, artifact templates, redaction requirements, expected result fields, failure classes, stop conditions, and the selected next lane.
+
+## Blocking gate
+
+Execution is blocked until `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-REVIEW-GATE-001` explicitly authorizes smoke. If the review gate is missing, incomplete, ambiguous, or does not approve smoke, the future operator must stop before running any smoke command.
+
+## Implementation-aware surface
+
+The merged local runtime path is represented by:
+
+- `LocalLLMRuntimeConfig.from_env()` for explicit environment-based local runtime configuration.
+- `OllamaLocalHTTPBackend` for the default-off Ollama-style local HTTP backend.
+- `urllib_ollama_json_transport()` for local `http` JSON transport with redirects disabled.
+- `run_configured_local_llm_runtime()` for future authorized local runtime invocation.
+
+The packet must preserve the implementation's narrow evidence model: successful output is `status="non_evidence"`, `reason="local_llm_provider_adapter_wiring_only"`, and `behavior_evidence=false`; failures are bounded `failed_closed` outcomes.
+
+## Required local setup fields
+
+Actual values must be confirmed by the operator at execution time:
+
+```dotenv
+MODEL_PROVIDER=local_llm
+ALPHA_LOCAL_LLM_ENABLED=true
+ALPHA_LOCAL_LLM_ENDPOINT=<localhost-or-loopback-http-endpoint>
+ALPHA_LOCAL_LLM_MODEL=<exact-local-model-name>
+ALPHA_LOCAL_LLM_TIMEOUT_SECONDS=<finite-positive-number>
+```
+
+Historical examples only: endpoint pattern `http://127.0.0.1:11434/api/chat`, model `gemma3:4b`, timeout `120`.
+
+## Packet outputs
+
+The future execution packet requires preserving:
+
+- raw command;
+- raw stdout;
+- raw stderr;
+- exit code;
+- execution timestamps;
+- config summary;
+- raw result object or failure object;
+- sanitized result;
+- stop-condition or failure classification when applicable.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-packet/smoke-packet-preservation-checklist.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-packet/smoke-packet-preservation-checklist.md
@@ -1,0 +1,35 @@
+# Smoke Packet Preservation Checklist
+
+Lane ID: `ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-PACKET-001`
+
+- [x] Kept this lane docs-only.
+- [x] Added files only under `docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-packet/`.
+- [x] Did not change source code.
+- [x] Did not change test code.
+- [x] Did not change runtime behavior.
+- [x] Did not change provider behavior.
+- [x] Did not change `/v1/solve`.
+- [x] Did not change dashboard files.
+- [x] Did not call a local model.
+- [x] Did not call hosted providers.
+- [x] Did not make network calls.
+- [x] Did not add or use provider keys.
+- [x] Did not execute smoke.
+- [x] Did not import smoke results.
+- [x] Stated this packet is not runtime smoke evidence.
+- [x] Stated smoke is blocked until `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-REVIEW-GATE-001` explicitly authorizes smoke.
+- [x] Used implementation-specific config fields from the merged runtime implementation.
+- [x] Included exact future-use command templates based on the merged implementation surface.
+- [x] Included local setup fields for `MODEL_PROVIDER`, `ALPHA_LOCAL_LLM_ENABLED`, `ALPHA_LOCAL_LLM_ENDPOINT`, `ALPHA_LOCAL_LLM_MODEL`, and `ALPHA_LOCAL_LLM_TIMEOUT_SECONDS`.
+- [x] Preserved historical endpoint, model, and timeout values as examples only.
+- [x] Required actual values to be confirmed by the operator at execution time.
+- [x] Required localhost / loopback HTTP endpoint only.
+- [x] Required exact local model name.
+- [x] Required finite timeout.
+- [x] Required no provider keys for local mode.
+- [x] Required no hosted fallback.
+- [x] Required raw stdout, stderr, command, exit code, config summary, and sanitized result preservation.
+- [x] Included required stop conditions.
+- [x] Included post-execution import instructions for a future docs-only import lane.
+- [x] Recorded exactly one selected next lane.
+- [x] Preserved narrow evidence-boundary language.


### PR DESCRIPTION
### Motivation

- Prepare a final manual runtime smoke execution packet for the optional local LLM runtime path that is implementation-aware but strictly docs-only and does not execute any smoke run. 
- Ensure operator guidance, exact future-use command templates, artifact capture and sanitization templates, redaction rules, and stop conditions are available for a future authorized execution. 
- Preserve the canonical evidence boundary and block smoke until `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-REVIEW-GATE-001` explicitly authorizes execution. 

### Description

- Added a docs-only packet under `docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-packet/` with the required files: `README.md`, `smoke-execution-packet-summary.md`, `prerequisite-gates.md`, `operator-runbook.md`, `local-runtime-smoke-command.md`, `raw-artifact-capture-template.md`, `sanitized-artifact-template.md`, `expected-result-fields.md`, `failure-classification.md`, `redaction-rules.md`, `post-execution-import-instructions.md`, `evidence-boundary.md`, `smoke-packet-preservation-checklist.md`, and `selected-next-lane.md`. 
- Documented implementation-aware configuration fields from the merged runtime (`MODEL_PROVIDER=local_llm`, `ALPHA_LOCAL_LLM_ENABLED`, `ALPHA_LOCAL_LLM_ENDPOINT`, `ALPHA_LOCAL_LLM_MODEL`, `ALPHA_LOCAL_LLM_TIMEOUT_SECONDS`), provided exact future-use command templates invoking `run_configured_local_llm_runtime()` and the loopback `urllib_ollama_json_transport()` seam, and preserved historical examples as context only. 
- Included precise raw and sanitized artifact templates, redaction rules, required raw-preservation fields (command, stdout, stderr, exit code, timestamps, config summary), a comprehensive list of stop conditions/failure classifications, and the selected next lane `ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-001`. 

### Testing

- Verified changed paths contain only files under `docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-packet/` by running `git diff --name-only` and path-restriction checks, and the checks passed. 
- Ran repository-level validations including `git diff --cached --check`, presence checks for all required packet files, and grep-based assertions for required config field names, evidence-boundary phrases, and a single selected next lane, and all checks passed. 
- Confirmed no source, test, runtime, provider, or dashboard files were modified and that no local model, hosted provider, network call, or smoke result import occurred by inspection of the working tree and grep outputs, and these validations passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a232f755e348329b3d98e5f96e3e306)