### PR TITLE
Add Level 3 validation execution authorization packet (authorize execution lane)

### DIFF
--- a/docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-authorization/README.md
+++ b/docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-authorization/README.md
@@ -1,0 +1,45 @@
+# Level 3 Validation Execution Authorization Decision Packet
+
+## Lane
+
+`ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-LEVEL-3-VALIDATION-EXECUTION-AUTHORIZATION-001`
+
+## Objective
+
+Create a docs-only Level 3 validation execution authorization decision packet that decides, from repository evidence only, whether a later, separate Level 3 validation execution lane can be authorized.
+
+## Prior selected lane from PR #378
+
+PR #378 selected exactly this lane:
+
+`ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-LEVEL-3-VALIDATION-EXECUTION-AUTHORIZATION-001`
+
+The frozen packet states that this authorization lane may decide whether a later execution lane can be authorized, and that it must not execute validation unless a later, separate execution lane is selected and merged.
+
+## Authorization decision
+
+`AUTHORIZE_LEVEL_3_VALIDATION_EXECUTION_LANE`
+
+## Selected next lane
+
+`ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-LEVEL-3-VALIDATION-EXECUTION-001`
+
+This packet records the selected next lane only. This PR does not start the selected next lane and does not execute validation.
+
+## Blocker fallback lane
+
+`ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-LEVEL-3-VALIDATION-EXECUTION-AUTHORIZATION-FIX-001`
+
+## Files in this packet
+
+- `README.md`
+- `source-evidence-reviewed.md`
+- `authorization-criteria.md`
+- `risk-review.md`
+- `decision-options.md`
+- `selected-decision.md`
+- `selected-next-lane.md`
+- `blocker-fallback-lane.md`
+- `evidence-boundary.md`
+- `non-actions.md`
+- `checks-run.md`

--- a/docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-authorization/authorization-criteria.md
+++ b/docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-authorization/authorization-criteria.md
@@ -1,0 +1,22 @@
+# Authorization Criteria
+
+## Criteria applied
+
+A later, separate Level 3 validation execution lane may be authorized only if repository evidence satisfies all criteria below:
+
+1. A frozen validation packet exists and is internally complete as documentation.
+2. The frozen packet selected this execution-authorization lane.
+3. The frozen packet contains frozen test-case IDs, invocation template, artifact capture template, runbook, rubric/scoring, review checklist, stop conditions, redaction policy, evidence boundary, selected next lane, and blocker fallback.
+4. The frozen packet and prior selected lane do not execute validation.
+5. The Level 2 controlled usage path remains closed.
+6. The accepted evidence boundary remains Level 2 local operator usability only until a later approved lane changes evidence semantics.
+7. The repository evidence does not promote controlled usage artifacts or frozen-packet artifacts to blocked readiness or evidence claims.
+8. The selected execution lane remains a later, separate lane and must inherit the frozen local-only/no-fallback boundaries.
+
+## Criteria outcome
+
+All criteria are satisfied by the reviewed repo evidence.
+
+## Authorization implication
+
+Because all criteria are satisfied, this packet may authorize a later, separate execution lane. This authorization does not execute validation and does not start that later lane.

--- a/docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-authorization/blocker-fallback-lane.md
+++ b/docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-authorization/blocker-fallback-lane.md
@@ -1,0 +1,13 @@
+# Blocker Fallback Lane
+
+## Lane
+
+`ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-LEVEL-3-VALIDATION-EXECUTION-AUTHORIZATION-FIX-001`
+
+## Use this lane if blocked
+
+Use this lane if this authorization decision packet is incomplete, unsafe, internally inconsistent, missing required evidence review, found to have modified preserved artifacts, found to have crossed any execution boundary, or found to have made any blocked readiness/evidence claim.
+
+## Boundary
+
+The blocker fallback lane must remain docs-only unless a later explicit lane says otherwise. It must not execute validation, promote evidence, reopen Level 2 controlled usage, or modify preserved source artifacts.

--- a/docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-authorization/checks-run.md
+++ b/docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-authorization/checks-run.md
@@ -1,0 +1,44 @@
+# Checks Run
+
+This file records checks for the docs-only execution authorization decision lane. It does not record validation execution.
+
+## Required checks
+
+- `git status --short`
+- `git diff --name-only`
+- `git diff --check`
+- `rg "ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-LEVEL-3-VALIDATION-EXECUTION-AUTHORIZATION-001" docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-authorization`
+- `rg "AUTHORIZE_LEVEL_3_VALIDATION_EXECUTION_LANE" docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-authorization`
+- `rg "ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-LEVEL-3-VALIDATION-EXECUTION-001" docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-authorization`
+- `rg "ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-LEVEL-3-VALIDATION-EXECUTION-AUTHORIZATION-FIX-001" docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-authorization`
+- `rg "production readiness|MVP readiness|benchmark evidence|local model quality evidence|provider-orchestration evidence|Alpha superiority|billing evidence|dashboard readiness|/v1/solve readiness|broad runtime readiness|evidence-model promotion" docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-authorization`
+- `rg "L3-FROZEN-TC-00[1-5]" docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-frozen-packet/frozen-test-set.md docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-authorization`
+- `rg "local-only|loopback-only|no hosted fallback|no provider fallback|no_hosted_fallback=true|no_provider_keys_required=true|behavior_evidence=false" docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-frozen-packet docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-authorization docs/local_llm_solver_orchestration_operator_guide/command-reference.md alpha/local_llm/operator_cli.py alpha/local_llm/orchestration_runner.py alpha/local_llm/provider_adapter.py`
+- Confirm no source artifact files were modified.
+- Confirm no frozen-packet files were modified.
+- Confirm no `alpha/` or `tests/` files changed.
+
+## Non-actions confirmed
+
+No local model inference, Ollama, smoke rerun, hosted provider call, `/v1/solve`, dashboard route, provider fallback, hosted fallback, benchmark, billing, evidence promotion, Google Sheets update, or backlog workbook action was run.
+
+## Checks executed for this PR
+
+Recorded after final checks.
+
+- PASS: `git status --short` showed only the new docs-only authorization packet directory before staging.
+- PASS: `git diff --name-only` produced no tracked-file modifications before staging because all changes were new untracked docs files.
+- PASS: `git diff --check` reported no whitespace errors for tracked unstaged changes.
+- PASS: `rg "ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-LEVEL-3-VALIDATION-EXECUTION-AUTHORIZATION-001" docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-authorization` found the lane name.
+- PASS: `rg "AUTHORIZE_LEVEL_3_VALIDATION_EXECUTION_LANE" docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-authorization` found the selected decision.
+- PASS: `rg "ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-LEVEL-3-VALIDATION-EXECUTION-001" docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-authorization` found the selected next lane.
+- PASS: `rg "ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-LEVEL-3-VALIDATION-EXECUTION-AUTHORIZATION-FIX-001" docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-authorization` found the blocker fallback lane.
+- PASS: `rg "production readiness|MVP readiness|benchmark evidence|local model quality evidence|provider-orchestration evidence|Alpha superiority|billing evidence|dashboard readiness|/v1/solve readiness|broad runtime readiness|evidence-model promotion" docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-authorization` found blocked non-claim terms only in boundary/non-action contexts.
+- PASS: `rg "L3-FROZEN-TC-00[1-5]" docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-frozen-packet/frozen-test-set.md docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-authorization` found the frozen test-case IDs.
+- PASS: `rg "local-only|loopback-only|no hosted fallback|no provider fallback|no_hosted_fallback=true|no_provider_keys_required=true|behavior_evidence=false" docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-frozen-packet docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-authorization docs/local_llm_solver_orchestration_operator_guide/command-reference.md alpha/local_llm/operator_cli.py alpha/local_llm/orchestration_runner.py alpha/local_llm/provider_adapter.py` found local-only and no-fallback boundaries.
+- PASS: source artifact files were not modified.
+- PASS: frozen-packet files were not modified.
+- PASS: no `alpha/` or `tests/` files changed.
+- PASS: `git diff --cached --name-only` listed only the new authorization packet docs files.
+- PASS: `git diff --cached --check` reported no whitespace errors for staged changes.
+- PASS: `git status --short docs/evals/runs/20260607-local-llm-controlled-usage-operator-run-001/source-artifact docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-frozen-packet alpha tests` produced no output, confirming no source artifact, frozen-packet, `alpha/`, or `tests/` files changed.

--- a/docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-authorization/decision-options.md
+++ b/docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-authorization/decision-options.md
@@ -1,0 +1,25 @@
+# Decision Options
+
+## Option 1: `AUTHORIZE_LEVEL_3_VALIDATION_EXECUTION_LANE`
+
+Use if repo evidence supports authorizing a later, separate execution lane.
+
+Selected next lane if chosen:
+
+`ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-LEVEL-3-VALIDATION-EXECUTION-001`
+
+## Option 2: `REQUIRE_FROZEN_PACKET_FIX_BEFORE_EXECUTION_AUTHORIZATION`
+
+Use if the frozen packet is incomplete, unsafe, internally inconsistent, or missing required execution prerequisites.
+
+Selected next lane if chosen:
+
+`ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-LEVEL-3-VALIDATION-FROZEN-PACKET-FIX-001`
+
+## Option 3: `NO_LEVEL_3_VALIDATION_EXECUTION_LANE_SELECTED`
+
+Use if repo evidence does not support safe execution authorization.
+
+Selected next action if chosen:
+
+`NO_LEVEL_3_VALIDATION_EXECUTION_LANE_SELECTED`

--- a/docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-authorization/evidence-boundary.md
+++ b/docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-authorization/evidence-boundary.md
@@ -1,0 +1,27 @@
+# Evidence Boundary
+
+## Packet boundary
+
+This is docs-only execution authorization decision work.
+
+## Explicit non-execution boundary
+
+This packet does not execute validation. It does not run local model inference, Ollama, smoke reruns, hosted provider calls, `/v1/solve`, dashboard routes, provider fallback, hosted fallback, benchmarks, billing work, runtime changes, or evidence promotion.
+
+## Explicit non-claim boundary
+
+This packet does not establish production readiness, MVP readiness, benchmark evidence, local model quality evidence, provider-orchestration evidence, Alpha superiority, billing evidence, dashboard readiness, `/v1/solve` readiness, broad runtime readiness, or evidence-model promotion.
+
+## Level 2 preservation boundary
+
+This packet does not reopen Level 2 controlled usage.
+
+The accepted controlled usage boundary remains Level 2 local operator usability only until a later approved lane changes evidence semantics.
+
+## Artifact preservation boundary
+
+This packet does not modify preserved source artifacts or frozen test packet artifacts.
+
+## Local-only invariant boundary
+
+Any later execution lane must preserve local-only, default-off, explicit opt-in, loopback-only, finite-timeout, no hosted fallback, no provider fallback, no hosted provider keys required or accepted, `behavior_evidence=false` unless a later evidence model explicitly changes it, `no_hosted_fallback=true`, and `no_provider_keys_required=true`.

--- a/docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-authorization/non-actions.md
+++ b/docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-authorization/non-actions.md
@@ -1,0 +1,33 @@
+# Non-Actions
+
+This authorization packet did not perform any of the following actions:
+
+- did not execute validation;
+- did not run local model inference;
+- did not run Ollama;
+- did not rerun smoke;
+- did not call hosted providers;
+- did not expose or call `/v1/solve`;
+- did not expose or call dashboard routes;
+- did not add provider fallback;
+- did not add hosted fallback;
+- did not run benchmarks;
+- did not perform billing work;
+- did not make runtime changes;
+- did not update Google Sheets;
+- did not update backlog workbooks;
+- did not promote evidence;
+- did not establish production readiness;
+- did not establish MVP readiness;
+- did not establish benchmark evidence;
+- did not establish local model quality evidence;
+- did not establish provider-orchestration evidence;
+- did not establish Alpha superiority;
+- did not establish billing evidence;
+- did not establish dashboard readiness;
+- did not establish `/v1/solve` readiness;
+- did not establish broad runtime readiness;
+- did not establish evidence-model promotion;
+- did not reopen Level 2 controlled usage;
+- did not modify preserved source artifacts;
+- did not modify frozen test packet artifacts.

--- a/docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-authorization/risk-review.md
+++ b/docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-authorization/risk-review.md
@@ -1,0 +1,16 @@
+# Risk Review
+
+## Risks reviewed
+
+| Risk | Evidence and handling | Authorization impact |
+| --- | --- | --- |
+| Frozen packet missing required execution prerequisites. | Frozen packet includes frozen test set, invocation template, artifact template, runbook, rubric/scoring, checklist, stop conditions, redaction policy, evidence boundary, selected next lane, and blocker fallback. | Not blocking. |
+| Authorization packet accidentally executes validation. | This packet is docs-only and contains no runtime artifact capture, no model output, and no execution result. | Not blocking; boundary remains explicit. |
+| Level 2 controlled usage reopened. | Closeout selected `NO_FURTHER_LEVEL_2_CONTROLLED_USAGE_LANES_SELECTED`; this packet does not modify closeout artifacts. | Not blocking. |
+| Evidence promotion or readiness claim leakage. | Reviewed evidence blocks production readiness, MVP readiness, benchmark evidence, local model quality evidence, provider-orchestration evidence, Alpha superiority, billing evidence, dashboard readiness, `/v1/solve` readiness, broad runtime readiness, and evidence-model promotion. | Not blocking; future execution must preserve this boundary. |
+| Hosted provider, provider fallback, hosted fallback, `/v1/solve`, dashboard, benchmark, billing, Google Sheets, or backlog action leakage. | Frozen packet and operator references require local-only, default-off, loopback-only, finite-timeout, no hosted fallback, no provider fallback, no hosted provider keys required or accepted, `behavior_evidence=false`, `no_hosted_fallback=true`, and `no_provider_keys_required=true`. | Not blocking; future execution lane must stop on violations. |
+| Preserved artifacts modified. | This packet creates a new authorization directory only. | Not blocking. |
+
+## Residual constraints for the future execution lane
+
+A later execution lane, if started by a separate PR, must not broaden evidence semantics, must not change the frozen test packet unless an approved fix lane does so, and must stop if any frozen packet stop condition or redaction boundary is violated.

--- a/docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-authorization/selected-decision.md
+++ b/docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-authorization/selected-decision.md
@@ -1,0 +1,15 @@
+# Selected Decision
+
+## Decision
+
+`AUTHORIZE_LEVEL_3_VALIDATION_EXECUTION_LANE`
+
+## Rationale
+
+Repository evidence supports authorizing a later, separate Level 3 validation execution lane because the frozen validation packet exists, selected this authorization lane, contains the required frozen execution prerequisites, preserves explicit non-execution boundaries, and leaves Level 2 controlled usage closed as Level 2 local operator usability only.
+
+The reviewed evidence does not promote the controlled usage artifact or frozen packet to production readiness, MVP readiness, benchmark evidence, local model quality evidence, provider-orchestration evidence, Alpha superiority, billing evidence, dashboard readiness, `/v1/solve` readiness, broad runtime readiness, or evidence-model promotion.
+
+## Non-start statement
+
+This selected decision does not start the selected next lane and does not execute validation.

--- a/docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-authorization/selected-next-lane.md
+++ b/docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-authorization/selected-next-lane.md
@@ -1,0 +1,17 @@
+# Selected Next Lane
+
+## Exactly one selected next lane
+
+`ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-LEVEL-3-VALIDATION-EXECUTION-001`
+
+## Scope
+
+The selected next lane may execute the already-frozen Level 3 validation packet in a later, separate PR only if it preserves the frozen packet boundaries and captures artifacts under the frozen packet templates.
+
+## Boundary inherited by the selected next lane
+
+The selected next lane must preserve local-only, default-off, explicit opt-in, loopback-only, finite-timeout, no hosted fallback, no provider fallback, no hosted provider keys required or accepted, `behavior_evidence=false` unless a later evidence model explicitly changes it, `no_hosted_fallback=true`, and `no_provider_keys_required=true`.
+
+## Non-start statement
+
+This authorization PR records the selected next lane only. It does not start `ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-LEVEL-3-VALIDATION-EXECUTION-001` and does not execute validation.

--- a/docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-authorization/source-evidence-reviewed.md
+++ b/docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-authorization/source-evidence-reviewed.md
@@ -1,0 +1,44 @@
+# Source Evidence Reviewed
+
+## Required pre-write verification result
+
+| Required verification | Repo evidence reviewed | Result |
+| --- | --- | --- |
+| Frozen validation packet exists. | `docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-frozen-packet/README.md` and the frozen-packet directory file inventory. | PASS: frozen packet exists. |
+| Frozen packet selected this authorization lane. | `docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-frozen-packet/selected-next-lane.md` | PASS: selected `ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-LEVEL-3-VALIDATION-EXECUTION-AUTHORIZATION-001`. |
+| Frozen packet includes frozen test-case IDs. | `docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-frozen-packet/frozen-test-set.md` | PASS: includes `L3-FROZEN-TC-001` through `L3-FROZEN-TC-005`. |
+| Frozen packet includes frozen invocation template. | `docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-frozen-packet/frozen-invocation-template.md` | PASS: template uses `python -m alpha.local_llm.operator_cli` with explicit local opt-in, loopback endpoint, model, and finite timeout fields. |
+| Frozen packet includes artifact capture template. | `docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-frozen-packet/artifact-capture-template.md` | PASS: lists per-test-case artifacts and normalized JSON expectations. |
+| Frozen packet includes runbook. | `docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-frozen-packet/operator-runbook.md` | PASS: runbook exists. |
+| Frozen packet includes rubric/scoring. | `docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-frozen-packet/rubric-and-scoring.md` | PASS: scoring is limited to artifact completeness, status validity, and boundary preservation. |
+| Frozen packet includes review checklist. | `docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-frozen-packet/review-checklist.md` | PASS: checklist exists and references frozen test-case IDs. |
+| Frozen packet includes stop conditions. | `docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-frozen-packet/stop-conditions.md` | PASS: stop conditions exist and point to the frozen-packet fix lane. |
+| Frozen packet includes redaction policy. | `docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-frozen-packet/redaction-policy.md` | PASS: redaction policy exists and preserves required status/safety fields. |
+| Frozen packet includes evidence boundary. | `docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-frozen-packet/evidence-boundary.md` | PASS: evidence boundary explicitly blocks execution, readiness claims, and evidence promotion. |
+| Frozen packet includes selected next lane. | `docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-frozen-packet/selected-next-lane.md` | PASS: exactly one selected next lane is recorded. |
+| Frozen packet includes blocker fallback. | `docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-frozen-packet/blocker-fallback-lane.md` | PASS: blocker fallback lane exists. |
+| Selected next lane from PR #378 explicitly does not execute validation. | `docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-frozen-packet/README.md` and `selected-next-lane.md` | PASS: both state no validation execution by that PR/lane before a later separate lane is selected and merged. |
+| Level 2 controlled usage path remains closed. | `docs/evals/runs/20260607-local-llm-controlled-usage-operator-run-001/closeout/README.md` and `selected-next-action.md` | PASS: closed as Level 2 local operator usability only with `NO_FURTHER_LEVEL_2_CONTROLLED_USAGE_LANES_SELECTED`. |
+| Accepted boundary remains Level 2 local operator usability only until a later approved lane changes evidence semantics. | Controlled usage closeout, post-closeout next-track decision, level-3 readiness decision, design packet, and frozen packet evidence boundaries. | PASS: evidence semantics remain non-promoted. |
+| No repo evidence promotes controlled usage artifact or frozen packet to blocked readiness/evidence claims. | Controlled usage closeout/import/final-decision/source-artifact, post-closeout next-track decision, readiness decision, design packet, frozen packet, controlled usage packet, operator CLI wrapper docs, command reference, and local LLM seams. | PASS: reviewed evidence blocks production readiness, MVP readiness, benchmark evidence, local model quality evidence, provider-orchestration evidence, Alpha superiority, billing evidence, dashboard readiness, `/v1/solve` readiness, broad runtime readiness, and evidence-model promotion. |
+
+## Source paths reviewed
+
+- `docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-frozen-packet/`
+- `docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-design-packet/`
+- `docs/evals/runs/20260607-local-llm-controlled-usage-operator-run-001/level-3-validation-readiness-decision/`
+- `docs/evals/runs/20260607-local-llm-controlled-usage-operator-run-001/post-closeout-next-track-decision/`
+- `docs/evals/runs/20260607-local-llm-controlled-usage-operator-run-001/closeout/`
+- `docs/evals/runs/20260607-local-llm-controlled-usage-operator-run-001/import-final-decision/`
+- `docs/evals/runs/20260607-local-llm-controlled-usage-operator-run-001/source-artifact/`
+- `docs/local_llm_solver_orchestration_controlled_usage_packet/`
+- `docs/local_llm_solver_orchestration_operator_cli_wrapper_implementation/`
+- `docs/local_llm_solver_orchestration_operator_cli_wrapper_decision/`
+- `docs/local_llm_solver_orchestration_operator_guide/command-reference.md`
+- `alpha/local_llm/operator_cli.py`
+- `alpha/local_llm/orchestration_runner.py`
+- `alpha/local_llm/provider_adapter.py`
+
+## Preservation note
+
+This packet reviewed the source evidence but did not modify preserved source artifacts, controlled usage closeout/import/final-decision/source-artifact/post-closeout/readiness-decision files, design-packet files, frozen-packet files, source code, or tests.


### PR DESCRIPTION
### Motivation

- Provide a docs-only decision packet that, from repo evidence only, decides whether a later, separate Level 3 validation execution lane may be authorized. 
- Preserve the frozen-packet guarantees (frozen test-case IDs, invocation template, artifact capture template, runbook, rubric/scoring, review checklist, stop conditions, redaction policy, evidence boundary, selected next lane, and blocker fallback) without executing validation. 
- Maintain the accepted Level 2 boundary (Level 2 local operator usability only) and explicitly avoid reopening or promoting controlled-usage evidence. 

### Description

- Added a new docs-only authorization packet at `docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-authorization/` containing `README.md`, `source-evidence-reviewed.md`, `authorization-criteria.md`, `risk-review.md`, `decision-options.md`, `selected-decision.md`, `selected-next-lane.md`, `blocker-fallback-lane.md`, `evidence-boundary.md`, `non-actions.md`, and `checks-run.md`.
- Recorded the authorization decision `AUTHORIZE_LEVEL_3_VALIDATION_EXECUTION_LANE`, selected exactly one next lane `ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-LEVEL-3-VALIDATION-EXECUTION-001`, and recorded the blocker fallback lane `ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-LEVEL-3-VALIDATION-EXECUTION-AUTHORIZATION-FIX-001` while making explicit non-start/non-execution language.
- Explicitly documented evidence boundaries and non-actions: this packet is docs-only and does not execute validation, run local model inference or Ollama, rerun smoke, call hosted providers, expose or call `/v1/solve` or dashboard routes, add fallback behavior, run benchmarks, perform billing work, update external ledgers, or promote evidence, and it does not modify preserved source artifacts or frozen test packet artifacts. 

### Testing

- Ran repository checks and scans: `git status --short`, `git diff --name-only`, `git diff --check`, `git diff --cached --name-only`, `git diff --cached --check`, and ripgrep-based checks for the lane name, selected decision, selected next lane, blocker fallback lane, blocked non-claim terms, frozen test-case IDs, and local-only/no-fallback boundaries, and recorded all as PASS in `checks-run.md`.
- Confirmed staged changes are docs-only and committed the new packet (no `alpha/`, `tests/`, source artifact, or frozen-packet files were modified). 
- No runtime tests or model executions were run as required by the evidence boundary; all checks were docs/metadata validations and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a255610bef083299fbe90f3c859b124)