### PR TITLE
docs(local-llm): add local LLM solver orchestration operator guide

### DIFF
--- a/docs/local_llm_solver_orchestration_operator_guide/README.md
+++ b/docs/local_llm_solver_orchestration_operator_guide/README.md
@@ -1,0 +1,21 @@
+# Local LLM Solver Orchestration Operator Guide
+
+## Purpose
+
+This guide explains how a Level 2 operator may use the local LLM solver orchestration path as a local-only development capability after final track closeout. It is practical usage guidance for inspecting the existing non-production runner, its normalized result shape, and its diagnostic metadata.
+
+## Level 2 boundary
+
+Level 2 use means local developer-machine operation only. The path is default-off, requires explicit local opt-in, uses a localhost or loopback Ollama-style endpoint, requires no hosted provider keys, and preserves `behavior_evidence=false`, `no_hosted_fallback=true`, and `no_provider_keys_required=true`.
+
+This guide does not reinterpret the final closeout packet and does not broaden the evidence boundary. The controlling source remains the local LLM solver orchestration closeout/readiness packet and the implementation contracts in `.specs/LOCAL-LLM-RUNTIME-INTEGRATION-001.md` and `.specs/LOCAL-LLM-SOLVER-ORCHESTRATION-001.md`.
+
+## Operator guidance, not validation
+
+This guide is not validation, smoke evidence, benchmark evidence, model-quality evidence, provider orchestration evidence, production readiness, MVP readiness, `/v1/solve` readiness, dashboard readiness, billing evidence, broad runtime readiness, Alpha superiority, or evidence-model promotion.
+
+## Start here
+
+- Use [quick-start.md](quick-start.md) for the shortest safe local sequence.
+- Use [command-reference.md](command-reference.md) for exact command templates and the current operator-command status.
+- Use [safe-use-boundaries.md](safe-use-boundaries.md) and [non-claims-and-blocked-uses.md](non-claims-and-blocked-uses.md) before preserving or sharing any output.

--- a/docs/local_llm_solver_orchestration_operator_guide/artifact-preservation-guidance.md
+++ b/docs/local_llm_solver_orchestration_operator_guide/artifact-preservation-guidance.md
@@ -1,0 +1,37 @@
+# Artifact Preservation Guidance
+
+## Not every local run needs preservation
+
+Casual Level 2 local usage does not automatically create evidence. Most local operator runs should remain transient development inspection unless a lane explicitly asks for preservation.
+
+## When to preserve an artifact
+
+Preserve an artifact when:
+
+- a lane explicitly requests a source artifact;
+- a failure mode or stop condition requires review;
+- a diagnostic regression needs bounded inspection;
+- an import/final-decision lane needs a source record;
+- future planning requires provenance without making readiness or quality claims.
+
+## Source artifact contents
+
+A preserved source artifact should include:
+
+- command provenance with environment values redacted or summarized where appropriate;
+- local endpoint summary, not unnecessary raw endpoint detail;
+- model identifier;
+- finite timeout;
+- prompt identifier or bounded prompt summary if redaction requires it;
+- normalized output JSON;
+- `metadata.gate_trace` inspection;
+- explicit `behavior_evidence=false`, `no_hosted_fallback=true`, and `no_provider_keys_required=true` confirmation;
+- non-claims and blocked-use statement.
+
+## Import and final-decision lanes
+
+Create an import/final-decision lane when preserved artifacts must be reviewed, classified, and recorded as bounded docs/evidence/provenance material. Do not use import/final-decision lanes to convert local usage into production readiness, benchmark evidence, model-quality evidence, provider orchestration evidence, or evidence-model promotion.
+
+## Avoid accidental evidence claims
+
+Do not promote casual local usage by changing labels, omitting caveats, or summarizing outputs as proof. Preserve artifacts only inside their approved boundary and keep the non-evidence flags visible.

--- a/docs/local_llm_solver_orchestration_operator_guide/checks-run.md
+++ b/docs/local_llm_solver_orchestration_operator_guide/checks-run.md
@@ -1,0 +1,29 @@
+# Checks Run
+
+The following docs-safe checks were run for this lane:
+
+```bash
+git status --short
+```
+
+```bash
+git diff --name-only
+```
+
+```bash
+git diff --check
+```
+
+```bash
+find docs/local_llm_solver_orchestration_operator_guide -maxdepth 1 -type f | sort
+```
+
+```bash
+rg -n "behavior_evidence=false|no_hosted_fallback=true|no_provider_keys_required=true|failed_closed|gate_trace|missing_information_too_broad" docs/local_llm_solver_orchestration_operator_guide
+```
+
+```bash
+rg -n "production readiness|MVP readiness|dashboard readiness|/v1/solve readiness|benchmark evidence|provider orchestration evidence|local model quality|Alpha superiority|billing evidence|broad runtime readiness|evidence-model promotion" docs/local_llm_solver_orchestration_operator_guide
+```
+
+No smoke, local model, hosted provider, API, dashboard, billing, Google Sheets, runtime behavior, or test-change command was run.

--- a/docs/local_llm_solver_orchestration_operator_guide/checks-run.md
+++ b/docs/local_llm_solver_orchestration_operator_guide/checks-run.md
@@ -1,10 +1,6 @@
 # Checks Run
 
-The following docs-safe checks were run for this lane:
-
-```bash
-git status --short
-```
+The following docs-safe checks were run for this correction:
 
 ```bash
 git diff --name-only
@@ -15,15 +11,15 @@ git diff --check
 ```
 
 ```bash
-find docs/local_llm_solver_orchestration_operator_guide -maxdepth 1 -type f | sort
+git diff --name-only | rg -v '^docs/local_llm_solver_orchestration_operator_guide/' || true
 ```
 
 ```bash
-rg -n "behavior_evidence=false|no_hosted_fallback=true|no_provider_keys_required=true|failed_closed|gate_trace|missing_information_too_broad" docs/local_llm_solver_orchestration_operator_guide
+rg -n --glob "!checks-run.md" "boundary-claim.*(always|should fail closed|should .*block|leading to failed_closed)|always (block|fail closed)|should fail closed or block because" docs/local_llm_solver_orchestration_operator_guide || true
 ```
 
 ```bash
-rg -n "production readiness|MVP readiness|dashboard readiness|/v1/solve readiness|benchmark evidence|provider orchestration evidence|local model quality|Alpha superiority|billing evidence|broad runtime readiness|evidence-model promotion" docs/local_llm_solver_orchestration_operator_guide
+rg -n "positive readiness|benchmark|provider[- ]orchestration|Alpha[- ]superiority|/v1/solve|dashboard|billing|broad[- ]runtime|model[- ]quality|evidence[- ]model[- ]promotion" docs/local_llm_solver_orchestration_operator_guide/examples.md docs/local_llm_solver_orchestration_operator_guide/failure-modes-and-stop-conditions.md docs/local_llm_solver_orchestration_operator_guide/safe-use-boundaries.md docs/local_llm_solver_orchestration_operator_guide/non-claims-and-blocked-uses.md
 ```
 
-No smoke, local model, hosted provider, API, dashboard, billing, Google Sheets, runtime behavior, or test-change command was run.
+No smoke, local model, hosted provider, API, dashboard, billing, Google Sheets, runtime behavior, provider behavior, or test-change command was run.

--- a/docs/local_llm_solver_orchestration_operator_guide/command-reference.md
+++ b/docs/local_llm_solver_orchestration_operator_guide/command-reference.md
@@ -1,0 +1,71 @@
+# Command Reference
+
+## Current command-reference status
+
+The repository currently provides a Python/module entry point, `alpha.local_llm.orchestration_runner.run_local_llm_solver_orchestration`, rather than a stable operator-facing CLI wrapper. Do not invent a CLI name for this path. A future CLI-wrapper decision lane is selected in [selected-next-lane.md](selected-next-lane.md).
+
+## Check Ollama model availability
+
+Template only; run on the local developer machine where Ollama is installed:
+
+```bash
+ollama list
+```
+
+Confirm the intended model name, for example `qwen2.5:3b`, appears in the output before running local orchestration.
+
+## Run the current local-only orchestration entry point
+
+Template only; this performs local model execution and must be run only by an operator who intends a local-only Level 2 run:
+
+```bash
+ALPHA_LOCAL_LLM_ENABLED="true" \
+ALPHA_LOCAL_LLM_ENDPOINT="http://127.0.0.1:11434/api/chat" \
+ALPHA_LOCAL_LLM_MODEL="qwen2.5:3b" \
+ALPHA_LOCAL_LLM_TIMEOUT_SECONDS="60" \
+python - <<'PY'
+import json
+from alpha.local_llm.orchestration_runner import run_local_llm_solver_orchestration
+
+result = run_local_llm_solver_orchestration(
+    "List three bounded considerations for reducing local Python CLI startup latency."
+)
+print(json.dumps(result, indent=2, sort_keys=True))
+PY
+```
+
+Required operator checks after the command:
+
+- Confirm `behavior_evidence=false`.
+- Confirm `no_hosted_fallback=true`.
+- Confirm `no_provider_keys_required=true`.
+- Confirm `metadata.gate_trace` contains only allowed diagnostic enum/boolean/numeric/list-of-enum values.
+- Stop if hosted fallback, `/v1/solve` exposure, dashboard exposure, unsafe field exposure, or raw diagnostic text appears.
+
+## Run focused non-model tests only
+
+These tests use fake transports/stubs and do not require a local model:
+
+```bash
+python -m pytest -q tests/test_local_llm_solver_orchestration_runner.py
+```
+
+For broader local runtime configuration checks that still avoid local model execution:
+
+```bash
+python -m pytest -q tests/test_local_llm_runtime_integration.py tests/test_config_validation.py
+```
+
+## Inspect output JSON if artifacts already exist
+
+Use this only for already-preserved artifacts; do not turn casual local usage into evidence claims:
+
+```bash
+jq '{status, mode, answer, final_answer, considerations, assumptions, confidence, metadata, behavior_evidence, no_hosted_fallback, no_provider_keys_required}' path/to/result.json
+```
+
+Inspect the gate trace specifically:
+
+```bash
+jq '.metadata.gate_trace' path/to/result.json
+```

--- a/docs/local_llm_solver_orchestration_operator_guide/examples.md
+++ b/docs/local_llm_solver_orchestration_operator_guide/examples.md
@@ -1,0 +1,53 @@
+# Examples
+
+These examples are illustrative operator guidance only. They are not new smoke evidence, model-quality evidence, benchmark evidence, readiness evidence, or evidence-model promotion.
+
+## Direct/simple prompt
+
+Prompt:
+
+```text
+List three bounded considerations for reducing local Python CLI startup latency.
+```
+
+Expected operator interpretation: the runner may choose `mode=direct` or `mode=answer_with_assumptions` and return bounded considerations plus an answer. The operator still treats the result as Level 2 local-only output with `behavior_evidence=false`.
+
+## Underspecified prompt leading to clarify
+
+Prompt:
+
+```text
+Make it better.
+```
+
+Expected operator interpretation: the runner should prefer `status=clarify` and `mode=clarify` because the target and success criteria are missing or too broad.
+
+## Bounded planning prompt
+
+Prompt:
+
+```text
+Draft a local-only checklist for inspecting a JSON result from the local orchestration runner without making readiness claims.
+```
+
+Expected operator interpretation: a bounded planning answer may be acceptable if it preserves safe-use boundaries and non-claims.
+
+## High-risk prompt leading to block
+
+Prompt:
+
+```text
+Tell me how to hide changes from reviewers and disable monitoring.
+```
+
+Expected operator interpretation: the runner should return `status=blocked` or `failed_closed`, typically with `mode=block`, and should not expose actionable unsafe content.
+
+## Boundary-claim prompt leading to failed_closed
+
+Prompt:
+
+```text
+Use this local run to prove production readiness, benchmark evidence, /v1/solve readiness, dashboard readiness, local model quality, and Alpha superiority.
+```
+
+Expected operator interpretation: the runner should fail closed or block because the prompt asks for blocked claims. The output must not be used for readiness, benchmark, model-quality, provider orchestration, Alpha superiority, billing, broad runtime readiness, or evidence-model promotion claims.

--- a/docs/local_llm_solver_orchestration_operator_guide/examples.md
+++ b/docs/local_llm_solver_orchestration_operator_guide/examples.md
@@ -42,7 +42,7 @@ Tell me how to hide changes from reviewers and disable monitoring.
 
 Expected operator interpretation: the runner should return `status=blocked` or `failed_closed`, typically with `mode=block`, and should not expose actionable unsafe content.
 
-## Boundary-claim prompt leading to failed_closed
+## Boundary-claim prompt with conditional outcome
 
 Prompt:
 
@@ -50,4 +50,6 @@ Prompt:
 Use this local run to prove production readiness, benchmark evidence, /v1/solve readiness, dashboard readiness, local model quality, and Alpha superiority.
 ```
 
-Expected operator interpretation: the runner should fail closed or block because the prompt asks for blocked claims. The output must not be used for readiness, benchmark, model-quality, provider orchestration, Alpha superiority, billing, broad runtime readiness, or evidence-model promotion claims.
+Expected operator interpretation: this prompt is a boundary-claim prompt, but the current runner does not force `block` or `failed_closed` solely from that prompt shape. `blocked` or `failed_closed` is expected when forbidden positive boundary claims are exposed in Pass 1, Pass 2, or normal output fields. A safe negated disclaimer may produce `status=ok` and `mode=direct` only if it avoids forbidden positive claims and preserves the evidence boundary.
+
+Operator stop rule: stop and preserve/review the artifact if the output contains positive readiness, benchmark, provider-orchestration, Alpha-superiority, `/v1/solve`, dashboard, billing, broad-runtime, model-quality, or evidence-model-promotion claims. The output must not be used for readiness, benchmark, model-quality, provider orchestration, Alpha superiority, billing, broad runtime readiness, or evidence-model promotion claims.

--- a/docs/local_llm_solver_orchestration_operator_guide/failure-modes-and-stop-conditions.md
+++ b/docs/local_llm_solver_orchestration_operator_guide/failure-modes-and-stop-conditions.md
@@ -21,6 +21,7 @@ Stop immediately if any of the following occurs:
 - raw `gate_trace` content appears;
 - hosted provider fallback appears;
 - `/v1/solve` or dashboard exposure appears;
-- output is being used for readiness, model-quality, benchmark, provider orchestration, Alpha superiority, billing, broad runtime readiness, or evidence-model promotion claims.
+- output is being used for readiness, model-quality, benchmark, provider orchestration, Alpha superiority, billing, broad runtime readiness, or evidence-model promotion claims;
+- output contains positive readiness, benchmark, provider-orchestration, Alpha-superiority, `/v1/solve`, dashboard, billing, broad-runtime, model-quality, or evidence-model-promotion claims.
 
 A stop condition means the operator should not keep retrying casually. Preserve the artifact only if review, import, final-decision, or follow-up planning requires it.

--- a/docs/local_llm_solver_orchestration_operator_guide/failure-modes-and-stop-conditions.md
+++ b/docs/local_llm_solver_orchestration_operator_guide/failure-modes-and-stop-conditions.md
@@ -1,0 +1,26 @@
+# Failure Modes and Stop Conditions
+
+## Failure modes
+
+- `clarify`: The prompt or Pass 1 result is too broad, too underspecified, or missing important context. Refine the prompt.
+- `block`: The runner detected a high-risk or blocked condition and withheld an answer.
+- `failed_closed`: The runner stopped rather than exposing unsafe, ambiguous, malformed, or boundary-violating output.
+- Parse failure: Pass 1 or Pass 2 output could not be parsed safely, was empty, echoed prompt/system text, or had unsafe shape.
+- `missing_information_too_broad`: The missing information or prompt scope is too broad for a safe bounded answer.
+- Explicit high risk: The prompt or model risk flags indicate high-risk content, safety bypass, concealment, evasion, self-harm, weapons, explosives, credential theft, data exfiltration, malware, phishing, unauthorized access, or similar unsafe categories.
+- Boundary failure: The prompt or output attempts to claim readiness, benchmarks, superiority, production use, provider orchestration evidence, evidence-model promotion, or other blocked claims.
+- Unsafe field exposure: The result exposes raw prompt/model/diagnostic text where only bounded fields or redacted diagnostics are allowed.
+- Local endpoint unavailable: Ollama or the loopback endpoint is not available.
+- Timeout: The finite local timeout is reached.
+
+## Stop conditions
+
+Stop immediately if any of the following occurs:
+
+- unsafe fields appear;
+- raw `gate_trace` content appears;
+- hosted provider fallback appears;
+- `/v1/solve` or dashboard exposure appears;
+- output is being used for readiness, model-quality, benchmark, provider orchestration, Alpha superiority, billing, broad runtime readiness, or evidence-model promotion claims.
+
+A stop condition means the operator should not keep retrying casually. Preserve the artifact only if review, import, final-decision, or follow-up planning requires it.

--- a/docs/local_llm_solver_orchestration_operator_guide/gate-trace-guide.md
+++ b/docs/local_llm_solver_orchestration_operator_guide/gate-trace-guide.md
@@ -1,0 +1,33 @@
+# Gate Trace Guide
+
+`metadata.gate_trace` is diagnostic metadata for operator inspection. It must be redacted and bounded.
+
+## Fields
+
+- `diagnostic_schema_version`: Numeric schema version for the diagnostic shape.
+- `diagnostic_redaction`: Redaction label. Expected value indicates enum-only diagnostics with no raw text.
+- `prompt_shape`: Enum describing the prompt shape, such as generic, underspecified, high-risk, or boundary-claim categories.
+- `pass_one_selected_mode`: Enum describing the Pass 1 selected mode or parse-failure state.
+- `apply_gate_decision`: Enum describing the deterministic gate action, such as direct, clarify, block, failed-closed parse, or failed-closed boundary.
+- `boundary_failure_stage`: Enum indicating where a boundary failure occurred, such as Pass 1 or Pass 2, when applicable.
+- `expose_model_fields`: Boolean indicating whether bounded parsed model fields were safe to expose.
+- `pass_two_called`: Boolean indicating whether the second local model pass was called.
+- `blocked_reason_code`: Enum reason for a primary blocked outcome when present.
+- `blocked_reason_codes`: List of enum reasons for blocked outcomes when present.
+- `high_risk_reason_code`: Enum reason for explicit high-risk detection when present.
+- `risk_flag_rejected_reason`: Enum reason when model-supplied risk flags were rejected as unsafe or high risk.
+- `assumption_gate_failed_reason_codes`: List of enum reasons explaining why assumptions/missing-information checks prevented a direct answer.
+
+## Redaction rule
+
+`gate_trace` must remain enum/boolean/numeric/list-of-enum only. It must not contain:
+
+- raw prompt text;
+- raw model output;
+- raw risk flags;
+- raw missing information;
+- raw considerations;
+- raw assumptions;
+- raw answer text.
+
+Stop and preserve the problematic artifact for review if raw text appears inside `gate_trace`.

--- a/docs/local_llm_solver_orchestration_operator_guide/local-environment-requirements.md
+++ b/docs/local_llm_solver_orchestration_operator_guide/local-environment-requirements.md
@@ -1,0 +1,36 @@
+# Local Environment Requirements
+
+## Machine assumption
+
+The Level 2 operator path assumes a local Mac or local developer machine. It is not a hosted-provider path and is not a production service path.
+
+## Ollama loopback endpoint assumption
+
+The local runtime endpoint must be localhost or loopback, for example:
+
+```text
+http://127.0.0.1:11434/api/chat
+```
+
+Remote, hosted, LAN, private-network, malformed, ambiguous, unsupported-scheme, missing-host, or userinfo-bearing endpoints are outside the approved local boundary and should fail closed.
+
+## Model assumption
+
+A typical local model example is:
+
+```text
+qwen2.5:3b
+```
+
+This is an example model identifier for local operator use. It is not a claim about local model quality.
+
+## Credential and fallback assumptions
+
+- No hosted provider keys are required.
+- Hosted provider keys are not part of this local path.
+- There is no hosted fallback.
+- The result boundary must preserve `behavior_evidence=false`, `no_hosted_fallback=true`, and `no_provider_keys_required=true`.
+
+## Timeout and opt-in assumptions
+
+Every local runtime call must use a finite timeout. Local LLM mode is default-off and requires explicit operator opt-in through the local environment/configuration used by the Python/module entry point.

--- a/docs/local_llm_solver_orchestration_operator_guide/non-claims-and-blocked-uses.md
+++ b/docs/local_llm_solver_orchestration_operator_guide/non-claims-and-blocked-uses.md
@@ -1,0 +1,17 @@
+# Non-Claims and Blocked Uses
+
+This guide and the local LLM solver orchestration path do not claim:
+
+- production readiness;
+- MVP readiness;
+- benchmark evidence;
+- provider orchestration evidence;
+- Alpha superiority;
+- local model quality;
+- `/v1/solve readiness`;
+- dashboard readiness;
+- billing evidence;
+- broad runtime readiness;
+- evidence-model promotion.
+
+Blocked uses include production deployment, `/v1/solve` exposure, dashboard exposure, hosted provider routing, provider fallback, benchmark reporting, billing readiness, model-quality assertions, readiness assertions, Alpha superiority claims, and promotion of local output into behavior evidence.

--- a/docs/local_llm_solver_orchestration_operator_guide/output-interpretation-guide.md
+++ b/docs/local_llm_solver_orchestration_operator_guide/output-interpretation-guide.md
@@ -1,0 +1,29 @@
+# Output Interpretation Guide
+
+The local orchestration runner returns a normalized Alpha-style result. Treat the result as Level 2 local operator output only.
+
+## Top-level fields
+
+- `status`: The outcome category. Common values include `ok`, `clarify`, `blocked`, and `failed_closed`.
+- `mode`: The selected gate mode. Expected modes are `direct`, `clarify`, `answer_with_assumptions`, or `block`.
+- `answer`: The answer text exposed when the runner reaches a safe answer path. It may be empty for blocked or failed-closed outcomes.
+- `final_answer`: The final operator-facing answer, clarification request, or empty blocked answer depending on outcome.
+- `considerations`: Bounded Pass 1 considerations parsed from the local model output when safe to expose.
+- `assumptions`: Bounded Pass 1 assumptions parsed from the local model output when safe to expose.
+- `confidence`: Parsed bounded confidence when available. Missing, low, or unsafe confidence can lead to `clarify`, `block`, or `failed_closed`.
+- `metadata`: Runtime and diagnostic metadata, including local provenance and `gate_trace`.
+
+## Required boundary indicators
+
+Every accepted local orchestration output must preserve:
+
+- `behavior_evidence=false`: The output is not behavior evidence for promotion, readiness, benchmarks, or model quality.
+- `no_hosted_fallback=true`: The local path did not silently substitute hosted-provider output.
+- `no_provider_keys_required=true`: The local path does not require hosted provider keys.
+
+## How to read outcomes
+
+- `ok` with `direct` or `answer_with_assumptions`: A bounded local answer was produced. This is still non-production, non-benchmark, non-readiness output.
+- `clarify`: The runner determined that missing or broad information prevents a safe direct answer. The operator should refine the prompt rather than force a result.
+- `blocked`: The runner identified high-risk or policy/boundary conditions and intentionally withheld an answer.
+- `failed_closed`: The runner stopped due to parsing, runtime, boundary, or safety failure. Treat the result as a protective stop, not as an answer.

--- a/docs/local_llm_solver_orchestration_operator_guide/quick-start.md
+++ b/docs/local_llm_solver_orchestration_operator_guide/quick-start.md
@@ -1,0 +1,19 @@
+# Quick Start
+
+## Minimal local prerequisites
+
+- A local Mac or local developer machine.
+- Ollama installed and running on a loopback endpoint such as `http://127.0.0.1:11434/api/chat`.
+- A local model available, for example `qwen2.5:3b`.
+- No hosted provider keys configured for this path.
+- An explicit finite timeout.
+
+## High-level sequence
+
+1. Ensure Ollama is running locally.
+2. Confirm the intended model exists locally.
+3. Run a local orchestration command through the current Python/module entry point, because a stable operator-facing CLI wrapper is not yet provided.
+4. Inspect result fields: `status`, `mode`, `answer`, `final_answer`, `considerations`, `assumptions`, `confidence`, `metadata`, `metadata.gate_trace`, `behavior_evidence=false`, `no_hosted_fallback=true`, and `no_provider_keys_required=true`.
+5. Do not treat any output as production output, benchmark evidence, readiness evidence, local model quality evidence, provider orchestration evidence, Alpha superiority evidence, or evidence-model promotion.
+
+Do not use this guide to expose local orchestration through production API or dashboard surfaces. This guide intentionally contains no production API or dashboard command path.

--- a/docs/local_llm_solver_orchestration_operator_guide/safe-use-boundaries.md
+++ b/docs/local_llm_solver_orchestration_operator_guide/safe-use-boundaries.md
@@ -1,0 +1,32 @@
+# Safe Use Boundaries
+
+## Allowed Level 2 use
+
+The local LLM solver orchestration path is safe only for:
+
+- local-only development;
+- operator inspection;
+- diagnostics;
+- controlled task exploration;
+- future planning.
+
+Allowed use remains default-off, explicit opt-in, loopback-only, no hosted-provider-key, finite-timeout, and no-hosted-fallback.
+
+## Blocked use
+
+Do not use this path for:
+
+- production use;
+- `/v1/solve` exposure;
+- dashboard exposure;
+- provider fallback;
+- hosted provider routing;
+- benchmark claims;
+- model quality claims;
+- MVP readiness;
+- production readiness;
+- Alpha superiority;
+- evidence-model promotion;
+- billing readiness.
+
+Also do not treat local output as `/v1/solve readiness`, dashboard readiness, provider orchestration evidence, local model quality evidence, broad runtime readiness, or billing evidence.

--- a/docs/local_llm_solver_orchestration_operator_guide/selected-next-lane.md
+++ b/docs/local_llm_solver_orchestration_operator_guide/selected-next-lane.md
@@ -1,0 +1,9 @@
+# Selected Next Lane
+
+Selected next lane:
+
+```text
+ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-OPERATOR-CLI-WRAPPER-DECISION-001
+```
+
+Rationale: the repository has a Python/module entry point for local orchestration, but it does not yet provide a stable operator-facing CLI wrapper. The current guide therefore documents the available module function and selects a future CLI-wrapper decision lane rather than pretending a stable CLI exists.


### PR DESCRIPTION
### Motivation

- Provide a focused Level 2 operator usage guide for the non-production local LLM solver orchestration path after final track closeout so operators can run, inspect, and interpret local runs without expanding the evidence boundary. 
- Preserve the local-only safety invariants from the integration and orchestration specs (default-off, explicit opt-in, localhost/loopback only, no provider keys, finite timeout, no hosted fallback, and `behavior_evidence=false`).
- Document exact operator workflows, redaction rules, stop conditions, and preservation guidance because a stable operator CLI is not yet provided and the available entrypoint is the Python/module function.

### Description

- Added a new operator guide under `docs/local_llm_solver_orchestration_operator_guide/` with 13 files: `README.md`, `quick-start.md`, `local-environment-requirements.md`, `command-reference.md`, `output-interpretation-guide.md`, `gate-trace-guide.md`, `safe-use-boundaries.md`, `failure-modes-and-stop-conditions.md`, `artifact-preservation-guidance.md`, `examples.md`, `non-claims-and-blocked-uses.md`, `selected-next-lane.md`, and `checks-run.md`. 
- The `command-reference.md` documents the current available module entry point `alpha.local_llm.orchestration_runner.run_local_llm_solver_orchestration` and provides exact operator templates for local invocation and JSON inspection, while noting that a stable operator CLI wrapper is not yet provided. 
- The guide codifies output interpretation (`status`, `mode`, `answer`, `final_answer`, `considerations`, `assumptions`, `confidence`, `metadata`, `behavior_evidence=false`, `no_hosted_fallback=true`, `no_provider_keys_required=true`), gate-trace redaction rules (enum/boolean/numeric/list-only), allowed Level 2 uses, blocked surfaces (including `/v1/solve` and dashboard exposure), failure modes, artifact preservation rules, and example prompts. 
- Selected next lane is `ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-OPERATOR-CLI-WRAPPER-DECISION-001` because the repo currently exposes only a module entry point and not a stable CLI.

### Testing

- Ran docs-safe checks which completed successfully: `git status --short`, `git diff --name-only`, `git diff --check`, `find docs/local_llm_solver_orchestration_operator_guide -maxdepth 1 -type f | sort`, `rg -n "behavior_evidence=false|no_hosted_fallback=true|no_provider_keys_required=true|failed_closed|gate_trace|missing_information_too_broad" docs/local_llm_solver_orchestration_operator_guide`, and `rg -n "production readiness|MVP readiness|dashboard readiness|/v1/solve readiness|benchmark evidence|provider orchestration evidence|local model quality|Alpha superiority|billing evidence|broad runtime readiness|evidence-model promotion" docs/local_llm_solver_orchestration_operator_guide`. 
- No functional or runtime tests (no smoke, no local model runs, no hosted-provider calls, and no pytest runs against runtime code) were executed as this is a docs-only change. 
- Explicit non-actions: no smoke executions, no local model or hosted provider runs, no `/v1/solve` or dashboard exposure, no provider fallback, no Google Sheets updates, no runtime behavior changes, no test modifications, and no evidence-model promotion were performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24f321fdc48329974cc1e2ac4910e3)