### PR TITLE
Add local LLM evidence-boundary static checker

### DIFF
--- a/scripts/check_local_llm_evidence_boundaries.py
+++ b/scripts/check_local_llm_evidence_boundaries.py
@@ -38,6 +38,14 @@ BLOCKER_FALLBACK_LANE = "ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-EVIDENCE-BOUNDARY-
 FINAL_PACKET_DIR = Path(
     "docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-001/closeout"
 )
+AUTHORITATIVE_FINAL_PACKET_FILES = (
+    "README.md",
+    "accepted-result.md",
+    "final-boundary.md",
+    "final-status.md",
+    "selected-next-action.md",
+    "blocked-claims.md",
+)
 REQUIRED_FINAL_PACKET_PHRASES = (
     "behavior_evidence=False",
     "no_hosted_fallback=True",
@@ -213,8 +221,9 @@ def find_required_final_packet_findings(root: Path = ROOT) -> list[Finding]:
             )
         ]
     combined_parts: list[str] = []
-    for path in sorted(packet_dir.rglob("*")):
-        if path.is_file() and path.suffix.lower() in TEXT_SUFFIXES:
+    for name in AUTHORITATIVE_FINAL_PACKET_FILES:
+        path = packet_dir / name
+        if path.is_file():
             combined_parts.append(path.read_text(encoding="utf-8"))
     combined = "\n".join(combined_parts)
     findings: list[Finding] = []

--- a/scripts/check_local_llm_evidence_boundaries.py
+++ b/scripts/check_local_llm_evidence_boundaries.py
@@ -38,6 +38,9 @@ BLOCKER_FALLBACK_LANE = "ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-EVIDENCE-BOUNDARY-
 FINAL_PACKET_DIR = Path(
     "docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-001/closeout"
 )
+# Only these decision/boundary/status files may satisfy required final-packet
+# phrases. checks-run.md, command logs, and other check/log files are
+# intentionally excluded so recorded rg commands cannot satisfy evidence terms.
 AUTHORITATIVE_FINAL_PACKET_FILES = (
     "README.md",
     "accepted-result.md",

--- a/scripts/check_local_llm_evidence_boundaries.py
+++ b/scripts/check_local_llm_evidence_boundaries.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Static evidence-boundary checker for local LLM solver orchestration docs.
+
+Purpose and limits:
+- This is a deterministic, offline documentation hardening check.
+- It scans local LLM solver orchestration evidence-boundary docs for risky
+  promotional claim phrases and requires nearby boundary language.
+- It also checks that the final Level 3 closeout packet preserves the accepted
+  non-promotional boundary phrases.
+- It does not validate behavior, run benchmarks, call models/providers, read
+  secrets, start Ollama, or exercise runtime routes.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNS_DIR = Path("docs/evals/runs")
+DOCS_DIR_PREFIXES = (
+    "docs/local_llm_solver_orchestration",
+)
+LOCAL_ORCHESTRATION_DIR_MARKER = "local-llm-solver-orchestration"
+SOURCE_ARTIFACT_MARKERS = (
+    "/source-artifact/",
+    "-source-artifact-",
+)
+TEXT_SUFFIXES = {".md", ".txt", ".rst"}
+
+LANE_NAME = "ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-EVIDENCE-BOUNDARY-STATIC-CHECK-SCAFFOLD-001"
+SELECTED_NEXT_ACTION = "NO_FURTHER_EVIDENCE_BOUNDARY_STATIC_CHECK_SCAFFOLD_LANES_SELECTED"
+BLOCKER_FALLBACK_LANE = "ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-EVIDENCE-BOUNDARY-STATIC-CHECK-SCAFFOLD-FIX-001"
+
+FINAL_PACKET_DIR = Path(
+    "docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-001/closeout"
+)
+REQUIRED_FINAL_PACKET_PHRASES = (
+    "behavior_evidence=False",
+    "no_hosted_fallback=True",
+    "no_provider_keys_required=True",
+    "NO_FURTHER_LEVEL_3_VALIDATION_LANES_SELECTED",
+    "LEVEL_3_VALIDATION_EXECUTION_ACCEPTED_AS_ARTIFACT_COMPLETE_NON_PROMOTIONAL_LOCAL_ORCHESTRATION_EVIDENCE",
+)
+
+UNSUPPORTED_CLAIM_PHRASES = (
+    "production readiness",
+    "MVP readiness",
+    "benchmark evidence",
+    "local model quality evidence",
+    "provider-orchestration evidence",
+    "provider orchestration evidence",
+    "Alpha superiority",
+    "billing evidence",
+    "dashboard readiness",
+    "/v1/solve readiness",
+    "broad runtime readiness",
+    "evidence-model promotion",
+    "provider fallback readiness",
+    "hosted fallback readiness",
+)
+
+BOUNDARY_LANGUAGE_PATTERNS = tuple(
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"\bblocked(?:-|\s)?claims?\b",
+        r"\bevidence(?:-|\s)?boundary\b",
+        r"\bboundary\b",
+        r"\bdecision boundary\b",
+        r"\baccepted boundary\b",
+        r"\bexcluded(?: evidence)? categories\b",
+        r"\bnon(?:-|\s)?claims?\b",
+        r"\bnon(?:-|\s)?actions?\b",
+        r"\bnon(?:-|\s)?decision\b",
+        r"\bnon(?:-|\s)?execution\b",
+        r"\bnon(?:-|\s)?promotional\b",
+        r"\bunsupported\b",
+        r"\bdenied\b",
+        r"\bunsafe\b",
+        r"\bforbidden\b",
+        r"\bnot\b",
+        r"\bdoes not\b",
+        r"\bdo not\b",
+        r"\bno\b",
+        r"\bwithout\b",
+        r"\bseparate from\b",
+        r"\bis not\b",
+        r"\bnot prove\b",
+        r"\bnot changed\b",
+        r"\bremains bounded\b",
+        r"\bmust not\b",
+    )
+)
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: Path
+    line: int
+    phrase: str
+    message: str
+
+    def format(self) -> str:
+        return f"{self.path}:{self.line}: {self.phrase}: {self.message}"
+
+
+def _repo_relative(path: Path, root: Path = ROOT) -> Path:
+    try:
+        return path.resolve().relative_to(root.resolve())
+    except ValueError:
+        return path
+
+
+def _is_source_artifact(path: Path) -> bool:
+    as_posix = path.as_posix()
+    return any(marker in as_posix for marker in SOURCE_ARTIFACT_MARKERS)
+
+
+def is_relevant_doc(path: Path) -> bool:
+    """Return True for local LLM solver orchestration docs that should be scanned."""
+    if path.suffix.lower() not in TEXT_SUFFIXES:
+        return False
+    rel = _repo_relative(path).as_posix()
+    if _is_source_artifact(Path(rel)):
+        return False
+    if rel.startswith(DOCS_DIR_PREFIXES):
+        return True
+    return rel.startswith(RUNS_DIR.as_posix()) and LOCAL_ORCHESTRATION_DIR_MARKER in rel
+
+
+def iter_relevant_docs(root: Path = ROOT) -> list[Path]:
+    docs: list[Path] = []
+    for base in (root / "docs",):
+        if not base.exists():
+            continue
+        for path in base.rglob("*"):
+            if path.is_file() and is_relevant_doc(path):
+                docs.append(_repo_relative(path, root))
+    return sorted(docs, key=lambda item: item.as_posix())
+
+
+def _window(lines: list[str], index: int, radius: int = 2) -> str:
+    start = max(0, index - radius)
+    end = min(len(lines), index + radius + 1)
+    return "\n".join(lines[start:end])
+
+
+def _has_boundary_language(text: str) -> bool:
+    return any(pattern.search(text) for pattern in BOUNDARY_LANGUAGE_PATTERNS)
+
+
+def _path_is_boundary_context(path: Path) -> bool:
+    path_text = path.as_posix().lower()
+    return any(
+        marker in path_text
+        for marker in (
+            "blocked",
+            "boundary",
+            "non-claim",
+            "non_claim",
+            "safe-use",
+            "allowed-cli-boundary",
+            "failure-modes",
+            "stop-conditions",
+            "checks-run",
+        )
+    )
+
+
+def _section_context(lines: list[str], index: int) -> str:
+    section_start = 0
+    for candidate in range(index, -1, -1):
+        if lines[candidate].lstrip().startswith("#"):
+            section_start = candidate
+            break
+    return "\n".join(lines[section_start : index + 1])
+
+
+def find_promotional_claim_findings(path: Path, text: str) -> list[Finding]:
+    if _path_is_boundary_context(path):
+        return []
+
+    lines = text.splitlines()
+    findings: list[Finding] = []
+    for index, line in enumerate(lines):
+        for phrase in UNSUPPORTED_CLAIM_PHRASES:
+            if re.search(re.escape(phrase), line, re.IGNORECASE):
+                context = "\n".join((_window(lines, index, radius=3), _section_context(lines, index)))
+                if not _has_boundary_language(context):
+                    findings.append(
+                        Finding(
+                            path=path,
+                            line=index + 1,
+                            phrase=phrase,
+                            message="unsupported promotional claim phrase lacks nearby boundary language",
+                        )
+                    )
+    return findings
+
+
+def find_required_final_packet_findings(root: Path = ROOT) -> list[Finding]:
+    packet_dir = root / FINAL_PACKET_DIR
+    if not packet_dir.exists():
+        return [
+            Finding(
+                path=FINAL_PACKET_DIR,
+                line=1,
+                phrase="final packet directory",
+                message="required final packet directory is missing",
+            )
+        ]
+    combined_parts: list[str] = []
+    for path in sorted(packet_dir.rglob("*")):
+        if path.is_file() and path.suffix.lower() in TEXT_SUFFIXES:
+            combined_parts.append(path.read_text(encoding="utf-8"))
+    combined = "\n".join(combined_parts)
+    findings: list[Finding] = []
+    for phrase in REQUIRED_FINAL_PACKET_PHRASES:
+        if phrase not in combined:
+            findings.append(
+                Finding(
+                    path=FINAL_PACKET_DIR,
+                    line=1,
+                    phrase=phrase,
+                    message="required final packet boundary phrase is missing",
+                )
+            )
+    return findings
+
+
+def check_paths(paths: Iterable[Path], root: Path = ROOT) -> list[Finding]:
+    findings: list[Finding] = []
+    for rel_path in paths:
+        path = root / rel_path
+        text = path.read_text(encoding="utf-8")
+        findings.extend(find_promotional_claim_findings(rel_path, text))
+    findings.extend(find_required_final_packet_findings(root))
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Check local LLM solver orchestration docs for evidence-boundary phrasing."
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        help="Optional repo-relative files to scan. Defaults to relevant docs.",
+    )
+    args = parser.parse_args(argv)
+
+    paths = args.paths or iter_relevant_docs(ROOT)
+    paths = [path for path in paths if is_relevant_doc(path)]
+    findings = check_paths(paths, ROOT)
+    if findings:
+        print("Local LLM evidence-boundary static check failed:", file=sys.stderr)
+        for finding in findings:
+            print(f"  {finding.format()}", file=sys.stderr)
+        return 1
+
+    print(f"Local LLM evidence-boundary static check passed ({len(paths)} files scanned).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_local_llm_evidence_boundaries.py
+++ b/tests/test_local_llm_evidence_boundaries.py
@@ -6,6 +6,7 @@ Ollama, hosted providers, benchmarks, dashboard routes, or /v1/solve.
 from pathlib import Path
 
 from scripts.check_local_llm_evidence_boundaries import (
+    AUTHORITATIVE_FINAL_PACKET_FILES,
     FINAL_PACKET_DIR,
     REQUIRED_FINAL_PACKET_PHRASES,
     check_paths,
@@ -49,14 +50,44 @@ def test_promotional_claim_with_boundary_language_is_allowed():
     assert findings == []
 
 
+def _write_authoritative_packet(root: Path, phrases: tuple[str, ...]) -> None:
+    packet_dir = root / FINAL_PACKET_DIR
+    packet_dir.mkdir(parents=True)
+    for name in AUTHORITATIVE_FINAL_PACKET_FILES:
+        (packet_dir / name).write_text("# Placeholder\n", encoding="utf-8")
+    (packet_dir / "accepted-result.md").write_text("\n".join(phrases), encoding="utf-8")
+
+
+def test_required_phrase_only_in_checks_run_does_not_satisfy_enforcement(tmp_path):
+    missing_phrase = REQUIRED_FINAL_PACKET_PHRASES[0]
+    authoritative_phrases = tuple(
+        phrase for phrase in REQUIRED_FINAL_PACKET_PHRASES if phrase != missing_phrase
+    )
+    _write_authoritative_packet(tmp_path, authoritative_phrases)
+    (tmp_path / FINAL_PACKET_DIR / "checks-run.md").write_text(
+        f'`rg "{missing_phrase}" docs/evals/runs/.../closeout`\n',
+        encoding="utf-8",
+    )
+
+    findings = find_required_final_packet_findings(tmp_path)
+
+    assert [finding.phrase for finding in findings] == [missing_phrase]
+
+
+def test_required_phrases_in_authoritative_closeout_files_satisfy_enforcement(tmp_path):
+    _write_authoritative_packet(tmp_path, REQUIRED_FINAL_PACKET_PHRASES)
+
+    assert find_required_final_packet_findings(tmp_path) == []
+
+
 def test_final_packet_contains_required_boundary_phrases():
     findings = find_required_final_packet_findings()
 
     assert findings == []
     packet_text = "\n".join(
-        path.read_text(encoding="utf-8")
-        for path in sorted(FINAL_PACKET_DIR.rglob("*"))
-        if path.is_file() and path.suffix == ".md"
+        (FINAL_PACKET_DIR / name).read_text(encoding="utf-8")
+        for name in AUTHORITATIVE_FINAL_PACKET_FILES
+        if (FINAL_PACKET_DIR / name).is_file()
     )
     for phrase in REQUIRED_FINAL_PACKET_PHRASES:
         assert phrase in packet_text

--- a/tests/test_local_llm_evidence_boundaries.py
+++ b/tests/test_local_llm_evidence_boundaries.py
@@ -68,6 +68,10 @@ def test_required_phrase_only_in_checks_run_does_not_satisfy_enforcement(tmp_pat
         f'`rg "{missing_phrase}" docs/evals/runs/.../closeout`\n',
         encoding="utf-8",
     )
+    (tmp_path / FINAL_PACKET_DIR / "command-log.md").write_text(
+        f"command output mentioned {missing_phrase}\n",
+        encoding="utf-8",
+    )
 
     findings = find_required_final_packet_findings(tmp_path)
 

--- a/tests/test_local_llm_evidence_boundaries.py
+++ b/tests/test_local_llm_evidence_boundaries.py
@@ -1,0 +1,69 @@
+"""Tests for the local LLM solver orchestration evidence-boundary checker.
+
+The checker is a static docs guard only. These tests do not run local inference,
+Ollama, hosted providers, benchmarks, dashboard routes, or /v1/solve.
+"""
+from pathlib import Path
+
+from scripts.check_local_llm_evidence_boundaries import (
+    FINAL_PACKET_DIR,
+    REQUIRED_FINAL_PACKET_PHRASES,
+    check_paths,
+    find_promotional_claim_findings,
+    find_required_final_packet_findings,
+    is_relevant_doc,
+    iter_relevant_docs,
+)
+
+
+def test_relevant_docs_include_closeout_and_skip_source_artifacts():
+    assert is_relevant_doc(
+        Path(
+            "docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-001/closeout/final-boundary.md"
+        )
+    )
+    assert not is_relevant_doc(
+        Path(
+            "docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-001/source-artifact/run_level3_validation.sh"
+        )
+    )
+    assert not is_relevant_doc(Path("docs/RUNTIME_READINESS.md"))
+
+
+def test_promotional_claim_without_boundary_language_is_flagged():
+    findings = find_promotional_claim_findings(
+        Path("docs/evals/runs/example-local-llm-solver-orchestration/example.md"),
+        "This proves production readiness for the lane.\n",
+    )
+
+    assert len(findings) == 1
+    assert findings[0].phrase == "production readiness"
+
+
+def test_promotional_claim_with_boundary_language_is_allowed():
+    findings = find_promotional_claim_findings(
+        Path("docs/evals/runs/example-local-llm-solver-orchestration/evidence-boundary.md"),
+        "## Evidence boundary\n\nThis does not prove production readiness.\n",
+    )
+
+    assert findings == []
+
+
+def test_final_packet_contains_required_boundary_phrases():
+    findings = find_required_final_packet_findings()
+
+    assert findings == []
+    packet_text = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in sorted(FINAL_PACKET_DIR.rglob("*"))
+        if path.is_file() and path.suffix == ".md"
+    )
+    for phrase in REQUIRED_FINAL_PACKET_PHRASES:
+        assert phrase in packet_text
+
+
+def test_current_relevant_docs_pass_static_check():
+    docs = iter_relevant_docs()
+
+    assert docs, "expected local LLM solver orchestration docs to be discovered"
+    assert check_paths(docs) == []


### PR DESCRIPTION
### Motivation

- Lane: `ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-EVIDENCE-BOUNDARY-STATIC-CHECK-SCAFFOLD-001`; add a lightweight, deterministic docs guard to prevent accidental promotion of local LLM solver orchestration artifacts into unsupported readiness/benchmark/provider/dashboard/billing/Alpha-superiority claims.  
- Keep the scope narrow and offline: build hardening / docs linting only, following existing scripts/tests conventions in the repo.

### Description

- Added `scripts/check_local_llm_evidence_boundaries.py`, a deterministic offline checker that discovers relevant local-orchestration docs, skips preserved source-artifact paths, flags unsupported promotional claim phrases unless nearby boundary language or an explicit boundary-path context is present, and enforces required final closeout packet phrases.  
- Enforced required final-packet phrases: `behavior_evidence=False`, `no_hosted_fallback=True`, `no_provider_keys_required=True`, `NO_FURTHER_LEVEL_3_VALIDATION_LANES_SELECTED`, and `LEVEL_3_VALIDATION_EXECUTION_ACCEPTED_AS_ARTIFACT_COMPLETE_NON_PROMOTIONAL_LOCAL_ORCHESTRATION_EVIDENCE`.  
- Added lane metadata constants (`LANE_NAME`, `SELECTED_NEXT_ACTION`, `BLOCKER_FALLBACK_LANE`) and a CLI entrypoint consistent with other `scripts/` checks.  
- Added tests `tests/test_local_llm_evidence_boundaries.py` covering relevant-doc selection, source-artifact skipping, unsupported-claim detection, allowance when boundary language is present, enforcement of final-packet phrases, and a full repo-docs smoke pass for the new checker.

### Testing

- Inspected repo conventions and files: `AGENTS.md`, `scripts/check_docstrings.py`, `scripts/check_case_collisions.py`, `tests/tooling/test_case_collisions.py`, `tests/test_output_diff_a3_operator_checklist.py`, `Makefile`, `pyproject.toml`, and relevant `docs/evals/runs/.../closeout` files.  
- Commands run and results: `python -m py_compile scripts/check_local_llm_evidence_boundaries.py` (ok); `python scripts/check_local_llm_evidence_boundaries.py` (checker run across repo docs; final run passed and reported all scanned files); `python -m pytest -q tests/test_local_llm_evidence_boundaries.py` (all tests passed).  
- Checks executed: `git status --short`, `git diff --name-only`, `git diff --check`, `git diff --cached --check`, repo `rg` checks for required phrases and blocked claim tokens, and verification that no preserved source-artifact files, Google Sheets, or backlog workbook files were modified.  
- Selected next action: `NO_FURTHER_EVIDENCE_BOUNDARY_STATIC_CHECK_SCAFFOLD_LANES_SELECTED`.  
- Blocker fallback lane: `ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-EVIDENCE-BOUNDARY-STATIC-CHECK-SCAFFOLD-FIX-001`.  
- Evidence-boundary and non-actions (explicit): this PR is documentation/build hardening only and does not change runtime behavior; it does not run local model inference, Ollama, hosted providers, `/v1/solve`, dashboards, provider fallback/hosted fallback, benchmarks, billing work, evidence promotion, or update Google Sheets/backlog workbooks.  
- Statement: this PR does not change runtime behavior and does not reopen Level 3 validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a257294a70883299ba64bfddf0c68fa)