### PR TITLE
fix(local-llm): refine bounded assumption path gating

### DIFF
--- a/alpha/local_llm/orchestration_runner.py
+++ b/alpha/local_llm/orchestration_runner.py
@@ -459,7 +459,7 @@ def _unsafe_output(output_text: str, system_text: str, prompt_text: str) -> bool
 
 def _pass_one_has_forbidden_boundary_claim(gate: _PassOneGate) -> bool:
     return any(
-        _FORBIDDEN_BOUNDARY_TERM_RE.search(text) and not _NEGATED_BOUNDARY_CLAIM_RE.search(text)
+        _has_forbidden_boundary_claim(text)
         for text in (
             *gate.considerations,
             *gate.assumptions,

--- a/alpha/local_llm/orchestration_runner.py
+++ b/alpha/local_llm/orchestration_runner.py
@@ -62,6 +62,7 @@ _HIGH_RISK_FLAG_RE = re.compile(
     r"secret\s+extraction|data\s+(?:exfiltration|theft)|exfiltration|"
     r"malware|phishing|unauthori[sz]ed\s+access|account\s+takeover|"
     r"exploit(?:\s+chain)?|evasion|evade|concealment|conceal|bypass|"
+    r"avoid\s+(?:audit(?:\s+trails?)?|logs?|logging)|"
     r"hide\s+from\s+reviewers?|disable\s+safety|disable\s+monitoring|"
     r"self[-\s]?harm|suicide|weapons?|explosives?"
     r")\b",
@@ -87,6 +88,19 @@ _LOW_RISK_FLAG_ALLOWLIST = frozenset(
         "refactor",
         "planning",
         "unknown",
+    }
+)
+_LOW_RISK_FLAG_TOKEN_ALLOWLIST = frozenset(
+    {
+        "cli",
+        "later",
+        "latency",
+        "local",
+        "optimization",
+        "optimisation",
+        "performance",
+        "profiling",
+        "startup",
     }
 )
 
@@ -445,8 +459,13 @@ def _unsafe_output(output_text: str, system_text: str, prompt_text: str) -> bool
 
 def _pass_one_has_forbidden_boundary_claim(gate: _PassOneGate) -> bool:
     return any(
-        _has_forbidden_boundary_claim(text)
-        for text in (*gate.considerations, *gate.assumptions)
+        _FORBIDDEN_BOUNDARY_TERM_RE.search(text) and not _NEGATED_BOUNDARY_CLAIM_RE.search(text)
+        for text in (
+            *gate.considerations,
+            *gate.assumptions,
+            *gate.missing_information,
+            *gate.risk_flags,
+        )
     )
 
 
@@ -649,11 +668,20 @@ def _high_risk(gate: _PassOneGate, user_prompt: str) -> bool:
         return True
     for flag in gate.risk_flags:
         normalized = _normalize_risk_flag(flag)
-        if _HIGH_RISK_FLAG_RE.search(normalized):
-            return True
-        if normalized not in _LOW_RISK_FLAG_ALLOWLIST:
+        if not _low_risk_flag_allowed(normalized):
             return True
     return False
+
+
+def _low_risk_flag_allowed(normalized: str) -> bool:
+    if _HIGH_RISK_FLAG_RE.search(normalized):
+        return False
+    if normalized in _LOW_RISK_FLAG_ALLOWLIST:
+        return True
+    tokens = tuple(re.findall(r"[a-z0-9]+", normalized))
+    if not tokens:
+        return True
+    return all(token in _LOW_RISK_FLAG_TOKEN_ALLOWLIST for token in tokens)
 
 
 def _normalize_risk_flag(flag: str) -> str:

--- a/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-boundary-guard-assumption-path-fix/README.md
+++ b/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-boundary-guard-assumption-path-fix/README.md
@@ -1,0 +1,25 @@
+# Boundary Guard and Assumption Path Fix
+
+## Lane
+
+`ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-BOUNDARY-GUARD-AND-ASSUMPTION-PATH-FIX-001`
+
+## Scope
+
+This package records a narrow implementation fix and fake-transport test coverage for local LLM solver orchestration bounded assumption-path gating.
+
+## Source decision
+
+PR #341 recorded final decision `MANUAL_LOCAL_ORCHESTRATION_SMOKE_RETRY_002_FAIL_REQUIRES_FIX` and selected this lane.
+
+## Package files
+
+- `failure-source-summary.md`
+- `implementation-summary.md`
+- `assumption-path-gating-summary.md`
+- `boundary-guard-preservation.md`
+- `risk-flag-classification-summary.md`
+- `test-summary.md`
+- `evidence-boundary.md`
+- `blocked-work.md`
+- `selected-next-lane.md`

--- a/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-boundary-guard-assumption-path-fix/assumption-path-gating-summary.md
+++ b/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-boundary-guard-assumption-path-fix/assumption-path-gating-summary.md
@@ -1,0 +1,13 @@
+# Assumption Path Gating Summary
+
+A pass-one `block` or `answer_with_assumptions` result may proceed to pass two only when the existing bounded assumption gate is satisfied:
+
+- confidence parses to a number and meets the configured threshold;
+- considerations are present;
+- assumptions are present;
+- missing information is absent or bounded;
+- considerations, assumptions, and missing information do not contain high-risk text or forbidden boundary terms;
+- assumptions are not empty placeholders such as `none`, `n/a`, or `unknown`;
+- risk flags are exact low-risk labels or benign composites made only from the narrow allowed low-risk tokens.
+
+The Prompt 3-shaped fake-transport test covers the bounded local Python CLI startup-time planning prompt and verifies `status=ok`, `mode=answer_with_assumptions`, `pass_count=2`, and matching `answer` / `final_answer` fields.

--- a/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-boundary-guard-assumption-path-fix/blocked-work.md
+++ b/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-boundary-guard-assumption-path-fix/blocked-work.md
@@ -1,0 +1,17 @@
+# Blocked Work
+
+The following work remains outside this lane:
+
+- manual smoke execution;
+- local runtime smoke rerun;
+- source artifact import;
+- Google Sheets update;
+- local model quality assessment;
+- hosted provider evidence collection;
+- `/v1/solve` exposure;
+- dashboard exposure;
+- provider fallback;
+- hosted provider behavior changes;
+- evidence-model semantics changes;
+- broad runtime readiness work;
+- billing work.

--- a/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-boundary-guard-assumption-path-fix/boundary-guard-preservation.md
+++ b/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-boundary-guard-assumption-path-fix/boundary-guard-preservation.md
@@ -11,3 +11,7 @@ Preserved checks:
 - safe negative boundary disclaimers in pass two remain allowed by the existing sentence-scoped check.
 
 The tests cover forbidden pass-one terms across considerations, assumptions, missing information, and risk flags, and cover pass-two forbidden claim suppression.
+
+## PR #342 correction
+
+Pass-one boundary screening is sentence scoped by reusing the same forbidden-claim helper as pass two. A negated disclaimer sentence can remain allowed, but a separate forbidden positive sentence in the same pass-one field still fails closed before pass two.

--- a/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-boundary-guard-assumption-path-fix/boundary-guard-preservation.md
+++ b/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-boundary-guard-assumption-path-fix/boundary-guard-preservation.md
@@ -1,0 +1,13 @@
+# Boundary Guard Preservation
+
+Boundary handling remains fail-closed for untrusted model fields.
+
+Preserved checks:
+
+- pass-one forbidden boundary terms fail closed before normal answer exposure;
+- pass-two forbidden positive boundary claims fail closed before normal answer exposure;
+- prompt echo and system echo remain unsafe output;
+- blocked high-risk paths suppress model-produced answer, final answer, considerations, and assumptions;
+- safe negative boundary disclaimers in pass two remain allowed by the existing sentence-scoped check.
+
+The tests cover forbidden pass-one terms across considerations, assumptions, missing information, and risk flags, and cover pass-two forbidden claim suppression.

--- a/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-boundary-guard-assumption-path-fix/evidence-boundary.md
+++ b/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-boundary-guard-assumption-path-fix/evidence-boundary.md
@@ -1,0 +1,22 @@
+# Evidence Boundary
+
+This PR is a narrow implementation fix plus focused fake-transport tests for bounded assumption-path gating and boundary guard preservation.
+
+It is not:
+
+- manual smoke execution;
+- runtime smoke evidence;
+- local model quality evidence;
+- hosted provider evidence;
+- `/v1/solve` readiness;
+- dashboard readiness;
+- MVP validation;
+- production readiness;
+- benchmark evidence;
+- provider orchestration evidence;
+- Alpha superiority evidence;
+- evidence-model promotion;
+- broad runtime readiness evidence;
+- billing evidence.
+
+`behavior_evidence=false`, `no_hosted_fallback=true`, and `no_provider_keys_required=true` remain preserved.

--- a/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-boundary-guard-assumption-path-fix/failure-source-summary.md
+++ b/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-boundary-guard-assumption-path-fix/failure-source-summary.md
@@ -1,0 +1,13 @@
+# Failure Source Summary
+
+Retry 002 import/final-decision classified the remaining failure as `mode_mismatch_answer_with_assumptions_path`.
+
+Observed prompt outcomes from that lane:
+
+- Prompt 1: direct behavior passed.
+- Prompt 2: clarify behavior passed.
+- Prompt 3: bounded assumption planning prompt returned `mode=block` instead of `mode=answer_with_assumptions`.
+- Prompt 4: high-risk block behavior passed with empty normal output fields.
+- Prompt 5: boundary guard expectation passed for prompt/system echo and forbidden positive claim categories, with a residual caveat for non-empty considerations and assumptions.
+
+The likely deterministic cause was that benign composite local optimization flags such as startup/performance/optimization were treated as non-allowlisted risk flags.

--- a/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-boundary-guard-assumption-path-fix/implementation-summary.md
+++ b/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-boundary-guard-assumption-path-fix/implementation-summary.md
@@ -1,0 +1,13 @@
+# Implementation Summary
+
+The implementation is limited to `alpha/local_llm/orchestration_runner.py` and focused fake-transport tests.
+
+Changes made:
+
+- Added a narrow deterministic token allowlist for benign composite low-risk flags made only from local performance, startup, profiling, latency, CLI, and optimization terms.
+- Kept exact low-risk single-token and existing low-risk labels intact.
+- Kept serious or unknown risk flags blocked by default.
+- Extended high-risk risk-flag matching to catch audit/log avoidance wording.
+- Applied pass-one boundary-term screening across considerations, assumptions, missing information, and risk flags so unsafe pass-one fields fail closed before normal output exposure.
+
+No runtime surface, provider fallback path, hosted provider path, `/v1/solve` route, or dashboard path was changed.

--- a/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-boundary-guard-assumption-path-fix/risk-flag-classification-summary.md
+++ b/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-boundary-guard-assumption-path-fix/risk-flag-classification-summary.md
@@ -1,0 +1,23 @@
+# Risk Flag Classification Summary
+
+## Allowed only when all other bounded assumption requirements pass
+
+The new composite low-risk allowance is token based and narrow. Examples covered by tests:
+
+- `performance optimization`
+- `startup performance`
+- `startup performance optimization`
+- `latency optimization`
+- `local profiling`
+
+## Still blocked
+
+Composite flags containing serious-risk tokens remain blocked. Examples covered by tests:
+
+- `performance optimization bypass`
+- `startup performance credential theft`
+- `latency optimization exfiltration`
+
+Unknown non-allowlisted flags remain blocked by default. The focused test keeps `ambiguous external automation` blocked without a pass-two call.
+
+Additional serious-risk examples remain covered by existing tests, including credential theft, malware, exfiltration, phishing, unauthorized access, exploit, evasion, concealment, bypass, self-harm, weapons, and explosives.

--- a/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-boundary-guard-assumption-path-fix/selected-next-lane.md
+++ b/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-boundary-guard-assumption-path-fix/selected-next-lane.md
@@ -1,0 +1,5 @@
+# Selected Next Lane
+
+`ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-MANUAL-SMOKE-RETRY-003`
+
+Exactly one selected next lane is recorded in this package.

--- a/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-boundary-guard-assumption-path-fix/test-summary.md
+++ b/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-boundary-guard-assumption-path-fix/test-summary.md
@@ -1,0 +1,15 @@
+# Test Summary
+
+Focused tests were added or updated in `tests/test_local_llm_solver_orchestration_runner.py` using fake or sequenced transports only.
+
+Covered behavior:
+
+- Prompt 3-shaped bounded local Python CLI startup-time planning prompt reaches `answer_with_assumptions`.
+- Benign composite low-risk flags can proceed only when bounded assumption requirements are satisfied.
+- Composite flags with high-risk tokens block without a pass-two call.
+- Unknown non-allowlisted risk flags block without a pass-two call.
+- Prompt 5-style pass-one boundary guard blocks forbidden fields without exposing normal output.
+- High-risk prompt non-exposure remains preserved.
+- Existing local-only and compatibility invariants remain covered.
+
+No local model calls, hosted provider calls, network calls, smoke rerun, source artifact import, or Google Sheets update were performed.

--- a/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-boundary-guard-assumption-path-fix/test-summary.md
+++ b/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-boundary-guard-assumption-path-fix/test-summary.md
@@ -13,3 +13,7 @@ Covered behavior:
 - Existing local-only and compatibility invariants remain covered.
 
 No local model calls, hosted provider calls, network calls, smoke rerun, source artifact import, or Google Sheets update were performed.
+
+## PR #342 correction tests
+
+Additional fake-transport coverage verifies that mixed negated and positive pass-one boundary claims in one field fail closed without exposure, while a negated disclaimer-only field can proceed when the bounded assumption gate is otherwise satisfied.

--- a/tests/test_local_llm_solver_orchestration_runner.py
+++ b/tests/test_local_llm_solver_orchestration_runner.py
@@ -556,7 +556,7 @@ def test_pass_one_forbidden_boundary_claim_fails_closed_without_exposing_fields(
         ("considerations", "This confirms dashboard readiness."),
         ("assumptions", "Assume it is ready for production."),
         ("assumptions", "Assume Alpha is superior."),
-        ("missing_information", "Need proof of local model quality."),
+        ("missing_information", "This proves local model quality."),
         ("risk_flags", "validated billing accuracy"),
         ("risk_flags", "evidence-model promotion validated"),
     ],
@@ -590,6 +590,66 @@ def test_prompt_five_boundary_guard_blocks_forbidden_pass_one_fields_without_exp
     assert result["considerations"] == []
     assert result["assumptions"] == []
     assert len(transport.calls) == 1
+
+
+def test_pass_one_boundary_guard_is_sentence_scoped_for_mixed_negated_and_positive_claim():
+    forbidden_text = "This does not prove production readiness. It validates dashboard readiness."
+    transport = SequencedTransport(
+        _pass_one(
+            mode="answer_with_assumptions",
+            considerations=[forbidden_text],
+            assumptions=["Assume ordinary local-only execution."],
+            confidence=0.8,
+            missing_information=[],
+            risk_flags=["low"],
+        ),
+        "Unexpected pass two answer.",
+    )
+
+    result = run_local_llm_solver_orchestration(
+        "Keep mixed boundary claims out of pass one.",
+        env=_valid_env(),
+        transport=transport,
+    )
+
+    assert result["status"] in {"failed_closed", "blocked"}
+    assert result["mode"] == "block"
+    assert result["pass_count"] == 1
+    _assert_compatible_answer_fields(result, "")
+    assert forbidden_text not in result["answer"]
+    assert forbidden_text not in result["final_answer"]
+    assert result["considerations"] == []
+    assert result["assumptions"] == []
+    assert len(transport.calls) == 1
+
+
+def test_pass_one_boundary_guard_allows_negated_disclaimer_only_on_bounded_path():
+    disclaimer = "This does not prove production readiness."
+    final_answer = "Proceed with a bounded local plan while preserving the stated assumption."
+    transport = SequencedTransport(
+        _pass_one(
+            mode="answer_with_assumptions",
+            considerations=[disclaimer, "The planning scope is local and bounded."],
+            assumptions=["Assume later profiling will guide the implementation choice."],
+            confidence=0.8,
+            missing_information=["Profiler results can be supplied later."],
+            risk_flags=["startup performance optimization"],
+        ),
+        final_answer,
+    )
+
+    result = run_local_llm_solver_orchestration(
+        "Plan local Python CLI startup improvements with assumptions.",
+        env=_valid_env(),
+        transport=transport,
+    )
+
+    assert result["status"] == "ok"
+    assert result["mode"] == "answer_with_assumptions"
+    assert result["pass_count"] == 2
+    assert disclaimer in result["considerations"]
+    _assert_compatible_answer_fields(result, final_answer)
+    assert len(transport.calls) == 2
 
 
 @pytest.mark.parametrize("field", ["behavior_evidence", "no_hosted_fallback", "no_provider_keys_required"])

--- a/tests/test_local_llm_solver_orchestration_runner.py
+++ b/tests/test_local_llm_solver_orchestration_runner.py
@@ -221,6 +221,106 @@ def test_pass_one_block_bounded_assumptions_proceeds_to_pass_two():
     assert len(transport.calls) == 2
 
 
+def test_prompt_three_shaped_bounded_assumptions_with_composite_flag_proceeds_to_pass_two():
+    final_answer = "Profile startup, inspect imports, defer larger changes, and keep assumptions explicit."
+    transport = SequencedTransport(
+        _pass_one(
+            mode="block",
+            considerations=["Startup latency work can be planned before profiling results are available."],
+            assumptions=["Assume the CLI is a small local Python tool with no external service dependency."],
+            confidence=0.76,
+            missing_information=["Exact profiler output can be collected later."],
+            risk_flags=["startup performance optimization"],
+        ),
+        final_answer,
+    )
+
+    result = run_local_llm_solver_orchestration(
+        "Draft a concise execution plan to improve a small Python CLI's startup time "
+        "when only profiling later is available; state assumptions.",
+        env=_valid_env(),
+        transport=transport,
+    )
+
+    assert result["status"] == "ok"
+    assert result["mode"] == "answer_with_assumptions"
+    assert result["pass_count"] == 2
+    _assert_compatible_answer_fields(result, final_answer)
+    assert len(transport.calls) == 2
+
+
+@pytest.mark.parametrize(
+    "risk_flag",
+    [
+        "performance optimization",
+        "startup performance",
+        "startup performance optimization",
+        "latency optimization",
+        "local profiling",
+    ],
+)
+def test_benign_composite_low_risk_flags_can_use_bounded_assumption_path(risk_flag):
+    final_answer = f"Bounded assumption answer for {risk_flag}."
+    transport = SequencedTransport(
+        _pass_one(
+            mode="answer_with_assumptions",
+            considerations=["The planning scope is local, bounded, and limited to performance work."],
+            assumptions=["Assume later measurements will guide the final implementation choice."],
+            confidence=0.75,
+            missing_information=["Profiler results can be supplied later."],
+            risk_flags=[risk_flag],
+        ),
+        final_answer,
+    )
+
+    result = run_local_llm_solver_orchestration(
+        "Plan local Python CLI startup improvements with assumptions.",
+        env=_valid_env(),
+        transport=transport,
+    )
+
+    assert result["status"] == "ok"
+    assert result["mode"] == "answer_with_assumptions"
+    assert result["pass_count"] == 2
+    _assert_compatible_answer_fields(result, final_answer)
+    assert len(transport.calls) == 2
+
+
+@pytest.mark.parametrize(
+    "risk_flag",
+    [
+        "performance optimization bypass",
+        "startup performance credential theft",
+        "latency optimization exfiltration",
+    ],
+)
+def test_composite_risk_flag_with_high_risk_token_blocks_without_pass_two(risk_flag):
+    transport = SequencedTransport(
+        _pass_one(
+            mode="answer_with_assumptions",
+            considerations=["The safe-looking tokens are not enough to override serious risk text."],
+            assumptions=["Assume the local fixture otherwise appears bounded."],
+            confidence=0.8,
+            risk_flags=[risk_flag],
+        ),
+        "Unexpected pass two answer.",
+    )
+
+    result = run_local_llm_solver_orchestration(
+        "Plan local Python CLI startup improvements with assumptions.",
+        env=_valid_env(),
+        transport=transport,
+    )
+
+    assert result["status"] in {"blocked", "failed_closed"}
+    assert result["mode"] == "block"
+    assert result["pass_count"] == 1
+    _assert_compatible_answer_fields(result, "")
+    assert result["considerations"] == []
+    assert result["assumptions"] == []
+    assert len(transport.calls) == 1
+
+
 def test_pass_one_block_missing_information_high_risk_cue_blocks_without_pass_two():
     unsafe_missing_information = "Need approval to bypass monitoring."
     transport = SequencedTransport(
@@ -443,6 +543,52 @@ def test_pass_one_forbidden_boundary_claim_fails_closed_without_exposing_fields(
     assert forbidden_consideration not in result["considerations"]
     assert forbidden_assumption not in result["assumptions"]
     _assert_compatible_answer_fields(result, "")
+    assert len(transport.calls) == 1
+
+
+@pytest.mark.parametrize(
+    ("field", "forbidden_text"),
+    [
+        ("considerations", "This validates production readiness."),
+        ("considerations", "This proves benchmark evidence."),
+        ("considerations", "This confirms provider orchestration evidence."),
+        ("considerations", "This proves /v1/solve readiness."),
+        ("considerations", "This confirms dashboard readiness."),
+        ("assumptions", "Assume it is ready for production."),
+        ("assumptions", "Assume Alpha is superior."),
+        ("missing_information", "Need proof of local model quality."),
+        ("risk_flags", "validated billing accuracy"),
+        ("risk_flags", "evidence-model promotion validated"),
+    ],
+)
+def test_prompt_five_boundary_guard_blocks_forbidden_pass_one_fields_without_exposure(
+    field, forbidden_text
+):
+    pass_one = {
+        "mode": "answer_with_assumptions",
+        "considerations": ["The safe portion is bounded."],
+        "assumptions": ["Assume ordinary local-only execution."],
+        "confidence": 0.8,
+        "missing_information": [],
+        "risk_flags": ["low"],
+    }
+    pass_one[field] = [forbidden_text]
+    transport = SequencedTransport(json.dumps(pass_one), "Unexpected pass two answer.")
+
+    result = run_local_llm_solver_orchestration(
+        "State the boundary safely without echoing readiness claims.",
+        env=_valid_env(),
+        transport=transport,
+    )
+
+    assert result["status"] in {"failed_closed", "blocked"}
+    assert result["mode"] == "block"
+    assert result["pass_count"] == 1
+    _assert_compatible_answer_fields(result, "")
+    assert forbidden_text not in result["answer"]
+    assert forbidden_text not in result["final_answer"]
+    assert result["considerations"] == []
+    assert result["assumptions"] == []
     assert len(transport.calls) == 1
 
 


### PR DESCRIPTION
### Motivation

- Retry 002 found Prompt 3 (bounded local planning with stated assumptions) returned `mode=block` instead of `answer_with_assumptions`, indicating the deterministic gating treated benign composite optimization/profiling flags as non-allowlisted or rejected safe pass-one fields too strictly. 
- The change must allow narrow low-risk, local optimization prompts to proceed when confidence, bounded considerations, bounded assumptions, and benign risk flags are present while preserving all existing safety, boundary-claim, and non-exposure invariants. 

### Description

- Adjusted pass-one risk handling in `alpha/local_llm/orchestration_runner.py` by adding a narrow token-level allowlist `_LOW_RISK_FLAG_TOKEN_ALLOWLIST` and a helper `def _low_risk_flag_allowed(normalized: str) -> bool:` that permits benign composite flags only when all tokens are in the token allowlist and no high-risk token patterns match. 
- Strengthened high-risk matching by extending `_HIGH_RISK_FLAG_RE` to cover audit/log-avoidance wording and updated `_high_risk` to call `_low_risk_flag_allowed` so serious tokens still block while safe composites pass deterministically. 
- Expanded pass-one forbidden-boundary screening (`_pass_one_has_forbidden_boundary_claim`) to inspect `considerations`, `assumptions`, `missing_information`, and `risk_flags` and to apply the forbidden-term/negation logic so unsafe pass-one fields fail closed without exposing model fields. 
- Added focused tests and documentation: updated `tests/test_local_llm_solver_orchestration_runner.py` with (a) Prompt-3-shaped bounded-assumption test, (b) parametrized benign composite low-risk flag tests, (c) composite-with-high-risk-token block tests, and (d) expanded pass-one forbidden-field boundary-guard tests; and added a docs package under `docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-boundary-guard-assumption-path-fix/` recording the failure summary, implementation notes, gating and evidence boundaries, and selected next lane. 

### Testing

- Ran unit tests with `python -m pytest -q tests/test_local_llm_solver_orchestration_runner.py` and the broader local-LLM test set with `python -m pytest -q tests/test_local_llm*.py`, and all tests passed. 
- Ran static checks with `python -m ruff check alpha/local_llm/orchestration_runner.py tests/test_local_llm_solver_orchestration_runner.py` and received no issues. 
- Confirmations performed: `git diff --name-only` shows only `alpha/local_llm/orchestration_runner.py`, `tests/test_local_llm_solver_orchestration_runner.py`, and the new docs under `docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-boundary-guard-assumption-path-fix/`; no `/v1/solve`, dashboard, provider fallback, hosted-provider, smoke execution, or evidence-model semantics changes were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a246a19249c8329a70437b110fe2528)