### PR TITLE
Add local LLM guardrail runbook docs

### DIFF
--- a/docs/local_llm_solver_orchestration_guardrails/README.md
+++ b/docs/local_llm_solver_orchestration_guardrails/README.md
@@ -1,0 +1,50 @@
+# Local LLM Solver Orchestration Guardrail Runbook
+
+## Lane
+
+`ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-POST-LEVEL-3-GUARDRAIL-RUNBOOK-001`
+
+## Purpose
+
+This docs-only runbook explains the local LLM solver orchestration checker suite and how operators should respond when the guardrails fail. It is a clean replacement for the polluted PR #392 attempt and is scoped only to runbook documentation under `docs/local_llm_solver_orchestration_guardrails/`.
+
+The suite protects local LLM solver orchestration documentation from path drift, stale packet state, and unsupported evidence claims. It preserves evidence boundaries and does not promote documentation artifacts into behavior evidence.
+
+## Guardrail suite entrypoint
+
+Run the aggregate Makefile target first:
+
+```bash
+make check-local-llm-orchestration-guardrails
+```
+
+The aggregate target runs all three guardrail checkers:
+
+```bash
+python scripts/check_local_llm_evidence_boundaries.py
+python scripts/check_local_llm_doc_paths.py
+python scripts/check_local_llm_packet_consistency.py
+```
+
+Use the direct checker commands only as fallback or manual alternatives when isolating one failure class.
+
+## Files in this runbook
+
+- [checker-inventory.md](checker-inventory.md) explains each checker and what it protects.
+- [how-to-run.md](how-to-run.md) gives the normal command flow and manual fallback commands.
+- [failure-triage.md](failure-triage.md) maps failure classes to safe responses.
+- [common-fixes.md](common-fixes.md) describes allowed documentation fixes that preserve checker intent.
+- [non-actions.md](non-actions.md) records actions this runbook must not take.
+- [checks-run.md](checks-run.md) records the validation commands for this docs-only lane.
+
+## Selected next action
+
+`NO_FURTHER_GUARDRAIL_RUNBOOK_LANES_SELECTED`
+
+## Blocker fallback lane
+
+`ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-POST-LEVEL-3-GUARDRAIL-RUNBOOK-FIX-001`
+
+## Evidence boundary
+
+This is docs-only guardrail runbook work. It does not start the release-readiness ladder, Level 4, runtime work, provider work, benchmark work, dashboard work, `/v1/solve` work, billing work, or evidence promotion.

--- a/docs/local_llm_solver_orchestration_guardrails/checker-inventory.md
+++ b/docs/local_llm_solver_orchestration_guardrails/checker-inventory.md
@@ -1,0 +1,84 @@
+# Checker Inventory
+
+## Aggregate target
+
+The normal entrypoint is:
+
+```bash
+make check-local-llm-orchestration-guardrails
+```
+
+That Makefile target runs these checkers in sequence:
+
+```bash
+python scripts/check_local_llm_evidence_boundaries.py
+python scripts/check_local_llm_doc_paths.py
+python scripts/check_local_llm_packet_consistency.py
+```
+
+Direct checker commands are fallback or manual alternatives for isolating a failure after the aggregate target fails.
+
+## Evidence-boundary checker
+
+Command:
+
+```bash
+python scripts/check_local_llm_evidence_boundaries.py
+```
+
+What it protects:
+
+- Scans local LLM solver orchestration documentation for risky promotional claim phrases.
+- Requires nearby boundary language when a risky phrase appears.
+- Confirms required final Level 3 closeout boundary phrases are present in authoritative closeout files.
+- Excludes preserved source-artifact payload files from the scan.
+- Does not validate runtime behavior, run benchmarks, call models, start Ollama, use providers, read secrets, or exercise routes.
+
+Safe interpretation:
+
+- A pass means the scanned docs maintain required static evidence-boundary wording.
+- A pass does not prove model quality, readiness, provider behavior, benchmark results, billing readiness, dashboard readiness, or `/v1/solve` readiness.
+
+## Docs path/link checker
+
+Command:
+
+```bash
+python scripts/check_local_llm_doc_paths.py
+```
+
+What it protects:
+
+- Scans the operator guide, the local LLM solver orchestration evidence index, and selected Level 3 packet docs.
+- Verifies repo-relative local LLM documentation paths and key source paths referenced by those docs exist in the checkout.
+- Detects simple stale selected-next-lane conflicts inside a single document.
+- Excludes preserved source-artifact payload files from scanning while still allowing the source-artifact directory itself to be referenced.
+- Does not call GitHub, access the network, run models, start Ollama, expose routes, run benchmarks, or promote evidence.
+
+Safe interpretation:
+
+- A pass means the scanned documentation references resolvable local paths and does not contain the simple stale selected-next conflict patterns checked by the script.
+- A pass does not prove that unscanned docs are complete or that any runtime workflow was executed.
+
+## Packet consistency checker
+
+Command:
+
+```bash
+python scripts/check_local_llm_packet_consistency.py
+```
+
+What it protects:
+
+- Discovers local LLM solver orchestration packet directories under `docs/evals/runs/`.
+- Requires selected-next state or an explicit closed/no-further state where applicable.
+- Requires blocker fallback lane files when packet patterns indicate they are needed.
+- Requires evidence-boundary, blocked-claims, non-actions, or equivalent boundary files when packet patterns indicate they are needed.
+- Ensures no-further-lanes decisions are not contradicted by selected implementation lanes.
+- Verifies expected decision markers are present in authoritative packet/status files, not only in command logs.
+- Excludes source-artifact payload files from packet enforcement.
+
+Safe interpretation:
+
+- A pass means packet metadata and decision markers are internally consistent for the checker scope.
+- A pass does not infer missing packet fields from memory and does not promote packet text into runtime evidence.

--- a/docs/local_llm_solver_orchestration_guardrails/checks-run.md
+++ b/docs/local_llm_solver_orchestration_guardrails/checks-run.md
@@ -1,0 +1,45 @@
+# Checks Run
+
+This file records the validation commands for the docs-only guardrail runbook lane.
+
+## Required commands
+
+```bash
+git status --short
+```
+
+```bash
+git diff --name-only
+```
+
+```bash
+git diff --check
+```
+
+```bash
+make check-local-llm-orchestration-guardrails
+```
+
+```bash
+python scripts/check_local_llm_evidence_boundaries.py
+```
+
+```bash
+python scripts/check_local_llm_doc_paths.py
+```
+
+```bash
+python scripts/check_local_llm_packet_consistency.py
+```
+
+```bash
+rg "check-local-llm-orchestration-guardrails|check_local_llm_evidence_boundaries.py|check_local_llm_doc_paths.py|check_local_llm_packet_consistency.py|NO_FURTHER_GUARDRAIL_RUNBOOK_LANES_SELECTED|ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-POST-LEVEL-3-GUARDRAIL-RUNBOOK-FIX-001" docs/local_llm_solver_orchestration_guardrails
+```
+
+```bash
+git diff --name-only | grep -v '^docs/local_llm_solver_orchestration_guardrails/' && exit 1 || true
+```
+
+## Evidence boundary
+
+The commands above are documentation and static checker commands only. They do not run local model inference, start Ollama, call hosted providers, expose `/v1/solve`, expose dashboard routes, add provider fallback, add hosted fallback, run benchmarks, perform billing work, update Google Sheets or backlog workbooks, or promote evidence.

--- a/docs/local_llm_solver_orchestration_guardrails/common-fixes.md
+++ b/docs/local_llm_solver_orchestration_guardrails/common-fixes.md
@@ -1,0 +1,35 @@
+# Common Fixes That Preserve Guardrails
+
+## Preserve checker intent
+
+Allowed documentation fixes should make the contract clearer without loosening enforcement:
+
+- Correct stale repo-relative links to existing local LLM solver orchestration docs.
+- Add explicit evidence-boundary wording near risky phrases.
+- Restore a missing selected-next action in the authoritative selected-next file.
+- Restore a missing blocker fallback lane in the packet file that owns it.
+- Move required decision markers from log-only locations into authoritative decision/status files.
+- Clarify that an old lane token is historical, preserved, or closed when it is not the current selected-next action.
+
+## Do not weaken the checker
+
+Do not respond to a failure by changing checker scope, disabling phrase detection, excluding the failing document, or broadening accepted paths. This runbook is docs-only and does not modify checker scripts or tests.
+
+## Do not move claims into logs
+
+`checks-run.md`, command logs, stdout captures, and similar files are not authoritative decision files. Do not fix a missing decision marker by copying it only into a log or checks-run file.
+
+## Do not infer missing fields from memory
+
+If a packet is missing a selected-next action, blocker fallback lane, evidence boundary, or accepted decision marker, use the controlling lane, source-of-truth packet, or accepted spec. Do not reconstruct packet fields from memory.
+
+## Preserve evidence boundaries
+
+When adding boundary wording, be explicit:
+
+- This docs-only runbook does not start the release-readiness ladder.
+- This docs-only runbook does not start Level 4.
+- This docs-only runbook does not change runtime behavior.
+- This docs-only runbook does not change provider behavior.
+- This docs-only runbook does not provide benchmark evidence; this is an explicit boundary, not an accepted claim.
+- This docs-only runbook does not promote evidence.

--- a/docs/local_llm_solver_orchestration_guardrails/failure-triage.md
+++ b/docs/local_llm_solver_orchestration_guardrails/failure-triage.md
@@ -1,0 +1,96 @@
+# Failure Triage
+
+## Broken path
+
+Symptoms:
+
+- The docs path/link checker reports a missing repo-relative local LLM path.
+
+Safe response:
+
+- Confirm whether the referenced path should exist.
+- Correct the link to the current authoritative path if the document reference is stale.
+- Create documentation only when the spec or accepted packet requires that artifact and the current lane permits it.
+- Do not move or rename preserved source artifacts to satisfy a link.
+
+## Stale selected-next state
+
+Symptoms:
+
+- The docs path/link checker or packet consistency checker reports contradictory selected-next state.
+- A document says no further lanes are selected while also selecting a future implementation lane.
+
+Safe response:
+
+- Update the authoritative selected-next file to the accepted state.
+- For this runbook lane, the required selected next action is:
+
+```text
+NO_FURTHER_GUARDRAIL_RUNBOOK_LANES_SELECTED
+```
+
+- Do not leave historical implementation lane text in a current selected-next section.
+- If historical lane text must remain, clearly mark it as historical or closed context outside the current selected-next state.
+
+## Missing blocker fallback
+
+Symptoms:
+
+- The packet consistency checker reports `missing required blocker-fallback-lane.md`.
+
+Safe response:
+
+- Add or restore the authoritative blocker fallback lane file when the packet requires one.
+- For this runbook lane, the blocker fallback lane is:
+
+```text
+ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-POST-LEVEL-3-GUARDRAIL-RUNBOOK-FIX-001
+```
+
+- Do not infer a fallback lane from memory; use the lane value supplied by the accepted controlling lane or packet contract.
+
+## Missing evidence boundary
+
+Symptoms:
+
+- The evidence-boundary checker reports risky language without nearby boundary wording.
+- The packet consistency checker reports a missing evidence-boundary, blocked-claims, non-actions, or equivalent boundary file.
+
+Safe response:
+
+- Add explicit evidence-boundary language in the authoritative doc.
+- State what the artifact does not prove.
+- Keep the boundary close to any risky phrase.
+- Do not use boundary language to imply the claim is accepted.
+
+## Decision marker present only in logs
+
+Symptoms:
+
+- A required marker appears in `checks-run.md`, command output, or a log file but the checker still fails.
+
+Safe response:
+
+- Put required decision markers in authoritative decision/status files such as accepted-result, final-status, selected-next-action, final-boundary, blocked-claims, or the corresponding packet file required by the lane.
+- Keep command logs as logs only.
+- Do not fix by moving claims into logs or checks-run files.
+
+## Unsupported readiness or benchmark claim boundary
+
+Symptoms:
+
+- The evidence-boundary checker reports language that sounds like unsupported readiness, quality, or benchmark evidence.
+
+Safe response:
+
+- Rewrite the statement as a non-claim, blocked claim, or explicit boundary.
+- State that the docs-only artifact does not prove runtime readiness, model quality, provider behavior, benchmark results, billing behavior, dashboard behavior, or `/v1/solve` behavior.
+- If the claim is intended to be made, stop and route it to the proper future evidence lane instead of changing this runbook.
+
+## Checker failure that seems too strict
+
+Safe response:
+
+- Do not fix by weakening the checker.
+- First update the documentation so the evidence boundary, path reference, selected-next state, fallback lane, or packet field is explicit.
+- If the checker itself is truly wrong, use the blocker fallback lane instead of changing checker behavior in this docs-only runbook PR.

--- a/docs/local_llm_solver_orchestration_guardrails/how-to-run.md
+++ b/docs/local_llm_solver_orchestration_guardrails/how-to-run.md
@@ -1,0 +1,48 @@
+# How to Run the Guardrail Suite
+
+## Normal command
+
+Run the aggregate suite from the repository root:
+
+```bash
+make check-local-llm-orchestration-guardrails
+```
+
+The target runs all three guardrail checkers:
+
+```bash
+python scripts/check_local_llm_evidence_boundaries.py
+python scripts/check_local_llm_doc_paths.py
+python scripts/check_local_llm_packet_consistency.py
+```
+
+## Manual fallback commands
+
+Use direct commands only when isolating a failure class:
+
+```bash
+python scripts/check_local_llm_evidence_boundaries.py
+```
+
+```bash
+python scripts/check_local_llm_doc_paths.py
+```
+
+```bash
+python scripts/check_local_llm_packet_consistency.py
+```
+
+## Recommended operator flow
+
+1. Run `make check-local-llm-orchestration-guardrails` first.
+2. If it fails, read the checker name in the failure output.
+3. Run the matching direct checker command only if you need a smaller diagnostic loop.
+4. Fix the authoritative documentation artifact that the checker reports.
+5. Re-run the aggregate target.
+6. Do not fix a failure by weakening the checker.
+7. Do not fix a failure by moving claims into logs or checks-run files.
+8. Do not infer missing packet fields from memory; use authoritative packet files and source-of-truth docs.
+
+## Evidence boundary
+
+These commands are deterministic documentation checks. They do not run local model inference, start Ollama, call hosted providers, expose `/v1/solve`, expose dashboard routes, add provider fallback, add hosted fallback, run benchmarks, perform billing work, update Google Sheets or backlog workbooks, or promote evidence.

--- a/docs/local_llm_solver_orchestration_guardrails/non-actions.md
+++ b/docs/local_llm_solver_orchestration_guardrails/non-actions.md
@@ -1,0 +1,33 @@
+# Non-Actions and Evidence Boundary
+
+This runbook is documentation only. It records how to operate the guardrail checker suite and how to triage failures without weakening the guardrails.
+
+## Explicit non-actions
+
+This lane does not:
+
+- Modify `Makefile`.
+- Modify `.github/workflows/ci.yml`.
+- Modify checker scripts.
+- Modify tests.
+- Modify runtime behavior.
+- Modify local LLM provider adapter behavior.
+- Modify operator CLI behavior.
+- Modify preserved source artifacts.
+- Modify Level 2 or Level 3 closeout packets.
+- Modify `docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder/`.
+- Run local model inference.
+- Run Ollama.
+- Call hosted providers.
+- Expose or call `/v1/solve`.
+- Expose or call dashboard routes.
+- Add provider fallback.
+- Add hosted fallback.
+- Run benchmarks.
+- Perform billing work.
+- Update Google Sheets or backlog workbooks.
+- Promote evidence.
+
+## Boundary for unsupported claims
+
+This runbook does not prove runtime readiness, model quality, provider behavior, billing behavior, dashboard behavior, `/v1/solve` behavior, or benchmark outcomes. If those claims are needed, they require separate scoped evidence lanes and must not be inferred from this guardrail runbook.


### PR DESCRIPTION
### Motivation

- Create a docs-only runbook for the local LLM solver orchestration guardrail suite to explain what each checker enforces and how operators should triage failures under lane `ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-POST-LEVEL-3-GUARDRAIL-RUNBOOK-001`.
- Replace the polluted PR #392 attempt with a clean, narrowly-scoped set of runbook documents that do not change Makefile, CI, checker scripts, tests, runtime behavior, or packet contents. 
- Keep the scope strictly to operator guidance and preservation of evidence boundaries while providing required fallback and selected-next action guidance. 

### Description

- Added a new runbook directory `docs/local_llm_solver_orchestration_guardrails/` containing `README.md`, `checker-inventory.md`, `how-to-run.md`, `failure-triage.md`, `common-fixes.md`, `non-actions.md`, and `checks-run.md` that document the suite and operator responses. 
- The runbook explains the three checkers and their protections and documents that the aggregate entrypoint is `make check-local-llm-orchestration-guardrails` which runs `python scripts/check_local_llm_evidence_boundaries.py`, `python scripts/check_local_llm_doc_paths.py`, and `python scripts/check_local_llm_packet_consistency.py`. 
- Records the controlling lane, the selected next action `NO_FURTHER_GUARDRAIL_RUNBOOK_LANES_SELECTED`, and the required blocker fallback lane `ALPHA-LOCAL-LLM-SOLVER-ORCHESTRATION-POST-LEVEL-3-GUARDRAIL-RUNBOOK-FIX-001`, and explicitly states the evidence boundary and non-actions (no model runs, no checker/test/script modifications, no packet/promotions, etc.).
- The change set is docs-only and limited to `docs/local_llm_solver_orchestration_guardrails/` with no modifications to `Makefile`, `.github/workflows/ci.yml`, `scripts/`, `tests/`, `alpha/`, or any packet source-artifact paths. 

### Testing

- Preflight repository fingerprint checks were run and passed for required files such as `Makefile`, the three `scripts/check_local_llm_*.py` files, relevant `tests/*` and `docs/` index directories. 
- Ran `make check-local-llm-orchestration-guardrails` and each direct checker command (`python scripts/check_local_llm_evidence_boundaries.py`, `python scripts/check_local_llm_doc_paths.py`, `python scripts/check_local_llm_packet_consistency.py`) and all checks passed in this workspace. 
- Verified git checks and diff constraints: `git diff --name-only` and `git diff --name-only | grep -v '^docs/local_llm_solver_orchestration_guardrails/'` confirmed the final committed changes are only under `docs/local_llm_solver_orchestration_guardrails/` and a commit was recorded on branch `guardrail-runbook-docs-clean-replacement`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25e2c7c2bc83298a204f4381d85192)