### PR TITLE
Integrate local LLM evidence-boundary static checker into CI and Makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ jobs:
         run: |
           python -m pip install -U pip
           pip install -r requirements.txt
+      - name: Check local LLM evidence boundaries
+        run: |
+          python scripts/check_local_llm_evidence_boundaries.py
       - name: Run unit tests
         run: |
           pytest -q

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: run test test-gates fmt lint env-check clean smoke release
+.PHONY: run test test-gates check-local-llm-evidence-boundaries fmt lint env-check clean smoke release
 
 run:
 	uvicorn service.app:app --host 0.0.0.0 --port 8000
@@ -8,6 +8,9 @@ test:
 
 test-gates:
 	pytest -q -k "determinism or policy or budget or metrics"
+
+check-local-llm-evidence-boundaries:
+	python scripts/check_local_llm_evidence_boundaries.py
 
 fmt:
 	black . >/dev/null 2>&1 || echo "black not installed"


### PR DESCRIPTION
### Motivation
- Add a minimal, deterministic build-hardening guard so the existing local LLM evidence-boundary static checker runs as part of local developer flows and pull-request CI without changing runtime behavior or checker semantics.

### Description
- Add a `check-local-llm-evidence-boundaries` Makefile target that runs `python scripts/check_local_llm_evidence_boundaries.py` for easy local invocation.
- Add a pull-request CI step in `.github/workflows/ci.yml` to run `python scripts/check_local_llm_evidence_boundaries.py` before unit tests; no changes to the checker implementation, runtime code, or preserved source artifacts.

### Testing
- Ran `python scripts/check_local_llm_evidence_boundaries.py` and it passed.
- Ran `python -m pytest -q tests/test_local_llm_evidence_boundaries.py` and the tests passed.
- Ran `make check-local-llm-evidence-boundaries` and it invoked the checker successfully.
- Verified `git diff --check` and that only `Makefile` and `.github/workflows/ci.yml` were modified and that no runtime/provider/dashboard/API files or preserved source artifacts were changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25b27b5b80832993173891bf8098cf)