### PR TITLE
docs(local-llm): specify solver orchestration integration

### DIFF
--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -33,6 +33,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `HIGHER-HEADROOM-EVAL-001.md` | HIGHER-HEADROOM-EVAL-001 · Higher-Headroom Alpha-vs-Plain Prompt Set |
 | `FINOPS-BUDGET-001.md` | FINOPS-BUDGET-001 · Budget Guardrails |
 | `LOCAL-LLM-RUNTIME-INTEGRATION-001.md` | LOCAL-LLM-RUNTIME-INTEGRATION-001 · Local LLM Runtime Integration Implementation Contract |
+| `LOCAL-LLM-SOLVER-ORCHESTRATION-001.md` | LOCAL-LLM-SOLVER-ORCHESTRATION-001 · Local LLM Solver Orchestration Integration Contract |
 | `MCP-001.md` | CODE SPEC — MCP-001 · MCP Registry Loader & Wiring (MCP) |
 | `MCP-002.md` | CODE SPEC — MCP-002 · Router decision rule (MCP) |
 | `MCP-003.md` | CODE SPEC — MCP-003 · MCP OAuth/Secrets scaffold (auth surface) (MCP) |

--- a/.specs/LOCAL-LLM-SOLVER-ORCHESTRATION-001.md
+++ b/.specs/LOCAL-LLM-SOLVER-ORCHESTRATION-001.md
@@ -1,0 +1,173 @@
+# LOCAL-LLM-SOLVER-ORCHESTRATION-001 · Local LLM Solver Orchestration Integration Contract
+
+## Purpose
+
+This spec is the canonical implementation contract for wiring the optional local LLM runtime backend into Alpha Solver orchestration. The supporting lane record lives under `docs/evals/runs/20260605-alpha-local-llm-solver-orchestration-spec/`.
+
+The next goal is not more prompt engineering. The next goal is to connect bounded local LLM runtime output to an Alpha Solver orchestration surface while preserving the local-runtime safety boundary and while keeping production `/v1/solve` and dashboard exposure blocked.
+
+## Source-of-truth context
+
+This contract builds on `.specs/LOCAL-LLM-RUNTIME-INTEGRATION-001.md` and the current local runtime adapter seam in `alpha/local_llm/provider_adapter.py`.
+
+The existing local LLM runtime path is closed and proven only as bounded local runtime smoke evidence. The runtime track ended with terminal next action `STOP-HERE-LOCAL-LLM-RUNTIME-TRACK-CLOSED`. That closeout does not prove model quality, orchestration quality, production readiness, `/v1/solve` readiness, dashboard readiness, MVP validation, benchmark standing, hosted-provider behavior, or evidence-model promotion.
+
+## Safety invariants
+
+Every future implementation under this contract must preserve all of the following local LLM invariants:
+
+1. Local LLM use is optional and default-off.
+2. Explicit operator opt-in is required.
+3. Only localhost or loopback HTTP endpoints are allowed.
+4. No provider keys are required or accepted for local LLM mode.
+5. Every local runtime call uses a finite timeout.
+6. There is no hosted fallback from local LLM failure.
+7. `behavior_evidence=false` is preserved unless a separate approved evidence-model lane changes it.
+8. Hosted output must never be labeled as local LLM output.
+9. Local runtime errors fail closed and do not become successful answers.
+
+## Blocked surfaces
+
+This spec does not authorize any of the following:
+
+- production `/v1/solve` exposure;
+- dashboard exposure;
+- hosted provider fallback;
+- evidence-model promotion;
+- model-quality claims;
+- MVP adoption;
+- production readiness claims;
+- benchmark claims;
+- Alpha superiority claims;
+- provider orchestration claims;
+- billing-path changes.
+
+## First implementation target
+
+The first implementation target is a non-production local orchestration runner, not `/v1/solve`.
+
+The local orchestration runner must be an internal or CLI-callable path that can:
+
+- call the approved local LLM runtime backend;
+- wrap local output in an Alpha-style envelope;
+- preserve local runtime metadata;
+- run bounded expert-style passes;
+- run local confidence, clarify, or block decisions where possible;
+- fail closed on runtime errors;
+- preserve evidence boundaries.
+
+This runner is the selected integration approach. It is not a production route and must not be mounted into `/v1/solve` or dashboard preview by this lane.
+
+## Required local expert two-pass contract
+
+Local expert two-pass is the first quality-lift feature for implementation.
+
+### Pass 1: considerations and gate inputs
+
+Pass 1 asks the local LLM to extract:
+
+- considerations;
+- assumptions;
+- confidence;
+- uncertainty or missing-information notes when available.
+
+### Deterministic parse
+
+The implementation must deterministically parse Pass 1 output:
+
+1. parse JSON when valid JSON is available;
+2. fall back to conservative section parsing only where the section shape is safe and bounded;
+3. fail closed or mark the result as needing clarification or blocking when parsing is unsafe, empty, echoed, or ambiguous.
+
+### Gate
+
+The local runner must choose exactly one gate mode from:
+
+- `direct`;
+- `clarify`;
+- `answer_with_assumptions`;
+- `block`.
+
+The gate must be based on bounded local confidence and missing-information checks. If confidence or parse safety cannot be established, the runner must prefer fail-closed, `clarify`, or `block` over presenting unsupported output as successful behavior.
+
+### Pass 2: answer with context
+
+Pass 2 asks the local LLM to answer using the parsed considerations and assumptions from Pass 1. Pass 2 must preserve the same default-off, localhost-only, no-provider-key, finite-timeout, no-hosted-fallback runtime boundary.
+
+### Normalized output
+
+The local orchestration runner output must be normalized into an Alpha-style result containing at least:
+
+- `answer`;
+- `considerations`;
+- `assumptions`;
+- `confidence`;
+- `mode`;
+- `metadata`;
+- `evidence_boundary`.
+
+The result must preserve local runtime metadata, including provider mode, backend identifier, local model identifier, localhost or loopback confirmation, timeout, deterministic status or reason labels, no-provider-key status, no-hosted-fallback status, and `behavior_evidence=false`.
+
+## Later local ToT-lite contract
+
+Local ToT-lite is a later feature, not the first implementation target.
+
+A later local ToT-lite lane may consider:
+
+- a small branch count;
+- a low token budget;
+- no production exposure;
+- no dashboard exposure;
+- no model-quality claim;
+- no benchmark or superiority claim.
+
+Local ToT-lite remains blocked until a separate approved implementation lane selects it.
+
+## Later deterministic strategy surfaces
+
+`alpha/reasoning/react_lite.py`, `alpha/reasoning/cot.py`, and `alpha/reasoning/cot_self_validate.py` are existing deterministic strategy surfaces that can be considered in later integration. They are not required for the first implementation target and must not broaden this lane into unrelated reasoning refactors.
+
+## Built-code versus approved integration surfaces
+
+Existing code surfaces can contain local runtime seams, deterministic reasoning utilities, provider routes, preview routes, reference entrypoints, or legacy files. The presence of built code is not authorization to expose local LLM output through every available surface.
+
+Approved runtime integration for the first implementation is limited to the non-production local orchestration runner described here and the minimum supporting call path needed to invoke the already-approved local LLM runtime backend. Production `/v1/solve`, dashboard preview, hosted provider fallback, broad routing, MCP, SAFE-OUT, budget guard, determinism, replay, and SolverEnvelope behavior remain unchanged unless a later spec explicitly authorizes changes.
+
+`alpha_solver_v225_p2_experts.py` is not active unless separately approved as non-stub. It must not be treated as an approved non-stub orchestration target merely because it exists or is referenced.
+
+## Implementation boundary
+
+A future implementation lane may change only the narrow files needed to add the non-production runner and focused tests for this contract. It must not change production `/v1/solve`, dashboard routes, hosted provider behavior, provider credential behavior, evidence model semantics, or runtime smoke artifacts unless a separate lane authorizes those changes.
+
+## Required future tests and checks
+
+A future implementation must include focused tests or checks proving:
+
+1. the runner is not exposed through `/v1/solve`;
+2. the runner is not exposed through dashboard preview;
+3. local LLM mode remains default-off;
+4. explicit opt-in is required;
+5. localhost and loopback endpoints are accepted;
+6. non-local endpoints fail closed;
+7. provider keys are not required and hosted fallback does not occur;
+8. finite timeout is enforced;
+9. runtime errors fail closed;
+10. Pass 1 JSON parsing succeeds when valid JSON is returned;
+11. safe section parsing works only for bounded section shapes;
+12. unsafe, empty, echo, or malformed outputs do not become successful answers;
+13. gate mode is one of `direct`, `clarify`, `answer_with_assumptions`, or `block`;
+14. Pass 2 receives bounded considerations and assumptions;
+15. the normalized result includes answer, considerations, assumptions, confidence, mode, metadata, and evidence boundary;
+16. local runtime metadata and `behavior_evidence=false` are preserved.
+
+## Selected next lane
+
+Exactly one next lane is selected:
+
+`ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-IMPLEMENTATION-001`
+
+## Evidence boundary
+
+This spec is a docs-only canonical specification and implementation contract.
+
+It is not implementation, runtime smoke execution, local model quality evidence, hosted provider evidence, `/v1/solve` readiness, dashboard readiness, MVP validation, production readiness, benchmark evidence, provider orchestration evidence, Alpha superiority evidence, evidence-model promotion, runtime-readiness evidence, billing evidence, output reconstruction, or local LLM quality validation.

--- a/docs/evals/runs/20260605-alpha-local-llm-solver-orchestration-spec/README.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-solver-orchestration-spec/README.md
@@ -1,0 +1,31 @@
+# Local LLM Solver Orchestration Spec
+
+## Lane
+
+`ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-SPEC-001`
+
+## Purpose
+
+This docs package supports the canonical spec `.specs/LOCAL-LLM-SOLVER-ORCHESTRATION-001.md`.
+
+The local LLM runtime track is closed with terminal next action `STOP-HERE-LOCAL-LLM-RUNTIME-TRACK-CLOSED`. The closed runtime track provides bounded local runtime smoke evidence only. The next goal is not more prompt engineering; it is wiring local LLM output into a non-production Alpha Solver orchestration runner while preserving safety boundaries.
+
+## Required package files
+
+- `orchestration-objective.md`
+- `current-local-runtime-boundary.md`
+- `target-integration-surface.md`
+- `non-production-runner-contract.md`
+- `expert-two-pass-contract.md`
+- `local-tot-lite-contract.md`
+- `gating-and-confidence-contract.md`
+- `evidence-boundary.md`
+- `implementation-boundary.md`
+- `test-and-smoke-plan.md`
+- `blocked-work.md`
+- `spec-preservation-checklist.md`
+- `selected-next-lane.md`
+
+## Evidence boundary
+
+This package is docs-only specification support. It is not implementation, runtime smoke execution, local model quality evidence, hosted provider evidence, `/v1/solve` readiness, dashboard readiness, MVP validation, production readiness, benchmark evidence, provider orchestration evidence, Alpha superiority evidence, or evidence-model promotion.

--- a/docs/evals/runs/20260605-alpha-local-llm-solver-orchestration-spec/blocked-work.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-solver-orchestration-spec/blocked-work.md
@@ -1,0 +1,19 @@
+# Blocked Work
+
+This lane does not authorize:
+
+- source code changes;
+- test code changes;
+- runtime changes;
+- provider changes;
+- local model calls;
+- hosted provider calls;
+- network calls;
+- `/v1/solve` changes;
+- dashboard changes;
+- Google Sheets updates;
+- smoke execution;
+- output reconstruction;
+- readiness, validation, superiority, benchmark, billing, provider-orchestration, production, runtime-readiness, MVP, `/v1/solve` readiness, dashboard readiness, or local-LLM-quality claims.
+
+Blocked future features include production exposure, dashboard exposure, hosted fallback, evidence-model promotion, local ToT-lite implementation, ReAct-lite integration, CoT self-validation integration, and activation of `alpha_solver_v225_p2_experts.py` as a non-stub target unless separately approved.

--- a/docs/evals/runs/20260605-alpha-local-llm-solver-orchestration-spec/current-local-runtime-boundary.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-solver-orchestration-spec/current-local-runtime-boundary.md
@@ -1,0 +1,21 @@
+# Current Local Runtime Boundary
+
+## Closed local runtime track
+
+The local LLM runtime track is closed with terminal next action:
+
+`STOP-HERE-LOCAL-LLM-RUNTIME-TRACK-CLOSED`
+
+The closed track proves only bounded local runtime smoke evidence. It does not prove local model quality, Alpha behavior quality, production readiness, `/v1/solve` readiness, dashboard readiness, benchmark standing, MVP validation, provider orchestration, or evidence-model promotion.
+
+## Preserved runtime safety
+
+The orchestration lane must preserve the runtime safety contract:
+
+- default-off;
+- explicit operator opt-in;
+- localhost or loopback HTTP endpoint only;
+- no provider keys;
+- finite timeout;
+- no hosted fallback;
+- `behavior_evidence=false` unless a separate approved evidence-model lane changes it.

--- a/docs/evals/runs/20260605-alpha-local-llm-solver-orchestration-spec/evidence-boundary.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-solver-orchestration-spec/evidence-boundary.md
@@ -1,0 +1,24 @@
+# Evidence Boundary
+
+This PR is a docs-only canonical specification and implementation contract.
+
+It is not:
+
+- implementation;
+- runtime smoke execution;
+- local model quality evidence;
+- hosted provider evidence;
+- `/v1/solve` readiness;
+- dashboard readiness;
+- MVP validation;
+- production readiness;
+- benchmark evidence;
+- provider orchestration evidence;
+- Alpha superiority evidence;
+- evidence-model promotion;
+- runtime-readiness evidence;
+- billing evidence;
+- output reconstruction;
+- local LLM quality validation.
+
+The closed local runtime track remains bounded local runtime smoke evidence only. Local orchestration implementation and any later runtime smoke require separate approved lanes.

--- a/docs/evals/runs/20260605-alpha-local-llm-solver-orchestration-spec/expert-two-pass-contract.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-solver-orchestration-spec/expert-two-pass-contract.md
@@ -1,0 +1,39 @@
+# Expert Two-Pass Contract
+
+## First quality-lift feature
+
+Local expert two-pass is the first quality-lift feature selected for implementation.
+
+## Pass 1
+
+Pass 1 asks the local LLM to extract:
+
+- considerations;
+- assumptions;
+- confidence;
+- missing-information or uncertainty notes where available.
+
+## Deterministic parse
+
+The runner must parse Pass 1 deterministically:
+
+1. parse JSON when valid JSON is available;
+2. fall back to conservative section parsing only when the section structure is safe and bounded;
+3. fail closed, clarify, or block when parsing is unsafe, empty, echoed, malformed, or ambiguous.
+
+## Gate
+
+The runner must choose exactly one gate mode:
+
+- `direct`;
+- `clarify`;
+- `answer_with_assumptions`;
+- `block`.
+
+## Pass 2
+
+Pass 2 asks the local LLM to answer using the parsed considerations and assumptions. Pass 2 must preserve default-off, explicit opt-in, localhost-only, no-provider-key, finite-timeout, no-hosted-fallback, and `behavior_evidence=false` behavior.
+
+## Output
+
+The normalized Alpha-style result must include answer, considerations, assumptions, confidence, mode, metadata, and evidence boundary.

--- a/docs/evals/runs/20260605-alpha-local-llm-solver-orchestration-spec/gating-and-confidence-contract.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-solver-orchestration-spec/gating-and-confidence-contract.md
@@ -13,7 +13,9 @@ The local orchestration runner must choose exactly one mode:
 
 Confidence is a local orchestration signal only. It is not model-quality evidence, benchmark evidence, production-readiness evidence, or MVP validation.
 
-If confidence cannot be parsed safely or if missing information is material, the runner must prefer `clarify`, `answer_with_assumptions`, `block`, or fail-closed behavior rather than presenting unsupported local output as a successful answer.
+If Pass 1 confidence cannot be parsed safely, or if Pass 1 output is unsafe, empty, echoed, malformed, or ambiguous, the runner must not choose `direct` or `answer_with_assumptions`. It must fail closed, clarify, or block.
+
+If confidence is parsed safely but material information is missing, the runner may choose `answer_with_assumptions` only when assumptions are explicit, bounded, low-risk, and supported by parsed considerations. Otherwise it must clarify, block, or fail closed.
 
 ## Boundary
 

--- a/docs/evals/runs/20260605-alpha-local-llm-solver-orchestration-spec/gating-and-confidence-contract.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-solver-orchestration-spec/gating-and-confidence-contract.md
@@ -1,0 +1,20 @@
+# Gating and Confidence Contract
+
+## Gate modes
+
+The local orchestration runner must choose exactly one mode:
+
+- `direct`;
+- `clarify`;
+- `answer_with_assumptions`;
+- `block`.
+
+## Confidence handling
+
+Confidence is a local orchestration signal only. It is not model-quality evidence, benchmark evidence, production-readiness evidence, or MVP validation.
+
+If confidence cannot be parsed safely or if missing information is material, the runner must prefer `clarify`, `answer_with_assumptions`, `block`, or fail-closed behavior rather than presenting unsupported local output as a successful answer.
+
+## Boundary
+
+Gating and confidence must not promote `behavior_evidence` to true and must not create `/v1/solve` or dashboard exposure.

--- a/docs/evals/runs/20260605-alpha-local-llm-solver-orchestration-spec/implementation-boundary.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-solver-orchestration-spec/implementation-boundary.md
@@ -1,0 +1,17 @@
+# Implementation Boundary
+
+## Docs-only current lane
+
+This lane creates a canonical spec and supporting docs only. It must not change source code, test code, runtime behavior, provider behavior, `/v1/solve`, dashboard preview, Google Sheets, smoke artifacts, or output evidence.
+
+## Future implementation lane boundary
+
+The future implementation lane may add the non-production runner and focused tests needed for `.specs/LOCAL-LLM-SOLVER-ORCHESTRATION-001.md`.
+
+It must not expose local LLM orchestration through production `/v1/solve` or dashboard preview, must not add hosted fallback, and must not modify evidence-model semantics.
+
+## Built code versus approved surfaces
+
+Existing built code surfaces are not automatically approved runtime integration surfaces. Reference entrypoints, provider routes, preview routes, deterministic reasoning utilities, local runtime seams, and legacy files require explicit approval before being used as local LLM orchestration surfaces.
+
+`alpha_solver_v225_p2_experts.py` is not active unless separately approved as non-stub.

--- a/docs/evals/runs/20260605-alpha-local-llm-solver-orchestration-spec/local-tot-lite-contract.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-solver-orchestration-spec/local-tot-lite-contract.md
@@ -1,0 +1,20 @@
+# Local ToT-Lite Contract
+
+## Later feature
+
+Local ToT-lite is a later feature, not the first implementation target.
+
+## Constraints for any later lane
+
+A later local ToT-lite lane must use:
+
+- a small branch count;
+- a low token budget;
+- no production exposure;
+- no dashboard exposure;
+- no model-quality claim;
+- no benchmark or superiority claim.
+
+## Current status
+
+Local ToT-lite remains blocked until a separate approved implementation lane selects it.

--- a/docs/evals/runs/20260605-alpha-local-llm-solver-orchestration-spec/non-production-runner-contract.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-solver-orchestration-spec/non-production-runner-contract.md
@@ -1,0 +1,22 @@
+# Non-Production Runner Contract
+
+## Contract
+
+The non-production local orchestration runner is an internal or CLI-callable path for exercising local LLM orchestration without production exposure.
+
+## Required behavior
+
+The runner must:
+
+1. require explicit local LLM operator opt-in;
+2. invoke only the localhost or loopback local runtime backend;
+3. require no provider keys;
+4. use finite timeouts;
+5. avoid hosted fallback;
+6. fail closed on runtime, parse, echo, empty-output, or timeout errors;
+7. normalize successful bounded output into an Alpha-style result;
+8. preserve runtime metadata and `behavior_evidence=false`.
+
+## Not authorized
+
+This runner does not authorize production `/v1/solve`, dashboard preview, provider fallback, billing path changes, model-quality claims, or evidence-model promotion.

--- a/docs/evals/runs/20260605-alpha-local-llm-solver-orchestration-spec/orchestration-objective.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-solver-orchestration-spec/orchestration-objective.md
@@ -1,0 +1,13 @@
+# Orchestration Objective
+
+## Objective
+
+Define the canonical implementation contract for moving local LLM output from a prompt-contract local runtime runner into Alpha Solver orchestration.
+
+## Shift in goal
+
+The local runtime track established only a bounded local runtime smoke boundary. The next goal is not additional prompt engineering and not further standalone local runtime proof. The next goal is a non-production orchestration runner that can call the local LLM runtime backend, apply bounded Alpha-style orchestration steps, and return a normalized Alpha-style result without exposing the path to production `/v1/solve` or dashboard preview.
+
+## Selected integration approach
+
+The selected integration approach is a non-production local orchestration runner. The runner may be internal or CLI-callable. It is not a production route, not dashboard functionality, and not an MVP adoption path.

--- a/docs/evals/runs/20260605-alpha-local-llm-solver-orchestration-spec/selected-next-lane.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-solver-orchestration-spec/selected-next-lane.md
@@ -1,0 +1,17 @@
+# Selected Next Lane
+
+Lane ID: `ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-SPEC-001`
+
+## Selection
+
+Exactly one next lane is selected:
+
+`ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-IMPLEMENTATION-001`
+
+## Selected integration approach
+
+The selected integration approach is a non-production local orchestration runner that can call the optional local LLM runtime backend, run bounded local expert-style passes, normalize the result into an Alpha-style envelope, preserve local runtime metadata, and preserve evidence boundaries.
+
+## Non-selections
+
+No other next lane is selected by this package. Production `/v1/solve`, dashboard exposure, provider fallback, evidence-model promotion, local ToT-lite implementation, and model-quality validation remain non-selections.

--- a/docs/evals/runs/20260605-alpha-local-llm-solver-orchestration-spec/spec-preservation-checklist.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-solver-orchestration-spec/spec-preservation-checklist.md
@@ -1,0 +1,19 @@
+# Spec Preservation Checklist
+
+- [x] Canonical spec added at `.specs/LOCAL-LLM-SOLVER-ORCHESTRATION-001.md`.
+- [x] `.specs/INDEX.md` updated with `LOCAL-LLM-SOLVER-ORCHESTRATION-001.md`.
+- [x] Existing local runtime path described as closed and bounded to runtime smoke evidence only.
+- [x] Next goal stated as orchestration wiring, not more prompt engineering.
+- [x] Safety invariants preserved: default-off, opt-in, localhost/loopback only, no provider keys, finite timeout, no hosted fallback, `behavior_evidence=false`.
+- [x] Production `/v1/solve` exposure remains blocked.
+- [x] Dashboard exposure remains blocked.
+- [x] Provider fallback remains blocked.
+- [x] Evidence-model promotion remains blocked.
+- [x] Model-quality, MVP, production, benchmark, and superiority claims remain blocked.
+- [x] First implementation target selected as a non-production local orchestration runner.
+- [x] Expert two-pass selected as the first quality-lift feature.
+- [x] Local ToT-lite recorded as a later feature.
+- [x] ReAct-lite and CoT self-validation recorded as later optional deterministic strategy surfaces.
+- [x] Built code surfaces distinguished from approved runtime integration surfaces.
+- [x] `alpha_solver_v225_p2_experts.py` stated as inactive unless separately approved as non-stub.
+- [x] Exactly one selected next lane recorded.

--- a/docs/evals/runs/20260605-alpha-local-llm-solver-orchestration-spec/target-integration-surface.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-solver-orchestration-spec/target-integration-surface.md
@@ -1,0 +1,21 @@
+# Target Integration Surface
+
+## First target
+
+The first implementation target is a non-production local orchestration runner, not `/v1/solve`.
+
+## Allowed capabilities
+
+The runner can:
+
+- call the local LLM runtime backend;
+- wrap outputs in an Alpha-style envelope;
+- preserve local runtime metadata;
+- run bounded expert-style passes;
+- run local confidence, clarify, or block decisions where possible;
+- fail closed on runtime errors;
+- preserve evidence boundaries.
+
+## Blocked surfaces
+
+The runner must not be exposed through production `/v1/solve` or dashboard preview. Those surfaces require separate approval after this non-production runner contract is implemented and reviewed.

--- a/docs/evals/runs/20260605-alpha-local-llm-solver-orchestration-spec/test-and-smoke-plan.md
+++ b/docs/evals/runs/20260605-alpha-local-llm-solver-orchestration-spec/test-and-smoke-plan.md
@@ -1,0 +1,17 @@
+# Test and Smoke Plan
+
+## Current lane
+
+No runtime smoke is executed in this docs-only lane.
+
+## Required checks for this lane
+
+- confirm `git diff --name-only` includes only the canonical spec, `.specs/INDEX.md`, and this docs package;
+- confirm `.specs/INDEX.md` contains `LOCAL-LLM-SOLVER-ORCHESTRATION-001.md`;
+- confirm exactly one selected next lane is recorded: `ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-IMPLEMENTATION-001`;
+- confirm no source, test, runtime, provider, or dashboard files changed;
+- confirm evidence-boundary language remains narrow.
+
+## Future implementation tests
+
+A future implementation must add focused tests for default-off behavior, explicit opt-in, localhost or loopback endpoint acceptance, non-local endpoint rejection, provider-key independence, finite timeout enforcement, no hosted fallback, fail-closed runtime errors, expert two-pass parsing and gating, normalized output shape, metadata preservation, and `behavior_evidence=false` preservation.


### PR DESCRIPTION
### Motivation

- Create a canonical implementation contract that specifies how an optional local LLM runtime backend should be wired into Alpha Solver orchestration, shifting the next goal from prompt engineering to safe orchestration wiring while preserving the closed local-runtime evidence boundary. 
- Preserve strict safety invariants and evidence boundaries (default-off, explicit opt-in, localhost/loopback-only, no provider keys, finite timeout, no hosted fallback, `behavior_evidence=false`) and explicitly block production `/v1/solve`, dashboard exposure, provider fallback, evidence-model promotion, and model-quality or production claims.

### Description

- Added the canonical spec at `.specs/LOCAL-LLM-SOLVER-ORCHESTRATION-001.md`, registered it in `.specs/INDEX.md`, and added the docs package at `docs/evals/runs/20260605-alpha-local-llm-solver-orchestration-spec/` containing the required support files (`README.md`, `orchestration-objective.md`, `current-local-runtime-boundary.md`, `target-integration-surface.md`, `non-production-runner-contract.md`, `expert-two-pass-contract.md`, `local-tot-lite-contract.md`, `gating-and-confidence-contract.md`, `evidence-boundary.md`, `implementation-boundary.md`, `test-and-smoke-plan.md`, `blocked-work.md`, `spec-preservation-checklist.md`, `selected-next-lane.md`).
- Selected integration approach: a non-production local orchestration runner (internal/CLI-callable) that can call the approved local LLM runtime backend, run bounded expert two-pass passes, normalize output into an Alpha-style envelope, preserve local runtime metadata, fail closed on runtime errors, and preserve evidence boundaries; recorded exactly one next lane: `ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-IMPLEMENTATION-001`.
- This is docs-only work; no source, test, runtime, provider, dashboard, or smoke execution changes were made or authorized by this PR.

### Testing

- Ran repository checks and validations: `git diff --cached --name-only` and a path allowlist check to confirm only `.specs/LOCAL-LLM-SOLVER-ORCHESTRATION-001.md`, `.specs/INDEX.md`, and files under `docs/evals/runs/20260605-alpha-local-llm-solver-orchestration-spec/` changed, and used `rg` to confirm the index entry, the selected next lane, and evidence-boundary language; all checks passed.
- Verified commit on branch `docs-local-llm-solver-orchestration-spec-20260605` with commit `09b50d2` and confirmed `git status --short --branch` shows the new branch; commit recorded successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2383aca5988329a82cc4aeb5839270)