### PR TITLE
docs(local-llm): import retry smoke and close local runtime track

### DIFF
--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-final-decision/README.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-final-decision/README.md
@@ -1,0 +1,21 @@
+# Local LLM Runtime Smoke Retry Final Decision
+
+## Lane
+
+`ALPHA-LOCAL-LLM-RUNTIME-SMOKE-RETRY-FINAL-DECISION-001`
+
+## Source evidence
+
+`docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-retry/source-evidence/ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-RETRY-002.md`
+
+## Selected terminal next action
+
+`STOP-HERE-LOCAL-LLM-RUNTIME-TRACK-CLOSED`
+
+## Decision basis
+
+The import is complete. Attempt 002 preserved exact executable command and script provenance, precheck passed, smoke ran, smoke exit code is `0`, status is `non_evidence`, output text is `OK`, `behavior_evidence` is `false`, `no_hosted_fallback` is `true`, `no_provider_keys_required` is `true`, and no artifact-integrity blocker remains.
+
+## Evidence boundary
+
+This lane uses only the repo-source retry artifact at `docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-retry/source-evidence/ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-RETRY-002.md`. It is local LLM runtime smoke retry execution evidence only. It is not local model quality evidence, hosted provider evidence, `/v1/solve` readiness, dashboard preview readiness, MVP validation, production readiness, benchmark evidence, provider orchestration evidence, Alpha superiority evidence, broad runtime readiness evidence, billing evidence, or evidence-model promotion.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-final-decision/blocked-work.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-final-decision/blocked-work.md
@@ -1,0 +1,13 @@
+# Blocked Work
+
+## Source evidence
+
+`docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-retry/source-evidence/ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-RETRY-002.md`
+
+## Work not authorized by this decision
+
+Future `/v1/solve` exposure, dashboard exposure, provider fallback, evidence-model promotion, model-quality evaluation, MVP adoption, hosted provider use, benchmark work, provider orchestration, production changes, billing work, or broad runtime readiness work require separate explicit lanes and are not authorized by this final decision.
+
+## Current local LLM runtime track status
+
+No further local LLM runtime lane is recommended unless the operator explicitly reopens the track.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-final-decision/decision-options.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-final-decision/decision-options.md
@@ -1,0 +1,13 @@
+# Decision Options
+
+## Evaluated options
+
+- `STOP-HERE-LOCAL-LLM-RUNTIME-TRACK-CLOSED`: selected because the successful attempt 002 evidence satisfies the closeout rule.
+- `ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-RETRY-003`: not selected because the source evidence exists and required raw fields are present.
+- `ALPHA-LOCAL-LLM-RUNTIME-SMOKE-FAILURE-INTERPRETATION-001`: not selected because attempt 002 did not fail closed; it exited with code `0` and returned `non_evidence`.
+- `ALPHA-LOCAL-LLM-RUNTIME-SMOKE-RESULTS-IMPORT-REPAIR-001`: not selected because no redaction or artifact-integrity blocker remains.
+- `ALPHA-LOCAL-LLM-RUNTIME-INTEGRATION-REPAIR-001`: not selected because the imported result does not suggest an implementation defect within the bounded evidence.
+
+## Exactly one selected option
+
+`STOP-HERE-LOCAL-LLM-RUNTIME-TRACK-CLOSED`

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-final-decision/decision-summary.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-final-decision/decision-summary.md
@@ -1,0 +1,15 @@
+# Decision Summary
+
+## Source evidence
+
+`docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-retry/source-evidence/ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-RETRY-002.md`
+
+## Final decision
+
+Select exactly one terminal next action:
+
+`STOP-HERE-LOCAL-LLM-RUNTIME-TRACK-CLOSED`
+
+## Rationale
+
+The successful attempt 002 retry smoke result satisfies the closeout rule: the repo-source artifact exists, the required raw fields are present, command/script provenance is complete, precheck passed, the smoke ran, the smoke exit code was `0`, the result was `non_evidence`, output text was `OK`, `behavior_evidence` remained `false`, hosted fallback was excluded, provider keys were not required, and the preserved local artifact hygiene caveats do not create an artifact-integrity blocker.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-final-decision/evidence-boundary.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-final-decision/evidence-boundary.md
@@ -1,0 +1,7 @@
+# Evidence Boundary
+
+This lane uses only the repo-source retry artifact at `docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-retry/source-evidence/ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-RETRY-002.md`. It is local LLM runtime smoke retry execution evidence only. It is not local model quality evidence, hosted provider evidence, `/v1/solve` readiness, dashboard preview readiness, MVP validation, production readiness, benchmark evidence, provider orchestration evidence, Alpha superiority evidence, broad runtime readiness evidence, billing evidence, or evidence-model promotion.
+
+## Decision boundary
+
+The decision closes only the local LLM runtime track based on bounded retry smoke execution evidence. It does not close or modify Batch C, which is already closed separately, and does not authorize future exposure, promotion, quality, benchmark, production, provider fallback, or MVP work.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-final-decision/final-decision-preservation-checklist.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-final-decision/final-decision-preservation-checklist.md
@@ -1,0 +1,13 @@
+# Final Decision Preservation Checklist
+
+- [x] Exactly one terminal next action is selected.
+- [x] Selected terminal next action is `STOP-HERE-LOCAL-LLM-RUNTIME-TRACK-CLOSED`.
+- [x] Source evidence exists and is cited by exact repo path.
+- [x] Import completeness is part of the decision basis.
+- [x] Attempt 002 command/script provenance is part of the decision basis.
+- [x] Precheck success is part of the decision basis.
+- [x] `smoke_ran: yes` and `smoke_exit_code: 0` are part of the decision basis.
+- [x] `status: non_evidence`, `output_text: OK`, and `behavior_evidence: false` are part of the decision basis.
+- [x] `no_hosted_fallback: true` and `no_provider_keys_required: true` are part of the decision basis.
+- [x] Artifact hygiene caveats are preserved and not treated as blockers.
+- [x] Forbidden broad claims are excluded.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-final-decision/selected-next-lane.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-final-decision/selected-next-lane.md
@@ -1,0 +1,13 @@
+# Selected Next Lane
+
+## Selection
+
+No further lane is selected for the local LLM runtime track.
+
+## Terminal next action
+
+`STOP-HERE-LOCAL-LLM-RUNTIME-TRACK-CLOSED`
+
+## Basis
+
+The successful attempt 002 retry smoke evidence supports closing the local LLM runtime track without recommending another local LLM runtime lane, unless the operator explicitly reopens the track.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-interpretation/README.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-interpretation/README.md
@@ -1,0 +1,21 @@
+# Local LLM Runtime Smoke Retry Interpretation
+
+## Lane
+
+`ALPHA-LOCAL-LLM-RUNTIME-SMOKE-RETRY-INTERPRETATION-001`
+
+## Source evidence
+
+`docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-retry/source-evidence/ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-RETRY-002.md`
+
+## Scope
+
+Interpret only the imported retry smoke evidence from attempt 002 and its preserved attempt 001 context.
+
+## Interpretation summary
+
+Attempt 001 failed before runtime because repo-root `PYTHONPATH` was missing, causing a runner/import-path failure rather than a local LLM runtime failure. Attempt 002 corrected the runner setup by including repo-root `PYTHONPATH`, preserved exact executable command and script provenance, passed the configuration precheck, ran the local loopback runtime smoke, exited with code `0`, and returned the recorded `non_evidence` result with `output_text: OK` and `behavior_evidence: false`.
+
+## Evidence boundary
+
+This lane uses only the repo-source retry artifact at `docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-retry/source-evidence/ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-RETRY-002.md`. It is local LLM runtime smoke retry execution evidence only. It is not local model quality evidence, hosted provider evidence, `/v1/solve` readiness, dashboard preview readiness, MVP validation, production readiness, benchmark evidence, provider orchestration evidence, Alpha superiority evidence, broad runtime readiness evidence, billing evidence, or evidence-model promotion.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-interpretation/evidence-boundary-review.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-interpretation/evidence-boundary-review.md
@@ -1,0 +1,13 @@
+# Evidence Boundary Review
+
+## Source evidence
+
+`docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-retry/source-evidence/ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-RETRY-002.md`
+
+## Boundary
+
+This lane uses only the repo-source retry artifact at `docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-retry/source-evidence/ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-RETRY-002.md`. It is local LLM runtime smoke retry execution evidence only. It is not local model quality evidence, hosted provider evidence, `/v1/solve` readiness, dashboard preview readiness, MVP validation, production readiness, benchmark evidence, provider orchestration evidence, Alpha superiority evidence, broad runtime readiness evidence, billing evidence, or evidence-model promotion.
+
+## Boundary conclusion
+
+The imported retry smoke evidence is sufficient only for a bounded local loopback runtime smoke statement. It is not sufficient for readiness, validation, superiority, benchmark, billing, provider-orchestration, production, MVP, `/v1/solve`, dashboard, hosted provider, or local model quality claims.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-interpretation/implementation-surface-observations.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-interpretation/implementation-surface-observations.md
@@ -1,0 +1,17 @@
+# Implementation Surface Observations
+
+## Source evidence
+
+`docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-retry/source-evidence/ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-RETRY-002.md`
+
+## Observations from imported evidence only
+
+- The smoke script reached `alpha.local_llm.provider_adapter.run_configured_local_llm_runtime` after repo-root `PYTHONPATH` was set.
+- The source artifact records `provider_mode: local_llm` and `ALPHA_LOCAL_LLM_ENABLED=true`.
+- The endpoint was recorded only as localhost / loopback using `http://127.0.0.1:11434/api/chat`.
+- Metadata records `local_backend: ollama_chat`, `backend_class: ollama-local-http-runtime`, and `local_model: gemma3:4b`.
+- Hosted provider use is bounded out by `no_hosted_fallback: true`, `no_provider_keys_required: true`, `no_real_provider_call: true`, and `real_provider_call_enabled: false`.
+
+## Non-observations
+
+No source code behavior is changed or revalidated in this interpretation lane. No `/v1/solve`, dashboard, provider fallback, evidence-model promotion, benchmark, or model-quality surface is authorized or interpreted from this evidence.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-interpretation/interpretation-preservation-checklist.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-interpretation/interpretation-preservation-checklist.md
@@ -1,0 +1,15 @@
+# Interpretation Preservation Checklist
+
+- [x] Interpretation uses only the imported repo-source retry smoke evidence.
+- [x] Attempt 001 is preserved as runner/import-path failure, not local LLM runtime failure.
+- [x] Attempt 002 repo-root `PYTHONPATH` correction is preserved.
+- [x] Exact executable command and script provenance are preserved.
+- [x] Script call to `run_configured_local_llm_runtime(USER_PROMPT, env=os.environ)` is preserved.
+- [x] JSON serialization of returned result is preserved.
+- [x] Precheck success is preserved.
+- [x] Runtime smoke execution and exit code `0` are preserved.
+- [x] Loopback endpoint, `gemma3:4b`, and `120` second timeout are preserved.
+- [x] `non_evidence`, `OK`, and `behavior_evidence: false` are preserved.
+- [x] `no_hosted_fallback` and `no_provider_keys_required` are preserved.
+- [x] Local artifact hygiene caveats are preserved and interpreted narrowly.
+- [x] Forbidden broad claims are excluded.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-interpretation/interpretation-summary.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-interpretation/interpretation-summary.md
@@ -1,0 +1,34 @@
+# Interpretation Summary
+
+## Source evidence
+
+`docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-retry/source-evidence/ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-RETRY-002.md`
+
+## Interpretation
+
+- Attempt 001 failed before runtime due missing repo-root `PYTHONPATH`.
+- Attempt 001 is interpreted as a runner/import-path failure, not a local LLM runtime failure.
+- Attempt 002 included repo-root `PYTHONPATH`.
+- Attempt 002 preserved exact executable command and exact Python script provenance.
+- The Python script calls `run_configured_local_llm_runtime` with `USER_PROMPT`.
+- The Python script serializes the returned result to JSON.
+- The precheck completed successfully with `exit_code: 0`.
+- The runtime smoke retry executed with `smoke_ran: yes`.
+- The runtime smoke retry exited successfully with `smoke_exit_code: 0`.
+- The configured endpoint was localhost / loopback.
+- The configured model was `gemma3:4b`.
+- The configured timeout was `120` seconds.
+- The result status was `non_evidence`.
+- The output text was `OK`.
+- `behavior_evidence` remained `false`.
+- `no_hosted_fallback` was preserved as `true`.
+- `no_provider_keys_required` was preserved as `true`.
+- Metadata distinguished local LLM runtime output from hosted provider output through loopback endpoint metadata, local backend/model metadata, no-hosted-fallback metadata, and no-real-provider-call metadata.
+
+## Bounded supported statement
+
+The retry smoke supports only that the merged optional local LLM runtime path executed one local loopback retry smoke with complete executable command provenance and returned the recorded `non_evidence` result.
+
+## Non-support
+
+The retry smoke does not support local model quality claims, hosted provider claims, `/v1/solve` readiness, dashboard preview readiness, MVP validation, production readiness, benchmark claims, provider orchestration claims, Alpha superiority claims, broad runtime readiness claims, billing claims, or evidence-model promotion.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-interpretation/observed-outcome.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-interpretation/observed-outcome.md
@@ -1,0 +1,36 @@
+# Observed Outcome
+
+## Source evidence
+
+`docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-retry/source-evidence/ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-RETRY-002.md`
+
+## Observed facts
+
+- `attempt_id`: `002`
+- `retry_reason`: `prior smoke artifact had incomplete exact executable command provenance; attempt 001 failed before runtime due missing repo-root PYTHONPATH`
+- Attempt 001 context: prior failed runner/import-path attempt caused by missing repo-root `PYTHONPATH`; this is not treated as a local LLM runtime failure.
+- Attempt 002 correction: repo root was included in `PYTHONPATH`; the exact executable shell command and exact Python script were preserved.
+- The preserved Python script imports and calls `run_configured_local_llm_runtime(USER_PROMPT, env=os.environ)`.
+- The preserved Python script serializes the returned result to JSON with `json.dumps(record, sort_keys=True, indent=2)`.
+- Precheck command: `PYTHONPATH="<repo-root>" python3 scripts/check_env.py`
+- Precheck exit code: `0`
+- `smoke_ran`: `yes`
+- `smoke_exit_code`: `0`
+- `provider_mode`: `local_llm`
+- `ALPHA_LOCAL_LLM_ENABLED`: `true`
+- Endpoint summary: localhost / loopback HTTP endpoint.
+- `endpoint_pattern_used`: `http://127.0.0.1:11434/api/chat`
+- Model: `gemma3:4b`
+- Timeout: `120` seconds
+- Result status: `non_evidence`
+- Result reason: `local_llm_provider_adapter_wiring_only`
+- Result `output_text`: `OK`
+- Result `behavior_evidence`: `false`
+- Metadata includes `backend_class: ollama-local-http-runtime`, `endpoint_host_label: loopback`, `endpoint_is_loopback: true`, `local_backend: ollama_chat`, `local_model: gemma3:4b`, `no_hosted_fallback: true`, `no_provider_keys_required: true`, `no_real_provider_call: true`, `provider_mode: local_llm`, `real_provider_call_enabled: false`, and `timeout_seconds: 120.0`.
+- Prompt source fingerprint metadata is present: `prompt_source_fingerprint`, `prompt_source_fingerprint_algorithm: sha256`, `prompt_source_path: alpha_solver_portable.py`, and `prompt_source_sha256`.
+- Raw precheck stdout/stderr and raw runtime smoke stdout/stderr are preserved in the source evidence.
+- Local artifact hygiene caveats are preserved: an untracked prior smoke artifact at repo root and untracked manual-artifact folders from prior local attempts were present in the source artifact repo status sections.
+
+## Outcome interpretation
+
+The observed attempt 002 outcome is a successful bounded local loopback smoke execution with a `non_evidence` result. Because `behavior_evidence` is `false`, the outcome remains wiring/runtime-smoke evidence only and is not promoted to evidence of model behavior quality.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-interpretation/residual-risk-review.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-interpretation/residual-risk-review.md
@@ -1,0 +1,16 @@
+# Residual Risk Review
+
+## Source evidence
+
+`docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-retry/source-evidence/ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-RETRY-002.md`
+
+## Residual caveats
+
+- Attempt 001 failed before runtime due a missing repo-root `PYTHONPATH`; this remains prior runner/import-path context.
+- The source artifact records untracked local artifacts from prior attempts: a prior smoke artifact at repo root and manual-artifact folders.
+- These are interpreted narrowly as local artifact hygiene caveats.
+- These caveats do not invalidate the attempt 002 result because attempt 002 preserves complete command/script provenance, precheck success, smoke execution, and successful smoke exit.
+
+## Remaining boundaries
+
+Any future `/v1/solve` exposure, dashboard exposure, provider fallback, evidence-model promotion, model-quality evaluation, or MVP adoption requires separate explicit lanes and is not authorized by this interpretation.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-results-import/README.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-results-import/README.md
@@ -1,0 +1,44 @@
+# Local LLM Runtime Smoke Retry Results Import
+
+## Lane
+
+`ALPHA-LOCAL-LLM-RUNTIME-SMOKE-RETRY-RESULTS-IMPORT-001`
+
+## Source evidence
+
+Source path preserved exactly: `docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-retry/source-evidence/ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-RETRY-002.md`
+
+## Import scope
+
+This folder imports only the repo-source retry artifact. No uploaded files, terminal transcript material outside the repo artifact, smoke re-execution, retry execution, local model calls, hosted provider calls, network calls, output reconstruction, source-code changes, test changes, runtime changes, provider changes, `/v1/solve` changes, dashboard changes, Google Sheets updates, benchmarks, model-quality scoring, provider comparison, secrets, credentials, or private URLs are used.
+
+## Imported facts
+
+- `attempt_id`: `002`
+- `retry_reason`: `prior smoke artifact had incomplete exact executable command provenance; attempt 001 failed before runtime due missing repo-root PYTHONPATH`
+- Attempt 001 context: prior failed runner/import-path attempt caused by missing repo-root `PYTHONPATH`; this is not treated as a local LLM runtime failure.
+- Attempt 002 correction: repo root was included in `PYTHONPATH`; the exact executable shell command and exact Python script were preserved.
+- The preserved Python script imports and calls `run_configured_local_llm_runtime(USER_PROMPT, env=os.environ)`.
+- The preserved Python script serializes the returned result to JSON with `json.dumps(record, sort_keys=True, indent=2)`.
+- Precheck command: `PYTHONPATH="<repo-root>" python3 scripts/check_env.py`
+- Precheck exit code: `0`
+- `smoke_ran`: `yes`
+- `smoke_exit_code`: `0`
+- `provider_mode`: `local_llm`
+- `ALPHA_LOCAL_LLM_ENABLED`: `true`
+- Endpoint summary: localhost / loopback HTTP endpoint.
+- `endpoint_pattern_used`: `http://127.0.0.1:11434/api/chat`
+- Model: `gemma3:4b`
+- Timeout: `120` seconds
+- Result status: `non_evidence`
+- Result reason: `local_llm_provider_adapter_wiring_only`
+- Result `output_text`: `OK`
+- Result `behavior_evidence`: `false`
+- Metadata includes `backend_class: ollama-local-http-runtime`, `endpoint_host_label: loopback`, `endpoint_is_loopback: true`, `local_backend: ollama_chat`, `local_model: gemma3:4b`, `no_hosted_fallback: true`, `no_provider_keys_required: true`, `no_real_provider_call: true`, `provider_mode: local_llm`, `real_provider_call_enabled: false`, and `timeout_seconds: 120.0`.
+- Prompt source fingerprint metadata is present: `prompt_source_fingerprint`, `prompt_source_fingerprint_algorithm: sha256`, `prompt_source_path: alpha_solver_portable.py`, and `prompt_source_sha256`.
+- Raw precheck stdout/stderr and raw runtime smoke stdout/stderr are preserved in the source evidence.
+- Local artifact hygiene caveats are preserved: an untracked prior smoke artifact at repo root and untracked manual-artifact folders from prior local attempts were present in the source artifact repo status sections.
+
+## Evidence boundary
+
+This lane uses only the repo-source retry artifact at `docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-retry/source-evidence/ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-RETRY-002.md`. It is local LLM runtime smoke retry execution evidence only. It is not local model quality evidence, hosted provider evidence, `/v1/solve` readiness, dashboard preview readiness, MVP validation, production readiness, benchmark evidence, provider orchestration evidence, Alpha superiority evidence, broad runtime readiness evidence, billing evidence, or evidence-model promotion.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-results-import/import-reviewer-checklist.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-results-import/import-reviewer-checklist.md
@@ -1,0 +1,30 @@
+# Import Reviewer Checklist
+
+- [x] Retry source artifact exists at `docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-retry/source-evidence/ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-RETRY-002.md`.
+- [x] Only the repo-source retry artifact was imported.
+- [x] Source path is preserved exactly.
+- [x] `attempt_id: 002` is imported.
+- [x] Retry reason is imported exactly.
+- [x] Attempt 001 failure context is imported and treated as runner/import-path failure.
+- [x] Attempt 002 repo-root `PYTHONPATH` correction is imported.
+- [x] Exact executable shell command is imported.
+- [x] Exact Python script is imported.
+- [x] Script call to `run_configured_local_llm_runtime` with `USER_PROMPT` is imported.
+- [x] Script JSON serialization of returned result is imported.
+- [x] Precheck command and `exit_code: 0` are imported.
+- [x] `smoke_ran: yes` is imported.
+- [x] `smoke_exit_code: 0` is imported.
+- [x] Localhost / loopback endpoint is imported.
+- [x] `gemma3:4b` model is imported.
+- [x] `timeout_seconds: 120` is imported.
+- [x] `output_text: OK` is imported.
+- [x] `status: non_evidence` is imported.
+- [x] `reason: local_llm_provider_adapter_wiring_only` is imported.
+- [x] `behavior_evidence: false` is imported.
+- [x] `no_hosted_fallback: true` is imported.
+- [x] `no_provider_keys_required: true` is imported.
+- [x] Prompt source fingerprint metadata is preserved.
+- [x] Stdout and stderr sections are preserved.
+- [x] Local artifact hygiene caveats are preserved.
+- [x] Terminal wrapper noise is not imported as smoke evidence.
+- [x] Evidence-boundary language remains narrow.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-results-import/raw-artifact-preservation-log.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-results-import/raw-artifact-preservation-log.md
@@ -1,0 +1,28 @@
+# Raw Artifact Preservation Log
+
+## Source artifact
+
+`docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-retry/source-evidence/ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-RETRY-002.md`
+
+## Preserved raw sections
+
+- Execution metadata, including `attempt_id: 002` and retry reason.
+- Precheck command, stdout, stderr, and `exit_code: 0`.
+- Runtime smoke execution fields, including `smoke_ran: yes` and `smoke_exit_code: 0`.
+- Exact executable shell command.
+- Exact Python script executed.
+- Runtime smoke stdout JSON.
+- Runtime smoke stderr.
+- Artifact preservation notes.
+- Evidence boundary and non-claims.
+- Repo status caveats before and after retry artifacts.
+
+## Exact preserved command
+
+```bash
+PYTHONPATH="<repo-root>" python3 "docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-retry/manual-artifacts-attempt-002/runtime_smoke_retry_executable.py"
+```
+
+## Preservation decision
+
+The source artifact was imported from the repo only. Terminal wrapper material outside the source artifact was not imported as smoke evidence.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-results-import/redaction-and-anomaly-log.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-results-import/redaction-and-anomaly-log.md
@@ -1,0 +1,23 @@
+# Redaction and Anomaly Log
+
+## Source evidence
+
+`docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-retry/source-evidence/ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-RETRY-002.md`
+
+## Redaction status
+
+No private URLs, provider key values, secrets, or credentials were imported. The source artifact records that provider keys were unset before execution and records the endpoint only as localhost / loopback.
+
+## Anomalies and caveats preserved
+
+- Attempt 001 failed before runtime due missing repo-root `PYTHONPATH`; this is a runner/import-path failure, not a local LLM runtime failure.
+- Source repo status sections listed an untracked prior smoke artifact at repo root.
+- Source repo status sections listed untracked manual-artifact folders from prior local attempts.
+
+## Narrow interpretation of caveats
+
+The untracked artifact entries are local artifact hygiene caveats. They are preserved and not hidden. They are not treated as invalidating the successful attempt 002 retry smoke result because the source artifact preserves complete attempt 002 command/script provenance, precheck success, smoke execution, and smoke exit code `0`.
+
+## Exclusions
+
+Terminal wrapper noise is not imported as smoke evidence. No output was reconstructed.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-results-import/runtime-smoke-retry-result-log.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-results-import/runtime-smoke-retry-result-log.md
@@ -1,0 +1,40 @@
+# Runtime Smoke Retry Result Log
+
+## Source evidence
+
+`docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-retry/source-evidence/ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-RETRY-002.md`
+
+## Result log
+
+- `attempt_id`: `002`
+- `retry_reason`: `prior smoke artifact had incomplete exact executable command provenance; attempt 001 failed before runtime due missing repo-root PYTHONPATH`
+- Attempt 001 context: prior failed runner/import-path attempt caused by missing repo-root `PYTHONPATH`; this is not treated as a local LLM runtime failure.
+- Attempt 002 correction: repo root was included in `PYTHONPATH`; the exact executable shell command and exact Python script were preserved.
+- The preserved Python script imports and calls `run_configured_local_llm_runtime(USER_PROMPT, env=os.environ)`.
+- The preserved Python script serializes the returned result to JSON with `json.dumps(record, sort_keys=True, indent=2)`.
+- Precheck command: `PYTHONPATH="<repo-root>" python3 scripts/check_env.py`
+- Precheck exit code: `0`
+- `smoke_ran`: `yes`
+- `smoke_exit_code`: `0`
+- `provider_mode`: `local_llm`
+- `ALPHA_LOCAL_LLM_ENABLED`: `true`
+- Endpoint summary: localhost / loopback HTTP endpoint.
+- `endpoint_pattern_used`: `http://127.0.0.1:11434/api/chat`
+- Model: `gemma3:4b`
+- Timeout: `120` seconds
+- Result status: `non_evidence`
+- Result reason: `local_llm_provider_adapter_wiring_only`
+- Result `output_text`: `OK`
+- Result `behavior_evidence`: `false`
+- Metadata includes `backend_class: ollama-local-http-runtime`, `endpoint_host_label: loopback`, `endpoint_is_loopback: true`, `local_backend: ollama_chat`, `local_model: gemma3:4b`, `no_hosted_fallback: true`, `no_provider_keys_required: true`, `no_real_provider_call: true`, `provider_mode: local_llm`, `real_provider_call_enabled: false`, and `timeout_seconds: 120.0`.
+- Prompt source fingerprint metadata is present: `prompt_source_fingerprint`, `prompt_source_fingerprint_algorithm: sha256`, `prompt_source_path: alpha_solver_portable.py`, and `prompt_source_sha256`.
+- Raw precheck stdout/stderr and raw runtime smoke stdout/stderr are preserved in the source evidence.
+- Local artifact hygiene caveats are preserved: an untracked prior smoke artifact at repo root and untracked manual-artifact folders from prior local attempts were present in the source artifact repo status sections.
+
+## Bounded result statement
+
+The imported retry smoke supports only that the merged optional local LLM runtime path executed one local loopback retry smoke with complete executable command provenance and returned the recorded `non_evidence` result with `output_text: OK` and `behavior_evidence: false`.
+
+## Excluded evidence
+
+Terminal wrapper noise is not imported as smoke evidence. The import does not reconstruct missing fields and does not use material outside the repo-source artifact.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-results-import/source-evidence/sanitized-runtime-smoke-retry-execution-artifact.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-results-import/source-evidence/sanitized-runtime-smoke-retry-execution-artifact.md
@@ -1,0 +1,175 @@
+# ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-RETRY-002
+
+## Source cleanup note
+
+This repo-source artifact preserves the successful second manual local LLM runtime smoke retry attempt from the operator-provided terminal output. Terminal wrapper material outside the artifact preview was excluded.
+
+Attempt 001 is preserved as context in the retry reason: the prior retry attempt failed before runtime execution because the executable script did not include repo-root `PYTHONPATH`, causing `ModuleNotFoundError: No module named 'alpha'`. This attempt added repo root to `PYTHONPATH` and reached the local runtime smoke path.
+
+This file is source evidence for future local LLM runtime smoke retry import, interpretation, final decision, and closeout lanes only. It is local LLM runtime smoke execution retry evidence only. It is not local model quality evidence, hosted provider evidence, `/v1/solve` readiness, dashboard preview readiness, MVP validation, production readiness, benchmark evidence, provider orchestration evidence, Alpha superiority evidence, broad runtime readiness evidence, billing evidence, or evidence-model promotion.
+
+## Execution metadata
+
+- lane_id: `ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-RETRY-001`
+- attempt_id: `002`
+- retry_reason: `prior smoke artifact had incomplete exact executable command provenance; attempt 001 failed before runtime due missing repo-root PYTHONPATH`
+- start_time_utc: `2026-06-05T22:23:52Z`
+- end_time_utc: `2026-06-05T22:24:40Z`
+- repo_path: `<repo-root>`
+- git_head: `4513eead8e640ae152b03219696546a343724067`
+- provider_mode: `local_llm`
+- alpha_local_llm_enabled: `true`
+- endpoint_public_summary: `localhost-or-loopback-http endpoint`
+- endpoint_pattern_used: `http://127.0.0.1:11434/api/chat`
+- model: `gemma3:4b`
+- timeout_seconds: `120`
+- pythonpath_repo_root_set: `yes`
+- provider_keys_unset_before_execution: `OPENAI_API_KEY, ANTHROPIC_API_KEY, GOOGLE_API_KEY, GEMINI_API_KEY, DEEPSEEK_API_KEY`
+
+## Repo status before retry artifacts
+
+```text
+## main...origin/main
+?? ALPHA-LOCAL-LLM-SMOKE-TEST-EXECUTION-001.md
+?? docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-retry/
+?? docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution/manual-artifacts/
+```
+
+## Precondition check
+
+- required_retry_lane_doc: `docs/evals/runs/20260605-alpha-local-llm-runtime-final-decision/selected-next-lane.md`
+- required_retry_lane_present: `yes`
+
+## Precheck result
+
+- command: `PYTHONPATH="<repo-root>" python3 scripts/check_env.py`
+- exit_code: `0`
+
+### Precheck stdout
+
+```text
+Environment looks good. This validates configuration only; no remote provider API calls were made.
+```
+
+### Precheck stderr
+
+```text
+
+```
+
+## Runtime smoke execution
+
+- smoke_ran: `yes`
+- smoke_exit_code: `0`
+
+## Exact executable shell command
+
+This is the exact command form used from the repo root after exporting the local LLM environment variables listed above.
+
+```bash
+PYTHONPATH="<repo-root>" python3 "docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-retry/manual-artifacts-attempt-002/runtime_smoke_retry_executable.py"
+```
+
+## Exact Python script executed
+
+```python
+import json
+import os
+import sys
+
+from alpha.local_llm.provider_adapter import run_configured_local_llm_runtime
+
+USER_PROMPT = "Reply with exactly OK."
+
+result = run_configured_local_llm_runtime(USER_PROMPT, env=os.environ)
+
+record = {
+    "status": result.status,
+    "reason": result.reason,
+    "behavior_evidence": result.behavior_evidence,
+    "output_text": result.output_text,
+    "metadata": dict(result.metadata),
+}
+
+print(json.dumps(record, sort_keys=True, indent=2))
+
+if result.status == "failed_closed":
+    sys.exit(2)
+
+sys.exit(0)
+```
+
+## Runtime smoke stdout
+
+```json
+{
+  "behavior_evidence": false,
+  "metadata": {
+    "backend_class": "ollama-local-http-runtime",
+    "behavior_evidence": false,
+    "endpoint_host_label": "loopback",
+    "endpoint_is_loopback": true,
+    "evidence_label": "non_evidence_local_llm_provider_adapter_wiring",
+    "local_backend": "ollama_chat",
+    "local_model": "gemma3:4b",
+    "model": "gemma3:4b",
+    "no_hosted_fallback": true,
+    "no_provider_keys_required": true,
+    "no_real_provider_call": true,
+    "prompt_source_fingerprint": "98841febea17e2ea4d0155df63537bcb76f948e51395bddc1ce870b349d3c7bb",
+    "prompt_source_fingerprint_algorithm": "sha256",
+    "prompt_source_path": "alpha_solver_portable.py",
+    "prompt_source_sha256": "98841febea17e2ea4d0155df63537bcb76f948e51395bddc1ce870b349d3c7bb",
+    "provider_mode": "local_llm",
+    "real_provider_call_enabled": false,
+    "timeout_seconds": 120.0
+  },
+  "output_text": "OK",
+  "reason": "local_llm_provider_adapter_wiring_only",
+  "status": "non_evidence"
+}
+```
+
+## Runtime smoke stderr
+
+```text
+
+```
+
+## Repo status after retry artifacts
+
+```text
+## main...origin/main
+?? ALPHA-LOCAL-LLM-SMOKE-TEST-EXECUTION-001.md
+?? docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-retry/
+?? docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution/manual-artifacts/
+```
+
+## Artifact preservation notes
+
+- Exact executable shell command is preserved.
+- Exact Python script executed is preserved.
+- Repo root was added to PYTHONPATH before precheck and runtime smoke execution.
+- The script calls `run_configured_local_llm_runtime` with a user prompt.
+- The script serializes the returned result to JSON.
+- Raw precheck stdout and stderr were preserved.
+- Raw runtime smoke stdout and stderr were preserved.
+- Provider keys were unset before execution.
+- Endpoint is recorded only as localhost / loopback.
+- No hosted provider endpoint or provider key is used by this smoke command.
+- If precheck failed, smoke was not executed and the artifact records the stop condition.
+
+## Evidence boundary
+
+This artifact is local LLM runtime smoke execution retry evidence only.
+
+It is not local model quality evidence, hosted provider evidence, `/v1/solve` readiness, dashboard preview readiness, MVP validation, production readiness, benchmark evidence, provider orchestration evidence, Alpha superiority evidence, broad runtime readiness evidence, billing evidence, or evidence-model promotion.
+
+## Non-claims
+
+- No readiness claim is made.
+- No quality claim is made.
+- No benchmark claim is made.
+- No production claim is made.
+- No provider-orchestration claim is made.
+- No Alpha-superiority claim is made.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-track-closeout/README.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-track-closeout/README.md
@@ -1,0 +1,21 @@
+# Local LLM Runtime Smoke Retry Track Closeout
+
+## Lane
+
+`ALPHA-LOCAL-LLM-RUNTIME-SMOKE-RETRY-TRACK-CLOSEOUT-001`
+
+## Source evidence
+
+`docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-retry/source-evidence/ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-RETRY-002.md`
+
+## Terminal next action
+
+`STOP-HERE-LOCAL-LLM-RUNTIME-TRACK-CLOSED`
+
+## Closeout scope
+
+This closeout summarizes the completed local LLM runtime track only. Batch C is already closed separately and is not modified here. No further local LLM runtime lane is recommended unless the operator explicitly reopens the track.
+
+## Evidence boundary
+
+This lane uses only the repo-source retry artifact at `docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-retry/source-evidence/ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-RETRY-002.md`. It is local LLM runtime smoke retry execution evidence only. It is not local model quality evidence, hosted provider evidence, `/v1/solve` readiness, dashboard preview readiness, MVP validation, production readiness, benchmark evidence, provider orchestration evidence, Alpha superiority evidence, broad runtime readiness evidence, billing evidence, or evidence-model promotion.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-track-closeout/blocked-work.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-track-closeout/blocked-work.md
@@ -1,0 +1,20 @@
+# Blocked Work
+
+## Not authorized by closeout
+
+- Future `/v1/solve` exposure.
+- Dashboard exposure.
+- Provider fallback.
+- Evidence-model promotion.
+- Model-quality evaluation.
+- MVP adoption.
+- Hosted provider claims or calls.
+- Benchmarks.
+- Provider orchestration claims.
+- Production changes.
+- Billing claims.
+- Broad runtime readiness claims.
+
+## Reopen rule
+
+No further local LLM runtime lane is recommended unless the operator explicitly reopens the track.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-track-closeout/closeout-summary.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-track-closeout/closeout-summary.md
@@ -1,0 +1,17 @@
+# Closeout Summary
+
+## Source evidence
+
+`docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-retry/source-evidence/ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-RETRY-002.md`
+
+## Summary
+
+The local LLM runtime track is closed based on the successful bounded attempt 002 retry smoke evidence. The evidence shows one local loopback runtime smoke executed with complete executable command provenance, precheck success, smoke exit code `0`, and the recorded `non_evidence` result with `output_text: OK` and `behavior_evidence: false`.
+
+## Track status
+
+`STOP-HERE-LOCAL-LLM-RUNTIME-TRACK-CLOSED`
+
+## Scope notes
+
+Batch C is already closed separately and is not modified here. No further local LLM runtime lane is recommended unless the operator explicitly reopens the track.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-track-closeout/completed-lanes.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-track-closeout/completed-lanes.md
@@ -1,0 +1,12 @@
+# Completed Lanes
+
+## This PR lane bundle
+
+- `ALPHA-LOCAL-LLM-RUNTIME-SMOKE-RETRY-RESULTS-IMPORT-001`
+- `ALPHA-LOCAL-LLM-RUNTIME-SMOKE-RETRY-INTERPRETATION-001`
+- `ALPHA-LOCAL-LLM-RUNTIME-SMOKE-RETRY-FINAL-DECISION-001`
+- `ALPHA-LOCAL-LLM-RUNTIME-SMOKE-RETRY-TRACK-CLOSEOUT-001`
+
+## Closeout note
+
+These lanes close the local LLM runtime track only. Batch C is already closed separately and is not modified by this closeout.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-track-closeout/evidence-ledger.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-track-closeout/evidence-ledger.md
@@ -1,0 +1,39 @@
+# Evidence Ledger
+
+## Primary source
+
+- `docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-retry/source-evidence/ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-RETRY-002.md`
+
+## Imported support folders
+
+- `docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-results-import/`
+- `docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-interpretation/`
+- `docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-final-decision/`
+- `docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-track-closeout/`
+
+## Ledger facts
+
+- `attempt_id`: `002`
+- `retry_reason`: `prior smoke artifact had incomplete exact executable command provenance; attempt 001 failed before runtime due missing repo-root PYTHONPATH`
+- Attempt 001 context: prior failed runner/import-path attempt caused by missing repo-root `PYTHONPATH`; this is not treated as a local LLM runtime failure.
+- Attempt 002 correction: repo root was included in `PYTHONPATH`; the exact executable shell command and exact Python script were preserved.
+- The preserved Python script imports and calls `run_configured_local_llm_runtime(USER_PROMPT, env=os.environ)`.
+- The preserved Python script serializes the returned result to JSON with `json.dumps(record, sort_keys=True, indent=2)`.
+- Precheck command: `PYTHONPATH="<repo-root>" python3 scripts/check_env.py`
+- Precheck exit code: `0`
+- `smoke_ran`: `yes`
+- `smoke_exit_code`: `0`
+- `provider_mode`: `local_llm`
+- `ALPHA_LOCAL_LLM_ENABLED`: `true`
+- Endpoint summary: localhost / loopback HTTP endpoint.
+- `endpoint_pattern_used`: `http://127.0.0.1:11434/api/chat`
+- Model: `gemma3:4b`
+- Timeout: `120` seconds
+- Result status: `non_evidence`
+- Result reason: `local_llm_provider_adapter_wiring_only`
+- Result `output_text`: `OK`
+- Result `behavior_evidence`: `false`
+- Metadata includes `backend_class: ollama-local-http-runtime`, `endpoint_host_label: loopback`, `endpoint_is_loopback: true`, `local_backend: ollama_chat`, `local_model: gemma3:4b`, `no_hosted_fallback: true`, `no_provider_keys_required: true`, `no_real_provider_call: true`, `provider_mode: local_llm`, `real_provider_call_enabled: false`, and `timeout_seconds: 120.0`.
+- Prompt source fingerprint metadata is present: `prompt_source_fingerprint`, `prompt_source_fingerprint_algorithm: sha256`, `prompt_source_path: alpha_solver_portable.py`, and `prompt_source_sha256`.
+- Raw precheck stdout/stderr and raw runtime smoke stdout/stderr are preserved in the source evidence.
+- Local artifact hygiene caveats are preserved: an untracked prior smoke artifact at repo root and untracked manual-artifact folders from prior local attempts were present in the source artifact repo status sections.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-track-closeout/non-claims-and-boundaries.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-track-closeout/non-claims-and-boundaries.md
@@ -1,0 +1,13 @@
+# Non-Claims and Boundaries
+
+## Evidence boundary
+
+This lane uses only the repo-source retry artifact at `docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-retry/source-evidence/ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-RETRY-002.md`. It is local LLM runtime smoke retry execution evidence only. It is not local model quality evidence, hosted provider evidence, `/v1/solve` readiness, dashboard preview readiness, MVP validation, production readiness, benchmark evidence, provider orchestration evidence, Alpha superiority evidence, broad runtime readiness evidence, billing evidence, or evidence-model promotion.
+
+## Non-claims
+
+This closeout makes no local model quality, hosted provider, `/v1/solve` readiness, dashboard preview readiness, MVP validation, production readiness, benchmark, provider orchestration, Alpha superiority, broad runtime readiness, billing, or evidence-model promotion claim.
+
+## Future work boundary
+
+Future `/v1/solve` exposure, dashboard exposure, provider fallback, evidence-model promotion, model-quality evaluation, or MVP adoption would require separate explicit lanes and are not authorized by this closeout.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-track-closeout/residual-caveats.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-track-closeout/residual-caveats.md
@@ -1,0 +1,15 @@
+# Residual Caveats
+
+## Source evidence
+
+`docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-retry/source-evidence/ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-RETRY-002.md`
+
+## Preserved caveats
+
+- Prior attempt 001 failed before runtime due missing repo-root `PYTHONPATH`.
+- The source artifact repo status listed an untracked prior smoke artifact at repo root.
+- The source artifact repo status listed untracked manual-artifact folders from prior local attempts.
+
+## Interpretation
+
+These caveats are preserved narrowly as local artifact hygiene caveats and prior runner/import-path context. They do not invalidate the successful attempt 002 retry smoke result because the attempt 002 source evidence preserves complete executable command and script provenance, precheck success, smoke execution, smoke exit code `0`, and the recorded output.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-track-closeout/selected-next-action.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-track-closeout/selected-next-action.md
@@ -1,0 +1,13 @@
+# Selected Next Action
+
+## Terminal next action
+
+`STOP-HERE-LOCAL-LLM-RUNTIME-TRACK-CLOSED`
+
+## Meaning
+
+The local LLM runtime track is closed. No further local LLM runtime lane is recommended unless the operator explicitly reopens the track.
+
+## Boundary
+
+This selected next action is based only on local LLM runtime smoke retry execution evidence and does not authorize future `/v1/solve` exposure, dashboard exposure, provider fallback, evidence-model promotion, model-quality evaluation, or MVP adoption.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-track-closeout/smoke-retry-result-summary.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-track-closeout/smoke-retry-result-summary.md
@@ -1,0 +1,22 @@
+# Smoke Retry Result Summary
+
+## Source evidence
+
+`docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-retry/source-evidence/ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-RETRY-002.md`
+
+## Summary
+
+- Attempt 001 failed before runtime due missing repo-root `PYTHONPATH`; it is preserved as runner/import-path context, not as a local LLM runtime failure.
+- Attempt 002 corrected repo-root `PYTHONPATH` and preserved exact executable command and Python script provenance.
+- Precheck command `PYTHONPATH="<repo-root>" python3 scripts/check_env.py` exited `0`.
+- Runtime smoke ran: `yes`.
+- Runtime smoke exit code: `0`.
+- Endpoint: localhost / loopback, `http://127.0.0.1:11434/api/chat`.
+- Model: `gemma3:4b`.
+- Timeout: `120` seconds.
+- Result: `status: non_evidence`, `reason: local_llm_provider_adapter_wiring_only`, `output_text: OK`, `behavior_evidence: false`.
+- Hosted provider separation: `no_hosted_fallback: true`, `no_provider_keys_required: true`, `no_real_provider_call: true`, `real_provider_call_enabled: false`.
+
+## Bounded closeout statement
+
+The smoke retry result supports closing the local LLM runtime track only; it does not support broader claims or authorize future exposure/promotion lanes.

--- a/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-track-closeout/track-closeout-checklist.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-track-closeout/track-closeout-checklist.md
@@ -1,0 +1,14 @@
+# Track Closeout Checklist
+
+- [x] Completed local LLM runtime track only is summarized.
+- [x] Retry smoke result facts are preserved without broadening.
+- [x] Batch C is recorded as already closed separately and not modified here.
+- [x] No further local LLM runtime lane is recommended unless the operator explicitly reopens the track.
+- [x] Future `/v1/solve` exposure requires a separate explicit lane.
+- [x] Future dashboard exposure requires a separate explicit lane.
+- [x] Future provider fallback requires a separate explicit lane.
+- [x] Future evidence-model promotion requires a separate explicit lane.
+- [x] Future model-quality evaluation requires a separate explicit lane.
+- [x] Future MVP adoption requires a separate explicit lane.
+- [x] Exactly one terminal next action is recorded: `STOP-HERE-LOCAL-LLM-RUNTIME-TRACK-CLOSED`.
+- [x] Evidence-boundary language remains narrow.


### PR DESCRIPTION
### Motivation

- Import the repo-source local LLM runtime smoke retry artifact and preserve full executable/script provenance and raw stdout/stderr for auditability.
- Interpret the bounded retry outcome (runner fix then successful loopback smoke) without expanding claims about model quality, hosting, or readiness.
- Record a final decision and close the local LLM runtime track when the imported evidence satisfies the closeout rule.

### Description

- Added documentation artifacts (30 files) under `docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-retry-results-import/`, `...-interpretation/`, `...-final-decision/`, and `...-track-closeout/` that import and preserve the source evidence at `docs/evals/runs/20260605-alpha-local-llm-runtime-smoke-execution-retry/source-evidence/ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-RETRY-002.md` exactly.
- Preserved and recorded required facts including `attempt_id: 002`, the retry reason (attempt 001 was a runner/import-path failure due to missing repo-root `PYTHONPATH`), the exact executable shell command, the exact Python script, the script call to `run_configured_local_llm_runtime(USER_PROMPT, env=os.environ)`, JSON serialization with `json.dumps(...)`, precheck `PYTHONPATH="<repo-root>" python3 scripts/check_env.py` with `exit_code: 0`, `smoke_ran: yes`, `smoke_exit_code: 0`, endpoint `http://127.0.0.1:11434/api/chat`, model `gemma3:4b`, timeout `120`, and runtime result `status: non_evidence`, `reason: local_llm_provider_adapter_wiring_only`, `output_text: OK`, `behavior_evidence: false`.
- Recorded the final decision and exactly one terminal next action: `STOP-HERE-LOCAL-LLM-RUNTIME-TRACK-CLOSED`, and added checklists, preservation logs, redaction/anomaly notes, interpretation, and closeout summaries limited to the evidence boundary.

### Testing

- Confirmed source artifact exists and previewed it with `test -f docs/evals/runs/.../ALPHA-LOCAL-LLM-RUNTIME-SMOKE-EXECUTION-RETRY-002.md && sed -n '1,240p' ...` (passed).
- Ran an automated content/coverage verification (`python3` script) that asserts required fields/messages are present in the new docs and that the exact set of required files was created (passed: "documentation retry import/interpretation/decision/closeout checks passed").
- Scanned for private URLs and secrets with a regex check (allowed loopback endpoint only) and confirmed no secrets or private URLs were introduced (passed).
- Performed `git add` and committed the changes on branch `docs-local-llm-runtime-smoke-retry-import-decision-closeout-20260605` (commit `44cc9f9`), and all staged diffs contained only the four allowed doc folders (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2350cf9e088329b77bf0a91f9c0e40)