### PR TITLE
Add post-Level-3 release-readiness authoring guide

### DIFF
--- a/docs/evals/runs/alpha-solver-post-level-3-authoring-guide/README.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-authoring-guide/README.md
@@ -1,0 +1,57 @@
+# Alpha Solver Post-Level-3 Release-Readiness Authoring Guide
+
+## Lane
+
+`ALPHA-SOLVER-POST-LEVEL-3-RELEASE-READINESS-AUTHORING-GUIDE-001`
+
+## Purpose
+
+This docs-only guide helps future authors create bounded `alpha-solver-post-level-3-*` release-readiness packets without changing runtime behavior or promoting evidence beyond the accepted post-Level-3 state.
+
+It explains how to preserve lane structure, selected-next continuity, blocker fallback state, evidence boundaries, non-actions, and compatibility with the local LLM solver orchestration guardrail suite.
+
+## Accepted prior state
+
+Future authoring must preserve this state unless a later approved packet explicitly changes it with bounded evidence:
+
+- The post-Level-3 roadmap selected the release-readiness ladder.
+- The release-readiness ladder packet selected Level 4 as the next packet.
+- The guardrail runbook exists.
+- The guardrail suite exists and is integrated into CI.
+- Level 2 and Level 3 are closed with bounded evidence only.
+
+## Source evidence reviewed
+
+This guide was authored from these source-of-truth areas without editing them:
+
+- `docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder/`
+- `docs/local_llm_solver_orchestration_guardrails/`
+- `docs/evals/runs/local-llm-solver-orchestration-index/`
+- `scripts/check_local_llm_evidence_boundaries.py`
+- `scripts/check_local_llm_doc_paths.py`
+- `scripts/check_local_llm_packet_consistency.py`
+- `Makefile`
+
+## Files in this guide
+
+- `packet-structure.md` defines the expected file pattern for future post-Level-3 packets.
+- `selected-next-and-fallback.md` explains selected-next and blocker fallback lane authoring.
+- `evidence-boundaries.md` explains bounded evidence, blocked claims, and checks-run limits.
+- `checks-and-guardrails.md` explains how to run the guardrails and when to run packet-specific consistency checks by path.
+- `anti-patterns.md` lists common unsafe authoring patterns.
+- `non-actions.md` records explicit actions not taken by this authoring guide.
+- `checks-run.md` records the checks required and run for this guide.
+- `selected-next-action.md` records the selected next action for this guide.
+- `blocker-fallback-lane.md` records the blocker fallback lane for this guide.
+
+## Selected next action
+
+`NO_FURTHER_RELEASE_READINESS_AUTHORING_GUIDE_LANES_SELECTED`
+
+## Blocker fallback lane
+
+`ALPHA-SOLVER-POST-LEVEL-3-RELEASE-READINESS-AUTHORING-GUIDE-FIX-001`
+
+## Evidence boundary
+
+This is docs-only authoring guidance. It does not start Level 4, run models, run Ollama, rerun validation, call hosted providers, expose `/v1/solve`, expose dashboard routes, add fallback, run benchmarks, perform billing work, or promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-authoring-guide/anti-patterns.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-authoring-guide/anti-patterns.md
@@ -1,0 +1,73 @@
+# Common Anti-Patterns
+
+Avoid these patterns when authoring future post-Level-3 release-readiness packets.
+
+## Claiming readiness from docs-only packets
+
+Unsafe:
+
+> This docs-only packet proves release readiness.
+
+Safe:
+
+> This docs-only packet defines authoring guidance and does not prove release readiness.
+
+## Treating logs as final decision files
+
+Unsafe:
+
+> The decision is authoritative because it appears in `checks-run` output.
+
+Safe:
+
+> The decision is recorded in `selected-next-lane.md`, `selected-next-action.md`, `README.md`, or another authoritative decision file; `checks-run.md` only records validation commands.
+
+## Selecting multiple current next lanes
+
+Unsafe:
+
+> The packet selects Level 4, quality evaluation, provider orchestration, dashboard readiness, `/v1/solve`, billing, benchmark, and MVP readiness lanes.
+
+Safe:
+
+> The packet selects exactly one next lane or one no-further selected next action.
+
+## Omitting blocker fallback lane
+
+Unsafe:
+
+> If this packet is unsafe or incomplete, proceed directly to downstream work.
+
+Safe:
+
+> If this packet is unsafe or incomplete, use the packet's blocker fallback lane.
+
+## Modifying source artifacts to satisfy docs
+
+Unsafe:
+
+> Edit preserved source artifacts so the new packet can claim a cleaner history.
+
+Safe:
+
+> Leave preserved source artifacts unchanged and document any limitation in the new packet boundary.
+
+## Using prior chat context as packet evidence
+
+Unsafe:
+
+> The packet can rely on the previous chat for the accepted prior state.
+
+Safe:
+
+> The packet cites repo source-of-truth files for the accepted prior state.
+
+## Starting downstream work inside a design packet
+
+Unsafe:
+
+> While writing the design packet, also run local model inference, start Ollama, call hosted providers, expose `/v1/solve`, expose dashboard routes, add provider fallback, run benchmarks, perform billing work, or promote evidence.
+
+Safe:
+
+> Keep the packet docs-only and route downstream work to a separately approved lane.

--- a/docs/evals/runs/alpha-solver-post-level-3-authoring-guide/blocker-fallback-lane.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-authoring-guide/blocker-fallback-lane.md
@@ -1,0 +1,7 @@
+# Blocker Fallback Lane
+
+If this authoring guide is incomplete, inconsistent, unsafe, or unable to preserve the accepted evidence boundary, use this blocker fallback lane:
+
+`ALPHA-SOLVER-POST-LEVEL-3-RELEASE-READINESS-AUTHORING-GUIDE-FIX-001`
+
+The blocker fallback lane is for fixing this authoring guide only. It does not start Level 4, product-surface work, quality-evaluation work, provider-orchestration work, dashboard work, `/v1/solve` work, billing work, benchmark work, or MVP readiness work.

--- a/docs/evals/runs/alpha-solver-post-level-3-authoring-guide/checks-and-guardrails.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-authoring-guide/checks-and-guardrails.md
@@ -1,0 +1,57 @@
+# Checks and Guardrails
+
+Future post-Level-3 packet authors should run static documentation checks before requesting review.
+
+## Aggregate guardrail command
+
+Run the aggregate guardrail suite from the repository root:
+
+```bash
+make check-local-llm-orchestration-guardrails
+```
+
+The Makefile target runs:
+
+```bash
+python scripts/check_local_llm_evidence_boundaries.py
+python scripts/check_local_llm_doc_paths.py
+python scripts/check_local_llm_packet_consistency.py
+```
+
+A pass means the checked documentation satisfied the static guardrails in scope. It does not prove runtime behavior, model quality, provider behavior, dashboard readiness, `/v1/solve` readiness, billing readiness, benchmark results, MVP readiness, or production readiness.
+
+## Packet-specific consistency check by path
+
+If checker discovery has not yet been extended to discover a new `alpha-solver-post-level-3-*` packet automatically, run the packet consistency checker with the packet directory path explicitly:
+
+```bash
+python scripts/check_local_llm_packet_consistency.py docs/evals/runs/<packet-directory>
+```
+
+Use this path-specific check when:
+
+- the aggregate guardrail target passes but the new packet family may not be in automatic discovery scope;
+- a new docs-only packet has selected-next, blocker fallback, or evidence-boundary state that should be checked immediately;
+- the packet author needs to confirm one packet without changing checker discovery behavior.
+
+Do not modify checker scripts, tests, CI, or the Makefile merely to satisfy a docs-only authoring packet unless that change is explicitly approved in a separate lane.
+
+## Recommended local checks
+
+For docs-only post-Level-3 authoring packets, record at least:
+
+- `git status --short`
+- `git diff --name-only`
+- `git diff --check`
+- `make check-local-llm-orchestration-guardrails`
+- `python scripts/check_local_llm_evidence_boundaries.py`
+- `python scripts/check_local_llm_doc_paths.py`
+- `python scripts/check_local_llm_packet_consistency.py`
+- `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/<packet-directory>` when discovery may not include the new packet
+- `rg` checks for selected-next, blocker fallback, evidence boundary, and guardrail terms in the new packet
+- `git diff --name-only -- 'docs/evals/runs/**/source-artifact/**'`
+- `git diff --name-only -- scripts tests Makefile .github/workflows/ci.yml`
+
+## Guardrail-compatible fixes
+
+Safe fixes update the packet's own docs to restore required state. Unsafe fixes weaken guardrails, modify closed packets, edit preserved source artifacts, or alter runtime/provider/dashboard/API behavior to make documentation pass.

--- a/docs/evals/runs/alpha-solver-post-level-3-authoring-guide/checks-run.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-authoring-guide/checks-run.md
@@ -1,0 +1,45 @@
+# Checks Run
+
+This guide is docs-only. Checks should confirm authoring-guide consistency and guardrail compatibility without running local model inference, Ollama, validation, smoke, hosted providers, `/v1/solve`, dashboard routes, provider fallback, hosted fallback, benchmarks, billing work, evidence promotion, Google Sheets updates, or backlog workbook updates.
+
+## Required checks for this PR
+
+- `git status --short`
+- `git diff --name-only`
+- `git diff --name-only --cached`
+- `git diff --check`
+- `git diff --check --cached`
+- `make check-local-llm-orchestration-guardrails`
+- `python scripts/check_local_llm_evidence_boundaries.py`
+- `python scripts/check_local_llm_doc_paths.py`
+- `python scripts/check_local_llm_packet_consistency.py`
+- `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-authoring-guide`
+- `rg "NO_FURTHER_RELEASE_READINESS_AUTHORING_GUIDE_LANES_SELECTED|ALPHA-SOLVER-POST-LEVEL-3-RELEASE-READINESS-AUTHORING-GUIDE-FIX-001|check-local-llm-orchestration-guardrails|checks-run|selected-next|blocker fallback|evidence boundary" docs/evals/runs/alpha-solver-post-level-3-authoring-guide`
+- `git diff --name-only -- 'docs/evals/runs/**/source-artifact/**'`
+- `git diff --name-only --cached -- 'docs/evals/runs/**/source-artifact/**'`
+- `git diff --name-only -- alpha service cli scripts tests Makefile .github/workflows/ci.yml`
+- `git diff --name-only --cached -- alpha service cli scripts tests Makefile .github/workflows/ci.yml`
+
+## Interpretation boundary
+
+Passing checks only confirms static documentation consistency within checker scope. It does not establish release readiness, model quality, provider readiness, dashboard readiness, `/v1/solve` readiness, billing readiness, benchmark evidence, MVP readiness, or production readiness.
+
+## Results recorded for this packet
+
+- PASS: `git status --short` showed only new staged files under `docs/evals/runs/alpha-solver-post-level-3-authoring-guide/`.
+- PASS: `git diff --name-only` produced no output after staging, confirming no unstaged tracked-file changes.
+- PASS: `git diff --name-only --cached` showed only new authoring-guide files.
+- PASS: `git diff --check` reported no unstaged whitespace errors.
+- PASS: `git diff --check --cached` reported no staged whitespace errors.
+- PASS: `make check-local-llm-orchestration-guardrails` passed.
+- PASS: `python scripts/check_local_llm_evidence_boundaries.py` passed.
+- PASS: `python scripts/check_local_llm_doc_paths.py` passed.
+- PASS: `python scripts/check_local_llm_packet_consistency.py` passed.
+- PASS: `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-authoring-guide` passed and reported `1 packet directories scanned`, confirming the new authoring-guide packet was checked explicitly by path.
+- PASS: `rg "NO_FURTHER_RELEASE_READINESS_AUTHORING_GUIDE_LANES_SELECTED|ALPHA-SOLVER-POST-LEVEL-3-RELEASE-READINESS-AUTHORING-GUIDE-FIX-001|check-local-llm-orchestration-guardrails|checks-run|selected-next|blocker fallback|evidence boundary" docs/evals/runs/alpha-solver-post-level-3-authoring-guide` found the selected-next action, blocker fallback lane, guardrail command, checks-run references, and boundary terms.
+- PASS: `git diff --name-only -- 'docs/evals/runs/**/source-artifact/**'` produced no output, confirming no unstaged preserved source artifact files changed.
+- PASS: `git diff --name-only --cached -- 'docs/evals/runs/**/source-artifact/**'` produced no output, confirming no staged preserved source artifact files changed.
+- PASS: `git diff --name-only -- alpha service cli scripts tests Makefile .github/workflows/ci.yml` produced no output, confirming no unstaged runtime/provider/dashboard/API/checker/test/Makefile/CI files changed.
+- PASS: `git diff --name-only --cached -- alpha service cli scripts tests Makefile .github/workflows/ci.yml` produced no output, confirming no staged runtime/provider/dashboard/API/checker/test/Makefile/CI files changed.
+
+These results are not authoritative decisions. Authoritative selected-next and fallback state live in `selected-next-action.md`, `blocker-fallback-lane.md`, and `README.md`.

--- a/docs/evals/runs/alpha-solver-post-level-3-authoring-guide/evidence-boundaries.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-authoring-guide/evidence-boundaries.md
@@ -1,0 +1,52 @@
+# Evidence Boundaries
+
+Post-Level-3 packets must keep evidence claims bounded to the artifacts they actually create or review.
+
+## Current boundary to preserve
+
+Future packets should preserve these constraints unless a later approved lane produces new bounded evidence:
+
+- Level 2 remains local operator usability evidence only.
+- Level 3 remains artifact-complete, non-promotional local orchestration evidence only.
+- Release-readiness ladder work defines future gates; it does not complete those gates.
+- Docs-only authoring packets do not prove runtime, provider, product, dashboard, billing, benchmark, or MVP readiness.
+
+## Avoid promoting Level 2 and Level 3 evidence
+
+Do not use Level 2 or Level 3 local-only evidence as proof of product readiness, model quality, hosted-provider readiness, provider fallback readiness, dashboard readiness, `/v1/solve` readiness, benchmark performance, billing readiness, Alpha superiority, or MVP readiness.
+
+Safe wording:
+
+> Level 3 is closed as artifact-complete, non-promotional local orchestration evidence only.
+
+Unsafe wording:
+
+> Level 3 proves that Alpha Solver is ready for users, hosted providers, dashboards, and benchmarks.
+
+## Preserve blocked claims
+
+A packet may list blocked claims to make boundaries explicit. Blocked claims should remain blocked until a later approved packet defines and satisfies the necessary evidence requirements.
+
+Safe wording:
+
+> This packet does not establish production readiness, MVP readiness, benchmark evidence, provider-orchestration evidence, dashboard readiness, `/v1/solve` readiness, or billing readiness.
+
+Unsafe wording:
+
+> Because the docs are complete, readiness is established.
+
+## Checks-run files are not authoritative evidence
+
+`checks-run.md` records commands and outputs used to validate packet consistency. It should not be the only place where selected-next state, fallback state, final decisions, or evidence boundaries appear.
+
+Safe wording:
+
+> The selected-next action is recorded in `selected-next-action.md`; `checks-run.md` only records that checks were run.
+
+Unsafe wording:
+
+> The selected-next action exists because it appears in the `rg` command output in `checks-run.md`.
+
+## Evidence boundary for this guide
+
+This guide is docs-only authoring guidance. It does not start Level 4, run models, run Ollama, rerun validation, call hosted providers, expose `/v1/solve`, expose dashboard routes, add fallback, run benchmarks, perform billing work, or promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-authoring-guide/non-actions.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-authoring-guide/non-actions.md
@@ -1,0 +1,39 @@
+# Non-Actions
+
+This is a docs-only authoring guide.
+
+This guide did not:
+
+- start Level 4;
+- select a product-surface lane;
+- select a quality-evaluation lane;
+- select a provider-orchestration lane;
+- select a dashboard lane;
+- select a `/v1/solve` lane;
+- select a billing lane;
+- select a benchmark lane;
+- select an MVP readiness lane;
+- run local model inference;
+- run Ollama;
+- rerun validation;
+- rerun smoke;
+- call hosted providers;
+- expose or call `/v1/solve`;
+- expose or call dashboard routes;
+- add provider fallback;
+- add hosted fallback;
+- run benchmarks;
+- perform billing work;
+- update Google Sheets;
+- update backlog workbooks;
+- promote evidence;
+- modify runtime behavior;
+- modify local LLM provider adapter behavior;
+- modify operator CLI behavior;
+- modify checker scripts;
+- modify tests;
+- modify the Makefile;
+- modify `.github/workflows/ci.yml`;
+- modify preserved source artifacts;
+- modify closed Level 2 or Level 3 packets;
+- modify release-readiness ladder packet content.

--- a/docs/evals/runs/alpha-solver-post-level-3-authoring-guide/packet-structure.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-authoring-guide/packet-structure.md
@@ -1,0 +1,45 @@
+# Packet Structure for Future Post-Level-3 Packets
+
+Future `alpha-solver-post-level-3-*` packets should be narrow, docs-first, and explicit about what they do not prove. A packet should be understandable from its files alone, without relying on prior chat context, command history, or uncommitted operator memory.
+
+## Required structure
+
+Use a directory under `docs/evals/runs/` with a stable lane-oriented name. Within that directory, include authoritative decision files rather than burying decisions in command logs.
+
+A typical packet should include:
+
+- `README.md` with the lane name, purpose, accepted prior state, files in the packet, selected next state, blocker fallback lane, and evidence boundary.
+- A source-evidence section or file that lists the repo artifacts reviewed before authoring.
+- One or more design or requirements files that contain the actual packet content.
+- `selected-next-lane.md` or `selected-next-action.md`, but not both for the same packet.
+- `blocker-fallback-lane.md` when the packet records or depends on a blocker fallback state.
+- A boundary file such as `evidence-boundary.md`, `blocked-claims.md`, `non-actions.md`, or an equivalent file that keeps unsupported claims blocked.
+- `checks-run.md` that records validation commands, while making clear that command logs are not authoritative decision files.
+
+## Lane naming
+
+Use one lane token for the packet itself and one current selected-next state. The selected-next state may be a future packet lane or a closed/no-further action, but it must not select competing lanes.
+
+Safe wording:
+
+> This packet selects exactly one next lane: `ALPHA-SOLVER-POST-LEVEL-3-LEVEL-4-PRE-PRODUCT-SURFACE-REQUIREMENTS-PACKET-001`.
+
+Unsafe wording:
+
+> This packet selects Level 4, provider orchestration, dashboard readiness, and MVP readiness as current next lanes.
+
+## Decision files versus logs
+
+Decision markers belong in authoritative packet files such as `README.md`, `selected-next-lane.md`, `selected-next-action.md`, `final-decision.md`, or a comparable decision file. `checks-run.md` may record that a command found a marker, but the marker must also be present in an authoritative file.
+
+Safe wording:
+
+> `checks-run.md` records checks only; it does not establish the packet decision.
+
+Unsafe wording:
+
+> The `rg` output in `checks-run.md` is the final selected-next decision.
+
+## Source artifacts
+
+Do not edit preserved source artifacts to make a new packet easier to write. If a source artifact appears stale or confusing, record the limitation and use a blocker fallback lane rather than modifying preserved evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-authoring-guide/selected-next-action.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-authoring-guide/selected-next-action.md
@@ -1,0 +1,13 @@
+# Selected Next Action
+
+This guide selects exactly one next action:
+
+`NO_FURTHER_RELEASE_READINESS_AUTHORING_GUIDE_LANES_SELECTED`
+
+## Rationale
+
+This lane creates docs-only authoring guidance and does not need a follow-on authoring-guide lane.
+
+## Non-start statement
+
+No follow-on lane is started by this guide. This guide does not start Level 4 and does not select product-surface, quality-evaluation, provider-orchestration, dashboard, `/v1/solve`, billing, benchmark, or MVP readiness work.

--- a/docs/evals/runs/alpha-solver-post-level-3-authoring-guide/selected-next-and-fallback.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-authoring-guide/selected-next-and-fallback.md
@@ -1,0 +1,56 @@
+# Selected-Next and Blocker Fallback Authoring
+
+Selected-next and blocker fallback files keep packet continuity clear for future agents and guardrail checks.
+
+## Selected-next lane files
+
+Use `selected-next-lane.md` when the packet intentionally selects one future packet lane. Use `selected-next-action.md` when the packet closes with a no-further action instead of selecting a future lane. Do not include both files in the same packet unless a future checker explicitly allows that pattern.
+
+A selected-next file should contain:
+
+1. A short heading.
+2. Exactly one selected lane or action.
+3. Rationale for why that state follows from the packet.
+4. A non-start statement when the selection identifies future work.
+
+Safe wording for a future lane:
+
+> This packet selects exactly one next lane: `ALPHA-SOLVER-POST-LEVEL-3-LEVEL-4-PRE-PRODUCT-SURFACE-REQUIREMENTS-PACKET-001`.
+>
+> This selection does not start Level 4. It only identifies the next packet to create if work continues.
+
+Safe wording for a closed/no-further action:
+
+> Selected next action: `NO_FURTHER_RELEASE_READINESS_AUTHORING_GUIDE_LANES_SELECTED`.
+>
+> No follow-on lane is started by this guide.
+
+Unsafe wording:
+
+> Level 4 is selected, and the packet also begins MVP readiness implementation.
+
+## Blocker fallback lane files
+
+Use `blocker-fallback-lane.md` to identify the fix lane that should be used if the packet is incomplete, inconsistent, unsafe, or unable to preserve the accepted evidence boundary.
+
+A blocker fallback file should contain:
+
+- The fallback lane token.
+- The conditions that route work to the fallback lane.
+- A statement that the fallback lane fixes the current packet rather than starting downstream product work.
+
+Safe wording:
+
+> If this packet is incomplete, inconsistent, or unable to preserve the evidence boundary, use `ALPHA-SOLVER-POST-LEVEL-3-RELEASE-READINESS-AUTHORING-GUIDE-FIX-001`.
+
+Unsafe wording:
+
+> If blocked, skip the fix lane and begin `/v1/solve`, dashboard, provider orchestration, or MVP readiness work.
+
+## Continuity rules
+
+- Preserve the accepted prior state in the README or equivalent packet overview.
+- Select only one current next lane or one no-further action.
+- Keep fallback state separate from selected-next state.
+- Do not treat fallback lanes as product lanes.
+- Do not use prior chat context as packet evidence.


### PR DESCRIPTION
### Motivation

- Provide a docs-only authoring guide to help future authors create bounded `alpha-solver-post-level-3-*` release-readiness packets that preserve lane structure, selected-next continuity, blocker fallback state, evidence boundaries, non-actions, and compatibility with the guardrail suite.

### Description

- Added a new docs-only packet at `docs/evals/runs/alpha-solver-post-level-3-authoring-guide/` with guidance files and authoritative decision files; lane name is `ALPHA-SOLVER-POST-LEVEL-3-RELEASE-READINESS-AUTHORING-GUIDE-001` and the blocker fallback lane is `ALPHA-SOLVER-POST-LEVEL-3-RELEASE-READINESS-AUTHORING-GUIDE-FIX-001`.
- Files added: `README.md`, `packet-structure.md`, `selected-next-and-fallback.md`, `evidence-boundaries.md`, `checks-and-guardrails.md`, `anti-patterns.md`, `non-actions.md`, `checks-run.md`, `selected-next-action.md`, and `blocker-fallback-lane.md` which together document required packet structure, how to write selected-next and blocker fallback files, how to preserve non-actions/blocked claims, and examples of safe/unsafe wording.
- Selected next action for this guide is `NO_FURTHER_RELEASE_READINESS_AUTHORING_GUIDE_LANES_SELECTED`, and the guide explicitly preserves the evidence boundary that Level 2 and Level 3 remain local-only and that this docs work does not start Level 4 or any runtime/provider/product/dashboard/benchmark/billing/API work.
- No runtime code, provider adapters, operator CLI, checker scripts, tests, Makefile, CI workflows, preserved source-artifact payloads, closed Level 2/Level 3 packets, or release-readiness ladder packet content were modified.

### Testing

- Static guardrail and packet checks were run and passed: `make check-local-llm-orchestration-guardrails` (which runs `python scripts/check_local_llm_evidence_boundaries.py`, `python scripts/check_local_llm_doc_paths.py`, and `python scripts/check_local_llm_packet_consistency.py`) and the path-specific check `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-authoring-guide` all passed.
- Additional repository checks executed and passed: `git status --short`, `git diff --name-only`, `git diff --name-only --cached`, `git diff --check`, `git diff --check --cached`, `rg "NO_FURTHER_RELEASE_READINESS_AUTHORING_GUIDE_LANES_SELECTED|ALPHA-SOLVER-POST-LEVEL-3-RELEASE-READINESS-AUTHORING-GUIDE-FIX-001|check-local-llm-orchestration-guardrails|checks-run|selected-next|blocker fallback|evidence boundary" docs/evals/runs/alpha-solver-post-level-3-authoring-guide`, and `git diff --name-only -- 'docs/evals/runs/**/source-artifact/**'` (both staged and unstaged) which confirmed no preserved source-artifact or runtime/provider/CI/test/Makefile changes.
- Evidence-boundary confirmation and explicit non-actions: this PR did not start Level 4 and did not run local models, Ollama, hosted providers, `/v1/solve`, dashboard routes, add provider/hosted fallback, run benchmarks, perform billing work, promote evidence, or edit prohibited artifacts or scripts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25ea1535d883299c30e57ae7216b42)