### PR TITLE
docs(local-llm): allow safe risk-flag diagnostic in retry 007 packet

### DIFF
--- a/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-manual-smoke-retry-007-operator-packet/diagnostic-inspection-checklist.md
+++ b/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-manual-smoke-retry-007-operator-packet/diagnostic-inspection-checklist.md
@@ -16,6 +16,7 @@ Use this checklist after the exact Mac command finishes and before any later ret
 - Confirm `metadata.gate_trace` includes safe diagnostic metadata such as:
   - `prompt_shape=underspecified_edit_or_performance`; and
   - `apply_gate_decision=shape_clarify` or an equivalent safe clarify-routing enum.
+- Confirm Prompt 2 may include `risk_flag_rejected_reason=vague_risk_advisory_for_shape` as a safe enum diagnostic token when a vague risk advisory is rejected for shape-based clarify routing.
 - Confirm Prompt 2 does not expose raw model considerations, assumptions, missing information, risk flags, answer text, or raw prompt text through `gate_trace`.
 
 ## Prompt 3 assumption routing

--- a/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-manual-smoke-retry-007-operator-packet/exact-mac-command.md
+++ b/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-manual-smoke-retry-007-operator-packet/exact-mac-command.md
@@ -86,6 +86,7 @@ allowed_trace_fields = [
     "blocked_reason_code",
     "blocked_reason_codes",
     "high_risk_reason_code",
+    "risk_flag_rejected_reason",
     "assumption_gate_failed_reason_codes",
 ]
 allowed_result_fields = ["status", "mode", "pass_count"]
@@ -119,6 +120,9 @@ allowed_enum_values = {
         "enum_only_no_raw_text",
         "redacted",
         "safe_enums_only",
+    },
+    "risk_flag_rejected_reason": {
+        "vague_risk_advisory_for_shape",
     },
 }
 


### PR DESCRIPTION
### Motivation
- The retry 007 operator-packet post-run inspection falsely failed because `metadata.gate_trace.risk_flag_rejected_reason` was not included in the allowlist of safe diagnostic fields; this is a docs-only fix-forward to unblock the operator inspection while preserving redaction safety. 
- This change follows up on work from source PRs `#357` and `#358` which addressed prior operator-packet safety issues and keeps the fix scoped to documentation and the generated operator inspection command.

### Description
- Added `risk_flag_rejected_reason` to the `allowed_trace_fields` in the generated operator inspection command in `docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-manual-smoke-retry-007-operator-packet/exact-mac-command.md` and declared the safe enum value `vague_risk_advisory_for_shape` under `allowed_enum_values` for that field. 
- Updated the operator `diagnostic-inspection-checklist.md` to document that Prompt 2 may include `risk_flag_rejected_reason=vague_risk_advisory_for_shape` as a safe diagnostic token while still forbidding raw leakages. 
- Preserved all runtime and safety behaviors: raw `gate_trace` is not printed, forbidden raw fragments remain blocked, and the generated operator command still exits nonzero on JSON parse, artifact-structure, redaction, or inspection failures; the change is docs-only and does not alter runtime code.
- Files changed: `exact-mac-command.md` and `diagnostic-inspection-checklist.md` under `docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-manual-smoke-retry-007-operator-packet/` and the evidence boundary remains limited to this docs path.

### Testing
- Ran `git diff --name-only` and a static path check confirming only `docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-manual-smoke-retry-007-operator-packet/` files changed, and `git diff --check`; these checks passed. 
- Ran static content checks that verified the generated operator command: it includes `"risk_flag_rejected_reason"`, includes the enum value `"vague_risk_advisory_for_shape"`, still `exits nonzero on inspection failure`, does not print raw `gate_trace`, prints only the `SAFE_DIAGNOSTIC_SUMMARY` JSON, and still blocks forbidden raw fragments; all checks passed. 
- Confirmations: no local smoke run was executed, no local model or hosted provider calls were made, no runtime/test/provider/dashboard/API files were changed, and no `/v1/solve` or evidence-model promotion occurred. 
- Selected next lane: `ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-MANUAL-SMOKE-RETRY-007`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24d52fe2388329ac1e76d88ee62294)