### PR TITLE
Add post-Level-3 roadmap decision packet (select readiness-ladder)

### DIFF
--- a/docs/evals/runs/local-llm-solver-orchestration-post-level-3-roadmap-decision/README.md
+++ b/docs/evals/runs/local-llm-solver-orchestration-post-level-3-roadmap-decision/README.md
@@ -1,0 +1,52 @@
+# Local LLM Solver Orchestration Post-Level-3 Roadmap Decision
+
+## Lane
+
+`ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-POST-LEVEL-3-ROADMAP-DECISION-001`
+
+## Purpose
+
+This docs-only roadmap decision packet selects exactly one next major track for Alpha Solver local LLM solver orchestration work after the accepted Level 3 closeout, while preserving the completed Level 2 and Level 3 evidence boundaries.
+
+This packet does not start execution of the selected next lane.
+
+## Prior accepted Level 3 decision preserved
+
+`LEVEL_3_VALIDATION_EXECUTION_ACCEPTED_AS_ARTIFACT_COMPLETE_NON_PROMOTIONAL_LOCAL_ORCHESTRATION_EVIDENCE`
+
+## Prior selected next actions preserved
+
+- Level 3 closeout: `NO_FURTHER_LEVEL_3_VALIDATION_LANES_SELECTED`
+- Evidence index: `NO_FURTHER_LOCAL_LLM_SOLVER_ORCHESTRATION_INDEX_LANES_SELECTED`
+- Static evidence-boundary checker scaffold: `NO_FURTHER_EVIDENCE_BOUNDARY_STATIC_CHECK_SCAFFOLD_LANES_SELECTED`
+- Operator docs consolidation: `NO_FURTHER_OPERATOR_DOCS_CONSOLIDATION_LANES_SELECTED`
+
+## Selected decision
+
+`SELECT_RELEASE_READINESS_LADDER_TRACK`
+
+## Selected next lane
+
+`ALPHA-SOLVER-POST-LEVEL-3-RELEASE-READINESS-LADDER-PACKET-001`
+
+## Blocker fallback lane
+
+`ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-POST-LEVEL-3-ROADMAP-DECISION-FIX-001`
+
+## Files in this packet
+
+- `source-evidence-reviewed.md` records the repo evidence verified before writing this packet.
+- `current-state-summary.md` summarizes the accepted prior state and non-authorizations.
+- `decision-options.md` lists all five reviewed options.
+- `option-risk-review.md` explains why the selected option is safer or higher leverage and why alternatives are deferred.
+- `selected-decision.md` records the one selected decision.
+- `selected-next-lane.md` records the one selected next lane.
+- `blocker-fallback-lane.md` records the fallback lane if this roadmap packet is incomplete, unsafe, inconsistent, or unable to select one next lane.
+- `evidence-boundary.md` preserves the evidence boundary and non-promotional limits.
+- `non-actions.md` records explicit actions not taken by this PR.
+- `blocked-claims.md` records claims this packet does not establish.
+- `checks-run.md` records the checks used to verify the packet.
+
+## Non-start statement
+
+This PR selects a future readiness-ladder design lane only. It does not start `ALPHA-SOLVER-POST-LEVEL-3-RELEASE-READINESS-LADDER-PACKET-001`.

--- a/docs/evals/runs/local-llm-solver-orchestration-post-level-3-roadmap-decision/blocked-claims.md
+++ b/docs/evals/runs/local-llm-solver-orchestration-post-level-3-roadmap-decision/blocked-claims.md
@@ -1,0 +1,21 @@
+# Blocked Claims
+
+This packet blocks and does not establish the following claims:
+
+- production readiness;
+- MVP readiness;
+- benchmark evidence;
+- local model quality evidence;
+- provider-orchestration evidence;
+- Alpha superiority;
+- billing evidence;
+- dashboard readiness;
+- `/v1/solve` readiness;
+- broad runtime readiness;
+- evidence-model promotion;
+- provider fallback;
+- hosted fallback;
+- dashboard exposure;
+- `/v1/solve` exposure.
+
+These blocked claims remain outside the accepted Level 2 and Level 3 evidence boundaries.

--- a/docs/evals/runs/local-llm-solver-orchestration-post-level-3-roadmap-decision/blocker-fallback-lane.md
+++ b/docs/evals/runs/local-llm-solver-orchestration-post-level-3-roadmap-decision/blocker-fallback-lane.md
@@ -1,0 +1,7 @@
+# Blocker Fallback Lane
+
+If this roadmap decision packet is incomplete, unsafe, internally inconsistent, or cannot select exactly one next lane, use:
+
+`ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-POST-LEVEL-3-ROADMAP-DECISION-FIX-001`
+
+This fallback lane is not selected as the next roadmap track. It is only the repair path for this packet.

--- a/docs/evals/runs/local-llm-solver-orchestration-post-level-3-roadmap-decision/checks-run.md
+++ b/docs/evals/runs/local-llm-solver-orchestration-post-level-3-roadmap-decision/checks-run.md
@@ -1,0 +1,38 @@
+# Checks Run
+
+## Pre-write source-evidence checks
+
+- `rg -n "closed|CLOSED|accepted|ACCEPTED|selected next|NO_FURTHER" docs/evals/runs/20260607-local-llm-controlled-usage-operator-run-001/closeout`
+- `rg -n "closed|CLOSED|accepted|ACCEPTED|LEVEL_3_VALIDATION_EXECUTION_ACCEPTED_AS_ARTIFACT_COMPLETE_NON_PROMOTIONAL_LOCAL_ORCHESTRATION_EVIDENCE|NO_FURTHER_LEVEL_3_VALIDATION_LANES_SELECTED" docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-001/closeout docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-001/import-final-decision`
+- `rg -n "python -m alpha\.local_llm\.operator_cli" docs/local_llm_solver_orchestration_operator_guide alpha/local_llm/operator_cli.py`
+- `rg -n "NO_FURTHER_LOCAL_LLM_SOLVER_ORCHESTRATION_INDEX_LANES_SELECTED|NO_FURTHER_EVIDENCE_BOUNDARY_STATIC_CHECK_SCAFFOLD_LANES_SELECTED|NO_FURTHER_OPERATOR_DOCS_CONSOLIDATION_LANES_SELECTED" docs/evals/runs/local-llm-solver-orchestration-index docs/local_llm_solver_orchestration_operator_guide scripts/check_local_llm_evidence_boundaries.py tests/test_local_llm_evidence_boundaries.py`
+- `rg -n "production readiness|MVP readiness|benchmark evidence|local model quality evidence|provider-orchestration evidence|Alpha superiority|billing evidence|dashboard readiness|/v1/solve readiness|broad runtime readiness|evidence-model promotion|provider fallback|hosted fallback|dashboard exposure|/v1/solve exposure" docs/evals/runs/local-llm-solver-orchestration-index docs/local_llm_solver_orchestration_operator_guide docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-001 docs/evals/runs/20260607-local-llm-controlled-usage-operator-run-001/closeout scripts/check_local_llm_evidence_boundaries.py tests/test_local_llm_evidence_boundaries.py`
+
+## Post-write checks
+
+The required post-write checks for this packet are recorded after execution in the PR summary and commit history. They include:
+
+- `git status --short`
+- `git diff --name-only`
+- `git diff --check`
+- `python scripts/check_local_llm_evidence_boundaries.py`
+- `rg` checks for the final accepted Level 3 decision, prior selected next action, selected decision, selected next lane, blocker fallback lane, and blocked claim terms.
+- Confirmation that no preserved source artifact files were modified.
+- Confirmation that no `alpha/` files changed.
+- Confirmation that no runtime/provider/dashboard/API files changed.
+
+## Post-write results
+
+- PASS: `git status --short` showed only the new docs-only packet directory before staging.
+- PASS: `git diff --name-only` completed with no tracked-file diff output before staging because the packet was still untracked.
+- PASS: `git diff --check` completed with no whitespace errors.
+- PASS: `python scripts/check_local_llm_evidence_boundaries.py` completed with `Local LLM evidence-boundary static check passed (443 files scanned).`
+- PASS: `rg -n "LEVEL_3_VALIDATION_EXECUTION_ACCEPTED_AS_ARTIFACT_COMPLETE_NON_PROMOTIONAL_LOCAL_ORCHESTRATION_EVIDENCE" docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-001 docs/evals/runs/local-llm-solver-orchestration-post-level-3-roadmap-decision` found the final accepted Level 3 decision.
+- PASS: `rg -n "NO_FURTHER_LEVEL_3_VALIDATION_LANES_SELECTED" docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-001 docs/evals/runs/local-llm-solver-orchestration-post-level-3-roadmap-decision` found the final Level 3 selected next action.
+- PASS: `rg -n "SELECT_RELEASE_READINESS_LADDER_TRACK" docs/evals/runs/local-llm-solver-orchestration-post-level-3-roadmap-decision` found the selected decision.
+- PASS: `rg -n "ALPHA-SOLVER-POST-LEVEL-3-RELEASE-READINESS-LADDER-PACKET-001" docs/evals/runs/local-llm-solver-orchestration-post-level-3-roadmap-decision` found the selected next lane.
+- PASS: `rg -n "ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-POST-LEVEL-3-ROADMAP-DECISION-FIX-001" docs/evals/runs/local-llm-solver-orchestration-post-level-3-roadmap-decision` found the blocker fallback lane.
+- PASS: `rg -n "production readiness|MVP readiness|benchmark evidence|local model quality evidence|provider-orchestration evidence|Alpha superiority|billing evidence|dashboard readiness|/v1/solve readiness|broad runtime readiness|evidence-model promotion|provider fallback|hosted fallback|dashboard exposure|/v1/solve exposure" docs/evals/runs/local-llm-solver-orchestration-post-level-3-roadmap-decision` found blocked claim terms.
+- PASS: `git status --short -- docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-001/source-artifact` produced no output, confirming no preserved source artifact files were modified.
+- PASS: `git status --short -- alpha` produced no output, confirming no `alpha/` files changed.
+- PASS: `git status --short -- alpha/local_llm/operator_cli.py alpha/local_llm/orchestration_runner.py alpha/local_llm/provider_adapter.py alpha api app dashboard dashboards` produced no output, confirming no runtime/provider/dashboard/API files changed.

--- a/docs/evals/runs/local-llm-solver-orchestration-post-level-3-roadmap-decision/current-state-summary.md
+++ b/docs/evals/runs/local-llm-solver-orchestration-post-level-3-roadmap-decision/current-state-summary.md
@@ -1,0 +1,26 @@
+# Current State Summary
+
+## Accepted prior state
+
+- PR #370 through PR #386 are treated as merged and GS done per lane input.
+- Level 2 controlled usage is closed as a Level 2 local operator usability artifact only.
+- Level 3 validation execution is closed.
+- The post-Level-3 evidence index is complete.
+- The post-Level-3 static evidence-boundary checker scaffold is complete.
+- The post-Level-3 operator docs consolidation is complete.
+- The local-only operator CLI wrapper identity is stable as `python -m alpha.local_llm.operator_cli`.
+
+## Final Level 3 accepted decision
+
+`LEVEL_3_VALIDATION_EXECUTION_ACCEPTED_AS_ARTIFACT_COMPLETE_NON_PROMOTIONAL_LOCAL_ORCHESTRATION_EVIDENCE`
+
+## Preserved selected next actions
+
+- Level 3 closeout: `NO_FURTHER_LEVEL_3_VALIDATION_LANES_SELECTED`
+- Evidence index: `NO_FURTHER_LOCAL_LLM_SOLVER_ORCHESTRATION_INDEX_LANES_SELECTED`
+- Static evidence-boundary checker scaffold: `NO_FURTHER_EVIDENCE_BOUNDARY_STATIC_CHECK_SCAFFOLD_LANES_SELECTED`
+- Operator docs consolidation: `NO_FURTHER_OPERATOR_DOCS_CONSOLIDATION_LANES_SELECTED`
+
+## Current boundary
+
+The accepted state supports only completed local orchestration evidence as non-promotional artifact completeness. It does not authorize execution, deployment, provider fallback, hosted fallback, dashboard work, `/v1/solve` exposure, benchmark work, billing work, evidence promotion, or readiness claims.

--- a/docs/evals/runs/local-llm-solver-orchestration-post-level-3-roadmap-decision/decision-options.md
+++ b/docs/evals/runs/local-llm-solver-orchestration-post-level-3-roadmap-decision/decision-options.md
@@ -1,0 +1,53 @@
+# Decision Options Reviewed
+
+Exactly one option is selected by this packet.
+
+## Option 1
+
+Decision: `SELECT_PRODUCT_SURFACE_PLANNING_TRACK`
+
+Meaning: create a future planning/spec track that defines prerequisites for eventual `/v1/solve` or dashboard exposure, without exposing either surface yet.
+
+Selected next lane if chosen: `ALPHA-SOLVER-POST-LEVEL-3-PRODUCT-SURFACE-PLANNING-PACKET-001`
+
+Status: deferred.
+
+## Option 2
+
+Decision: `SELECT_QUALITY_EVALUATION_DESIGN_TRACK`
+
+Meaning: create a future quality evaluation design track that defines answer-quality evaluation methodology, task sets, scoring, and benchmark boundaries, without running benchmarks or making quality claims yet.
+
+Selected next lane if chosen: `ALPHA-SOLVER-POST-LEVEL-3-QUALITY-EVALUATION-DESIGN-PACKET-001`
+
+Status: deferred.
+
+## Option 3
+
+Decision: `SELECT_PROVIDER_ORCHESTRATION_DESIGN_TRACK`
+
+Meaning: create a future design track for hosted-provider orchestration or fallback planning, without implementing fallback, accepting hosted keys, calling hosted providers, or changing local-only behavior yet.
+
+Selected next lane if chosen: `ALPHA-SOLVER-POST-LEVEL-3-PROVIDER-ORCHESTRATION-DESIGN-PACKET-001`
+
+Status: deferred.
+
+## Option 4
+
+Decision: `SELECT_LOCAL_OPERATOR_WORKFLOW_EXPANSION_TRACK`
+
+Meaning: create a future local-only operator workflow expansion track that improves local CLI workflows, templates, artifact handling, or operator ergonomics while preserving local-only boundaries and without product exposure.
+
+Selected next lane if chosen: `ALPHA-SOLVER-POST-LEVEL-3-LOCAL-OPERATOR-WORKFLOW-EXPANSION-PACKET-001`
+
+Status: deferred.
+
+## Option 5
+
+Decision: `SELECT_RELEASE_READINESS_LADDER_TRACK`
+
+Meaning: create a future readiness-ladder design track that defines Levels 4, 5, and later gates from local artifacts toward product readiness, without claiming readiness or executing product work yet.
+
+Selected next lane if chosen: `ALPHA-SOLVER-POST-LEVEL-3-RELEASE-READINESS-LADDER-PACKET-001`
+
+Status: selected.

--- a/docs/evals/runs/local-llm-solver-orchestration-post-level-3-roadmap-decision/evidence-boundary.md
+++ b/docs/evals/runs/local-llm-solver-orchestration-post-level-3-roadmap-decision/evidence-boundary.md
@@ -1,0 +1,29 @@
+# Evidence Boundary
+
+## Scope
+
+This is docs-only roadmap decision work.
+
+It preserves the completed Level 2 and Level 3 evidence boundaries. It does not reinterpret, rescore, rerun, broaden, or promote any prior artifact.
+
+## Explicit non-execution boundary
+
+This packet:
+
+- does not run local model inference;
+- does not run Ollama;
+- does not rerun validation;
+- does not rerun smoke;
+- does not call hosted providers;
+- does not expose or call `/v1/solve`;
+- does not expose or call dashboards;
+- does not add provider fallback;
+- does not add hosted fallback;
+- does not run benchmarks;
+- does not perform billing work;
+- does not update Google Sheets or backlog workbooks;
+- does not promote evidence.
+
+## Claims not established
+
+This packet does not establish production readiness, MVP readiness, benchmark evidence, local model quality evidence, provider-orchestration evidence, Alpha superiority, billing evidence, dashboard readiness, `/v1/solve` readiness, broad runtime readiness, or evidence-model promotion.

--- a/docs/evals/runs/local-llm-solver-orchestration-post-level-3-roadmap-decision/non-actions.md
+++ b/docs/evals/runs/local-llm-solver-orchestration-post-level-3-roadmap-decision/non-actions.md
@@ -1,0 +1,25 @@
+# Non-Actions
+
+This docs-only roadmap decision packet did not perform any of the following actions:
+
+- run local model inference;
+- run Ollama;
+- rerun validation;
+- rerun smoke;
+- call hosted providers;
+- expose or call `/v1/solve`;
+- expose or call dashboards;
+- add provider fallback;
+- add hosted fallback;
+- run benchmarks;
+- perform billing work;
+- update Google Sheets;
+- update backlog workbooks;
+- promote evidence;
+- modify runtime behavior;
+- modify local LLM provider adapter behavior;
+- modify operator CLI behavior;
+- modify preserved source artifacts;
+- modify Level 2 closeout packets;
+- modify Level 3 closeout packets;
+- start `ALPHA-SOLVER-POST-LEVEL-3-RELEASE-READINESS-LADDER-PACKET-001`.

--- a/docs/evals/runs/local-llm-solver-orchestration-post-level-3-roadmap-decision/option-risk-review.md
+++ b/docs/evals/runs/local-llm-solver-orchestration-post-level-3-roadmap-decision/option-risk-review.md
@@ -1,0 +1,29 @@
+# Option Risk Review
+
+## Selected option
+
+`SELECT_RELEASE_READINESS_LADDER_TRACK` is selected.
+
+## Why this is safer and higher leverage
+
+A readiness-ladder design track is the safest bridge after Level 3 because it creates explicit future gates before any product, benchmark, provider, dashboard, `/v1/solve`, billing, or promotion work can be considered. It is higher leverage than immediately planning a single product surface, quality suite, provider fallback design, or local workflow expansion because it can define the prerequisites and stop conditions that those future tracks must satisfy.
+
+This selection preserves the current evidence boundary: the accepted Level 3 result remains artifact-complete, non-promotional, local orchestration evidence only.
+
+## Deferred options
+
+### Option 1: `SELECT_PRODUCT_SURFACE_PLANNING_TRACK`
+
+Deferred because product-surface planning for eventual `/v1/solve` or dashboard exposure is downstream of a readiness ladder. Without a ladder, planning product surfaces risks appearing to imply surface readiness before gates for evidence, safety, quality, operations, and promotion have been defined.
+
+### Option 2: `SELECT_QUALITY_EVALUATION_DESIGN_TRACK`
+
+Deferred because quality-evaluation design should inherit readiness-ladder constraints before defining task sets, scoring, or benchmark boundaries. This packet does not run benchmarks or make quality claims.
+
+### Option 3: `SELECT_PROVIDER_ORCHESTRATION_DESIGN_TRACK`
+
+Deferred because hosted-provider orchestration and fallback planning carries elevated boundary risk. It should wait until a readiness ladder defines when provider keys, hosted calls, fallback behavior, and provider evidence may be discussed or implemented. This packet does not add provider fallback or hosted fallback.
+
+### Option 4: `SELECT_LOCAL_OPERATOR_WORKFLOW_EXPANSION_TRACK`
+
+Deferred because local-only workflow improvements are useful but narrower than the cross-track gating need after Level 3. Workflow expansion should remain available later, after the readiness ladder defines which local-only ergonomics work is safe and how artifacts should be handled.

--- a/docs/evals/runs/local-llm-solver-orchestration-post-level-3-roadmap-decision/selected-decision.md
+++ b/docs/evals/runs/local-llm-solver-orchestration-post-level-3-roadmap-decision/selected-decision.md
@@ -1,0 +1,13 @@
+# Selected Decision
+
+## Decision
+
+`SELECT_RELEASE_READINESS_LADDER_TRACK`
+
+## Decision count
+
+Exactly one decision is selected by this packet.
+
+## Rationale
+
+The release-readiness ladder is selected because it is the safest post-Level-3 bridge from local artifact completeness toward future planning. It does not claim readiness and does not execute product, provider, quality, benchmark, dashboard, `/v1/solve`, billing, fallback, or evidence-promotion work.

--- a/docs/evals/runs/local-llm-solver-orchestration-post-level-3-roadmap-decision/selected-next-lane.md
+++ b/docs/evals/runs/local-llm-solver-orchestration-post-level-3-roadmap-decision/selected-next-lane.md
@@ -1,0 +1,13 @@
+# Selected Next Lane
+
+## Selected next lane
+
+`ALPHA-SOLVER-POST-LEVEL-3-RELEASE-READINESS-LADDER-PACKET-001`
+
+## Lane count
+
+Exactly one selected next lane is recorded by this packet.
+
+## Non-start statement
+
+This roadmap decision PR does not start `ALPHA-SOLVER-POST-LEVEL-3-RELEASE-READINESS-LADDER-PACKET-001`. A later PR must create that design packet if approved.

--- a/docs/evals/runs/local-llm-solver-orchestration-post-level-3-roadmap-decision/source-evidence-reviewed.md
+++ b/docs/evals/runs/local-llm-solver-orchestration-post-level-3-roadmap-decision/source-evidence-reviewed.md
@@ -1,0 +1,35 @@
+# Source Evidence Reviewed
+
+## Required verification before writing docs
+
+The following repo evidence was reviewed before creating this roadmap decision packet:
+
+- `docs/evals/runs/20260607-local-llm-controlled-usage-operator-run-001/closeout/`
+  - Verified the Level 2 controlled usage closeout exists and remains closed.
+  - Verified selected next action: `NO_FURTHER_LEVEL_2_CONTROLLED_USAGE_LANES_SELECTED`.
+- `docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-001/closeout/`
+  - Verified the Level 3 closeout exists and remains closed.
+  - Verified final accepted decision: `LEVEL_3_VALIDATION_EXECUTION_ACCEPTED_AS_ARTIFACT_COMPLETE_NON_PROMOTIONAL_LOCAL_ORCHESTRATION_EVIDENCE`.
+  - Verified selected next action: `NO_FURTHER_LEVEL_3_VALIDATION_LANES_SELECTED`.
+- `docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-001/import-final-decision/`
+  - Reviewed final-decision, evidence-boundary, blocked-claims, and selected-next-lane records.
+- `docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-001/source-artifact/`
+  - Confirmed this packet does not modify preserved source artifacts.
+- `docs/evals/runs/local-llm-solver-orchestration-index/`
+  - Verified the post-Level-3 evidence index exists.
+  - Verified selected next action: `NO_FURTHER_LOCAL_LLM_SOLVER_ORCHESTRATION_INDEX_LANES_SELECTED`.
+- `docs/local_llm_solver_orchestration_operator_guide/`
+  - Verified the consolidated operator guide exists.
+  - Verified it documents the stable local-only operator CLI wrapper: `python -m alpha.local_llm.operator_cli`.
+  - Verified selected next action: `NO_FURTHER_OPERATOR_DOCS_CONSOLIDATION_LANES_SELECTED`.
+- `scripts/check_local_llm_evidence_boundaries.py`
+  - Verified the static evidence-boundary checker scaffold exists.
+  - Verified selected next action referenced by the checker: `NO_FURTHER_EVIDENCE_BOUNDARY_STATIC_CHECK_SCAFFOLD_LANES_SELECTED`.
+- `tests/test_local_llm_evidence_boundaries.py`
+  - Verified static-checker test coverage exists.
+- `alpha/local_llm/operator_cli.py`, `alpha/local_llm/orchestration_runner.py`, and `alpha/local_llm/provider_adapter.py`
+  - Reviewed only as source-of-truth runtime paths that must not be modified by this docs-only PR.
+
+## Evidence not found / not authorized
+
+No reviewed repo evidence authorizes production readiness, MVP readiness, benchmark evidence, local model quality evidence, provider-orchestration evidence, Alpha superiority, billing evidence, dashboard readiness, `/v1/solve` readiness, broad runtime readiness, evidence-model promotion, provider fallback, hosted fallback, dashboard exposure, or `/v1/solve` exposure.


### PR DESCRIPTION
### Motivation

- Record a docs-only post-Level-3 roadmap decision that selects exactly one safe next major track while preserving completed Level 2 and Level 3 evidence boundaries.
- Make a non-executionary decision that avoids starting or authorizing any runtime, provider, dashboard, `/v1/solve`, benchmark, billing, or evidence-promotion work.

### Description

- Added a docs-only packet at `docs/evals/runs/local-llm-solver-orchestration-post-level-3-roadmap-decision/` containing `README.md`, `source-evidence-reviewed.md`, `current-state-summary.md`, `decision-options.md`, `option-risk-review.md`, `selected-decision.md`, `selected-next-lane.md`, `blocker-fallback-lane.md`, `evidence-boundary.md`, `non-actions.md`, `blocked-claims.md`, and `checks-run.md` to record the decision.
- Selected decision: `SELECT_RELEASE_READINESS_LADDER_TRACK` and recorded the single selected next lane `ALPHA-SOLVER-POST-LEVEL-3-RELEASE-READINESS-LADDER-PACKET-001`.
- Recorded blocker fallback lane `ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-POST-LEVEL-3-ROADMAP-DECISION-FIX-001` and explicit rationale for deferring the four other options (`SELECT_PRODUCT_SURFACE_PLANNING_TRACK`, `SELECT_QUALITY_EVALUATION_DESIGN_TRACK`, `SELECT_PROVIDER_ORCHESTRATION_DESIGN_TRACK`, `SELECT_LOCAL_OPERATOR_WORKFLOW_EXPANSION_TRACK`).
- Preserved and reiterated the evidence-boundary and non-actions (this is docs-only and does not run local inference, Ollama, validation, smoke, calls to hosted providers, `/v1/solve`, dashboard exposure, provider/hosted fallback, benchmarks, billing, Google Sheets/backlog updates, or evidence promotion), and made no runtime or `alpha/` code changes.

### Testing

- Ran the static evidence-boundary checker with `python scripts/check_local_llm_evidence_boundaries.py` which passed with the message `Local LLM evidence-boundary static check passed (443 files scanned)`. 
- Ran targeted text searches using `rg` to confirm presence of the final Level 3 accepted decision phrase, `NO_FURTHER_LEVEL_3_VALIDATION_LANES_SELECTED`, the selected decision, the selected next lane, the blocker fallback lane, and blocked-claim terms, and all returned the expected results. 
- Performed workspace verification with `git status --short`, `git diff --name-only`, and `git diff --check` to confirm only the new untracked docs packet was added and that no preserved source-artifact files or `alpha/` runtime/provider/dashboard/API files were modified, and these checks passed.
- All automated checks recorded in `checks-run.md` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25b1df6ab08329be07de5d7f15841e)