### PR TITLE
Add docs-only quality evaluation task taxonomy packet

### DIFF
--- a/docs/evals/runs/alpha-solver-post-level-3-quality-eval-task-taxonomy/README.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-quality-eval-task-taxonomy/README.md
@@ -1,0 +1,42 @@
+# Quality Evaluation Task Taxonomy Packet
+
+Lane:
+`ALPHA-SOLVER-POST-LEVEL-3-QUALITY-EVAL-TASK-TAXONOMY-PACKET-001`
+
+## Purpose
+
+This docs-only packet creates a supporting task taxonomy reference for future Alpha Solver quality evaluation design. It defines candidate task families, inclusion criteria, exclusion criteria, risk labels, and expected artifacts that a future authorized Level 5 quality evaluation design lane may choose to use, revise, supersede, or ignore.
+
+This taxonomy is a supporting reference only. It does not freeze a task set, start quality evaluation execution, run evaluations, score outputs, or claim quality.
+
+## Scope boundary
+
+The packet is limited to taxonomy design language for future review. It records possible families and guardrails, but it does not select prompts, define a frozen benchmark, define scoring thresholds, compare systems, or establish readiness evidence.
+
+Level 5 controls whether and how this taxonomy is used. Any future use must be explicitly authorized by a Level 5 quality evaluation design or execution packet before tasks are operationalized.
+
+## Files in this packet
+
+- `source-evidence-reviewed.md` records source areas reviewed without modifying source artifacts.
+- `taxonomy-overview.md` summarizes the non-execution taxonomy structure.
+- `candidate-task-families.md` lists candidate task families for future design consideration.
+- `inclusion-criteria.md` defines criteria a future task candidate should satisfy before consideration.
+- `exclusion-criteria.md` defines cases that must remain outside this taxonomy reference.
+- `risk-labels.md` defines non-scoring labels for future safety and review planning.
+- `artifact-expectations.md` defines expected documentation artifacts for future task candidates.
+- `non-actions.md` records explicit actions not taken by this docs-only packet.
+- `selected-next-action.md` records the selected next action.
+- `blocker-fallback-lane.md` records the blocker fallback lane.
+- `checks-run.md` records required checks and results.
+
+## Selected next action
+
+`NO_FURTHER_QUALITY_EVAL_TASK_TAXONOMY_LANES_SELECTED`
+
+## Blocker fallback lane
+
+`ALPHA-SOLVER-POST-LEVEL-3-QUALITY-EVAL-TASK-TAXONOMY-FIX-001`
+
+## Evidence boundary
+
+This is a docs-only supporting taxonomy. It does not run models, run Ollama, call providers, run benchmarks, score outputs, claim quality, expose `/v1/solve`, expose dashboards, add fallback, perform billing work, or promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-quality-eval-task-taxonomy/artifact-expectations.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-quality-eval-task-taxonomy/artifact-expectations.md
@@ -1,0 +1,37 @@
+# Artifact Expectations
+
+These expectations describe documentation artifacts a future authorized Level 5 lane may require before using this taxonomy. They do not authorize execution or define a frozen task set.
+
+## Future task-candidate artifact fields
+
+A future task candidate should document:
+
+- candidate family;
+- task purpose;
+- source evidence reviewed;
+- inclusion criteria satisfied;
+- exclusion criteria checked;
+- risk labels assigned;
+- expected reviewer actions;
+- expected non-actions;
+- claim boundaries;
+- artifact preservation requirements;
+- selected-next and blocker fallback implications, if any.
+
+## Future packet artifacts
+
+A future authorized packet that uses this taxonomy should include:
+
+- a source-evidence review;
+- task-family mapping;
+- inclusion and exclusion criteria mapping;
+- risk-label mapping;
+- artifact expectations for any task candidates;
+- explicit non-actions;
+- selected-next state;
+- blocker fallback lane;
+- checks run.
+
+## Artifact boundary
+
+Artifacts produced from this taxonomy remain documentation unless a later authorized Level 5 lane explicitly permits execution artifacts. Documentation artifacts do not establish quality evidence, benchmark evidence, readiness evidence, product evidence, provider evidence, API evidence, dashboard evidence, billing evidence, MVP evidence, or production evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-quality-eval-task-taxonomy/blocker-fallback-lane.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-quality-eval-task-taxonomy/blocker-fallback-lane.md
@@ -1,0 +1,17 @@
+# Blocker Fallback Lane
+
+If this packet is incomplete, inconsistent, unsafe, stale, overbroad, contradictory, or unable to preserve the accepted evidence boundary, use this blocker fallback lane:
+
+`ALPHA-SOLVER-POST-LEVEL-3-QUALITY-EVAL-TASK-TAXONOMY-FIX-001`
+
+## Fallback triggers
+
+Use the fallback lane if:
+
+- the taxonomy appears to start quality evaluation execution;
+- a frozen task set is created;
+- output scoring, benchmark execution, provider calls, local model inference, Ollama runs, dashboard exposure, `/v1/solve` exposure, fallback work, or billing work is required;
+- Level 5 control over taxonomy use is missing;
+- selected-next state is contradictory;
+- required candidate families, inclusion criteria, exclusion criteria, risk labels, artifact expectations, non-actions, or checks are missing;
+- preserved source artifacts, closed Level 2 packets, closed Level 3 packets, release-readiness ladder files, runtime files, provider files, CLI files, checker scripts, tests, Makefile targets, or CI files would need modification.

--- a/docs/evals/runs/alpha-solver-post-level-3-quality-eval-task-taxonomy/candidate-task-families.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-quality-eval-task-taxonomy/candidate-task-families.md
@@ -1,0 +1,43 @@
+# Candidate Task Families
+
+These families are candidates for future quality evaluation design discussion only. They are not a frozen task set and do not authorize execution, scoring, benchmarking, or quality claims.
+
+## Prompt-contract preservation
+
+Tasks may examine whether responses preserve explicit user instructions, scope limits, output-format requirements, and non-action boundaries without adding unsupported work.
+
+## Evidence-boundary correction
+
+Tasks may examine whether responses identify overclaims, unsupported evidence promotion, or claims that exceed accepted Level 2, Level 3, Level 4, or later boundaries.
+
+## Lane continuity and selected-next state
+
+Tasks may examine whether documentation preserves exactly one selected-next action or lane where required, avoids contradictory no-further-lanes state, and records blocker fallback state clearly.
+
+## Artifact review
+
+Tasks may examine whether packet artifacts are complete, internally consistent, source-bounded, and limited to allowed paths.
+
+## Claim-boundary review
+
+Tasks may examine whether responses avoid claims about quality, product readiness, provider readiness, dashboard readiness, `/v1/solve` readiness, billing readiness, benchmark evidence, production readiness, or Alpha superiority unless explicitly supported by authorized evidence.
+
+## Local operator guidance
+
+Tasks may examine whether operator-facing documentation is precise, non-promotional, reproducible, and clear about prerequisites, local-only boundaries, and non-execution limits.
+
+## Failure-mode triage
+
+Tasks may examine whether observed failures are classified without overstating root cause, introducing unapproved fallback, or changing behavior outside an authorized lane.
+
+## Source-evidence interpretation
+
+Tasks may examine whether a response distinguishes source artifacts, imported evidence, summaries, check outputs, and implementation contracts without treating provenance artifacts or backlog ledgers as implementation authority.
+
+## Docs-only packet review
+
+Tasks may examine whether docs-only packets stay within approved file paths, avoid runtime changes, include required non-actions, and record checks without promoting documentation to execution evidence.
+
+## Future product-surface safety review
+
+Tasks may examine future product-surface proposals for safety boundaries around user-facing exposure, API routes, dashboards, provider orchestration, fallback, billing, and readiness claims before any product-surface work starts.

--- a/docs/evals/runs/alpha-solver-post-level-3-quality-eval-task-taxonomy/checks-run.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-quality-eval-task-taxonomy/checks-run.md
@@ -1,0 +1,29 @@
+# Checks Run
+
+This packet is docs-only. Checks confirm static packet consistency and guardrail compatibility without running local model inference, Ollama, hosted providers, benchmarks, quality evaluations, output scoring, `/v1/solve`, dashboard routes, fallback, billing work, or evidence promotion.
+
+## Required checks for this packet
+
+- `git status --short`
+- `git diff --name-only`
+- `git diff --check`
+- `make check-local-llm-orchestration-guardrails`
+- `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-quality-eval-task-taxonomy`
+- `rg "NO_FURTHER_QUALITY_EVAL_TASK_TAXONOMY_LANES_SELECTED|ALPHA-SOLVER-POST-LEVEL-3-QUALITY-EVAL-TASK-TAXONOMY-FIX-001|task taxonomy|inclusion criteria|exclusion criteria|risk labels|does not run" docs/evals/runs/alpha-solver-post-level-3-quality-eval-task-taxonomy`
+- `git diff --name-only -- 'docs/evals/runs/**/source-artifact/**'`
+- `git diff --name-only -- alpha service cli scripts tests Makefile .github/workflows/ci.yml`
+
+## Results recorded for this packet
+
+- PASS: `git status --short` showed only the new docs-only packet directory before staging: `?? docs/evals/runs/alpha-solver-post-level-3-quality-eval-task-taxonomy/`.
+- PASS: `git diff --name-only` produced no tracked-file output before staging, confirming no existing tracked files were modified.
+- PASS: `git diff --check` reported no unstaged whitespace errors.
+- PASS: `make check-local-llm-orchestration-guardrails` passed, including evidence-boundary, doc-path/link, and packet-consistency checks.
+- PASS: `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-quality-eval-task-taxonomy` passed and reported `1 packet directories scanned`.
+- PASS: `rg "NO_FURTHER_QUALITY_EVAL_TASK_TAXONOMY_LANES_SELECTED|ALPHA-SOLVER-POST-LEVEL-3-QUALITY-EVAL-TASK-TAXONOMY-FIX-001|task taxonomy|inclusion criteria|exclusion criteria|risk labels|does not run" docs/evals/runs/alpha-solver-post-level-3-quality-eval-task-taxonomy` found the selected next action, blocker fallback lane, task taxonomy language, inclusion criteria, exclusion criteria, risk labels, and does-not-run boundary language.
+- PASS: `git diff --name-only -- 'docs/evals/runs/**/source-artifact/**'` produced no output, confirming no preserved source artifact files changed.
+- PASS: `git diff --name-only -- alpha service cli scripts tests Makefile .github/workflows/ci.yml` produced no output, confirming no runtime/provider/dashboard/API behavior files, checker scripts, tests, Makefile targets, or CI files changed.
+
+## Interpretation boundary
+
+Passing checks only confirms static documentation consistency within checker scope. It does not establish quality evidence, benchmark evidence, model quality, provider readiness, dashboard readiness, `/v1/solve` readiness, billing readiness, MVP readiness, production readiness, or product readiness.

--- a/docs/evals/runs/alpha-solver-post-level-3-quality-eval-task-taxonomy/exclusion-criteria.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-quality-eval-task-taxonomy/exclusion-criteria.md
@@ -1,0 +1,20 @@
+# Exclusion Criteria
+
+A future task candidate is excluded from this taxonomy reference if it requires or implies any forbidden action below.
+
+## Excluded task types
+
+- Tasks that run models, run Ollama, call providers, run benchmarks, score outputs, or claim quality.
+- Tasks that expose, call, or validate `/v1/solve`.
+- Tasks that expose, call, or validate dashboard routes.
+- Tasks that add provider fallback, hosted fallback, billing behavior, production behavior, or product-surface behavior.
+- Tasks that modify runtime, provider, CLI, checker scripts, tests, Makefile, CI, source artifacts, Level 2 packets, Level 3 packets, or release-readiness ladder files.
+- Tasks that create a frozen task set, fixed benchmark suite, pass/fail threshold, leaderboard, model ranking, or accepted quality score.
+- Tasks that promote Level 2 or Level 3 evidence into quality, product, benchmark, readiness, provider, dashboard, API, billing, MVP, or production claims.
+
+## Excluded claim patterns
+
+- Claims that Alpha Solver has demonstrated quality beyond accepted evidence.
+- Claims that local orchestration evidence proves product readiness.
+- Claims that a docs-only taxonomy starts Level 5 execution.
+- Claims that this taxonomy selects future tasks for execution.

--- a/docs/evals/runs/alpha-solver-post-level-3-quality-eval-task-taxonomy/inclusion-criteria.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-quality-eval-task-taxonomy/inclusion-criteria.md
@@ -1,0 +1,20 @@
+# Inclusion Criteria
+
+A future task candidate may be considered within this taxonomy reference only if all applicable criteria are satisfied.
+
+## Required criteria
+
+- The task is documentation-review or design-review oriented unless a later authorized lane explicitly permits execution.
+- The task has a clear Alpha Solver evidence boundary.
+- The task can be evaluated against repository source material, packet text, or explicit future source evidence.
+- The task can state what artifacts would be reviewed without requiring local model inference, provider calls, benchmarks, scoring, billing work, dashboards, or `/v1/solve` exposure.
+- The task identifies relevant inclusion criteria, exclusion criteria, risk labels, and expected artifacts.
+- The task can preserve selected-next and blocker fallback state without selecting a new lane unless the authorizing packet permits it.
+- The task can be completed without modifying preserved source artifacts, closed Level 2 packets, closed Level 3 packets, release-readiness ladder files, runtime files, provider files, CLI files, checker scripts, tests, Makefile targets, or CI files.
+
+## Preferred criteria
+
+- The task has a narrow source-evidence scope.
+- The task can be reviewed deterministically from text artifacts.
+- The task separates claim-boundary review from execution-quality measurement.
+- The task records non-actions explicitly.

--- a/docs/evals/runs/alpha-solver-post-level-3-quality-eval-task-taxonomy/non-actions.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-quality-eval-task-taxonomy/non-actions.md
@@ -1,0 +1,31 @@
+# Non-Actions
+
+This docs-only supporting taxonomy does not:
+
+- modify runtime behavior;
+- modify provider behavior;
+- modify CLI behavior;
+- modify checker scripts;
+- modify tests;
+- modify `Makefile`;
+- modify CI;
+- modify source artifacts;
+- modify Level 2 packets;
+- modify Level 3 packets;
+- modify release-readiness ladder files;
+- create a frozen task set;
+- run local model inference;
+- run Ollama;
+- call hosted providers;
+- run evaluations;
+- run benchmarks;
+- score outputs;
+- claim quality;
+- expose or call `/v1/solve`;
+- expose or call dashboards;
+- add provider fallback;
+- add hosted fallback;
+- perform billing work;
+- promote evidence;
+- start quality evaluation execution;
+- start product-surface work.

--- a/docs/evals/runs/alpha-solver-post-level-3-quality-eval-task-taxonomy/risk-labels.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-quality-eval-task-taxonomy/risk-labels.md
@@ -1,0 +1,21 @@
+# Risk Labels
+
+Risk labels are non-scoring review aids for future design planning. They do not rank tasks, score outputs, establish pass/fail criteria, or claim quality.
+
+## Boundary risk labels
+
+- `CLAIM_BOUNDARY_RISK`: The task may invite unsupported quality, readiness, benchmark, production, or superiority claims.
+- `EVIDENCE_PROMOTION_RISK`: The task may treat closed Level 2 or Level 3 evidence as broader evidence than accepted.
+- `SELECTED_NEXT_STATE_RISK`: The task may create contradictory selected-next, no-further-lanes, or blocker fallback state.
+
+## Execution risk labels
+
+- `MODEL_EXECUTION_RISK`: The task might be confused with running local model inference, Ollama, hosted providers, or benchmarks.
+- `PRODUCT_SURFACE_RISK`: The task might imply dashboard, `/v1/solve`, provider fallback, billing, MVP, or production surface work.
+- `FROZEN_TASK_SET_RISK`: The task might be mistaken for a frozen task set or accepted benchmark suite.
+
+## Artifact risk labels
+
+- `SOURCE_ARTIFACT_RISK`: The task may touch preserved source artifacts or closed packets.
+- `PATH_SCOPE_RISK`: The task may drift outside approved docs-only paths.
+- `TRACEABILITY_RISK`: The task may lack source references, artifact expectations, non-actions, or check records.

--- a/docs/evals/runs/alpha-solver-post-level-3-quality-eval-task-taxonomy/selected-next-action.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-quality-eval-task-taxonomy/selected-next-action.md
@@ -1,0 +1,13 @@
+# Selected Next Action
+
+Exactly one selected next action is recorded for this docs-only taxonomy packet:
+
+`NO_FURTHER_QUALITY_EVAL_TASK_TAXONOMY_LANES_SELECTED`
+
+## Rationale
+
+This packet creates a supporting reference only. It does not need a follow-on taxonomy lane because Level 5 controls whether and how this taxonomy is used, revised, superseded, or ignored.
+
+## Non-start boundary
+
+This selected next action does not start quality evaluation design, quality evaluation execution, benchmark execution, scoring, product-surface work, provider work, dashboard work, `/v1/solve` work, billing work, MVP review, or production readiness review.

--- a/docs/evals/runs/alpha-solver-post-level-3-quality-eval-task-taxonomy/source-evidence-reviewed.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-quality-eval-task-taxonomy/source-evidence-reviewed.md
@@ -1,0 +1,22 @@
+# Source Evidence Reviewed
+
+This packet reviewed existing repository documentation and guardrail context without modifying preserved source artifacts, closed Level 2 packets, closed Level 3 packets, release-readiness ladder files, runtime files, provider files, CLI files, checker scripts, tests, Makefile targets, or CI files.
+
+## Reviewed source areas
+
+- `docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder/`
+- `docs/evals/runs/alpha-solver-post-level-3-level-4-pre-product-surface-requirements/`
+- `docs/evals/runs/alpha-solver-post-level-3-authoring-guide/`
+- `docs/evals/runs/local-llm-solver-orchestration-index/`
+- `docs/local_llm_solver_orchestration_operator_guide/`
+- `docs/local_llm_solver_orchestration_guardrails/`
+- `scripts/check_local_llm_packet_consistency.py`
+- `Makefile`
+
+## Evidence-boundary observations
+
+- Level 2 controlled usage remains local operator usability evidence only.
+- Level 3 validation execution remains artifact-complete, non-promotional local orchestration evidence only.
+- Post-Level-3 packets preserve blocked claims around quality, product readiness, provider readiness, `/v1/solve`, dashboards, billing, benchmarks, and evidence promotion.
+- This task taxonomy is a supporting reference only and does not start quality evaluation execution.
+- Level 5 controls whether and how this taxonomy is used.

--- a/docs/evals/runs/alpha-solver-post-level-3-quality-eval-task-taxonomy/taxonomy-overview.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-quality-eval-task-taxonomy/taxonomy-overview.md
@@ -1,0 +1,25 @@
+# Taxonomy Overview
+
+This packet defines a non-execution taxonomy for future Alpha Solver quality evaluation design. The taxonomy is intended to help a future authorized Level 5 lane discuss task coverage without implying that any task has been selected, frozen, executed, scored, or accepted as quality evidence.
+
+## Taxonomy fields
+
+Future task candidates may be described with these fields:
+
+- candidate family;
+- task intent;
+- evidence boundary under review;
+- inclusion criteria satisfied;
+- exclusion criteria checked;
+- risk labels;
+- expected artifacts;
+- required source references;
+- non-actions and blocked claims.
+
+## Non-freezing rule
+
+No task family, candidate, prompt, rubric, threshold, output, or scoring method in this packet is frozen. Any future frozen task set must be created by a separate authorized lane that explicitly defines task IDs, source evidence, scoring rules, reviewers, execution controls, and acceptance boundaries.
+
+## Level 5 control
+
+Level 5 controls whether and how this taxonomy is used. A Level 5 packet may adopt, modify, narrow, expand, or reject this taxonomy before any quality evaluation design or execution work begins.


### PR DESCRIPTION
### Motivation

- Create a docs-only supporting taxonomy to inform future Alpha Solver Level 5 quality evaluation design without authorizing execution, scoring, benchmarks, or promoting evidence.
- Capture candidate task families, inclusion and exclusion criteria, non-scoring risk labels, and artifact expectations as a stable reference for later authorized lanes.

### Description

- Added a new docs-only packet under `docs/evals/runs/alpha-solver-post-level-3-quality-eval-task-taxonomy/` with files `README.md`, `source-evidence-reviewed.md`, `taxonomy-overview.md`, `candidate-task-families.md`, `inclusion-criteria.md`, `exclusion-criteria.md`, `risk-labels.md`, `artifact-expectations.md`, `non-actions.md`, `selected-next-action.md`, `blocker-fallback-lane.md`, and `checks-run.md` describing the taxonomy and scope boundary.
- The packet records the selected next action `NO_FURTHER_QUALITY_EVAL_TASK_TAXONOMY_LANES_SELECTED` and the blocker fallback lane `ALPHA-SOLVER-POST-LEVEL-3-QUALITY-EVAL-TASK-TAXONOMY-FIX-001` and explicitly states Level 5 controls whether and how the taxonomy is used.
- The taxonomy enumerates candidate families including prompt-contract preservation, evidence-boundary correction, lane continuity and selected-next state, artifact review, claim-boundary review, local operator guidance, failure-mode triage, source-evidence interpretation, docs-only packet review, and future product-surface safety review.
- The packet enforces an evidence boundary and non-actions that forbid running models, calling providers/Ollama, running benchmarks, scoring outputs, exposing `/v1/solve` or dashboards, modifying runtime/provider/CI/checker scripts, or promoting evidence.

### Testing

- Ran the required static checks: `git status --short`, `git diff --name-only`, and `git diff --check` to confirm no unintended tracked-file edits and there were no whitespace errors.
- Ran guardrail checks `make check-local-llm-orchestration-guardrails` and doc/path/evidence checks including `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-quality-eval-task-taxonomy` which reported the packet-consistency scan of the new packet directory.
- Ran the repository grep check `rg "NO_FURTHER_QUALITY_EVAL_TASK_TAXONOMY_LANES_SELECTED|ALPHA-SOLVER-POST-LEVEL-3-QUALITY-EVAL-TASK-TAXONOMY-FIX-001|task taxonomy|inclusion criteria|exclusion criteria|risk labels|does not run" docs/evals/runs/alpha-solver-post-level-3-quality-eval-task-taxonomy` to confirm presence of required markers.
- All automated checks listed above passed within the packet scope and no runtime/provider/CLI/checker/test/Makefile/CI/source-artifact files were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25f7bc314c832983cd6599cd04a818)