### PR TITLE
docs(evals): close Batch C track

### DIFF
--- a/docs/evals/runs/20260605-alpha-batch-c-track-closeout/README.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-track-closeout/README.md
@@ -1,0 +1,37 @@
+# Batch C Track Closeout
+
+Lane ID: `ALPHA-BATCH-C-TRACK-CLOSEOUT-001`
+
+## Purpose
+
+This docs-only packet closes the Batch C manual prompt-contract simulation track after results import, scoring, interpretation, and the post-results decision selected closeout.
+
+## Source evidence
+
+This closeout packet is based on the Batch C packet-prep, scoring-rubric, operator-execution, results-import, scoring, interpretation, and post-results decision evidence preserved under:
+
+- `docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/`
+- `docs/evals/runs/20260605-alpha-batch-c-scoring-rubric-packet/`
+- `docs/evals/runs/20260605-alpha-batch-c-operator-execution/source-evidence/ALPHA-BATCH-C-OPERATOR-EXECUTION-001.md`
+- `docs/evals/runs/20260605-alpha-batch-c-results-import/`
+- `docs/evals/runs/20260605-alpha-batch-c-scoring/`
+- `docs/evals/runs/20260605-alpha-batch-c-interpretation/`
+- `docs/evals/runs/20260605-alpha-batch-c-post-results-decision/`
+
+## Included closeout files
+
+- `closeout-summary.md`
+- `completed-lanes.md`
+- `evidence-ledger.md`
+- `scoring-and-decision-summary.md`
+- `residual-defects.md`
+- `non-claims-and-boundaries.md`
+- `blocked-work.md`
+- `track-closeout-checklist.md`
+- `selected-next-action.md`
+
+## Closeout status
+
+The Batch C manual prompt-contract simulation track is closed. No further Batch C prompt-contract simulation lane is recommended unless the operator explicitly reopens the track.
+
+The terminal next action is recorded in `selected-next-action.md`.

--- a/docs/evals/runs/20260605-alpha-batch-c-track-closeout/blocked-work.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-track-closeout/blocked-work.md
@@ -1,0 +1,29 @@
+# Blocked Work
+
+Lane ID: `ALPHA-BATCH-C-TRACK-CLOSEOUT-001`
+
+## Blocked or out-of-scope work
+
+The following work remains blocked or out of scope for this docs-only closeout packet:
+
+- Source code changes.
+- Test code changes.
+- Runtime changes.
+- Provider changes.
+- Local LLM changes.
+- `/v1/solve` changes.
+- Dashboard changes.
+- Google Sheets updates.
+- Batch C re-execution.
+- Output reconstruction.
+- Rescoring.
+- Unblinding.
+- New scoring.
+- Private URL inclusion.
+- Provider key inclusion.
+- Secret inclusion.
+- Readiness, validation, superiority, benchmark, billing, provider-orchestration, production, runtime, MVP, Batch C readiness, or local-LLM-quality claims.
+
+## Reopen condition
+
+No further Batch C prompt-contract simulation lane is recommended unless the operator explicitly reopens the track.

--- a/docs/evals/runs/20260605-alpha-batch-c-track-closeout/closeout-summary.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-track-closeout/closeout-summary.md
@@ -1,0 +1,23 @@
+# Closeout Summary
+
+Lane ID: `ALPHA-BATCH-C-TRACK-CLOSEOUT-001`
+
+## Closed track
+
+This packet closes the completed Batch C manual prompt-contract simulation track only. It summarizes the completed packet preparation, operator execution evidence, results import, scoring, interpretation, and post-results decision artifacts without adding new scoring, rerunning tasks, reconstructing outputs, or expanding the evidence boundary.
+
+## Prerequisite state preserved
+
+- PR #310 is recorded as squashed, merged, closed, and recorded in GS before this closeout lane.
+- PR #314 is recorded as squashed, merged, closed, and recorded in GS before this closeout lane.
+- PR #317 is recorded as squashed, merged, closed, and recorded in GS before this closeout lane.
+- PR #320 is recorded as squashed, merged, closed, and recorded in GS before this closeout lane.
+- PR #320 selected `ALPHA-BATCH-C-TRACK-CLOSEOUT-001`.
+
+## Closeout conclusion
+
+Batch C raw evidence was complete for `BC-001` through `BC-012`, and scorer-facing sanitized entries were complete for `BC-001` through `BC-012`. Source cleanup/provenance notes were not scored as task output.
+
+No further Batch C prompt-contract simulation lane is recommended unless the operator explicitly reopens the track.
+
+The terminal next action is recorded in `selected-next-action.md`.

--- a/docs/evals/runs/20260605-alpha-batch-c-track-closeout/completed-lanes.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-track-closeout/completed-lanes.md
@@ -1,0 +1,20 @@
+# Completed Lanes
+
+Lane ID: `ALPHA-BATCH-C-TRACK-CLOSEOUT-001`
+
+## Completed Batch C track sequence
+
+| Sequence | Lane or artifact | Closeout note |
+| --- | --- | --- |
+| 1 | Batch C frozen packet prep | Packet-prep materials were preserved as source evidence for the manual prompt-contract simulation track. |
+| 2 | Batch C scoring rubric packet | Rubric, dimensions, scoring instructions, stop-condition rules, and task-to-rubric mapping were preserved as source evidence. |
+| 3 | Batch C operator execution source evidence | The operator execution artifact was preserved as source evidence for `BC-001` through `BC-012`. |
+| 4 | Batch C results import | Raw evidence and scorer-facing sanitized entries were imported for `BC-001` through `BC-012`. |
+| 5 | Batch C scoring | Corrected applicable-dimension scoring was preserved as 173 / 174. |
+| 6 | Batch C interpretation | Interpretation remained limited to manual Batch C prompt-contract simulation evidence. |
+| 7 | Batch C post-results decision | PR #320 selected `ALPHA-BATCH-C-TRACK-CLOSEOUT-001`. |
+| 8 | Batch C track closeout | This packet records terminal closeout of the Batch C manual prompt-contract simulation track. |
+
+## Completion boundary
+
+This is a closeout of the Batch C manual prompt-contract simulation track only. It does not close, validate, or certify product/runtime behavior, `/v1/solve` behavior, local LLM behavior, provider behavior, benchmark performance, MVP status, production readiness, Batch C readiness, Alpha superiority, or broad plain-provider inferiority.

--- a/docs/evals/runs/20260605-alpha-batch-c-track-closeout/evidence-ledger.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-track-closeout/evidence-ledger.md
@@ -1,0 +1,24 @@
+# Evidence Ledger
+
+Lane ID: `ALPHA-BATCH-C-TRACK-CLOSEOUT-001`
+
+## Source-of-truth ledger
+
+| Evidence source | Role in closeout | Scored as task output? |
+| --- | --- | --- |
+| `docs/evals/runs/20260605-alpha-batch-c-frozen-packet-prep/` | Frozen packet prep, runbook, templates, preservation checklist, evidence boundary, and selected next lane context. | No |
+| `docs/evals/runs/20260605-alpha-batch-c-scoring-rubric-packet/` | Scoring rubric, rubric dimensions, task-to-rubric mapping, scorer instructions, stop-condition rules, and preservation checklist. | No |
+| `docs/evals/runs/20260605-alpha-batch-c-operator-execution/source-evidence/ALPHA-BATCH-C-OPERATOR-EXECUTION-001.md` | Raw operator execution source evidence for the manual prompt-contract simulation tasks. | Source for scored task outputs |
+| `docs/evals/runs/20260605-alpha-batch-c-results-import/` | Imported raw-output preservation log, redaction/anomaly log, scorer-facing sanitized entries, and import reviewer checklist. | Imported task outputs only |
+| `docs/evals/runs/20260605-alpha-batch-c-scoring/` | Corrected applicable-dimension scoring result, scoring method, scoring sheet, scoring summary, defect log, and preservation checklist. | Scoring record |
+| `docs/evals/runs/20260605-alpha-batch-c-interpretation/` | Narrow interpretation of the scored manual prompt-contract simulation results. | No new scoring |
+| `docs/evals/runs/20260605-alpha-batch-c-post-results-decision/` | Post-results decision selecting closeout as the next lane. | No new scoring |
+
+## Completeness statements
+
+- Raw evidence was complete for `BC-001` through `BC-012`.
+- Scorer-facing sanitized entries were complete for `BC-001` through `BC-012`.
+- Source cleanup/provenance notes were not scored as task output.
+- No Batch C re-execution was performed in this closeout.
+- No output reconstruction was performed in this closeout.
+- No rescoring, unblinding, or new scoring was performed in this closeout.

--- a/docs/evals/runs/20260605-alpha-batch-c-track-closeout/non-claims-and-boundaries.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-track-closeout/non-claims-and-boundaries.md
@@ -1,0 +1,28 @@
+# Non-Claims and Boundaries
+
+Lane ID: `ALPHA-BATCH-C-TRACK-CLOSEOUT-001`
+
+## Evidence boundary
+
+This closeout is limited to manual Batch C prompt-contract simulation evidence.
+
+It is not:
+
+- product/runtime evidence
+- `/v1/solve` evidence
+- local LLM evidence
+- provider evidence
+- benchmark evidence
+- MVP validation
+- production readiness
+- Batch C readiness
+- Alpha superiority evidence
+- broad plain-provider inferiority evidence
+
+## Non-claims
+
+This closeout makes no readiness, validation, superiority, benchmark, billing, provider-orchestration, production, runtime, MVP, Batch C readiness, local-LLM-quality, endpoint, or provider-quality claim.
+
+## Non-actions
+
+This closeout does not perform Batch C re-execution, output reconstruction, rescoring, unblinding, new scoring, Google Sheets updates, runtime changes, provider changes, local LLM changes, `/v1/solve` changes, dashboard changes, source code changes, or test code changes.

--- a/docs/evals/runs/20260605-alpha-batch-c-track-closeout/residual-defects.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-track-closeout/residual-defects.md
@@ -1,0 +1,20 @@
+# Residual Defects
+
+Lane ID: `ALPHA-BATCH-C-TRACK-CLOSEOUT-001`
+
+## Preserved residual defect
+
+| Task | Defect code | Severity | Preserved description | Closeout disposition |
+| --- | --- | --- | --- | --- |
+| `BC-007` | `D-WORDING-DRIFT` | Minor | Minor next-action wording drift. The output correctly identified that repository evidence controls over a planning ledger, but the next-action wording was broader than the most conservative preservation wording. | Preserved as minor `Refine`; does not block track closeout. |
+
+## Residual-defect boundary
+
+This closeout does not resolve, rescore, reinterpret, or expand the residual defect. It only preserves the residual-defect record from the Batch C scoring and post-results decision sequence.
+
+## Non-defect preservation
+
+- Source cleanup/provenance notes were not scored as task output.
+- No redaction failure is recorded as blocking this closeout.
+- No artifact-integrity issue is recorded as blocking this closeout.
+- No stop-condition scoring block is recorded for this closeout.

--- a/docs/evals/runs/20260605-alpha-batch-c-track-closeout/scoring-and-decision-summary.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-track-closeout/scoring-and-decision-summary.md
@@ -1,0 +1,22 @@
+# Scoring and Decision Summary
+
+Lane ID: `ALPHA-BATCH-C-TRACK-CLOSEOUT-001`
+
+## Preserved corrected scoring result
+
+This closeout preserves the corrected applicable-dimension scoring result from PR #320:
+
+- Aggregate total: 173 / 174.
+- Non-applicable dimensions excluded from totals: 86.
+- Dispositions: 11 `Keep`, 1 minor `Refine`, 0 `Reject`, 0 `Stop condition`.
+- Residual defect: `BC-007`, `D-WORDING-DRIFT`, minor next-action wording drift.
+
+No new scores are created in this closeout packet.
+
+## Decision summary
+
+PR #320 selected `ALPHA-BATCH-C-TRACK-CLOSEOUT-001` because all Batch C tasks were either `Keep` or minor `Refine`, with no `Reject` disposition and no stop-condition block.
+
+The closeout records no further Batch C prompt-contract simulation lane as recommended unless the operator explicitly reopens the track.
+
+The terminal next action is recorded in `selected-next-action.md`.

--- a/docs/evals/runs/20260605-alpha-batch-c-track-closeout/selected-next-action.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-track-closeout/selected-next-action.md
@@ -1,0 +1,11 @@
+# Selected Next Action
+
+Lane ID: `ALPHA-BATCH-C-TRACK-CLOSEOUT-001`
+
+## Terminal next action
+
+`STOP-HERE-BATCH-C-TRACK-CLOSED`
+
+## Closeout rule
+
+This is the only terminal next action recorded by the Batch C track closeout packet. No further Batch C prompt-contract simulation lane is recommended unless the operator explicitly reopens the track.

--- a/docs/evals/runs/20260605-alpha-batch-c-track-closeout/track-closeout-checklist.md
+++ b/docs/evals/runs/20260605-alpha-batch-c-track-closeout/track-closeout-checklist.md
@@ -1,0 +1,20 @@
+# Track Closeout Checklist
+
+Lane ID: `ALPHA-BATCH-C-TRACK-CLOSEOUT-001`
+
+- [x] Closeout summarizes the completed Batch C track only.
+- [x] Corrected applicable-dimension scoring result 173 / 174 is preserved.
+- [x] Non-applicable dimensions excluded from totals are preserved as 86.
+- [x] Dispositions are preserved as 11 `Keep`, 1 minor `Refine`, 0 `Reject`, 0 `Stop condition`.
+- [x] Residual defect `BC-007`, `D-WORDING-DRIFT`, minor next-action wording drift is preserved.
+- [x] Raw evidence completeness is recorded for `BC-001` through `BC-012`.
+- [x] Scorer-facing sanitized-entry completeness is recorded for `BC-001` through `BC-012`.
+- [x] Source cleanup/provenance notes are recorded as not scored as task output.
+- [x] PR #320 selection of `ALPHA-BATCH-C-TRACK-CLOSEOUT-001` is preserved.
+- [x] No new scores are created.
+- [x] No Batch C re-execution is performed.
+- [x] No output reconstruction is performed.
+- [x] No rescoring or unblinding is performed.
+- [x] Evidence-boundary language remains limited to manual Batch C prompt-contract simulation evidence.
+- [x] No further Batch C prompt-contract simulation lane is recommended unless the operator explicitly reopens the track.
+- [x] Exactly one terminal next action is recorded in `selected-next-action.md`.


### PR DESCRIPTION
### Motivation

- Close the Batch C manual prompt-contract simulation track with a docs-only closeout packet that preserves prior import, scoring, interpretation, and the post-results decision without adding new scoring or re-execution. 
- Preserve the corrected scoring and disposition facts and record a single terminal next action while keeping the evidence boundary narrowly limited to manual Batch C prompt-contract simulation evidence.

### Description

- Add a docs-only closeout packet under `docs/evals/runs/20260605-alpha-batch-c-track-closeout/` comprising `README.md`, `closeout-summary.md`, `completed-lanes.md`, `evidence-ledger.md`, `scoring-and-decision-summary.md`, `residual-defects.md`, `non-claims-and-boundaries.md`, `blocked-work.md`, `track-closeout-checklist.md`, and `selected-next-action.md`.
- Preserve the corrected applicable-dimension scoring result `173 / 174`, record `86` non-applicable dimensions excluded from totals, and preserve dispositions `11 Keep`, `1 minor Refine`, `0 Reject`, `0 Stop condition` and the residual defect `BC-007` / `D-WORDING-DRIFT` as a minor `Refine`.
- Record that raw evidence and scorer-facing sanitized entries were complete for `BC-001` through `BC-012`, assert that source cleanup/provenance notes were not scored as task output, and declare the single terminal next action `STOP-HERE-BATCH-C-TRACK-CLOSED`.
- Explicitly enumerate blocked/out-of-scope actions and non-claims to avoid any product/runtime, `/v1/solve`, provider, benchmark, or readiness claims.

### Testing

- Verified only files under `docs/evals/runs/20260605-alpha-batch-c-track-closeout/` were added and all required files exist using staged-diff and a Python presence check, and the assertions succeeded.
- Ran content-preservation checks with `rg` to confirm `173 / 174`, `86` non-applicable dimensions, dispositions `11 \`Keep\`, 1 minor \`Refine\`, 0 \`Reject\`, 0 \`Stop condition\``, presence of `BC-007` / `D-WORDING-DRIFT`, the residual-defect wording, and the literal `STOP-HERE-BATCH-C-TRACK-CLOSED`, and all checks passed.
- Confirmed exactly one literal occurrence of `STOP-HERE-BATCH-C-TRACK-CLOSED` and that no new scores were created via scripted assertions, and the script reported `Closeout packet checks passed.`
- Performed `git add` and `git commit -m "docs(evals): close Batch C track"` to record the changes; the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a232f7da8108329b2ae91501dca63e5)