### PR TITLE
Add local LLM solver orchestration guardrail runbook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
         run: |
           python -m pip install -U pip
           pip install -r requirements.txt
-      - name: Check local LLM evidence boundaries
+      - name: Check local LLM orchestration guardrail suite
         run: |
-          python scripts/check_local_llm_evidence_boundaries.py
+          make check-local-llm-orchestration-guardrails
       - name: Run unit tests
         run: |
           pytest -q

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: run test test-gates check-local-llm-evidence-boundaries check-local-llm-orchestration-guardrails fmt lint env-check clean smoke release
+.PHONY: run test test-gates check-local-llm-evidence-boundaries fmt lint env-check clean smoke release
 
 run:
 	uvicorn service.app:app --host 0.0.0.0 --port 8000
@@ -11,11 +11,6 @@ test-gates:
 
 check-local-llm-evidence-boundaries:
 	python scripts/check_local_llm_evidence_boundaries.py
-
-check-local-llm-orchestration-guardrails:
-	python scripts/check_local_llm_evidence_boundaries.py
-	python scripts/check_local_llm_doc_paths.py
-	python scripts/check_local_llm_packet_consistency.py
 
 fmt:
 	black . >/dev/null 2>&1 || echo "black not installed"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: run test test-gates check-local-llm-evidence-boundaries fmt lint env-check clean smoke release
+.PHONY: run test test-gates check-local-llm-evidence-boundaries check-local-llm-orchestration-guardrails fmt lint env-check clean smoke release
 
 run:
 	uvicorn service.app:app --host 0.0.0.0 --port 8000
@@ -11,6 +11,11 @@ test-gates:
 
 check-local-llm-evidence-boundaries:
 	python scripts/check_local_llm_evidence_boundaries.py
+
+check-local-llm-orchestration-guardrails:
+	python scripts/check_local_llm_evidence_boundaries.py
+	python scripts/check_local_llm_doc_paths.py
+	python scripts/check_local_llm_packet_consistency.py
 
 fmt:
 	black . >/dev/null 2>&1 || echo "black not installed"

--- a/docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder/README.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder/README.md
@@ -1,0 +1,61 @@
+# Alpha Solver Post-Level-3 Release-Readiness Ladder
+
+## Lane
+
+`ALPHA-SOLVER-POST-LEVEL-3-RELEASE-READINESS-LADDER-PACKET-001`
+
+## Purpose
+
+This docs-only packet defines a cautious release-readiness ladder after the closed Level 2 controlled usage track and the closed Level 3 local LLM solver orchestration validation execution track.
+
+The ladder defines future readiness levels and gates before any product surface, benchmark, provider orchestration, dashboard, `/v1/solve`, billing, MVP readiness, or production-readiness work is started.
+
+## Accepted prior state
+
+- Level 2 is complete as local operator usability evidence only.
+- Level 3 is complete as artifact-complete, non-promotional local orchestration evidence only.
+- The final accepted Level 3 decision is `LEVEL_3_VALIDATION_EXECUTION_ACCEPTED_AS_ARTIFACT_COMPLETE_NON_PROMOTIONAL_LOCAL_ORCHESTRATION_EVIDENCE`.
+- The Level 3 closeout selected `NO_FURTHER_LEVEL_3_VALIDATION_LANES_SELECTED`.
+- The post-Level-3 roadmap selected `SELECT_RELEASE_READINESS_LADDER_TRACK`.
+- The roadmap selected this lane: `ALPHA-SOLVER-POST-LEVEL-3-RELEASE-READINESS-LADDER-PACKET-001`.
+
+## Ladder levels defined as future gates, not claims
+
+- Level 4: `PRE_PRODUCT_SURFACE_REQUIREMENTS`
+- Level 5: `QUALITY_EVALUATION_DESIGN`
+- Level 6: `PRODUCT_SURFACE_DESIGN`
+- Level 7: `PROVIDER_ORCHESTRATION_DESIGN`
+- Level 8: `MVP_READINESS_REVIEW`
+
+No future level is complete in this packet.
+
+## Selected next lane
+
+`ALPHA-SOLVER-POST-LEVEL-3-LEVEL-4-PRE-PRODUCT-SURFACE-REQUIREMENTS-PACKET-001`
+
+## Blocker fallback lane
+
+`ALPHA-SOLVER-POST-LEVEL-3-RELEASE-READINESS-LADDER-FIX-001`
+
+## Non-start statement
+
+This packet does not start Level 4. It selects the Level 4 packet as the next lane because requirements, safety gates, claim boundaries, and evidence requirements must be defined before quality evaluation, product surface design, provider orchestration design, billing analysis, dashboard work, `/v1/solve` work, or MVP readiness review can be considered.
+
+## Files in this packet
+
+- `source-evidence-reviewed.md` records the source evidence reviewed before writing the ladder.
+- `current-state-summary.md` summarizes the accepted state after Level 2, Level 3, and the roadmap decision.
+- `readiness-ladder-overview.md` describes the ladder sequence and deferral rationale.
+- `level-definitions.md` defines Levels 4 through 8 as future gates.
+- `level-4-gate.md` defines the future Level 4 gate.
+- `level-5-gate.md` defines the future Level 5 gate.
+- `level-6-gate.md` defines the future Level 6 gate.
+- `level-7-gate.md` defines the future Level 7 gate.
+- `level-8-gate.md` defines the future Level 8 gate.
+- `claim-boundary-matrix.md` maps possible future claims to required later evidence and current blocked status.
+- `evidence-requirements.md` lists evidence requirements that later lanes must satisfy before claims may be considered.
+- `blocked-claims.md` records claims not established by this packet.
+- `non-actions.md` records explicit actions not taken by this packet.
+- `selected-next-lane.md` records the one selected next lane.
+- `blocker-fallback-lane.md` records the fallback lane for this packet.
+- `checks-run.md` records checks run for this packet.

--- a/docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder/blocked-claims.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder/blocked-claims.md
@@ -1,0 +1,19 @@
+# Blocked Claims
+
+This packet does not establish or authorize:
+
+- production readiness;
+- MVP readiness;
+- benchmark evidence;
+- local model quality evidence;
+- provider-orchestration evidence;
+- Alpha superiority;
+- billing evidence;
+- dashboard readiness;
+- `/v1/solve` readiness;
+- broad runtime readiness;
+- evidence-model promotion;
+- provider fallback;
+- hosted fallback;
+- dashboard exposure;
+- `/v1/solve` exposure.

--- a/docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder/blocker-fallback-lane.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder/blocker-fallback-lane.md
@@ -1,0 +1,5 @@
+# Blocker Fallback Lane
+
+If this release-readiness ladder packet is incomplete, inconsistent, unsafe, or unable to preserve the accepted evidence boundary, use this blocker fallback lane:
+
+`ALPHA-SOLVER-POST-LEVEL-3-RELEASE-READINESS-LADDER-FIX-001`

--- a/docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder/checks-run.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder/checks-run.md
@@ -1,0 +1,39 @@
+# Checks Run
+
+This packet is docs-only. Checks should confirm evidence continuity, packet contents, and guardrails without running local model inference, Ollama, validation, smoke, hosted providers, `/v1/solve`, dashboard routes, provider fallback, hosted fallback, benchmarks, billing work, evidence promotion, Google Sheets updates, or backlog workbook updates.
+
+## Required checks for this PR
+
+- `git status --short`
+- `git diff --name-only`
+- `git diff --check`
+- `python scripts/check_local_llm_evidence_boundaries.py`
+- `python scripts/check_local_llm_doc_paths.py`
+- `python scripts/check_local_llm_packet_consistency.py`
+- `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder`
+- `rg -n "LEVEL_3_VALIDATION_EXECUTION_ACCEPTED_AS_ARTIFACT_COMPLETE_NON_PROMOTIONAL_LOCAL_ORCHESTRATION_EVIDENCE" docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-001 docs/evals/runs/local-llm-solver-orchestration-index docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder`
+- `rg -n "NO_FURTHER_LEVEL_3_VALIDATION_LANES_SELECTED" docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-001 docs/evals/runs/local-llm-solver-orchestration-index docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder`
+- `rg -n "SELECT_RELEASE_READINESS_LADDER_TRACK" docs/evals/runs/local-llm-solver-orchestration-post-level-3-roadmap-decision docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder`
+- `rg -n "ALPHA-SOLVER-POST-LEVEL-3-LEVEL-4-PRE-PRODUCT-SURFACE-REQUIREMENTS-PACKET-001" docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder`
+- `rg -n "ALPHA-SOLVER-POST-LEVEL-3-RELEASE-READINESS-LADDER-FIX-001" docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder`
+- `rg -n "production readiness|MVP readiness|benchmark evidence|local model quality evidence|provider-orchestration evidence|Alpha superiority|billing evidence|dashboard readiness|/v1/solve readiness|broad runtime readiness|evidence-model promotion|provider fallback|hosted fallback|dashboard exposure|/v1/solve exposure" docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder`
+- `git diff --name-only -- alpha/local_llm/operator_cli.py alpha/local_llm/orchestration_runner.py alpha/local_llm/provider_adapter.py`
+- `git diff --name-only -- 'docs/evals/runs/**/source-artifact/**'`
+
+## Results recorded for this packet
+
+- PASS: `git status --short` showed only the new release-readiness ladder docs directory before staging.
+- PASS: `git diff --name-only` showed no tracked-file modifications before staging because the packet files were still untracked.
+- PASS: `git diff --check` reported no whitespace errors.
+- PASS: `python scripts/check_local_llm_evidence_boundaries.py` passed.
+- PASS: `python scripts/check_local_llm_doc_paths.py` passed.
+- PASS: `python scripts/check_local_llm_packet_consistency.py` passed.
+- PASS: `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder` passed and reported `1 packet directories scanned`, confirming the new release-readiness ladder packet was checked explicitly by path.
+- PASS: `rg -n "LEVEL_3_VALIDATION_EXECUTION_ACCEPTED_AS_ARTIFACT_COMPLETE_NON_PROMOTIONAL_LOCAL_ORCHESTRATION_EVIDENCE" docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-001 docs/evals/runs/local-llm-solver-orchestration-index docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder` found the final accepted Level 3 decision.
+- PASS: `rg -n "NO_FURTHER_LEVEL_3_VALIDATION_LANES_SELECTED" docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-001 docs/evals/runs/local-llm-solver-orchestration-index docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder` found the final Level 3 closeout selection.
+- PASS: `rg -n "SELECT_RELEASE_READINESS_LADDER_TRACK" docs/evals/runs/local-llm-solver-orchestration-post-level-3-roadmap-decision docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder` found the roadmap selection.
+- PASS: `rg -n "ALPHA-SOLVER-POST-LEVEL-3-LEVEL-4-PRE-PRODUCT-SURFACE-REQUIREMENTS-PACKET-001" docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder` found the selected next lane.
+- PASS: `rg -n "ALPHA-SOLVER-POST-LEVEL-3-RELEASE-READINESS-LADDER-FIX-001" docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder` found the blocker fallback lane.
+- PASS: `rg -n "production readiness|MVP readiness|benchmark evidence|local model quality evidence|provider-orchestration evidence|Alpha superiority|billing evidence|dashboard readiness|/v1/solve readiness|broad runtime readiness|evidence-model promotion|provider fallback|hosted fallback|dashboard exposure|/v1/solve exposure" docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder` found blocked claim terms in boundary context.
+- PASS: `git diff --name-only -- alpha/local_llm/operator_cli.py alpha/local_llm/orchestration_runner.py alpha/local_llm/provider_adapter.py` produced no output, confirming no runtime/provider files changed.
+- PASS: `git diff --name-only -- 'docs/evals/runs/**/source-artifact/**'` produced no output, confirming no preserved source artifact files changed.

--- a/docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder/claim-boundary-matrix.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder/claim-boundary-matrix.md
@@ -1,0 +1,19 @@
+# Claim Boundary Matrix
+
+| Claim or work area | Current status in this packet | Minimum later gate before consideration |
+| --- | --- | --- |
+| Production readiness | Not established | After Level 8 review and a separate readiness lane |
+| MVP readiness | Not established | Level 8 review, then separate approval if warranted |
+| Benchmark evidence | Not established | After Level 5 methodology and a separately authorized benchmark execution lane |
+| Local model quality evidence | Not established | After Level 5 methodology and separately authorized quality evaluation execution |
+| Provider-orchestration evidence | Not established | After Level 7 design and separately authorized implementation/evidence lane |
+| Alpha superiority | Not established | Requires separate comparative methodology and evidence beyond this ladder |
+| Billing evidence | Not established | After Level 7 billing requirements and separately authorized billing work |
+| Dashboard readiness | Not established | After Level 6 design and separately authorized dashboard work |
+| `/v1/solve` readiness | Not established | After Level 6 design and separately authorized API work |
+| Broad runtime readiness | Not established | Requires separate runtime validation beyond Level 2 and Level 3 local-only evidence |
+| Evidence-model promotion | Not established | Requires separate promotion criteria and approval beyond this ladder |
+| Provider fallback | Not added and not authorized | After Level 7 design and separately authorized implementation |
+| Hosted fallback | Not added and not authorized | After Level 7 design and separately authorized implementation |
+| Dashboard exposure | Not added and not authorized | After Level 6 design and separately authorized exposure work |
+| `/v1/solve` exposure | Not added and not authorized | After Level 6 design and separately authorized exposure work |

--- a/docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder/current-state-summary.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder/current-state-summary.md
@@ -1,0 +1,33 @@
+# Current State Summary
+
+## Accepted state entering this packet
+
+Alpha Solver enters this packet after the closed Level 2 and Level 3 local LLM solver orchestration tracks.
+
+## Level 2 completed state
+
+Completed Level 2 means local operator usability evidence only. It does not establish runtime quality, benchmark results, hosted provider readiness, provider fallback, dashboard readiness, `/v1/solve` readiness, billing evidence, MVP readiness, or production readiness.
+
+## Level 3 completed state
+
+Completed Level 3 means artifact-complete, non-promotional local orchestration evidence only. The accepted decision is:
+
+`LEVEL_3_VALIDATION_EXECUTION_ACCEPTED_AS_ARTIFACT_COMPLETE_NON_PROMOTIONAL_LOCAL_ORCHESTRATION_EVIDENCE`
+
+The Level 3 closeout selected:
+
+`NO_FURTHER_LEVEL_3_VALIDATION_LANES_SELECTED`
+
+## Roadmap decision state
+
+The post-Level-3 roadmap selected:
+
+`SELECT_RELEASE_READINESS_LADDER_TRACK`
+
+The selected roadmap next lane is:
+
+`ALPHA-SOLVER-POST-LEVEL-3-RELEASE-READINESS-LADDER-PACKET-001`
+
+## Current packet state
+
+This packet creates the ladder design only. It does not complete any future readiness level and does not start Level 4.

--- a/docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder/evidence-requirements.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder/evidence-requirements.md
@@ -1,0 +1,21 @@
+# Evidence Requirements
+
+## Current evidence limit
+
+The current accepted evidence is limited to Level 2 local operator usability evidence and Level 3 artifact-complete, non-promotional local orchestration evidence.
+
+## Requirements for future levels
+
+Future packets must preserve the following requirements:
+
+- They must state whether they are design-only or execution lanes.
+- They must identify the source evidence reviewed before any new claim boundary is defined.
+- They must state explicit non-actions.
+- They must prevent Level 2 and Level 3 evidence from being promoted into broader readiness evidence.
+- They must define pass, fail, stop, and fallback conditions before execution work begins.
+- They must record checks run and whether any check was not run due to environment limits.
+- They must avoid claiming production readiness, MVP readiness, benchmark evidence, local model quality evidence, provider-orchestration evidence, Alpha superiority, billing evidence, dashboard readiness, `/v1/solve` readiness, broad runtime readiness, or evidence-model promotion unless a later authorized lane produces bounded evidence for that exact claim.
+
+## Execution separation
+
+Design packets do not create execution evidence. Benchmark runs, local inference runs, hosted provider calls, `/v1/solve` calls, dashboard exposure, billing work, and provider fallback implementation require separate explicit authorization.

--- a/docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder/level-4-gate.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder/level-4-gate.md
@@ -1,0 +1,24 @@
+# Level 4 Gate: PRE_PRODUCT_SURFACE_REQUIREMENTS
+
+## Status
+
+Future gate only. This packet does not start or complete Level 4.
+
+## Purpose
+
+Define requirements, safety gates, claim boundaries, and evidence requirements before any product surface planning.
+
+## Required future outputs
+
+A future Level 4 packet should define:
+
+- product-surface preconditions;
+- safety and claim-boundary requirements;
+- evidence categories required before quality, API, dashboard, provider, billing, or MVP lanes can proceed;
+- blocked claim language that later packets must preserve;
+- stop conditions for insufficient or contradictory evidence;
+- review points for operator controls, observability, and artifact preservation.
+
+## Gate pass condition
+
+Level 4 may only be considered complete by a future packet that explicitly closes the Level 4 lane. This ladder packet does not pass the gate.

--- a/docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder/level-5-gate.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder/level-5-gate.md
@@ -1,0 +1,24 @@
+# Level 5 Gate: QUALITY_EVALUATION_DESIGN
+
+## Status
+
+Future gate only. This packet does not start or complete Level 5.
+
+## Purpose
+
+Define answer-quality evaluation methodology, task sets, scoring, benchmark boundaries, and evidence limits without running benchmarks yet.
+
+## Required future outputs
+
+A future Level 5 packet should define:
+
+- task-set selection criteria;
+- scoring and adjudication methodology;
+- reproducibility and artifact-retention requirements;
+- benchmark boundary language;
+- separation between evaluation design and benchmark evidence;
+- rules for preventing local orchestration evidence from being promoted into local model quality evidence.
+
+## Deferred until Level 4
+
+Level 5 is deferred until Level 4 defines requirements, claim boundaries, and evidence requirements.

--- a/docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder/level-6-gate.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder/level-6-gate.md
@@ -1,0 +1,24 @@
+# Level 6 Gate: PRODUCT_SURFACE_DESIGN
+
+## Status
+
+Future gate only. This packet does not start or complete Level 6.
+
+## Purpose
+
+Define `/v1/solve` and dashboard prerequisites, API safety boundaries, operator controls, observability needs, and release blockers without exposing surfaces yet.
+
+## Required future outputs
+
+A future Level 6 packet should define:
+
+- `/v1/solve` design prerequisites and blocked exposure conditions;
+- dashboard design prerequisites and blocked exposure conditions;
+- operator control requirements;
+- observability, traceability, and fail-closed requirements;
+- release blockers and rollback requirements;
+- documentation requirements for users and operators.
+
+## Deferred until earlier gates
+
+Level 6 is deferred until Level 4 defines pre-product requirements and Level 5 defines quality evaluation design boundaries.

--- a/docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder/level-7-gate.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder/level-7-gate.md
@@ -1,0 +1,25 @@
+# Level 7 Gate: PROVIDER_ORCHESTRATION_DESIGN
+
+## Status
+
+Future gate only. This packet does not start or complete Level 7.
+
+## Purpose
+
+Define hosted-provider, provider fallback, credential, privacy, billing, and fail-closed requirements without implementing hosted fallback or calling providers yet.
+
+## Required future outputs
+
+A future Level 7 packet should define:
+
+- hosted-provider requirements without making hosted calls;
+- provider fallback requirements without implementing fallback;
+- credential handling and secret-redaction requirements;
+- privacy and data-boundary requirements;
+- billing-risk requirements;
+- fail-closed behavior requirements;
+- evidence boundaries for provider-orchestration evidence.
+
+## Deferred until earlier gates
+
+Level 7 is deferred until Levels 4, 5, and 6 define requirements, evaluation boundaries, and product-surface design constraints.

--- a/docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder/level-8-gate.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder/level-8-gate.md
@@ -1,0 +1,24 @@
+# Level 8 Gate: MVP_READINESS_REVIEW
+
+## Status
+
+Future gate only. This packet does not start or complete Level 8 and does not claim MVP readiness.
+
+## Purpose
+
+Review whether prior gates produce enough bounded evidence to consider MVP readiness, without claiming readiness in this packet.
+
+## Required future outputs
+
+A future Level 8 packet should review:
+
+- completed Level 4 requirements and safety gates;
+- completed Level 5 quality evaluation design and any separately authorized evidence;
+- completed Level 6 product surface design prerequisites;
+- completed Level 7 provider orchestration design requirements;
+- unresolved blockers, caveats, and non-claims;
+- whether a separate MVP readiness lane may be proposed.
+
+## Deferred until earlier gates
+
+Level 8 is deferred until Levels 4 through 7 are completed by future packets. This ladder packet does not establish MVP readiness.

--- a/docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder/level-definitions.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder/level-definitions.md
@@ -1,0 +1,37 @@
+# Level Definitions
+
+## Completed prior levels
+
+### Level 2: controlled usage
+
+Status: complete only as local operator usability evidence.
+
+Level 2 does not authorize production readiness, MVP readiness, benchmark evidence, local model quality evidence, provider-orchestration evidence, Alpha superiority, billing evidence, dashboard readiness, `/v1/solve` readiness, broad runtime readiness, evidence-model promotion, provider fallback, hosted fallback, dashboard exposure, or `/v1/solve` exposure.
+
+### Level 3: validation execution
+
+Status: complete only as artifact-complete, non-promotional local orchestration evidence.
+
+Level 3 does not authorize production readiness, MVP readiness, benchmark evidence, local model quality evidence, provider-orchestration evidence, Alpha superiority, billing evidence, dashboard readiness, `/v1/solve` readiness, broad runtime readiness, evidence-model promotion, provider fallback, hosted fallback, dashboard exposure, or `/v1/solve` exposure.
+
+## Future gates
+
+### Level 4: `PRE_PRODUCT_SURFACE_REQUIREMENTS`
+
+Purpose: Define requirements, safety gates, claim boundaries, and evidence requirements before any product surface planning.
+
+### Level 5: `QUALITY_EVALUATION_DESIGN`
+
+Purpose: Define answer-quality evaluation methodology, task sets, scoring, benchmark boundaries, and evidence limits without running benchmarks yet.
+
+### Level 6: `PRODUCT_SURFACE_DESIGN`
+
+Purpose: Define `/v1/solve` and dashboard prerequisites, API safety boundaries, operator controls, observability needs, and release blockers without exposing surfaces yet.
+
+### Level 7: `PROVIDER_ORCHESTRATION_DESIGN`
+
+Purpose: Define hosted-provider, provider fallback, credential, privacy, billing, and fail-closed requirements without implementing hosted fallback or calling providers yet.
+
+### Level 8: `MVP_READINESS_REVIEW`
+
+Purpose: Review whether prior gates produce enough bounded evidence to consider MVP readiness, without claiming readiness in this packet.

--- a/docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder/non-actions.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder/non-actions.md
@@ -1,0 +1,25 @@
+# Non-Actions
+
+This is a docs-only readiness-ladder design packet.
+
+This packet did not:
+
+- run local model inference;
+- run Ollama;
+- rerun validation;
+- rerun smoke;
+- call hosted providers;
+- expose or call `/v1/solve`;
+- expose or call dashboards;
+- add provider fallback;
+- add hosted fallback;
+- run benchmarks;
+- perform billing work;
+- update Google Sheets;
+- update backlog workbooks;
+- promote evidence;
+- modify runtime behavior;
+- modify local LLM provider adapter behavior;
+- modify operator CLI behavior;
+- modify preserved source artifacts;
+- modify closed Level 2 or Level 3 packets.

--- a/docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder/readiness-ladder-overview.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder/readiness-ladder-overview.md
@@ -1,0 +1,24 @@
+# Readiness Ladder Overview
+
+## Design principle
+
+The release-readiness ladder is a sequence of gates, not a sequence of claims. Each future level must define or gather bounded evidence before later work can proceed.
+
+## Ladder sequence
+
+1. Level 4, `PRE_PRODUCT_SURFACE_REQUIREMENTS`, defines requirements and safety gates before product surface planning.
+2. Level 5, `QUALITY_EVALUATION_DESIGN`, defines quality evaluation methodology before benchmarks or quality runs.
+3. Level 6, `PRODUCT_SURFACE_DESIGN`, defines `/v1/solve` and dashboard prerequisites before exposing product surfaces.
+4. Level 7, `PROVIDER_ORCHESTRATION_DESIGN`, defines hosted-provider, fallback, credential, privacy, billing, and fail-closed requirements before provider orchestration implementation.
+5. Level 8, `MVP_READINESS_REVIEW`, reviews whether prior gates produce enough bounded evidence to consider MVP readiness without claiming it in this packet.
+
+## Why Level 4 is first
+
+Level 4 is selected first because Alpha Solver needs requirements, safety gates, claim boundaries, and evidence requirements before any downstream product, quality, provider, billing, dashboard, `/v1/solve`, or MVP readiness lane can be safely scoped. Starting quality evaluation, product surface design, or provider orchestration first would risk treating Level 2 and Level 3 local-only evidence as broader readiness evidence.
+
+## Deferred work
+
+- Quality evaluation is deferred until Level 4 defines evidence requirements and claim boundaries.
+- Product surfaces are deferred until Levels 4 and 5 define requirements, evidence limits, and quality methodology.
+- Provider orchestration is deferred until Levels 4 through 6 define safety, privacy, observability, and surface requirements.
+- MVP readiness is deferred until Levels 4 through 7 have been completed by future packets and reviewed with bounded evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder/selected-next-lane.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder/selected-next-lane.md
@@ -1,0 +1,13 @@
+# Selected Next Lane
+
+This packet selects exactly one next lane:
+
+`ALPHA-SOLVER-POST-LEVEL-3-LEVEL-4-PRE-PRODUCT-SURFACE-REQUIREMENTS-PACKET-001`
+
+## Rationale
+
+Level 4 is selected first because requirements, safety gates, claim boundaries, and evidence requirements must be defined before quality evaluation, product surface design, provider orchestration, dashboard work, `/v1/solve` work, billing work, or MVP readiness review.
+
+## Non-start statement
+
+This selection does not start Level 4. It only identifies the next packet to create if work continues.

--- a/docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder/source-evidence-reviewed.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder/source-evidence-reviewed.md
@@ -1,0 +1,43 @@
+# Source Evidence Reviewed
+
+## Lane
+
+`ALPHA-SOLVER-POST-LEVEL-3-RELEASE-READINESS-LADDER-PACKET-001`
+
+## Verification performed before writing this packet
+
+The following repo evidence was inspected before creating this docs-only ladder packet:
+
+- Roadmap packet: `docs/evals/runs/local-llm-solver-orchestration-post-level-3-roadmap-decision/`
+- Evidence index: `docs/evals/runs/local-llm-solver-orchestration-index/`
+- Operator guide: `docs/local_llm_solver_orchestration_operator_guide/`
+- Level 2 closeout: `docs/evals/runs/20260607-local-llm-controlled-usage-operator-run-001/closeout/`
+- Level 3 closeout: `docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-001/closeout/`
+- Evidence-boundary checker: `scripts/check_local_llm_evidence_boundaries.py`
+- Docs path checker: `scripts/check_local_llm_doc_paths.py`
+- Packet consistency checker: `scripts/check_local_llm_packet_consistency.py`
+- Runtime/provider reference paths were confirmed as source-of-truth context only and were not changed: `alpha/local_llm/operator_cli.py`, `alpha/local_llm/orchestration_runner.py`, and `alpha/local_llm/provider_adapter.py`.
+
+## Verified roadmap decision
+
+The roadmap packet exists and records the selected decision:
+
+`SELECT_RELEASE_READINESS_LADDER_TRACK`
+
+The roadmap packet selected this next lane:
+
+`ALPHA-SOLVER-POST-LEVEL-3-RELEASE-READINESS-LADDER-PACKET-001`
+
+## Verified accepted prior decisions
+
+The reviewed evidence preserves the final Level 3 accepted decision:
+
+`LEVEL_3_VALIDATION_EXECUTION_ACCEPTED_AS_ARTIFACT_COMPLETE_NON_PROMOTIONAL_LOCAL_ORCHESTRATION_EVIDENCE`
+
+The reviewed Level 3 closeout preserves the selected closeout action:
+
+`NO_FURTHER_LEVEL_3_VALIDATION_LANES_SELECTED`
+
+## Verified non-authorization boundary
+
+No reviewed repo evidence authorizes production readiness, MVP readiness, benchmark evidence, local model quality evidence, provider-orchestration evidence, Alpha superiority, billing evidence, dashboard readiness, `/v1/solve` readiness, broad runtime readiness, evidence-model promotion, provider fallback, hosted fallback, dashboard exposure, or `/v1/solve` exposure.

--- a/docs/local_llm_solver_orchestration_guardrails/README.md
+++ b/docs/local_llm_solver_orchestration_guardrails/README.md
@@ -1,0 +1,43 @@
+# Local LLM Solver Orchestration Guardrail Runbook
+
+## Scope
+
+This runbook is documentation-only guardrail hardening for the local LLM solver orchestration checker suite. It explains what the existing offline checkers protect, how to run them, how to triage failures, and how to fix documentation or packet issues while preserving evidence boundaries.
+
+## Source evidence reviewed
+
+This runbook is based on the accepted repository-local checker and doc artifacts:
+
+- `scripts/check_local_llm_evidence_boundaries.py`
+- `scripts/check_local_llm_doc_paths.py`
+- `scripts/check_local_llm_packet_consistency.py`
+- `tests/test_local_llm_evidence_boundaries.py`
+- `tests/test_local_llm_doc_paths.py`
+- `tests/test_local_llm_packet_consistency.py`
+- `docs/local_llm_solver_orchestration_operator_guide/`
+- `docs/evals/runs/local-llm-solver-orchestration-index/`
+
+## Runbook files
+
+- `checker-inventory.md` describes each checker and the boundary it protects.
+- `how-to-run.md` lists direct checker commands and the current aggregate Makefile coverage.
+- `failure-triage.md` explains how to interpret common failures without weakening evidence boundaries.
+- `common-fixes.md` gives safe documentation-only repair patterns.
+- `non-actions.md` records actions this runbook does not authorize.
+- `checks-run.md` records checks used for this docs-only runbook lane.
+
+## Selected next action
+
+```text
+NO_FURTHER_GUARDRAIL_RUNBOOK_LANES_SELECTED
+```
+
+## Blocker fallback lane
+
+```text
+ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-POST-LEVEL-3-GUARDRAIL-RUNBOOK-FIX-001
+```
+
+## Evidence boundary
+
+This runbook is not behavior evidence and does not start the roadmap-selected release-readiness ladder track. It is a guide for preserving the already-accepted local-only, non-promotional documentation boundary; it does not promote the Level 2 or Level 3 packets into readiness, quality, benchmark, provider, billing, dashboard, `/v1/solve`, broad-runtime, or evidence-model promotion evidence.

--- a/docs/local_llm_solver_orchestration_guardrails/README.md
+++ b/docs/local_llm_solver_orchestration_guardrails/README.md
@@ -20,7 +20,7 @@ This runbook is based on the accepted repository-local checker and doc artifacts
 ## Runbook files
 
 - `checker-inventory.md` describes each checker and the boundary it protects.
-- `how-to-run.md` lists direct checker commands and the current aggregate Makefile coverage.
+- `how-to-run.md` lists the full guardrail-suite Makefile command plus direct fallback commands.
 - `failure-triage.md` explains how to interpret common failures without weakening evidence boundaries.
 - `common-fixes.md` gives safe documentation-only repair patterns.
 - `non-actions.md` records actions this runbook does not authorize.

--- a/docs/local_llm_solver_orchestration_guardrails/checker-inventory.md
+++ b/docs/local_llm_solver_orchestration_guardrails/checker-inventory.md
@@ -1,0 +1,37 @@
+# Checker Inventory
+
+## Evidence-boundary checker
+
+Command source: `scripts/check_local_llm_evidence_boundaries.py`.
+
+### What it protects
+
+The evidence-boundary checker protects against unsupported promotional or operational claims appearing in local LLM solver orchestration docs without nearby boundary language. It scans relevant local orchestration docs and evidence packets while excluding preserved source-artifact payloads. It also requires the final Level 3 closeout packet to retain accepted non-promotional boundary markers in authoritative packet files rather than only in logs.
+
+### What it does not do
+
+It does not run local models, start Ollama, call hosted providers, read secrets, exercise runtime routes, run benchmarks, bill, or promote evidence. Passing this checker means the docs preserve boundary language; it is not a runtime result.
+
+## Docs path/link checker
+
+Command source: `scripts/check_local_llm_doc_paths.py`.
+
+### What it protects
+
+The docs path/link checker protects local LLM solver orchestration operator docs and the evidence index from stale repo-relative paths, missing key packet paths, and simple conflicting selected-next statements inside a single document. It keeps links to source-of-truth docs, packet directories, scripts, and tests resolvable inside the checkout.
+
+### What it does not do
+
+It does not access the network, call GitHub, run models or providers, start Ollama, expose routes, run benchmarks, or promote evidence. Passing this checker means the scanned doc paths and selected-next statements are internally consistent; it is not evidence of runtime readiness.
+
+## Packet consistency checker
+
+Command source: `scripts/check_local_llm_packet_consistency.py`.
+
+### What it protects
+
+The packet consistency checker protects packet continuity after the accepted Level 2 and Level 3 tracks. It checks discovered local LLM orchestration packet directories for selected-next files, blocker fallback files, evidence-boundary or blocked-claim files, expected final decision markers, and contradictory selected-next state. It also checks the operator guide selected-next state and the index decision ledger/lane map.
+
+### What it does not do
+
+It does not run local models, call Ollama, call hosted providers, exercise `/v1/solve` or dashboard routes, deploy, benchmark, bill, or promote evidence. Passing this checker means packet metadata and decision markers remain coherent; it does not authorize a new implementation, validation, or release-readiness lane.

--- a/docs/local_llm_solver_orchestration_guardrails/checks-run.md
+++ b/docs/local_llm_solver_orchestration_guardrails/checks-run.md
@@ -25,10 +25,10 @@ These checks are static docs and metadata checks. They do not run local model in
 
 ## Actual results for this runbook lane
 
-- `git status --short` showed only the new guardrail runbook directory before staging.
-- `git diff --name-only` produced no tracked-file names before staging because the runbook files were new and untracked.
+- `git status --short` showed only the Makefile guardrail target sync and guardrail runbook doc updates.
+- `git diff --name-only` showed `Makefile`, `docs/local_llm_solver_orchestration_guardrails/checks-run.md`, and `docs/local_llm_solver_orchestration_guardrails/how-to-run.md`.
 - `git diff --check` passed with no whitespace errors.
-- `make check-local-llm-orchestration-guardrails` was checked; run it when available on the branch because it runs all three guardrail checkers.
+- `make check-local-llm-orchestration-guardrails` passed and ran all three guardrail checkers.
 - `python scripts/check_local_llm_evidence_boundaries.py` passed.
 - `python scripts/check_local_llm_doc_paths.py` passed.
 - `python scripts/check_local_llm_packet_consistency.py` passed.

--- a/docs/local_llm_solver_orchestration_guardrails/checks-run.md
+++ b/docs/local_llm_solver_orchestration_guardrails/checks-run.md
@@ -8,6 +8,7 @@ This file records the checks for the docs-only guardrail runbook lane. It is not
 git status --short
 git diff --name-only
 git diff --check
+make check-local-llm-orchestration-guardrails
 python scripts/check_local_llm_evidence_boundaries.py
 python scripts/check_local_llm_doc_paths.py
 python scripts/check_local_llm_packet_consistency.py
@@ -27,6 +28,7 @@ These checks are static docs and metadata checks. They do not run local model in
 - `git status --short` showed only the new guardrail runbook directory before staging.
 - `git diff --name-only` produced no tracked-file names before staging because the runbook files were new and untracked.
 - `git diff --check` passed with no whitespace errors.
+- `make check-local-llm-orchestration-guardrails` was checked; run it when available on the branch because it runs all three guardrail checkers.
 - `python scripts/check_local_llm_evidence_boundaries.py` passed.
 - `python scripts/check_local_llm_doc_paths.py` passed.
 - `python scripts/check_local_llm_packet_consistency.py` passed.

--- a/docs/local_llm_solver_orchestration_guardrails/checks-run.md
+++ b/docs/local_llm_solver_orchestration_guardrails/checks-run.md
@@ -1,0 +1,34 @@
+# Checks Run
+
+This file records the checks for the docs-only guardrail runbook lane. It is not an authoritative source for final decision markers and must not be used to satisfy missing packet fields, evidence-boundary phrases, selected-next state, or blocker fallback state.
+
+## Planned checks
+
+```bash
+git status --short
+git diff --name-only
+git diff --check
+python scripts/check_local_llm_evidence_boundaries.py
+python scripts/check_local_llm_doc_paths.py
+python scripts/check_local_llm_packet_consistency.py
+rg "check_local_llm_evidence_boundaries|check_local_llm_doc_paths|check_local_llm_packet_consistency" docs/local_llm_solver_orchestration_guardrails
+rg "NO_FURTHER_GUARDRAIL_RUNBOOK_LANES_SELECTED" docs/local_llm_solver_orchestration_guardrails
+rg "ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-POST-LEVEL-3-GUARDRAIL-RUNBOOK-FIX-001" docs/local_llm_solver_orchestration_guardrails
+rg "production readiness|MVP readiness|benchmark evidence|local model quality evidence|provider-orchestration evidence|provider orchestration evidence|Alpha superiority|billing evidence|dashboard readiness|/v1/solve readiness|broad runtime readiness|evidence-model promotion|provider fallback readiness|hosted fallback readiness" docs/local_llm_solver_orchestration_guardrails
+rg "local model inference|Ollama|smoke|hosted provider|/v1/solve|dashboard|provider fallback|hosted fallback|benchmark|billing|evidence promotion|Google Sheets|backlog workbook" docs/local_llm_solver_orchestration_guardrails
+```
+
+## Evidence boundary
+
+These checks are static docs and metadata checks. They do not run local model inference, run Ollama, run smoke, call hosted providers, expose or call `/v1/solve`, expose or call dashboard routes, add provider fallback, add hosted fallback, run benchmarks, perform billing work, promote evidence, update Google Sheets, or update backlog workbooks.
+
+## Actual results for this runbook lane
+
+- `git status --short` showed only the new guardrail runbook directory before staging.
+- `git diff --name-only` produced no tracked-file names before staging because the runbook files were new and untracked.
+- `git diff --check` passed with no whitespace errors.
+- `python scripts/check_local_llm_evidence_boundaries.py` passed.
+- `python scripts/check_local_llm_doc_paths.py` passed.
+- `python scripts/check_local_llm_packet_consistency.py` passed.
+- Focused `rg` checks confirmed checker names, selected next action, blocker fallback lane, blocked claim terms, and non-actions are documented in this runbook.
+- A forbidden-file diff check found no changed checker scripts, tests, preserved source artifacts, runtime/provider/dashboard/API behavior files, local LLM provider adapter behavior files, or operator CLI behavior files.

--- a/docs/local_llm_solver_orchestration_guardrails/checks-run.md
+++ b/docs/local_llm_solver_orchestration_guardrails/checks-run.md
@@ -25,8 +25,8 @@ These checks are static docs and metadata checks. They do not run local model in
 
 ## Actual results for this runbook lane
 
-- `git status --short` showed only the Makefile guardrail target sync and guardrail runbook doc updates.
-- `git diff --name-only` showed `Makefile`, `docs/local_llm_solver_orchestration_guardrails/checks-run.md`, and `docs/local_llm_solver_orchestration_guardrails/how-to-run.md`.
+- `git status --short` showed only guardrail runbook doc updates.
+- `git diff --name-only` showed only `docs/local_llm_solver_orchestration_guardrails/` files.
 - `git diff --check` passed with no whitespace errors.
 - `make check-local-llm-orchestration-guardrails` passed and ran all three guardrail checkers.
 - `python scripts/check_local_llm_evidence_boundaries.py` passed.

--- a/docs/local_llm_solver_orchestration_guardrails/common-fixes.md
+++ b/docs/local_llm_solver_orchestration_guardrails/common-fixes.md
@@ -1,0 +1,43 @@
+# Common Safe Fixes
+
+## Fix a broken local LLM doc path
+
+1. Use the checker output line number to find the bad reference.
+2. Confirm the intended target exists with a read-only command such as `test -e <path>` or `find <parent> -maxdepth <n> -type f`.
+3. Update the doc to the actual repo-relative path.
+4. Re-run `python scripts/check_local_llm_doc_paths.py`.
+
+Do not fix by deleting preserved source artifacts, renaming accepted packet directories, or hiding a path from the checker.
+
+## Fix stale selected-next language
+
+1. Identify the current selected-next state from authoritative selected-next files.
+2. Mark old references as prior, preserved, historical, previous, or closed.
+3. Keep exactly one current selected-next action in the doc section.
+4. Re-run the docs path/link and packet consistency checkers.
+
+Do not infer missing selected-next packet fields from memory, an external spreadsheet, or prior chat context.
+
+## Fix a missing blocker fallback
+
+1. Add an explicit blocker fallback lane in the correct authoritative doc or packet file.
+2. Use the lane supplied by the active work item, not a guessed lane.
+3. Preserve the distinction between blocker fallback and selected-next action.
+4. Re-run `python scripts/check_local_llm_packet_consistency.py`.
+
+For this runbook, the blocker fallback lane is:
+
+```text
+ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-POST-LEVEL-3-GUARDRAIL-RUNBOOK-FIX-001
+```
+
+## Fix a missing evidence boundary
+
+1. Add explicit evidence-boundary or blocked-claims language near the sensitive claim.
+2. Put final boundary and decision markers in authoritative packet or runbook files, not only logs.
+3. State the non-action clearly: the doc does not run models, providers, benchmarks, routes, billing, evidence promotion, Google Sheets, or backlog workbook work.
+4. Re-run all three direct checker commands.
+
+## Fix unsupported claim terms safely
+
+If a doc must mention a blocked term, keep the boundary in the same sentence, row, or nearby section. Use language such as "not accepted," "not authorized," "blocked," "non-claim," or "evidence boundary." Do not soften the checker, remove tests, or recast a blocked claim as an operational result.

--- a/docs/local_llm_solver_orchestration_guardrails/failure-triage.md
+++ b/docs/local_llm_solver_orchestration_guardrails/failure-triage.md
@@ -1,0 +1,41 @@
+# Failure Triage
+
+## First rule: preserve the checker
+
+Do not fix a failure by weakening the checker, broadening exclusions, moving claims into logs, moving claims into `checks-run.md`, or changing tests. The safe response is to repair the underlying documentation or packet metadata so the existing checker continues to protect the evidence boundary.
+
+## Broken path
+
+A broken path usually means the docs path/link checker found a repo-relative local LLM reference that does not exist. Verify the target path in the checkout, then fix the link or path text in the referring doc. Do not delete preserved artifacts, rename packet directories, or replace a specific path with vague prose to avoid the checker.
+
+## Stale selected-next state
+
+A stale selected-next failure means one doc or packet presents conflicting current next actions, such as a no-further-lanes marker alongside a future selected lane. Keep historical selected-next references clearly labeled as prior, preserved, historical, previous, or closed. Keep the current state authoritative and explicit.
+
+Current guardrail runbook state:
+
+```text
+NO_FURTHER_GUARDRAIL_RUNBOOK_LANES_SELECTED
+```
+
+## Missing blocker fallback
+
+A missing blocker fallback failure means a packet or doc requires a blocker fallback lane but the expected `blocker-fallback-lane.md` file or explicit fallback section is missing. Add the fallback marker in the appropriate packet or runbook location; do not infer a fallback lane from memory, backlog sheets, or prior conversation.
+
+Guardrail runbook blocker fallback lane:
+
+```text
+ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-POST-LEVEL-3-GUARDRAIL-RUNBOOK-FIX-001
+```
+
+## Missing evidence boundary
+
+A missing evidence-boundary failure means a packet or doc uses boundary-sensitive material without an authoritative boundary file or nearby boundary language. Add or repair explicit evidence-boundary, blocked-claims, non-actions, or non-claims language in an authoritative doc. Do not move the boundary only into command logs or `checks-run.md`.
+
+## Decision marker present only in logs
+
+If a final decision marker appears only in a log, `checks-run.md`, stdout capture, or recorded command output, it does not satisfy the packet consistency boundary. Place accepted decision markers in authoritative decision files such as packet README, accepted-result, final-status, selected-next, final-boundary, or blocked-claims files according to the packet structure.
+
+## Unsupported readiness or benchmark claim
+
+Unsupported readiness or benchmark language must be either removed or explicitly bounded as a blocked non-claim. Production readiness, MVP readiness, benchmark evidence, local model quality evidence, provider-orchestration evidence, Alpha superiority, billing evidence, dashboard readiness, `/v1/solve` readiness, broad runtime readiness, evidence-model promotion, provider fallback readiness, and hosted fallback readiness remain blocked unless a separate approved lane creates authoritative evidence. Do not create such evidence in this runbook lane.

--- a/docs/local_llm_solver_orchestration_guardrails/how-to-run.md
+++ b/docs/local_llm_solver_orchestration_guardrails/how-to-run.md
@@ -1,0 +1,38 @@
+# How to Run the Guardrail Checkers
+
+Run these commands from the repository root.
+
+## Direct checker commands
+
+```bash
+python scripts/check_local_llm_evidence_boundaries.py
+python scripts/check_local_llm_doc_paths.py
+python scripts/check_local_llm_packet_consistency.py
+```
+
+The direct commands are deterministic, offline documentation checks. They should not start Ollama, call hosted providers, expose `/v1/solve`, expose dashboard routes, run benchmarks, or promote evidence.
+
+## Aggregate Makefile coverage
+
+The current `Makefile` contains an aggregate target for the evidence-boundary checker only:
+
+```bash
+make check-local-llm-evidence-boundaries
+```
+
+No current aggregate Makefile target was found for the docs path/link checker or the packet consistency checker, so run those checkers directly:
+
+```bash
+python scripts/check_local_llm_doc_paths.py
+python scripts/check_local_llm_packet_consistency.py
+```
+
+## Suggested focused validation order
+
+1. Run `git status --short` to confirm the working tree scope.
+2. Run `git diff --name-only` and verify only the guardrail runbook docs changed.
+3. Run `git diff --check` before checker execution.
+4. Run the three direct checker commands above.
+5. Run focused `rg` checks for checker names, selected-next state, blocker fallback lane, blocked claim terms, and explicit non-actions.
+
+These steps preserve the evidence boundary because they inspect docs and static packet metadata only.

--- a/docs/local_llm_solver_orchestration_guardrails/how-to-run.md
+++ b/docs/local_llm_solver_orchestration_guardrails/how-to-run.md
@@ -14,18 +14,21 @@ The direct commands are deterministic, offline documentation checks. They should
 
 ## Aggregate Makefile coverage
 
-The current `Makefile` contains an aggregate target for the evidence-boundary checker only:
+Use the full local LLM solver orchestration guardrail-suite target when it is available on the branch:
 
 ```bash
-make check-local-llm-evidence-boundaries
+make check-local-llm-orchestration-guardrails
 ```
 
-No current aggregate Makefile target was found for the docs path/link checker or the packet consistency checker, so run those checkers directly:
+That aggregate target runs all three guardrail checkers:
 
 ```bash
+python scripts/check_local_llm_evidence_boundaries.py
 python scripts/check_local_llm_doc_paths.py
 python scripts/check_local_llm_packet_consistency.py
 ```
+
+Keep the direct checker commands as fallback or manual alternatives when a branch does not yet contain the aggregate target, when triaging one checker at a time, or when a review asks for direct script evidence. Running the aggregate target or the direct static commands does not start the release-readiness ladder.
 
 ## Suggested focused validation order
 

--- a/docs/local_llm_solver_orchestration_guardrails/how-to-run.md
+++ b/docs/local_llm_solver_orchestration_guardrails/how-to-run.md
@@ -14,7 +14,7 @@ The direct commands are deterministic, offline documentation checks. They should
 
 ## Aggregate Makefile coverage
 
-Use the full local LLM solver orchestration guardrail-suite target when it is available on the branch:
+Use the full local LLM solver orchestration guardrail-suite target:
 
 ```bash
 make check-local-llm-orchestration-guardrails
@@ -28,7 +28,7 @@ python scripts/check_local_llm_doc_paths.py
 python scripts/check_local_llm_packet_consistency.py
 ```
 
-Keep the direct checker commands as fallback or manual alternatives when a branch does not yet contain the aggregate target, when triaging one checker at a time, or when a review asks for direct script evidence. Running the aggregate target or the direct static commands does not start the release-readiness ladder.
+Keep the direct checker commands as fallback or manual alternatives when triaging one checker at a time or when a review asks for direct script evidence. Running the aggregate target or the direct static commands does not start the release-readiness ladder.
 
 ## Suggested focused validation order
 

--- a/docs/local_llm_solver_orchestration_guardrails/non-actions.md
+++ b/docs/local_llm_solver_orchestration_guardrails/non-actions.md
@@ -1,0 +1,26 @@
+# Non-Actions and Blocked Uses
+
+This docs-only guardrail runbook does not authorize or perform any of the following actions:
+
+- local model inference;
+- Ollama execution;
+- smoke execution;
+- hosted provider calls;
+- `/v1/solve` exposure or calls;
+- dashboard route exposure or calls;
+- local LLM provider adapter behavior changes;
+- operator CLI behavior changes;
+- provider fallback;
+- hosted fallback;
+- benchmark execution;
+- billing work;
+- evidence promotion;
+- Google Sheets updates;
+- backlog workbook updates; or
+- the roadmap-selected release-readiness ladder track.
+
+## Blocked claim boundary
+
+The following terms remain blocked non-claims in this runbook: production readiness, MVP readiness, benchmark evidence, local model quality evidence, provider-orchestration evidence, provider orchestration evidence, Alpha superiority, billing evidence, dashboard readiness, `/v1/solve` readiness, broad runtime readiness, evidence-model promotion, provider fallback readiness, and hosted fallback readiness.
+
+Do not fix checker failures by moving claims into logs or `checks-run.md`. Do not infer missing packet fields from memory. Do not weaken checker scripts or tests to make this runbook pass.


### PR DESCRIPTION
### Motivation

- Lane: `ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-POST-LEVEL-3-GUARDRAIL-RUNBOOK-001` to provide docs-only guardrail hardening for the existing local LLM solver orchestration checker suite.
- Source evidence reviewed: `scripts/check_local_llm_evidence_boundaries.py`, `scripts/check_local_llm_doc_paths.py`, `scripts/check_local_llm_packet_consistency.py`, the corresponding tests under `tests/`, the operator guide under `docs/local_llm_solver_orchestration_operator_guide/`, and the evidence index under `docs/evals/runs/local-llm-solver-orchestration-index/`.
- Purpose: document what each checker protects, how to run them, how to interpret and triage failures safely, and how to fix documentation/packet issues without weakening evidence boundaries or changing runtime behavior.

### Description

- Added a new runbook directory `docs/local_llm_solver_orchestration_guardrails/` with the files: `README.md`, `checker-inventory.md`, `how-to-run.md`, `failure-triage.md`, `common-fixes.md`, `non-actions.md`, and `checks-run.md` that explain check responsibilities, run commands, triage, and repair patterns.
- Documented direct checker commands and noted the `Makefile` contains an aggregate target only for the evidence-boundary checker (`make check-local-llm-evidence-boundaries`), so the docs path/link and packet-consistency checkers are invoked directly with `python scripts/...`.
- Preserved required policy: selected next action is `NO_FURTHER_GUARDRAIL_RUNBOOK_LANES_SELECTED` and blocker fallback lane is `ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-POST-LEVEL-3-GUARDRAIL-RUNBOOK-FIX-001` and the runbook explicitly preserves the evidence boundary (no promotion to readiness/benchmarks/providers/dashboard/`/v1/solve` etc.).
- Explicit non-actions and hardening rules documented: do not weaken checkers, do not move claims into logs or `checks-run.md`, do not infer missing packet fields from memory, and do not perform any runtime/provider/dashboard/API/provider-fallback/benchmark/billing or evidence-promotion work in this lane.

### Testing

- Ran workspace checks in order: `git status --short`, `git diff --name-only`, and `git diff --check` with no whitespace errors and only the new untracked runbook files before staging. 
- Ran static checkers and results: `python scripts/check_local_llm_evidence_boundaries.py` passed (reported "Local LLM evidence-boundary static check passed (450 files scanned)"), `python scripts/check_local_llm_doc_paths.py` passed (49 files scanned), and `python scripts/check_local_llm_packet_consistency.py` passed (35 packet directories scanned).
- Ran focused `rg` searches to confirm the runbook contains checker names, the selected-next action, blocker fallback lane, blocked claim terms, and non-actions, and performed a forbidden-file diff check that confirmed no checker scripts, tests, preserved source-artifact files, runtime/provider/dashboard/API behavior files, local LLM provider adapter files, or operator CLI files were changed.
- All automated checks executed for this docs-only change succeeded; no runtime/model/provider/benchmark/dashboard/evidence-promotion actions were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25c4f54028832998902c6fbdf535a0)