### PR TITLE
Add operator CLI wrapper for local LLM orchestration (ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-OPERATOR-CLI-WRAPPER-IMPLEMENTATION-001)

### DIFF
--- a/alpha/local_llm/operator_cli.py
+++ b/alpha/local_llm/operator_cli.py
@@ -1,0 +1,156 @@
+"""Operator-only CLI wrapper for local LLM solver orchestration.
+
+This module provides a narrow, default-off command surface for approved local
+Level 2 operator use. It delegates to the existing local orchestration runner
+and does not expose production solver, dashboard, hosted fallback, or provider
+fallback paths.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Mapping, Sequence, TextIO
+
+from .orchestration_runner import run_local_llm_solver_orchestration
+
+_SUCCESS_STATUSES = frozenset({"ok", "clarify", "blocked"})
+
+_DESCRIPTION = """
+Stable operator-only wrapper for non-production, local-only Level 2 solver
+orchestration. The wrapper is default-off, requires explicit local opt-in, and
+is not smoke evidence, not model-quality evidence, not benchmark evidence,
+not readiness evidence, and not evidence-model promotion. It does not expose
+/v1/solve, dashboard routes, hosted fallback, provider fallback, or hosted
+provider credential inputs.
+"""
+
+_EPILOG = """
+Evidence boundary: this command may produce only normalized non-production local
+orchestration results from the existing local runner. It is operator-only and
+local-only. Do not use the output as production readiness, MVP readiness,
+benchmark evidence, local model quality evidence, hosted provider evidence,
+provider orchestration evidence, Alpha superiority evidence, billing evidence,
+broad runtime readiness evidence, /v1/solve readiness, dashboard readiness, or
+evidence-model promotion.
+"""
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the narrow local-only operator CLI parser."""
+
+    parser = argparse.ArgumentParser(
+        prog="python -m alpha.local_llm.operator_cli",
+        description=_DESCRIPTION,
+        epilog=_EPILOG,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--enable-local-llm",
+        action="store_true",
+        required=True,
+        help="Required explicit opt-in for default-off local-only operator execution.",
+    )
+    prompt_group = parser.add_mutually_exclusive_group(required=True)
+    prompt_group.add_argument(
+        "--prompt",
+        metavar="TEXT",
+        help="Prompt text for the local-only orchestration runner.",
+    )
+    prompt_group.add_argument(
+        "--prompt-file",
+        metavar="PATH",
+        help="Read prompt text from a local UTF-8 file.",
+    )
+    prompt_group.add_argument(
+        "--prompt-stdin",
+        action="store_true",
+        help="Read prompt text from stdin only when this flag is explicitly set.",
+    )
+    parser.add_argument(
+        "--endpoint-url",
+        required=True,
+        help=(
+            "Loopback Ollama-style local endpoint URL; existing runtime "
+            "validation enforces local-only endpoints."
+        ),
+    )
+    parser.add_argument(
+        "--model",
+        required=True,
+        help="Exact local model identifier for the local runtime.",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        required=True,
+        help="Finite positive local runtime timeout in seconds.",
+    )
+    return parser
+
+
+def _read_prompt(args: argparse.Namespace, *, stdin: TextIO) -> str:
+    if args.prompt is not None:
+        return args.prompt
+    if args.prompt_file is not None:
+        return Path(args.prompt_file).read_text(encoding="utf-8")
+    if args.prompt_stdin:
+        return stdin.read()
+    raise RuntimeError("prompt source missing after argparse validation")
+
+
+def _build_runner_env(
+    args: argparse.Namespace, source_env: Mapping[str, str]
+) -> dict[str, str]:
+    env = dict(source_env)
+    env.update(
+        {
+            "ALPHA_LOCAL_LLM_ENABLED": "true",
+            "ALPHA_LOCAL_LLM_ENDPOINT": args.endpoint_url,
+            "ALPHA_LOCAL_LLM_MODEL": args.model,
+            "ALPHA_LOCAL_LLM_TIMEOUT_SECONDS": args.timeout_seconds,
+        }
+    )
+    return env
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    stdin: TextIO | None = None,
+    stdout: TextIO | None = None,
+    stderr: TextIO | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> int:
+    """Run the operator CLI and return a process exit code."""
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    input_stream = sys.stdin if stdin is None else stdin
+    output_stream = sys.stdout if stdout is None else stdout
+    error_stream = sys.stderr if stderr is None else stderr
+
+    try:
+        prompt = _read_prompt(args, stdin=input_stream)
+    except OSError as exc:
+        print(f"prompt read failed: {exc.__class__.__name__}", file=error_stream)
+        return 2
+
+    if not isinstance(prompt, str) or not prompt.strip():
+        print("prompt is required and must not be empty", file=error_stream)
+        return 2
+
+    runner_env = _build_runner_env(args, os.environ if environ is None else environ)
+    result = run_local_llm_solver_orchestration(prompt, env=runner_env)
+    print(json.dumps(result, indent=2, sort_keys=True), file=output_stream)
+
+    status = result.get("status") if isinstance(result, Mapping) else None
+    if status in _SUCCESS_STATUSES:
+        return 0
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/alpha/local_llm/operator_cli.py
+++ b/alpha/local_llm/operator_cli.py
@@ -134,7 +134,7 @@ def main(
 
     try:
         prompt = _read_prompt(args, stdin=input_stream)
-    except OSError as exc:
+    except (OSError, UnicodeError) as exc:
         print(f"prompt read failed: {exc.__class__.__name__}", file=error_stream)
         return 2
 

--- a/docs/local_llm_solver_orchestration_operator_cli_wrapper_implementation/blocker-fallback-lane.md
+++ b/docs/local_llm_solver_orchestration_operator_cli_wrapper_implementation/blocker-fallback-lane.md
@@ -1,0 +1,17 @@
+# Blocker Fallback Lane
+
+## Blocker fallback lane
+
+```text
+ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-OPERATOR-CLI-WRAPPER-BLOCKER-FIX-001
+```
+
+## Fallback condition
+
+Use this fallback lane if the operator CLI wrapper implementation is blocked, incomplete, unsafe, or only partially tested.
+
+## Scope boundary
+
+This PR records the fallback lane for continuity only. It does not start or implement the blocker fallback lane.
+
+Any fallback work must preserve the local-only, default-off, non-production, operator-only, non-evidence boundary and must not introduce local model smoke, Ollama calls, hosted provider calls, `/v1/solve`, dashboard routes, provider fallback, hosted fallback, evidence-model promotion, Google Sheets edits, or backlog workbook edits.

--- a/docs/local_llm_solver_orchestration_operator_cli_wrapper_implementation/controlling-decision-verification.md
+++ b/docs/local_llm_solver_orchestration_operator_cli_wrapper_implementation/controlling-decision-verification.md
@@ -1,0 +1,25 @@
+# Controlling Decision Verification
+
+## Repo evidence inspected
+
+The implementation lane was checked against the repository decision packet under:
+
+```text
+docs/local_llm_solver_orchestration_operator_cli_wrapper_decision/
+```
+
+The controlling decision recorded in the repo evidence is:
+
+```text
+ADD_STABLE_CLI_WRAPPER
+```
+
+The selected implementation lane recorded by the decision packet is:
+
+```text
+ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-OPERATOR-CLI-WRAPPER-IMPLEMENTATION-001
+```
+
+## Verification result
+
+The implementation remains within the approved stable CLI wrapper scope. This PR does not start any follow-on lane and does not broaden local orchestration behavior, production API exposure, dashboard exposure, hosted fallback, provider fallback, provider orchestration, smoke evidence, model-quality claims, benchmark claims, billing claims, MVP readiness, production readiness, broad runtime readiness, or evidence-model promotion.

--- a/docs/local_llm_solver_orchestration_operator_cli_wrapper_implementation/implementation-summary.md
+++ b/docs/local_llm_solver_orchestration_operator_cli_wrapper_implementation/implementation-summary.md
@@ -12,6 +12,22 @@ Selected decision from the prior decision packet:
 ADD_STABLE_CLI_WRAPPER
 ```
 
+## Lane-governance continuity
+
+Selected next lane if this implementation is safe:
+
+```text
+ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-CONTROLLED-USAGE-PACKET-001
+```
+
+Blocker fallback lane if this implementation is blocked, incomplete, unsafe, or only partially tested:
+
+```text
+ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-OPERATOR-CLI-WRAPPER-BLOCKER-FIX-001
+```
+
+This PR records lane continuity only and does not start either follow-on lane.
+
 ## Command identity
 
 ```text

--- a/docs/local_llm_solver_orchestration_operator_cli_wrapper_implementation/implementation-summary.md
+++ b/docs/local_llm_solver_orchestration_operator_cli_wrapper_implementation/implementation-summary.md
@@ -1,0 +1,62 @@
+# Local LLM Solver Orchestration Operator CLI Wrapper Implementation Summary
+
+## Lane completed
+
+```text
+ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-OPERATOR-CLI-WRAPPER-IMPLEMENTATION-001
+```
+
+Selected decision from the prior decision packet:
+
+```text
+ADD_STABLE_CLI_WRAPPER
+```
+
+## Command identity
+
+```text
+python -m alpha.local_llm.operator_cli
+```
+
+## Allowed behavior
+
+The wrapper is a narrow Level 2 local operator command. It requires explicit local opt-in,
+accepts exactly one prompt source, accepts explicit local endpoint/model/timeout settings,
+delegates to `alpha.local_llm.orchestration_runner.run_local_llm_solver_orchestration`, and
+prints the normalized result JSON to stdout.
+
+Normal local orchestration statuses such as `ok`, `clarify`, and `blocked` exit `0`.
+Malformed invocation, missing prompt, missing explicit opt-in, invalid local config, or a
+`failed_closed` result exits non-zero.
+
+## Explicit safety invariants
+
+- Non-production, local-only, operator-only, and default-off.
+- Loopback endpoint validation remains delegated through the existing local runtime config path.
+- `answer` and `final_answer` are preserved exactly as returned by the runner.
+- `behavior_evidence=false`, `no_hosted_fallback=true`, and `no_provider_keys_required=true` are preserved from the runner result.
+- Hosted-provider-key CLI flags and API-key CLI arguments are not added.
+- Hosted provider keys are not printed, logged, serialized as values, forwarded to a hosted backend, or used to enable local behavior.
+- Existing fail-closed provider-key rejection remains surfaced as a normalized local failure result.
+
+## Tests run
+
+```text
+git status --short
+git diff --name-only
+git diff --check
+python -m pytest -q tests/test_local_llm_operator_cli.py tests/test_local_llm_solver_orchestration_runner.py tests/test_local_llm_runtime_integration.py tests/test_config_validation.py
+python -m alpha.local_llm.operator_cli --help
+rg -n '/v1/solve|dashboard|hosted fallback|provider fallback|hosted-provider-key|--.*api-key|evidence promotion' alpha/local_llm/operator_cli.py tests/test_local_llm_operator_cli.py docs/local_llm_solver_orchestration_operator_guide/command-reference.md docs/local_llm_solver_orchestration_operator_cli_wrapper_implementation/implementation-summary.md
+```
+
+## Evidence boundary
+
+This implementation is not local smoke evidence, not hosted-provider-call evidence, not
+`/v1/solve` evidence, not dashboard evidence, not provider fallback evidence, not provider
+orchestration evidence, not model-quality evidence, not benchmark evidence, not production or
+MVP readiness evidence, and not evidence-model promotion.
+
+No local smoke was run. No hosted calls were run. No `/v1/solve` route was exposed or called.
+No dashboard route was exposed or called. No provider fallback was added. No evidence model was
+promoted. No Google Sheets or backlog workbooks were edited.

--- a/docs/local_llm_solver_orchestration_operator_cli_wrapper_implementation/selected-next-lane.md
+++ b/docs/local_llm_solver_orchestration_operator_cli_wrapper_implementation/selected-next-lane.md
@@ -1,0 +1,17 @@
+# Selected Next Lane
+
+## Selected next lane
+
+```text
+ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-CONTROLLED-USAGE-PACKET-001
+```
+
+## Selection condition
+
+This is the exactly one selected next lane if the operator CLI wrapper implementation is safe to merge.
+
+## Scope boundary
+
+This PR records the selected next lane for continuity only. It does not start or implement `ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-CONTROLLED-USAGE-PACKET-001`.
+
+The selected next lane must remain evidence-bounded and must not be treated as local smoke evidence, hosted provider evidence, production readiness, MVP readiness, benchmark evidence, model-quality evidence, provider-orchestration evidence, Alpha-superiority evidence, billing evidence, dashboard readiness, `/v1/solve` readiness, broad-runtime readiness, or evidence-model promotion.

--- a/docs/local_llm_solver_orchestration_operator_guide/command-reference.md
+++ b/docs/local_llm_solver_orchestration_operator_guide/command-reference.md
@@ -1,8 +1,76 @@
 # Command Reference
 
-## Current command-reference status
+## Stable local-only operator wrapper
 
-The repository currently provides a Python/module entry point, `alpha.local_llm.orchestration_runner.run_local_llm_solver_orchestration`, rather than a stable operator-facing CLI wrapper. Do not invent a CLI name for this path. A future CLI-wrapper decision lane is selected in [selected-next-lane.md](selected-next-lane.md).
+The stable Level 2 operator-facing wrapper for the local LLM solver orchestration path is:
+
+```bash
+python -m alpha.local_llm.operator_cli \
+  --enable-local-llm \
+  --prompt "List three bounded considerations for reducing local Python CLI startup latency." \
+  --endpoint-url "http://127.0.0.1:11434/api/chat" \
+  --model "qwen2.5:3b" \
+  --timeout-seconds "60"
+```
+
+Command identity:
+
+```text
+python -m alpha.local_llm.operator_cli
+```
+
+This command is non-production, local-only, operator-only, and default-off. It delegates to
+`alpha.local_llm.orchestration_runner.run_local_llm_solver_orchestration` and prints the
+normalized result JSON to stdout. It is not smoke evidence, not model-quality evidence, not
+benchmark evidence, not readiness evidence, and not evidence-model promotion.
+
+Required local settings:
+
+- `--enable-local-llm` is required for explicit local opt-in.
+- Exactly one prompt source is required:
+  - `--prompt TEXT`
+  - `--prompt-file PATH`
+  - `--prompt-stdin`
+- `--endpoint-url` must be a loopback/local Ollama-style endpoint accepted by the existing local runtime config validation.
+- `--model` must be the exact local model identifier.
+- `--timeout-seconds` must be a finite positive timeout.
+
+Required operator checks after the command:
+
+- Confirm `behavior_evidence=false`.
+- Confirm `no_hosted_fallback=true`.
+- Confirm `no_provider_keys_required=true`.
+- Confirm `metadata.gate_trace` contains only allowed diagnostic enum/boolean/numeric/list-of-enum values.
+- Stop if hosted fallback, `/v1/solve` exposure, dashboard exposure, unsafe field exposure, raw diagnostic text, provider fallback, or evidence promotion appears.
+
+The wrapper does not accept hosted-provider-key CLI flags or API-key CLI arguments. If hosted provider keys are present in the environment and the existing local runtime config path rejects them, the wrapper surfaces the normalized fail-closed local result and exits non-zero without printing provider-key values.
+
+## Prompt-file form
+
+Template only; run on the local developer machine where the intended local runtime is installed:
+
+```bash
+python -m alpha.local_llm.operator_cli \
+  --enable-local-llm \
+  --prompt-file ./prompt.txt \
+  --endpoint-url "http://127.0.0.1:11434/api/chat" \
+  --model "qwen2.5:3b" \
+  --timeout-seconds "60"
+```
+
+## Prompt-stdin form
+
+Template only; stdin is read only when `--prompt-stdin` is explicitly supplied:
+
+```bash
+printf '%s\n' 'List three bounded local-only considerations.' | \
+python -m alpha.local_llm.operator_cli \
+  --enable-local-llm \
+  --prompt-stdin \
+  --endpoint-url "http://127.0.0.1:11434/api/chat" \
+  --model "qwen2.5:3b" \
+  --timeout-seconds "60"
+```
 
 ## Check Ollama model availability
 
@@ -14,40 +82,22 @@ ollama list
 
 Confirm the intended model name, for example `qwen2.5:3b`, appears in the output before running local orchestration.
 
-## Run the current local-only orchestration entry point
+## Advanced module entry point
 
-Template only; this performs local model execution and must be run only by an operator who intends a local-only Level 2 run:
+The lower-level Python/module entry point remains available for tests and advanced developer inspection:
 
-```bash
-ALPHA_LOCAL_LLM_ENABLED="true" \
-ALPHA_LOCAL_LLM_ENDPOINT="http://127.0.0.1:11434/api/chat" \
-ALPHA_LOCAL_LLM_MODEL="qwen2.5:3b" \
-ALPHA_LOCAL_LLM_TIMEOUT_SECONDS="60" \
-python - <<'PY'
-import json
-from alpha.local_llm.orchestration_runner import run_local_llm_solver_orchestration
-
-result = run_local_llm_solver_orchestration(
-    "List three bounded considerations for reducing local Python CLI startup latency."
-)
-print(json.dumps(result, indent=2, sort_keys=True))
-PY
+```text
+alpha.local_llm.orchestration_runner.run_local_llm_solver_orchestration
 ```
 
-Required operator checks after the command:
-
-- Confirm `behavior_evidence=false`.
-- Confirm `no_hosted_fallback=true`.
-- Confirm `no_provider_keys_required=true`.
-- Confirm `metadata.gate_trace` contains only allowed diagnostic enum/boolean/numeric/list-of-enum values.
-- Stop if hosted fallback, `/v1/solve` exposure, dashboard exposure, unsafe field exposure, or raw diagnostic text appears.
+Prefer the stable wrapper above for operator command use. The module entry point is still non-production and local-only, and does not turn casual local usage into evidence claims.
 
 ## Run focused non-model tests only
 
 These tests use fake transports/stubs and do not require a local model:
 
 ```bash
-python -m pytest -q tests/test_local_llm_solver_orchestration_runner.py
+python -m pytest -q tests/test_local_llm_operator_cli.py tests/test_local_llm_solver_orchestration_runner.py
 ```
 
 For broader local runtime configuration checks that still avoid local model execution:

--- a/tests/test_local_llm_operator_cli.py
+++ b/tests/test_local_llm_operator_cli.py
@@ -1,0 +1,345 @@
+from __future__ import annotations
+
+import ast
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from alpha.local_llm import operator_cli
+
+
+_BASE_ARGS = [
+    "--enable-local-llm",
+    "--endpoint-url",
+    "http://127.0.0.1:11434/api/chat",
+    "--model",
+    "llama3.2:1b-local-fixture",
+    "--timeout-seconds",
+    "2.5",
+]
+
+
+def _ok_result() -> dict[str, object]:
+    return {
+        "status": "ok",
+        "answer": "local answer fixture",
+        "final_answer": "local answer fixture",
+        "behavior_evidence": False,
+        "no_hosted_fallback": True,
+        "no_provider_keys_required": True,
+        "metadata": {
+            "behavior_evidence": False,
+            "no_hosted_fallback": True,
+            "no_provider_keys_required": True,
+        },
+    }
+
+
+class ReadForbiddenStdin(io.StringIO):
+    def read(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        raise AssertionError("stdin must not be read without --prompt-stdin")
+
+
+def test_help_text_includes_local_default_off_non_production_and_non_evidence_language(capsys):
+    with pytest.raises(SystemExit) as exc:
+        operator_cli.main(["--help"])
+
+    assert exc.value.code == 0
+    help_text = capsys.readouterr().out
+    assert "local-only" in help_text
+    assert "default-off" in help_text
+    assert "non-production" in help_text
+    assert "operator-only" in help_text
+    assert "not smoke evidence" in help_text
+    assert "not model-quality evidence" in help_text
+    assert "not benchmark evidence" in help_text
+    assert "not readiness evidence" in help_text
+    assert "not evidence-model promotion" in help_text
+
+
+def test_missing_explicit_opt_in_fails_before_runner_use(monkeypatch):
+    called = {"runner": False}
+
+    def forbidden_runner(prompt, *, env):  # type: ignore[no-untyped-def]
+        called["runner"] = True
+        return _ok_result()
+
+    monkeypatch.setattr(operator_cli, "run_local_llm_solver_orchestration", forbidden_runner)
+
+    with pytest.raises(SystemExit) as exc:
+        operator_cli.main(
+            [
+                "--prompt",
+                "hello",
+                "--endpoint-url",
+                "http://127.0.0.1:11434/api/chat",
+                "--model",
+                "llama3.2:1b-local-fixture",
+                "--timeout-seconds",
+                "2.5",
+            ]
+        )
+
+    assert exc.value.code == 2
+    assert called["runner"] is False
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        _BASE_ARGS,
+        [*_BASE_ARGS, "--prompt", "one", "--prompt-file", "prompt.txt"],
+        [*_BASE_ARGS, "--prompt", "one", "--prompt-stdin"],
+    ],
+)
+def test_missing_or_ambiguous_prompt_source_fails(args, monkeypatch):
+    called = {"runner": False}
+
+    def forbidden_runner(prompt, *, env):  # type: ignore[no-untyped-def]
+        called["runner"] = True
+        return _ok_result()
+
+    monkeypatch.setattr(operator_cli, "run_local_llm_solver_orchestration", forbidden_runner)
+
+    with pytest.raises(SystemExit) as exc:
+        operator_cli.main(args)
+
+    assert exc.value.code == 2
+    assert called["runner"] is False
+
+
+def test_empty_prompt_fails_without_runner_use(monkeypatch):
+    called = {"runner": False}
+
+    def forbidden_runner(prompt, *, env):  # type: ignore[no-untyped-def]
+        called["runner"] = True
+        return _ok_result()
+
+    monkeypatch.setattr(operator_cli, "run_local_llm_solver_orchestration", forbidden_runner)
+
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    rc = operator_cli.main([*_BASE_ARGS, "--prompt", "   "], stdout=stdout, stderr=stderr)
+
+    assert rc == 2
+    assert stdout.getvalue() == ""
+    assert "prompt is required" in stderr.getvalue()
+    assert called["runner"] is False
+
+
+def test_valid_prompt_calls_runner_and_prints_stable_json(monkeypatch):
+    observed: dict[str, object] = {}
+
+    def fake_runner(prompt, *, env):  # type: ignore[no-untyped-def]
+        observed["prompt"] = prompt
+        observed["env"] = env
+        return _ok_result()
+
+    monkeypatch.setattr(operator_cli, "run_local_llm_solver_orchestration", fake_runner)
+    stdout = io.StringIO()
+
+    rc = operator_cli.main([*_BASE_ARGS, "--prompt", "operator prompt"], stdout=stdout)
+
+    assert rc == 0
+    assert observed["prompt"] == "operator prompt"
+    env = observed["env"]
+    assert isinstance(env, dict)
+    assert env["ALPHA_LOCAL_LLM_ENABLED"] == "true"
+    assert env["ALPHA_LOCAL_LLM_ENDPOINT"] == "http://127.0.0.1:11434/api/chat"
+    assert env["ALPHA_LOCAL_LLM_MODEL"] == "llama3.2:1b-local-fixture"
+    assert env["ALPHA_LOCAL_LLM_TIMEOUT_SECONDS"] == "2.5"
+    parsed = json.loads(stdout.getvalue())
+    assert parsed["status"] == "ok"
+    assert parsed["answer"] == "local answer fixture"
+    assert parsed["final_answer"] == "local answer fixture"
+    assert parsed["behavior_evidence"] is False
+    assert parsed["no_hosted_fallback"] is True
+    assert parsed["no_provider_keys_required"] is True
+    assert stdout.getvalue().startswith('{\n  "answer"')
+
+
+def test_prompt_file_reads_prompt_text(monkeypatch, tmp_path):
+    prompt_file = tmp_path / "prompt.txt"
+    prompt_file.write_text("file prompt\n", encoding="utf-8")
+    observed: dict[str, str] = {}
+
+    def fake_runner(prompt, *, env):  # type: ignore[no-untyped-def]
+        observed["prompt"] = prompt
+        return {**_ok_result(), "status": "clarify"}
+
+    monkeypatch.setattr(operator_cli, "run_local_llm_solver_orchestration", fake_runner)
+    stdout = io.StringIO()
+
+    rc = operator_cli.main([*_BASE_ARGS, "--prompt-file", str(prompt_file)], stdout=stdout)
+
+    assert rc == 0
+    assert observed["prompt"] == "file prompt\n"
+    assert json.loads(stdout.getvalue())["status"] == "clarify"
+
+
+def test_prompt_stdin_reads_only_when_explicitly_requested(monkeypatch):
+    prompts: list[str] = []
+
+    def fake_runner(prompt, *, env):  # type: ignore[no-untyped-def]
+        prompts.append(prompt)
+        return {**_ok_result(), "status": "blocked"}
+
+    monkeypatch.setattr(operator_cli, "run_local_llm_solver_orchestration", fake_runner)
+
+    stdout = io.StringIO()
+    rc = operator_cli.main(
+        [*_BASE_ARGS, "--prompt", "direct prompt"],
+        stdin=ReadForbiddenStdin("stdin prompt"),
+        stdout=stdout,
+    )
+    assert rc == 0
+    assert prompts == ["direct prompt"]
+
+    stdout = io.StringIO()
+    rc = operator_cli.main(
+        [*_BASE_ARGS, "--prompt-stdin"],
+        stdin=io.StringIO("stdin prompt"),
+        stdout=stdout,
+    )
+    assert rc == 0
+    assert prompts == ["direct prompt", "stdin prompt"]
+
+
+def test_non_loopback_endpoint_fails_closed_through_existing_validation_path():
+    stdout = io.StringIO()
+
+    rc = operator_cli.main(
+        [
+            "--enable-local-llm",
+            "--prompt",
+            "No transport should be used for invalid endpoint.",
+            "--endpoint-url",
+            "http://example.com/api/chat",
+            "--model",
+            "llama3.2:1b-local-fixture",
+            "--timeout-seconds",
+            "2.5",
+        ],
+        stdout=stdout,
+        environ={},
+    )
+
+    parsed = json.loads(stdout.getvalue())
+    assert rc == 1
+    assert parsed["status"] == "failed_closed"
+    assert parsed["metadata"]["reason"] == "endpoint_not_local_non_evidence"
+    assert parsed["behavior_evidence"] is False
+    assert parsed["no_hosted_fallback"] is True
+
+
+@pytest.mark.parametrize("timeout", ["0", "-1", "nan", "inf", "not-a-number"])
+def test_invalid_timeout_fails_nonzero_without_transport(timeout):
+    stdout = io.StringIO()
+
+    rc = operator_cli.main(
+        [
+            "--enable-local-llm",
+            "--prompt",
+            "No transport should be used for invalid timeout.",
+            "--endpoint-url",
+            "http://127.0.0.1:11434/api/chat",
+            "--model",
+            "llama3.2:1b-local-fixture",
+            "--timeout-seconds",
+            timeout,
+        ],
+        stdout=stdout,
+        environ={},
+    )
+
+    parsed = json.loads(stdout.getvalue())
+    assert rc == 1
+    assert parsed["status"] == "failed_closed"
+    assert parsed["metadata"]["reason"] == "invalid_timeout_non_evidence"
+
+
+def test_hosted_provider_key_env_preserves_fail_closed_rejection_without_leak():
+    secret = "sk-test-secret-must-not-leak"
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+
+    rc = operator_cli.main(
+        [*_BASE_ARGS, "--prompt", "Provider key env must fail closed."],
+        stdout=stdout,
+        stderr=stderr,
+        environ={"OPENAI_API_KEY": secret},
+    )
+
+    stdout_text = stdout.getvalue()
+    stderr_text = stderr.getvalue()
+    parsed = json.loads(stdout_text)
+    assert rc == 1
+    assert parsed["status"] == "failed_closed"
+    assert parsed["metadata"]["reason"] == "provider_keys_forbidden_non_evidence"
+    assert secret not in stdout_text
+    assert secret not in stderr_text
+
+
+def test_no_hosted_provider_key_cli_flag_exists(capsys):
+    with pytest.raises(SystemExit) as exc:
+        operator_cli.main(["--help"])
+
+    assert exc.value.code == 0
+    help_text = capsys.readouterr().out
+    assert "--hosted-provider-key" not in help_text
+    assert "--api-key" not in help_text
+    assert "--openai-api-key" not in help_text
+    assert "--anthropic-api-key" not in help_text
+    assert "--google-api-key" not in help_text
+
+
+def test_wrapper_does_not_import_or_call_forbidden_surfaces():
+    source = Path("alpha/local_llm/operator_cli.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    imported_modules: list[str] = []
+    called_names: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_modules.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported_modules.append(node.module)
+        elif isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name):
+                called_names.append(func.id)
+            elif isinstance(func, ast.Attribute):
+                called_names.append(func.attr)
+
+    forbidden_import_fragments = ("webapp", "dashboard", "routes", "fallback")
+    assert not any(
+        fragment in module for module in imported_modules for fragment in forbidden_import_fragments
+    )
+    assert "run_local_llm_solver_orchestration" in called_names
+    assert "solve" not in called_names
+    assert "dashboard" not in called_names
+    assert "fallback" not in called_names
+
+
+def test_failed_closed_result_exits_nonzero_with_parseable_sorted_json(monkeypatch):
+    def fake_runner(prompt, *, env):  # type: ignore[no-untyped-def]
+        return {
+            "status": "failed_closed",
+            "answer": "",
+            "final_answer": "",
+            "behavior_evidence": False,
+            "no_hosted_fallback": True,
+            "no_provider_keys_required": True,
+            "metadata": {"reason": "fixture_failure"},
+        }
+
+    monkeypatch.setattr(operator_cli, "run_local_llm_solver_orchestration", fake_runner)
+    stdout = io.StringIO()
+
+    rc = operator_cli.main([*_BASE_ARGS, "--prompt", "prompt"], stdout=stdout)
+
+    assert rc == 1
+    parsed = json.loads(stdout.getvalue())
+    assert parsed["status"] == "failed_closed"
+    assert stdout.getvalue().startswith('{\n  "answer"')

--- a/tests/test_local_llm_operator_cli.py
+++ b/tests/test_local_llm_operator_cli.py
@@ -66,7 +66,9 @@ def test_missing_explicit_opt_in_fails_before_runner_use(monkeypatch):
         called["runner"] = True
         return _ok_result()
 
-    monkeypatch.setattr(operator_cli, "run_local_llm_solver_orchestration", forbidden_runner)
+    monkeypatch.setattr(
+        operator_cli, "run_local_llm_solver_orchestration", forbidden_runner
+    )
 
     with pytest.raises(SystemExit) as exc:
         operator_cli.main(
@@ -177,6 +179,41 @@ def test_prompt_file_reads_prompt_text(monkeypatch, tmp_path):
     assert rc == 0
     assert observed["prompt"] == "file prompt\n"
     assert json.loads(stdout.getvalue())["status"] == "clarify"
+
+
+def test_prompt_file_invalid_utf8_fails_cleanly_without_runner_or_content_leak(
+    monkeypatch, tmp_path
+):
+    invalid_bytes = b"valid-prefix-\xff\xfe-invalid-local-prompt"
+    prompt_file = tmp_path / "invalid-prompt.txt"
+    prompt_file.write_bytes(invalid_bytes)
+    called = {"runner": False}
+
+    def forbidden_runner(prompt, *, env):  # type: ignore[no-untyped-def]
+        called["runner"] = True
+        return _ok_result()
+
+    monkeypatch.setattr(
+        operator_cli, "run_local_llm_solver_orchestration", forbidden_runner
+    )
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+
+    rc = operator_cli.main(
+        [*_BASE_ARGS, "--prompt-file", str(prompt_file)],
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+    stderr_text = stderr.getvalue()
+    assert rc == 2
+    assert stdout.getvalue() == ""
+    assert "prompt read failed: UnicodeDecodeError" in stderr_text
+    assert called["runner"] is False
+    assert "valid-prefix" not in stderr_text
+    assert "invalid-local-prompt" not in stderr_text
+    assert "\xff" not in stderr_text
+    assert "\xfe" not in stderr_text
 
 
 def test_prompt_stdin_reads_only_when_explicitly_requested(monkeypatch):


### PR DESCRIPTION
### Motivation
- Implement the approved narrow Level 2 operator CLI wrapper lane `ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-OPERATOR-CLI-WRAPPER-IMPLEMENTATION-001` as the next step from decision `ADD_STABLE_CLI_WRAPPER` to provide a repeatable local-only operator surface.
- Provide a default-off, explicit-opt-in, loopback-only invocation that delegates to the existing `alpha.local_llm.orchestration_runner.run_local_llm_solver_orchestration` while preserving Level 2 safety and evidence boundaries.

### Controlling decision verification
- Repo decision packet inspected: `docs/local_llm_solver_orchestration_operator_cli_wrapper_decision/`.
- Selected decision: `ADD_STABLE_CLI_WRAPPER`.
- Selected implementation lane: `ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-OPERATOR-CLI-WRAPPER-IMPLEMENTATION-001`.
- Scope remains a Level 2 local-only operator CLI wrapper. This PR does not broaden local orchestration behavior, production API exposure, dashboard exposure, hosted fallback, provider fallback, provider orchestration, smoke evidence, model-quality claims, benchmark claims, billing claims, MVP readiness, production readiness, broad runtime readiness, or evidence-model promotion.

### Description
- Added `alpha/local_llm/operator_cli.py`, implementing `python -m alpha.local_llm.operator_cli` with required `--enable-local-llm`, mutually exclusive prompt sources `--prompt`, `--prompt-file`, or `--prompt-stdin`, and required local runtime flags `--endpoint-url`, `--model`, and `--timeout-seconds`.
- The wrapper delegates to `run_local_llm_solver_orchestration`, prints normalized JSON, and returns `0` only for normal local orchestration statuses.
- The CLI builds an env mapping from `os.environ` or the provided test stub, overrides only the `ALPHA_LOCAL_LLM_*` keys, and passes that mapping to the runner so existing fail-closed provider-key behavior is preserved.
- Added focused offline tests for help text, explicit opt-in, prompt-source validation, prompt-file and prompt-stdin semantics, invalid UTF-8 prompt files, loopback endpoint validation, invalid timeout handling, hosted-provider-key env rejection without leakage, absence of hosted-key CLI flags, forbidden-surface import/call checks, and stable parseable JSON output.
- Updated the operator guide to document the stable wrapper command identity.
- Added implementation-lane docs for summary, controlling decision verification, selected next lane, and blocker fallback lane.

### Changed files
- `alpha/local_llm/operator_cli.py`
- `tests/test_local_llm_operator_cli.py`
- `docs/local_llm_solver_orchestration_operator_guide/command-reference.md`
- `docs/local_llm_solver_orchestration_operator_cli_wrapper_implementation/implementation-summary.md`
- `docs/local_llm_solver_orchestration_operator_cli_wrapper_implementation/controlling-decision-verification.md`
- `docs/local_llm_solver_orchestration_operator_cli_wrapper_implementation/selected-next-lane.md`
- `docs/local_llm_solver_orchestration_operator_cli_wrapper_implementation/blocker-fallback-lane.md`

### Command identity
```text
python -m alpha.local_llm.operator_cli
```

### Selected next lane
Exactly one selected next lane is recorded for continuity only and is not started in this PR:

```text
ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-CONTROLLED-USAGE-PACKET-001
```

### Blocker fallback lane
If this implementation is blocked, incomplete, unsafe, or only partially tested, use:

```text
ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-OPERATOR-CLI-WRAPPER-BLOCKER-FIX-001
```

### Testing
- Ran `python -m pytest -q tests/test_local_llm_operator_cli.py` and the test file passed.
- Ran `python -m pytest -q tests/test_local_llm_operator_cli.py tests/test_local_llm_solver_orchestration_runner.py tests/test_local_llm_runtime_integration.py tests/test_config_validation.py` and all invoked tests passed.
- Verified `python -m alpha.local_llm.operator_cli --help` prints required non-production, local-only, default-off, and evidence-boundary language.
- Executed repository checks: `git status --short`, `git diff --name-only`, and `git diff --check`.
- Ran search checks for forbidden exposure terms, including `/v1/solve`, dashboard, hosted fallback, provider fallback, hosted-provider-key CLI flags, and evidence-promotion exposure.

### Evidence boundary and explicit non-actions
- This wrapper is non-production, local-only, operator-only, default-off, and preserves `behavior_evidence=false`, `no_hosted_fallback=true`, and `no_provider_keys_required=true` from the runner result.
- No local smoke was run.
- No Ollama or local model run was performed.
- No hosted provider call was performed.
- No `/v1/solve` exposure or call was added.
- No dashboard exposure or call was added.
- No provider fallback or hosted fallback was added.
- No evidence-model promotion was performed.
- No Google Sheets or backlog workbook edits were made.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25092fc6a883299a981887e038f465)