### PR TITLE
docs(local-llm): decide retry 007 prompt 3 expectation

### DIFF
--- a/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-007-prompt-3-spec-expectation-decision/README.md
+++ b/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-007-prompt-3-spec-expectation-decision/README.md
@@ -1,0 +1,41 @@
+# Local LLM solver orchestration retry 007 Prompt 3 spec expectation decision
+
+## Lane
+
+`ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-RETRY-007-PROMPT-3-SPEC-EXPECTATION-DECISION-001`
+
+## Purpose
+
+This packet records the docs/spec decision after the retry 007 diagnostic classification selected `prompt expectation mismatch requiring spec review` for Prompt 3.
+
+The decision is intentionally limited to the Prompt 3 contract. It does not change runtime behavior, test fixtures, provider behavior, smoke artifacts, Google Sheets, backlog workbooks, `/v1/solve`, dashboard exposure, billing, MCP, replay, observability, or unrelated solver behavior.
+
+## Selected decision
+
+Exactly one decision path is selected:
+
+`KEEP_CURRENT_RULE`
+
+`missing_information_too_broad` continues to block `answer_with_assumptions`. Prompt 3 `clarify` is acceptable when that reason code fires.
+
+## Selected next lane
+
+Exactly one selected next lane is recorded:
+
+`ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-RETRY-007-SMOKE-EXPECTATION-UPDATE-001`
+
+## Files in this packet
+
+1. `README.md`
+2. `source-classification-summary.md`
+3. `prompt-3-contract-review.md`
+4. `decision-options-reviewed.md`
+5. `selected-decision.md`
+6. `rationale.md`
+7. `safety-invariant-preservation.md`
+8. `implementation-authorization.md`
+9. `smoke-expectation-impact.md`
+10. `selected-next-lane.md`
+11. `blocked-work.md`
+12. `evidence-boundary.md`
+13. `checks-run.md`

--- a/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-007-prompt-3-spec-expectation-decision/blocked-work.md
+++ b/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-007-prompt-3-spec-expectation-decision/blocked-work.md
@@ -1,0 +1,25 @@
+# Blocked work
+
+The following work remains blocked by this decision packet:
+
+- runtime behavior changes for Prompt 3;
+- broad allowlist expansion;
+- weakening high-risk blocking;
+- weakening boundary fail-closed behavior;
+- exposing unsafe or hidden fields;
+- local model reruns;
+- hosted provider calls;
+- smoke reruns;
+- Google Sheets updates;
+- backlog workbook updates;
+- `/v1/solve` changes;
+- dashboard changes;
+- provider fallback changes;
+- hosted provider behavior changes;
+- billing changes;
+- MCP changes;
+- replay changes;
+- observability changes;
+- unrelated solver behavior changes.
+
+The only unblocked next action is the selected narrow smoke expectation update lane.

--- a/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-007-prompt-3-spec-expectation-decision/checks-run.md
+++ b/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-007-prompt-3-spec-expectation-decision/checks-run.md
@@ -1,0 +1,29 @@
+# Checks run
+
+## Repository inspection commands
+
+- `find .. -name AGENTS.md -print`
+- `git status --short --branch`
+- `git branch --show-current`
+- `sed -n '1,220p' AGENTS.md`
+- `rg -n "missing_information_too_broad|answer_with_assumptions|clarify|bounded|Prompt 3|prompt 3|expectation mismatch|spec review" .specs/LOCAL-LLM-RUNTIME-INTEGRATION-001.md .specs/LOCAL-LLM-SOLVER-ORCHESTRATION-001.md alpha/local_llm/orchestration_runner.py tests/test_local_llm_solver_orchestration_runner.py docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-diagnostic-router-reset docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-manual-smoke-retry-007-import-final-decision docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-007-diagnostic-classification`
+- `rg -n "def _assumption_gate_failed_reason_codes|missing_information_too_broad|bounded_local_python_cli_startup_plan|shape_answer_with_assumptions|blocked_assumption_gate_failed|def _apply_gate" alpha/local_llm/orchestration_runner.py .specs/LOCAL-LLM-SOLVER-ORCHESTRATION-001.md .specs/LOCAL-LLM-RUNTIME-INTEGRATION-001.md tests/test_local_llm_solver_orchestration_runner.py`
+- `sed -n '650,920p' alpha/local_llm/orchestration_runner.py`
+- `sed -n '1230,1620p' tests/test_local_llm_solver_orchestration_runner.py`
+- `rg -n "missing-information|missing information|missing_information|assumption|answer_with_assumptions|clarify|block|fail closed|fail-closed|bounded" .specs/LOCAL-LLM-SOLVER-ORCHESTRATION-001.md .specs/LOCAL-LLM-RUNTIME-INTEGRATION-001.md`
+- `find docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-007-diagnostic-classification -maxdepth 1 -type f -print | sort`
+
+## Scope and decision checks
+
+- `git diff --name-only`
+- `git diff --cached --name-only`
+- `python - <<'PY' ... confirm staged changed files are limited to the required Prompt 3 decision docs path ... PY`
+- `python - <<'PY' ... confirm exactly one decision path and exactly one selected next lane ... PY`
+- `python - <<'PY' ... confirm no forbidden runtime/source/test/provider/dashboard/API files changed in staged changes ... PY`
+- `git diff --cached --check`
+
+## Non-execution confirmations
+
+- No local model command was run.
+- No hosted provider command was run.
+- No smoke command was run.

--- a/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-007-prompt-3-spec-expectation-decision/decision-options-reviewed.md
+++ b/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-007-prompt-3-spec-expectation-decision/decision-options-reviewed.md
@@ -1,0 +1,33 @@
+# Decision options reviewed
+
+## 1. KEEP_CURRENT_RULE
+
+Selected.
+
+`missing_information_too_broad` continues to block `answer_with_assumptions`. Prompt 3 `clarify` is acceptable when that reason code fires.
+
+This option preserves the current code, current focused tests, and the current spec preference for bounded missing-information checks and safer `clarify` or `block` outcomes when support for an assumptions answer is too broad.
+
+## 2. AMEND_CONTRACT_NARROWLY
+
+Not selected.
+
+This option would allow Prompt 3 to answer with assumptions despite more than two missing-information items only when every missing item is bounded, non-risk, non-boundary, operationally acceptable, and does not require hidden or raw field exposure.
+
+That rule could be designed in a future lane, but the current evidence does not require it. Selecting it now would authorize a new distinction inside `missing_information_too_broad` without a stronger spec basis or focused fixture update.
+
+## 3. REDEFINE_SMOKE_EXPECTATION
+
+Not selected as the decision path.
+
+The practical impact of the selected rule is that a later smoke expectation update is appropriate, but the contract decision itself is to keep the current missing-information breadth rule. This packet therefore selects `KEEP_CURRENT_RULE` and sends the next lane to the smoke expectation update surface.
+
+## 4. STOP_CURRENT_TRACK
+
+Not selected.
+
+The evidence supports closing the Prompt 3 expectation mismatch without stopping all current local LLM solver orchestration work. The mismatch can be handled by preserving the current rule and updating the expectation path, while all safety boundaries remain intact.
+
+## Exactly one selected path
+
+Exactly one selected decision path is recorded in this packet: `KEEP_CURRENT_RULE`.

--- a/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-007-prompt-3-spec-expectation-decision/evidence-boundary.md
+++ b/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-007-prompt-3-spec-expectation-decision/evidence-boundary.md
@@ -1,0 +1,20 @@
+# Evidence boundary
+
+This packet is a docs-only Prompt 3 contract decision.
+
+It records review of existing specs, code, tests, and prior diagnostic artifacts. It does not create runtime evidence, smoke evidence, provider evidence, model-quality evidence, production evidence, benchmark evidence, billing evidence, or evidence-model evidence.
+
+## Boundary statements
+
+- No local model call was made.
+- No hosted provider call was made.
+- No smoke rerun occurred.
+- No Google Sheets update was made.
+- No backlog workbook was modified.
+- No runtime/source/test/provider/dashboard/API file was changed.
+- Exactly one decision path is selected.
+- Exactly one selected next lane is recorded.
+
+## Claims not made
+
+This packet does not claim final readiness, validation, model quality, benchmark evidence, production readiness, MVP readiness, provider orchestration evidence, Alpha superiority, `/v1/solve` readiness, dashboard readiness, billing evidence, broad runtime readiness, or evidence-model promotion.

--- a/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-007-prompt-3-spec-expectation-decision/implementation-authorization.md
+++ b/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-007-prompt-3-spec-expectation-decision/implementation-authorization.md
@@ -1,0 +1,28 @@
+# Implementation authorization
+
+## Runtime implementation authorization
+
+No runtime implementation change is authorized now.
+
+This packet does not authorize any change to:
+
+- `alpha/local_llm/orchestration_runner.py`;
+- local model calls;
+- hosted provider calls;
+- provider fallback;
+- `/v1/solve`;
+- dashboard exposure;
+- API behavior;
+- billing;
+- MCP;
+- replay;
+- observability;
+- broad solver behavior.
+
+## Later implementation authorization
+
+No later runtime behavior-fix lane is selected by this packet.
+
+The selected next lane is a smoke expectation update lane. Its allowed surface should be limited to the smoke expectation documentation or fixture surface needed to accept `clarify` when `missing_information_too_broad` is present for Prompt 3.
+
+If a future owner wants to amend the contract narrowly, that must be a separate spec lane and must define the exact safe bounded-missing-information criteria before any behavior change.

--- a/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-007-prompt-3-spec-expectation-decision/prompt-3-contract-review.md
+++ b/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-007-prompt-3-spec-expectation-decision/prompt-3-contract-review.md
@@ -1,0 +1,30 @@
+# Prompt 3 contract review
+
+## Code reviewed
+
+The current runner applies a shape-specific branch for `bounded_local_python_cli_startup_plan` when Pass 1 selects `block` or `clarify`.
+
+That branch routes to `answer_with_assumptions` only when `_assumption_gate_failed_reason_codes(gate)` returns no reasons. When any assumption-gate reason exists, the branch records `blocked_assumption_gate_failed`, keeps or restores a non-answering mode, suppresses model fields, and does not call Pass 2.
+
+The current assumption gate emits `missing_information_too_broad` when parsed `missing_information` contains more than two items.
+
+## Tests reviewed
+
+The existing focused tests encode both sides of the bounded startup-plan shape:
+
+- a bounded startup-plan prompt may route from a vague-risk `block` or `clarify` Pass 1 result to `answer_with_assumptions` when confidence, considerations, assumptions, and missing information remain inside the assumption gate;
+- the same shape must not answer with assumptions when an assumption-gate failure reason is present, including `missing_information_too_broad`.
+
+## Spec reviewed
+
+The orchestration spec requires the local runner gate to choose exactly one mode from `direct`, `clarify`, `answer_with_assumptions`, or `block`.
+
+The spec also requires the gate to be based on bounded local confidence and missing-information checks, and it instructs the runner to prefer fail-closed, `clarify`, or `block` when confidence or parse safety cannot be established rather than presenting unsupported output as successful behavior.
+
+The runtime spec's fail-closed contract also preserves the broader safety direction: failed or unsafe local output must not be converted into successful behavior, and no hosted fallback is allowed from local LLM mode.
+
+## Prompt 3 decision question
+
+The question for this lane is whether Prompt 3 should still require `answer_with_assumptions` when the deterministic assumption gate has already emitted `missing_information_too_broad`.
+
+The selected answer is no. Once `missing_information_too_broad` fires, Prompt 3 should not require `answer_with_assumptions`; `clarify` is acceptable for that condition.

--- a/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-007-prompt-3-spec-expectation-decision/rationale.md
+++ b/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-007-prompt-3-spec-expectation-decision/rationale.md
@@ -1,0 +1,21 @@
+# Rationale
+
+## Why `KEEP_CURRENT_RULE` is selected
+
+The current implementation already distinguishes a bounded startup-plan prompt that can answer with assumptions from one that cannot. The gate permits `answer_with_assumptions` only when confidence, considerations, assumptions, missing information, risk terms, and boundary terms satisfy the assumption gate.
+
+`missing_information_too_broad` is a deterministic indication that the parsed missing-information set is broader than the current assumption gate permits. Preserving that rule is safer than converting the result into a successful answer because Prompt 3's Pass 1 output asked for more missing context than the current contract treats as bounded enough for an assumptions answer.
+
+The selected rule is also more consistent with the orchestration spec's requirement that the gate use bounded local confidence and missing-information checks. It follows the spec preference for `clarify` or `block` over unsupported successful behavior when the runner cannot establish enough bounded support for an answer.
+
+## Why the alternatives are less consistent now
+
+`AMEND_CONTRACT_NARROWLY` would require a new secondary classification inside broad missing information. That could be useful later, but it is not supported by this lane's source evidence and would risk broadening behavior before the allowed surface is fully specified.
+
+`REDEFINE_SMOKE_EXPECTATION` describes the likely next work, but it is not the contract decision itself. The contract decision is to keep the current rule; a later lane can update the smoke expectation to reflect it.
+
+`STOP_CURRENT_TRACK` is too broad. The evidence identifies a Prompt 3 expectation mismatch, not a reason to stop the entire current local solver orchestration track.
+
+## Safety result
+
+The selected rule preserves the safer non-answering outcome when missing information is too broad, preserves field non-exposure for the failed assumption gate path, and preserves the prohibition on Pass 2 when the assumption gate fails.

--- a/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-007-prompt-3-spec-expectation-decision/safety-invariant-preservation.md
+++ b/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-007-prompt-3-spec-expectation-decision/safety-invariant-preservation.md
@@ -1,0 +1,20 @@
+# Safety invariant preservation
+
+This decision preserves all hard invariants for the Prompt 3 contract.
+
+## Preserved invariants
+
+- High-risk findings continue to block `answer_with_assumptions`.
+- Boundary fail-closed behavior remains unchanged.
+- Failed-closed non-exposure remains unchanged.
+- Diagnostics remain enum-only.
+- No `/v1/solve` exposure is authorized.
+- No dashboard exposure is authorized.
+- No provider fallback is authorized.
+- No hosted provider behavior change is authorized.
+- No local model quality statement is made.
+- No readiness, benchmark, MVP, production, superiority, billing, broad runtime readiness, or evidence-model claim is made.
+
+## Prompt 3-specific preservation
+
+When `missing_information_too_broad` fires for Prompt 3, the acceptable outcome remains `clarify`, with Pass 2 not called and model fields not exposed.

--- a/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-007-prompt-3-spec-expectation-decision/selected-decision.md
+++ b/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-007-prompt-3-spec-expectation-decision/selected-decision.md
@@ -1,0 +1,17 @@
+# Selected decision
+
+## Decision path
+
+`KEEP_CURRENT_RULE`
+
+## Contract statement
+
+`missing_information_too_broad` blocks `answer_with_assumptions` for Prompt 3 and for the bounded local Python CLI startup-plan shape.
+
+When `missing_information_too_broad` is present, Prompt 3 should not still require `answer_with_assumptions`. A `clarify` outcome is acceptable for that condition.
+
+## Implementation status
+
+No runtime implementation change is authorized by this decision packet.
+
+No test expectation change is made in this packet. The selected next lane may update the smoke expectation documentation or fixture surface narrowly to accept `clarify` when `missing_information_too_broad` is present.

--- a/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-007-prompt-3-spec-expectation-decision/selected-next-lane.md
+++ b/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-007-prompt-3-spec-expectation-decision/selected-next-lane.md
@@ -1,0 +1,17 @@
+# Selected next lane
+
+## Decision path
+
+`KEEP_CURRENT_RULE`
+
+## Selected next lane
+
+Exactly one selected next lane is recorded:
+
+`ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-RETRY-007-SMOKE-EXPECTATION-UPDATE-001`
+
+## Rationale for next lane
+
+The current contract is preserved, so no runtime behavior-fix lane is selected. The remaining mismatch is the smoke expectation that required `answer_with_assumptions` even though the gate trace contained `missing_information_too_broad`.
+
+The next lane should update only the narrow smoke expectation documentation or fixture surface needed to accept `clarify` for Prompt 3 when `missing_information_too_broad` is present.

--- a/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-007-prompt-3-spec-expectation-decision/smoke-expectation-impact.md
+++ b/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-007-prompt-3-spec-expectation-decision/smoke-expectation-impact.md
@@ -1,0 +1,15 @@
+# Smoke expectation impact
+
+## Impact
+
+The retry 007 Prompt 3 smoke expectation should no longer require `answer_with_assumptions` when the preserved gate trace contains `missing_information_too_broad`.
+
+For that condition, `clarify` is acceptable because the selected contract keeps the current assumption-gate breadth rule.
+
+## Required follow-up
+
+A later narrow smoke expectation update lane should update the relevant smoke expectation documentation or fixture surface so Prompt 3 accepts `clarify` when `missing_information_too_broad` is present.
+
+## Not changed in this packet
+
+This packet does not rerun smoke, alter smoke results, change tests, call a local model, call a hosted provider, or update Google Sheets.

--- a/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-007-prompt-3-spec-expectation-decision/source-classification-summary.md
+++ b/docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-007-prompt-3-spec-expectation-decision/source-classification-summary.md
@@ -1,0 +1,39 @@
+# Source classification summary
+
+## Source lane reviewed
+
+The source diagnostic classification packet is:
+
+`docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-007-diagnostic-classification/`
+
+## Source primary classification
+
+PR #362 recorded exactly one primary classification:
+
+`prompt expectation mismatch requiring spec review`
+
+The source packet explains that retry 007 Prompt 3 expected `answer_with_assumptions`, but the observed runner result was `clarify` because the deterministic assumption gate emitted `missing_information_too_broad`.
+
+## Source selected next lane
+
+PR #362 selected this lane as the next action:
+
+`ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-RETRY-007-PROMPT-3-SPEC-EXPECTATION-DECISION-001`
+
+## Source Prompt 3 gate trace
+
+The source classification preserved the following Prompt 3 diagnostic values:
+
+- `prompt_shape=bounded_local_python_cli_startup_plan`
+- `pass_one_selected_mode=clarify`
+- `apply_gate_decision=blocked_assumption_gate_failed`
+- `blocked_reason_code=assumption_gate_failed`
+- `blocked_reason_codes=["assumption_gate_failed"]`
+- `assumption_gate_failed_reason_codes=["missing_information_too_broad"]`
+- `risk_flag_rejected_reason=vague_risk_advisory_for_shape`
+- `pass_two_called=false`
+- `expose_model_fields=false`
+
+## Classification consequence for this lane
+
+This lane treats the source classification as a contract/expectation decision problem, not as evidence authorizing an immediate behavior patch.


### PR DESCRIPTION
### Motivation

- Resolve a Prompt 3 expectation mismatch identified by the retry-007 diagnostic classification and record an explicit contract decision for the bounded startup-plan prompt shape. 
- Preserve the runner's current safety-first behavior and evidence boundary while clarifying next steps for smoke expectations rather than changing runtime behavior now.

### Description

- Added a docs-only decision packet (13 files) under `docs/evals/runs/20260606-alpha-local-llm-solver-orchestration-retry-007-prompt-3-spec-expectation-decision/` that records the review, decision, rationale, safety preservation, and next-lane selection. 
- Selected decision path: `KEEP_CURRENT_RULE` — `missing_information_too_broad` continues to block `answer_with_assumptions` for Prompt 3 and `clarify` is acceptable when that reason code fires. 
- Selected next lane: `ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-RETRY-007-SMOKE-EXPECTATION-UPDATE-001` to update smoke expectations/fixtures to match the preserved contract. 
- No runtime, test, source, provider, dashboard, or API code was modified and no implementation change is authorized by this packet.

### Testing

- Ran repository inspection and validation checks including targeted `rg`/`sed` inspections, Python sanity assertions that staged changes are limited to the required docs path and that exactly one decision path and one next lane are recorded, and `git diff --cached --check`; all checks passed. 
- Reviewed relevant focused tests and specs for context (the existing tests already encode the assumption-gate behavior) but did not change or rerun unit smoke tests, and no local or hosted model was invoked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24e32fb79883298421b13dbc32f3fa)