### PR TITLE
Integrate local LLM orchestration guardrail suite into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
         run: |
           python -m pip install -U pip
           pip install -r requirements.txt
-      - name: Check local LLM evidence boundaries
+      - name: Check local LLM orchestration guardrail suite
         run: |
-          python scripts/check_local_llm_evidence_boundaries.py
+          make check-local-llm-orchestration-guardrails
       - name: Run unit tests
         run: |
           pytest -q

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: run test test-gates check-local-llm-evidence-boundaries fmt lint env-check clean smoke release
+.PHONY: run test test-gates check-local-llm-evidence-boundaries check-local-llm-orchestration-guardrails fmt lint env-check clean smoke release
 
 run:
 	uvicorn service.app:app --host 0.0.0.0 --port 8000
@@ -11,6 +11,11 @@ test-gates:
 
 check-local-llm-evidence-boundaries:
 	python scripts/check_local_llm_evidence_boundaries.py
+
+check-local-llm-orchestration-guardrails:
+	python scripts/check_local_llm_evidence_boundaries.py
+	python scripts/check_local_llm_doc_paths.py
+	python scripts/check_local_llm_packet_consistency.py
 
 fmt:
 	black . >/dev/null 2>&1 || echo "black not installed"


### PR DESCRIPTION
### Motivation
- Add a single local developer command and CI path that runs the completed deterministic guardrail checker suite for the local LLM solver orchestration docs as a build-hardening step without changing runtime behavior or exposing product surfaces.

### Description
- Lane name: `ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-POST-LEVEL-3-GUARDRAIL-SUITE-CI-INTEGRATION-001` and inspected source conventions: `AGENTS.md`, `.specs/LOCAL-LLM-SOLVER-ORCHESTRATION-001.md`, the existing `Makefile`, and `.github/workflows/ci.yml` to preserve narrow scope and safety invariants.
- Added a Makefile target `check-local-llm-orchestration-guardrails` that runs `python scripts/check_local_llm_evidence_boundaries.py`, `python scripts/check_local_llm_doc_paths.py`, and `python scripts/check_local_llm_packet_consistency.py`, and included it in `.PHONY`.
- Updated CI (`.github/workflows/ci.yml`) to invoke the new target via `make check-local-llm-orchestration-guardrails`, replacing the prior single evidence-boundary step so the full suite runs while preserving the evidence-boundary check as part of the suite.
- Selected next action: `NO_FURTHER_GUARDRAIL_SUITE_CI_INTEGRATION_LANES_SELECTED`; blocker fallback lane: `ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-POST-LEVEL-3-GUARDRAIL-SUITE-CI-INTEGRATION-FIX-001`; evidence boundary: this is build-hardening only and is not runtime/model/provider/dashboard/evidence promotion work; explicit non-actions: no changes to runtime files, no local model/Ollama/hosted-provider calls, no `/v1/solve` or dashboard exposure, no provider/hosted fallback, no benchmarking, no billing, no Google Sheets/backlog workbook updates, no evidence promotion.
- This PR does not start the roadmap-selected next track (release-readiness ladder) or change any runtime/provider/dashboard/API behavior.

### Testing
- Ran static checks and compilation: `python -m py_compile scripts/check_local_llm_evidence_boundaries.py scripts/check_local_llm_doc_paths.py scripts/check_local_llm_packet_consistency.py` which succeeded.
- Ran unit tests for the checkers: `python -m pytest -q tests/test_local_llm_evidence_boundaries.py tests/test_local_llm_doc_paths.py tests/test_local_llm_packet_consistency.py` which all passed.
- Executed each checker and the Make target: `python scripts/check_local_llm_evidence_boundaries.py`, `python scripts/check_local_llm_doc_paths.py`, `python scripts/check_local_llm_packet_consistency.py`, and `make check-local-llm-orchestration-guardrails`, all of which completed successfully with passing outputs.
- Confirmed changed files are only `Makefile` and `.github/workflows/ci.yml` and that no preserved source-artifact files or forbidden runtime/provider/dashboard/API files were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25c4ed1754832985602f9f3abc14d6)