### PR TITLE
Promote clarify->answer_with_assumptions and extend low-risk allowlist for benign ambiguity (retry-004 fix)

### DIFF
--- a/alpha/local_llm/orchestration_runner.py
+++ b/alpha/local_llm/orchestration_runner.py
@@ -87,6 +87,11 @@ _LOW_RISK_FLAG_ALLOWLIST = frozenset(
         "implementation",
         "refactor",
         "planning",
+        "benign ambiguity",
+        "missing context",
+        "missing information",
+        "unclear target",
+        "low information risk",
     }
 )
 _LOW_RISK_FLAG_TOKEN_ALLOWLIST = frozenset(
@@ -633,7 +638,7 @@ def _apply_gate(gate: _PassOneGate, user_prompt: str) -> _PassOneGate:
         return _replace_gate(gate, mode="block", expose_model_fields=False)
     if _is_underspecified_prompt(user_prompt):
         return _replace_gate(gate, mode="clarify", expose_model_fields=False)
-    if gate.mode == "block" and _assumption_answer_allowed(gate):
+    if gate.mode in {"block", "clarify"} and _assumption_answer_allowed(gate):
         return _replace_gate(gate, mode="answer_with_assumptions")
     if gate.mode == "block":
         return _replace_gate(gate, mode="block", expose_model_fields=False)

--- a/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-004-observed-failure-fix/README.md
+++ b/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-004-observed-failure-fix/README.md
@@ -1,0 +1,14 @@
+# Retry 004 observed failure fix
+
+Lane: `ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-RETRY-004-OBSERVED-FAILURE-FIX-001`
+
+This package records the narrow deterministic local LLM solver orchestration gate fix selected after retry 004 import/final-decision.
+
+Source decision from PR #347: `MANUAL_LOCAL_ORCHESTRATION_SMOKE_RETRY_004_FAIL_REQUIRES_FIX`.
+
+Officially classified retry 004 failures addressed here:
+
+- Prompt 2 expected `clarify` but observed `block`.
+- Prompt 3 expected `answer_with_assumptions` but observed `clarify`.
+
+Evidence boundary: this is a code fix plus focused fake-transport tests only. It is not manual smoke execution, runtime smoke evidence, model-quality evidence, hosted provider evidence, `/v1/solve` readiness, dashboard readiness, MVP validation, production readiness, benchmark evidence, provider orchestration evidence, Alpha superiority evidence, evidence-model promotion, broad runtime readiness evidence, or billing evidence.

--- a/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-004-observed-failure-fix/blocked-work.md
+++ b/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-004-observed-failure-fix/blocked-work.md
@@ -1,0 +1,13 @@
+# Blocked work
+
+The following work remains out of scope and blocked for this lane:
+
+- manual smoke rerun;
+- runtime smoke evidence collection;
+- source artifact import;
+- Google Sheets updates;
+- local model quality claims;
+- hosted provider evidence or fallback;
+- `/v1/solve` exposure;
+- dashboard exposure;
+- production, MVP, benchmark, superiority, provider-orchestration, billing, or evidence-model-promotion claims.

--- a/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-004-observed-failure-fix/boundary-guard-preservation.md
+++ b/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-004-observed-failure-fix/boundary-guard-preservation.md
@@ -1,0 +1,5 @@
+# Boundary guard preservation
+
+Pass-one forbidden boundary claims still fail closed before pass two. Pass-two forbidden boundary claims still fail closed before normal answer exposure.
+
+Focused tests confirm that forbidden readiness, validation, evidence, dashboard, and `/v1/solve` claims are not exposed through `answer`, `final_answer`, `considerations`, or `assumptions` on blocked or failed-closed paths.

--- a/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-004-observed-failure-fix/evidence-boundary.md
+++ b/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-004-observed-failure-fix/evidence-boundary.md
@@ -1,0 +1,7 @@
+# Evidence boundary
+
+This PR is a narrow implementation fix plus focused fake-transport tests for retry 004 observed failures.
+
+It is not manual smoke execution, runtime smoke evidence, local model quality evidence, hosted provider evidence, `/v1/solve` readiness, dashboard readiness, MVP validation, production readiness, benchmark evidence, provider orchestration evidence, Alpha superiority evidence, evidence-model promotion, broad runtime readiness evidence, or billing evidence.
+
+`behavior_evidence=false`, `no_hosted_fallback=true`, and `no_provider_keys_required=true` remain preserved by the runner metadata contract.

--- a/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-004-observed-failure-fix/failure-source-summary.md
+++ b/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-004-observed-failure-fix/failure-source-summary.md
@@ -1,0 +1,11 @@
+# Failure source summary
+
+Retry 004 import/final-decision recorded that Prompt 1, Prompt 4, and the stated Prompt 5 boundary guard expectation passed. It recorded two officially classified failures:
+
+1. Prompt 2: `Make it faster.` expected clarification, but the runner blocked.
+2. Prompt 3: the Python CLI startup planning prompt expected an assumption-bounded answer path, but the runner clarified.
+
+The implementation verified the likely gate causes in `alpha/local_llm/orchestration_runner.py`:
+
+- Underspecified prompt clarification was evaluated after high-risk risk-flag checks, so benign ambiguity classifications needed explicit low-risk handling to avoid default blocking.
+- The assumption answer upgrade applied only to `mode=block`, not to bounded `mode=clarify` pass-one outputs.

--- a/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-004-observed-failure-fix/implementation-summary.md
+++ b/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-004-observed-failure-fix/implementation-summary.md
@@ -1,0 +1,8 @@
+# Implementation summary
+
+The implementation is intentionally narrow:
+
+- Expanded the deterministic low-risk risk-flag allowlist for benign ambiguity and missing-context classifications associated with underspecified optimization requests.
+- Allowed `mode=clarify` to promote to `answer_with_assumptions` only when the existing `_assumption_answer_allowed` predicate passes.
+- Kept promotion after high-risk checks, underspecified prompt handling, and pass-one boundary-claim enforcement.
+- Did not change runtime configuration, provider adapter behavior, hosted provider behavior, `/v1/solve`, dashboard, or evidence semantics.

--- a/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-004-observed-failure-fix/prompt-2-clarify-gating-summary.md
+++ b/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-004-observed-failure-fix/prompt-2-clarify-gating-summary.md
@@ -1,0 +1,7 @@
+# Prompt 2 clarify gating summary
+
+Prompt: `Make it faster.`
+
+The fix preserves the underspecified prompt clarification outcome when pass one classifies the request with bounded low-risk ambiguity or missing-context flags such as `benign ambiguity`, `missing context`, `unclear target`, `optimization`, or `performance`.
+
+Serious risk terms remain blocked before clarification can proceed. The tests cover credential theft, bypass, exploit, exfiltration, and audit-log avoidance flags and confirm no pass-two call occurs and model fields are suppressed.

--- a/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-004-observed-failure-fix/prompt-3-assumption-path-summary.md
+++ b/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-004-observed-failure-fix/prompt-3-assumption-path-summary.md
@@ -1,0 +1,14 @@
+# Prompt 3 assumption path summary
+
+Prompt shape: draft a concise execution plan to improve a small Python CLI's startup time when only profiling later is available, and state assumptions.
+
+The fix lets a pass-one `mode=clarify` result proceed to pass two as `answer_with_assumptions` only when the existing deterministic assumption gate passes:
+
+- confidence is parsed and at or above threshold;
+- considerations and assumptions are non-empty and bounded;
+- missing information is bounded;
+- risk flags are safe and allowlisted;
+- no high-risk text is present;
+- no forbidden boundary claim is present.
+
+Low or unparseable confidence remains a clarify path with no pass-two call.

--- a/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-004-observed-failure-fix/risk-flag-preservation-summary.md
+++ b/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-004-observed-failure-fix/risk-flag-preservation-summary.md
@@ -1,0 +1,13 @@
+# Risk flag preservation summary
+
+The risk-flag change is limited to benign local optimization ambiguity and missing-context labels.
+
+Preserved behavior:
+
+- high-risk prompt text blocks;
+- serious risk flags block;
+- non-allowlisted unknown or ambiguous flags block by default;
+- composite flags containing high-risk tokens block;
+- high-risk blocked outputs suppress unsafe considerations and assumptions.
+
+Narrowing note: the ambiguous exact label `information risk` is not allowlisted. Only explicitly low or benign variants such as `low information risk` may be treated as low risk, and focused tests keep that path on the Prompt 2 clarification outcome with no pass-two call.

--- a/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-004-observed-failure-fix/selected-next-lane.md
+++ b/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-004-observed-failure-fix/selected-next-lane.md
@@ -1,0 +1,5 @@
+# Selected next lane
+
+Exactly one selected next lane is recorded:
+
+`ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-MANUAL-SMOKE-RETRY-005`

--- a/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-004-observed-failure-fix/test-summary.md
+++ b/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-004-observed-failure-fix/test-summary.md
@@ -1,0 +1,12 @@
+# Test summary
+
+Focused fake-transport tests were added or updated in `tests/test_local_llm_solver_orchestration_runner.py` for:
+
+- Prompt 2 benign ambiguity clarification without pass two;
+- Prompt 2 serious risk blocking without pass two or unsafe field exposure;
+- Prompt 3 bounded clarify-to-answer-with-assumptions promotion;
+- Prompt 3 low and unparseable confidence guards;
+- Prompt 3 boundary-claim fail-closed behavior;
+- existing local-only, high-risk, boundary, and pass-two invariants.
+
+No local model calls, hosted provider calls, smoke reruns, source artifact imports, or network-dependent tests were performed.

--- a/tests/test_local_llm_solver_orchestration_runner.py
+++ b/tests/test_local_llm_solver_orchestration_runner.py
@@ -302,6 +302,215 @@ def test_prompt_three_shaped_python_cli_composite_flag_proceeds_to_assumption_an
     assert len(transport.calls) == 2
 
 
+def test_retry_004_prompt_two_block_with_benign_ambiguity_clarifies_without_pass_two():
+    transport = SequencedTransport(
+        _pass_one(
+            mode="block",
+            considerations=["The request is benign but lacks an optimization target."],
+            assumptions=["Assume only ordinary local performance tuning is intended."],
+            confidence=0.8,
+            missing_information=["Which target should be made faster?"],
+            risk_flags=["benign ambiguity", "missing context", "unclear target", "optimization"],
+        ),
+        "Unexpected pass two answer.",
+    )
+
+    result = run_local_llm_solver_orchestration(
+        "Make it faster.", env=_valid_env(), transport=transport
+    )
+
+    assert result["status"] == "clarify"
+    assert result["mode"] == "clarify"
+    assert result["pass_count"] == 1
+    _assert_compatible_answer_fields(result, "Please clarify: Which target should be made faster?")
+    assert result["considerations"] == []
+    assert result["assumptions"] == []
+    assert len(transport.calls) == 1
+
+
+def test_retry_004_prompt_two_low_information_risk_clarifies_without_pass_two():
+    transport = SequencedTransport(
+        _pass_one(
+            mode="block",
+            considerations=["The request has low information risk because the target is missing."],
+            assumptions=["Assume the request is ordinary local performance tuning."],
+            confidence=0.8,
+            missing_information=["Which target should be made faster?"],
+            risk_flags=["low information risk"],
+        ),
+        "Unexpected pass two answer.",
+    )
+
+    result = run_local_llm_solver_orchestration(
+        "Make it faster.", env=_valid_env(), transport=transport
+    )
+
+    assert result["status"] == "clarify"
+    assert result["mode"] == "clarify"
+    assert result["pass_count"] == 1
+    _assert_compatible_answer_fields(result, "Please clarify: Which target should be made faster?")
+    assert result["considerations"] == []
+    assert result["assumptions"] == []
+    assert len(transport.calls) == 1
+
+
+def test_retry_004_prompt_two_information_risk_alone_blocks_without_pass_two_or_exposure():
+    transport = SequencedTransport(
+        _pass_one(
+            mode="block",
+            considerations=["The model returned an ambiguous information risk label."],
+            assumptions=["Assume the ambiguous information risk is safe."],
+            confidence=0.8,
+            missing_information=["Which target should be made faster?"],
+            risk_flags=["information risk"],
+        ),
+        "Unexpected pass two answer.",
+    )
+
+    result = run_local_llm_solver_orchestration(
+        "Make it faster.", env=_valid_env(), transport=transport
+    )
+
+    assert result["status"] in {"blocked", "failed_closed"}
+    assert result["mode"] == "block"
+    assert result["pass_count"] == 1
+    _assert_compatible_answer_fields(result, "")
+    assert result["considerations"] == []
+    assert result["assumptions"] == []
+    assert len(transport.calls) == 1
+
+
+@pytest.mark.parametrize(
+    "risk_flag",
+    [
+        "credential theft",
+        "bypass safeguards",
+        "exploit chain",
+        "data exfiltration",
+        "avoid audit logs",
+    ],
+)
+def test_retry_004_prompt_two_serious_risk_flags_block_without_pass_two_or_exposure(risk_flag):
+    unsafe_consideration = f"The request includes {risk_flag}."
+    unsafe_assumption = "Assume the risky path should proceed."
+    transport = SequencedTransport(
+        _pass_one(
+            mode="block",
+            considerations=[unsafe_consideration],
+            assumptions=[unsafe_assumption],
+            confidence=0.8,
+            missing_information=["Which target should be made faster?"],
+            risk_flags=["optimization", risk_flag],
+        ),
+        "Unexpected pass two answer.",
+    )
+
+    result = run_local_llm_solver_orchestration(
+        "Make it faster.", env=_valid_env(), transport=transport
+    )
+
+    assert result["status"] in {"blocked", "failed_closed"}
+    assert result["mode"] == "block"
+    assert result["pass_count"] == 1
+    _assert_compatible_answer_fields(result, "")
+    assert result["considerations"] == []
+    assert result["assumptions"] == []
+    assert unsafe_consideration not in result["considerations"]
+    assert unsafe_assumption not in result["assumptions"]
+    assert len(transport.calls) == 1
+
+
+def test_retry_004_prompt_three_clarify_with_bounded_assumptions_promotes_to_pass_two():
+    final_answer = "Assume a small CLI, profile startup next, inspect imports, then defer noncritical work."
+    transport = SequencedTransport(
+        _pass_one(
+            mode="clarify",
+            considerations=["Startup planning can be bounded before profiler output exists."],
+            assumptions=["Assume the CLI is a small local Python command with measurable startup time."],
+            confidence=0.8,
+            missing_information=["Exact profiling output can be collected later."],
+            risk_flags=["performance", "profiling", "startup", "python cli"],
+        ),
+        final_answer,
+    )
+
+    result = run_local_llm_solver_orchestration(
+        "Draft a concise execution plan to improve a small Python CLI's startup time "
+        "when only profiling later is available; state assumptions.",
+        env=_valid_env(),
+        transport=transport,
+    )
+
+    assert result["status"] == "ok"
+    assert result["mode"] == "answer_with_assumptions"
+    assert result["pass_count"] == 2
+    _assert_compatible_answer_fields(result, final_answer)
+    assert len(transport.calls) == 2
+
+
+@pytest.mark.parametrize("confidence", [0.54, "not parseable"])
+def test_retry_004_prompt_three_clarify_low_or_unparseable_confidence_does_not_answer(confidence):
+    transport = SequencedTransport(
+        _pass_one(
+            mode="clarify",
+            considerations=["Startup planning can be bounded before profiler output exists."],
+            assumptions=["Assume the CLI is a small local Python command with measurable startup time."],
+            confidence=confidence,
+            missing_information=["Exact profiling output can be collected later."],
+            risk_flags=["performance", "profiling", "startup", "python cli"],
+        ),
+        "Unexpected pass two answer.",
+    )
+
+    result = run_local_llm_solver_orchestration(
+        "Draft a concise execution plan to improve a small Python CLI's startup time "
+        "when only profiling later is available; state assumptions.",
+        env=_valid_env(),
+        transport=transport,
+    )
+
+    assert result["status"] == "clarify"
+    assert result["mode"] == "clarify"
+    assert result["mode"] != "answer_with_assumptions"
+    assert result["pass_count"] == 1
+    assert len(transport.calls) == 1
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["considerations", "assumptions", "missing_information", "risk_flags"],
+)
+def test_retry_004_prompt_three_clarify_boundary_claim_fails_closed_without_exposure(field):
+    forbidden_text = "This validates production readiness and /v1/solve readiness."
+    pass_one = {
+        "mode": "clarify",
+        "considerations": ["Startup planning can be bounded before profiler output exists."],
+        "assumptions": ["Assume the CLI is a small local Python command."],
+        "confidence": 0.8,
+        "missing_information": ["Exact profiling output can be collected later."],
+        "risk_flags": ["performance", "profiling", "startup", "python cli"],
+    }
+    pass_one[field] = [forbidden_text]
+    transport = SequencedTransport(json.dumps(pass_one), "Unexpected pass two answer.")
+
+    result = run_local_llm_solver_orchestration(
+        "Draft a concise execution plan to improve a small Python CLI's startup time "
+        "when only profiling later is available; state assumptions.",
+        env=_valid_env(),
+        transport=transport,
+    )
+
+    assert result["status"] in {"failed_closed", "blocked"}
+    assert result["mode"] == "block"
+    assert result["pass_count"] == 1
+    _assert_compatible_answer_fields(result, "")
+    assert forbidden_text not in result["answer"]
+    assert forbidden_text not in result["final_answer"]
+    assert result["considerations"] == []
+    assert result["assumptions"] == []
+    assert len(transport.calls) == 1
+
+
 @pytest.mark.parametrize(
     "risk_flag",
     [
@@ -454,6 +663,7 @@ def test_serious_risk_flag_blocks_even_when_prompt_text_is_neutral():
     assert result["pass_count"] == 1
     _assert_compatible_answer_fields(result, "")
     assert len(transport.calls) == 1
+
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Motivation

- Fix observed retry-004 failures where benignly ambiguous optimization requests were blocked instead of clarified and where a `clarify` pass could not promote to an `answer_with_assumptions` pass.
- Preserve existing high-risk blocking and boundary-guard behavior while enabling safe, bounded clarification flows for underspecified local optimization prompts.

### Description

- Extended the deterministic low-risk allowlist in `alpha/local_llm/orchestration_runner.py` by adding `"benign ambiguity"`, `"missing context"`, `"missing information"`, `"unclear target"`, and `"low information risk"` so benign ambiguity is treated as low risk.
- Allowed promotion from `mode="clarify"` to `mode="answer_with_assumptions"` by changing the gate promotion check to `if gate.mode in {"block","clarify"} and _assumption_answer_allowed(gate):` in `alpha/local_llm/orchestration_runner.py`.
- Kept all exposure and forbidden-boundary suppression semantics intact by continuing to suppress model fields on blocked/failed-closed paths.
- Added focused documentation under `docs/evals/runs/.../` describing the failure source, implementation summary, evidence boundary, and selected next lane for this narrow fix.

### Testing

- Added and ran focused fake-transport unit tests in `tests/test_local_llm_solver_orchestration_runner.py` covering Prompt 2 clarify/block permutations, Prompt 3 clarify->assumption promotion and confidence guards, boundary-claim fail-closed behavior, and serious-risk blocking invariants.
- The updated test suite for the local orchestration runner (`pytest tests/test_local_llm_solver_orchestration_runner.py`) completed successfully for the added and existing fake-transport tests.
- No network, hosted provider, or runtime smoke tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a248a3768f88329b2fe4f136a1c701e)