### PR TITLE
Add docs-only Alpha Solver post-Level-3 quality evaluation scoring rubric packet

### DIFF
--- a/docs/evals/runs/alpha-solver-post-level-3-quality-eval-scoring-rubric/README.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-quality-eval-scoring-rubric/README.md
@@ -1,0 +1,40 @@
+# Quality Evaluation Scoring Rubric Packet
+
+Lane:
+`ALPHA-SOLVER-POST-LEVEL-3-QUALITY-EVAL-SCORING-RUBRIC-PACKET-001`
+
+## Purpose
+
+This docs-only packet defines a supporting scoring-rubric reference for future Alpha Solver quality evaluation design. It records proposed scoring dimensions, scale definitions, reviewer rules, disagreement handling, invalid-result rules, and claim-boundary limits for later use by an explicitly approved quality evaluation lane.
+
+This rubric is a supporting reference only. It does not start scoring, does not score real outputs, and does not run benchmarks. Level 5 controls whether and how this rubric is used.
+
+## Included files
+
+- `source-evidence-reviewed.md` records the bounded source evidence reviewed for this docs-only packet.
+- `scoring-dimensions.md` defines scoring dimensions such as instruction preservation, evidence-boundary safety, source-grounding, claim discipline, lane-continuity correctness, artifact completeness, failure-mode recognition, actionable next step quality, and unsupported-claim avoidance.
+- `scale-definitions.md` defines the common score scale for future reviewers.
+- `reviewer-rules.md` defines reviewer conduct rules.
+- `disagreement-handling.md` defines future disagreement handling.
+- `invalid-result-rules.md` defines conditions that make a result invalid rather than merely low-scoring.
+- `claim-boundary-limits.md` defines claim limits and forbidden interpretations.
+- `non-actions.md` records actions intentionally not performed.
+- `selected-next-action.md` records the required no-further-lanes decision.
+- `blocker-fallback-lane.md` records the fallback lane if this packet is incomplete or unsafe.
+- `checks-run.md` records static checks run for this packet.
+
+## Decision boundary
+
+This packet does not claim quality, score quality, establish a benchmark, promote evidence, or authorize product-surface work. It is a design reference that future Level 5 quality evaluation work may accept, revise, reject, or supersede.
+
+## Selected next action
+
+`NO_FURTHER_QUALITY_EVAL_SCORING_RUBRIC_LANES_SELECTED`
+
+## Blocker fallback lane
+
+`ALPHA-SOLVER-POST-LEVEL-3-QUALITY-EVAL-SCORING-RUBRIC-FIX-001`
+
+## Evidence boundary
+
+This docs-only scoring-rubric design does not score outputs, run benchmarks, run models, call providers, claim quality, claim superiority, expose `/v1/solve`, expose dashboards, add fallback, perform billing work, or promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-quality-eval-scoring-rubric/blocker-fallback-lane.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-quality-eval-scoring-rubric/blocker-fallback-lane.md
@@ -1,0 +1,19 @@
+# Blocker Fallback Lane
+
+If this packet is incomplete, inconsistent, unsafe, stale, contradictory, overbroad, or unable to preserve the evidence boundary, use this blocker fallback lane:
+
+`ALPHA-SOLVER-POST-LEVEL-3-QUALITY-EVAL-SCORING-RUBRIC-FIX-001`
+
+## Fallback triggers
+
+Use the fallback lane if:
+
+- scoring dimensions are missing or ambiguous;
+- scale definitions are missing or ambiguous;
+- reviewer rules are missing or unsafe;
+- disagreement handling is missing or forces unsafe consensus;
+- invalid-result rules are missing or allow forbidden scoring;
+- claim-boundary limits are missing or overclaiming;
+- selected-next action is missing or contradictory;
+- the packet starts scoring or benchmark execution;
+- completing the packet would require forbidden non-docs changes.

--- a/docs/evals/runs/alpha-solver-post-level-3-quality-eval-scoring-rubric/checks-run.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-quality-eval-scoring-rubric/checks-run.md
@@ -1,0 +1,22 @@
+# Checks Run
+
+The required checks for this docs-only packet were run with the outcomes below.
+
+## Results
+
+- PASS: `git status --short` showed only the new docs-only scoring-rubric packet directory before staging.
+- PASS: `git diff --name-only` produced no tracked-file differences before staging because the packet files were still untracked.
+- PASS: `git diff --check` produced no whitespace errors before staging.
+- PASS: `make check-local-llm-orchestration-guardrails` completed successfully.
+- PASS: `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-quality-eval-scoring-rubric` completed successfully.
+- PASS: `rg "NO_FURTHER_QUALITY_EVAL_SCORING_RUBRIC_LANES_SELECTED|ALPHA-SOLVER-POST-LEVEL-3-QUALITY-EVAL-SCORING-RUBRIC-FIX-001|scoring dimensions|scale definitions|reviewer rules|does not score|does not run benchmarks" docs/evals/runs/alpha-solver-post-level-3-quality-eval-scoring-rubric` found the selected next action, blocker fallback lane, rubric content markers, and boundary phrases.
+
+## Scope confirmations
+
+- PASS: no preserved source artifact files were changed.
+- PASS: no runtime, provider, dashboard, or API behavior files were changed.
+- PASS: no checker script, test, `Makefile`, or CI files were changed.
+
+## Evidence-boundary confirmation
+
+These checks are documentation and static checker commands only. They did not run local model inference, start Ollama, score outputs, run benchmarks, call hosted providers, expose `/v1/solve`, expose dashboard routes, add fallback, perform billing work, update Google Sheets or backlog workbooks, or promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-quality-eval-scoring-rubric/claim-boundary-limits.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-quality-eval-scoring-rubric/claim-boundary-limits.md
@@ -1,0 +1,31 @@
+# Claim-Boundary Limits
+
+This packet defines claim-boundary limits for future quality evaluation design only.
+
+## Allowed claims for this packet
+
+- A docs-only scoring-rubric reference was created.
+- The packet defines proposed scoring dimensions, scale definitions, reviewer rules, disagreement handling, invalid-result rules, and claim-boundary limits.
+- The packet selects no further quality-eval scoring-rubric lanes.
+- The packet records a blocker fallback lane.
+- Level 5 controls whether and how this rubric is used.
+
+## Disallowed claims for this packet
+
+This packet must not be used to claim that Alpha Solver:
+
+- has measured quality;
+- is better than another system;
+- passed a benchmark;
+- has production readiness;
+- has API readiness;
+- has dashboard readiness;
+- has provider readiness;
+- has billing readiness;
+- has MVP readiness;
+- has scored real outputs;
+- has promoted Level 2 or Level 3 evidence.
+
+## Boundary statement
+
+This docs-only scoring-rubric design does not score outputs, run benchmarks, run models, call providers, claim quality, claim superiority, expose `/v1/solve`, expose dashboards, add fallback, perform billing work, or promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-quality-eval-scoring-rubric/disagreement-handling.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-quality-eval-scoring-rubric/disagreement-handling.md
@@ -1,0 +1,16 @@
+# Disagreement Handling
+
+This disagreement-handling procedure is a future-design reference only. It does not start scoring or benchmark execution.
+
+## Procedure
+
+1. Each reviewer records an independent score and short rationale for each dimension.
+2. Reviewers identify dimensions with score gaps of two or more points, invalid-vs-scoreable conflicts, or contradictory evidence interpretations.
+3. Reviewers cite the exact artifact text or missing evidence that caused the disagreement.
+4. Reviewers discuss only the disputed dimension and do not revise unrelated dimensions unless new evidence affects them.
+5. If the disagreement is caused by missing or ambiguous packet evidence, the result remains unresolved and should be routed to the blocker fallback process rather than forced to consensus.
+6. If a later Level 5 protocol appoints an adjudicator, the adjudicator may record a final score with rationale; otherwise, both scores and the disagreement note should remain visible.
+
+## Non-forcing rule
+
+A disagreement must not be hidden by averaging when one reviewer identifies an invalid-result trigger or forbidden claim. Invalid-result review takes precedence over numeric scoring.

--- a/docs/evals/runs/alpha-solver-post-level-3-quality-eval-scoring-rubric/invalid-result-rules.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-quality-eval-scoring-rubric/invalid-result-rules.md
@@ -1,0 +1,19 @@
+# Invalid-Result Rules
+
+A future result should be marked **Invalid - Not scoreable** instead of receiving a numeric score if any rule below applies.
+
+## Invalid triggers
+
+- The result scores real outputs without an approved scoring-execution lane.
+- The result runs benchmarks or claims benchmark findings without authorization.
+- The result runs local model inference, calls hosted providers, exposes `/v1/solve`, exposes dashboards, adds fallback, or performs billing work outside scope.
+- The result modifies runtime, provider, CLI, checker scripts, tests, Makefile, CI, source artifacts, Level 2 packets, Level 3 packets, or release-readiness ladder files when the lane is docs-only.
+- The result claims Alpha Solver quality, superiority, readiness, production fitness, API readiness, dashboard readiness, provider readiness, billing readiness, or MVP readiness without permitted evidence.
+- The result omits required selected-next or blocker fallback markers.
+- The result contains contradictory selected-next state, such as both a no-further-lanes decision and a selected implementation lane.
+- The result relies on source-artifact changes or preserved packet rewrites that were not authorized.
+- The result cannot be traced to allowed evidence and does not clearly label uncertainty.
+
+## Invalid-result disposition
+
+Invalid results should be repaired through the approved fallback lane or a later approved corrective lane. Reviewers must not convert an invalid result into a low numeric score merely to preserve a scoring table.

--- a/docs/evals/runs/alpha-solver-post-level-3-quality-eval-scoring-rubric/non-actions.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-quality-eval-scoring-rubric/non-actions.md
@@ -1,0 +1,29 @@
+# Non-Actions
+
+This docs-only scoring-rubric packet does not:
+
+- modify runtime behavior;
+- modify provider behavior;
+- modify CLI behavior;
+- modify checker scripts;
+- modify tests;
+- modify `Makefile`;
+- modify CI;
+- modify source artifacts;
+- modify Level 2 packets;
+- modify Level 3 packets;
+- modify release-readiness ladder files;
+- run local model inference;
+- run benchmarks;
+- score outputs;
+- call hosted providers;
+- expose or call `/v1/solve`;
+- expose or call dashboards;
+- add fallback;
+- perform billing work;
+- claim quality;
+- claim superiority;
+- promote evidence;
+- start scoring;
+- start benchmark execution;
+- start product-surface work.

--- a/docs/evals/runs/alpha-solver-post-level-3-quality-eval-scoring-rubric/reviewer-rules.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-quality-eval-scoring-rubric/reviewer-rules.md
@@ -1,0 +1,20 @@
+# Reviewer Rules
+
+These reviewer rules apply only if a later approved Level 5 quality evaluation lane chooses to use this rubric.
+
+## Rules
+
+1. Review only artifacts inside the authorized evaluation scope.
+2. Do not score outputs that the lane did not authorize for scoring.
+3. Do not run models, benchmarks, provider calls, dashboards, `/v1/solve`, billing flows, or fallback flows unless a later approved lane explicitly allows it.
+4. Separate observed artifact facts from reviewer interpretation.
+5. Treat missing evidence as missing, not as implied success.
+6. Treat contradictions between selected-next state and blocker fallback state as material issues.
+7. Preserve prior accepted Level 2 and Level 3 boundaries unless a later approved lane explicitly changes them.
+8. Record uncertainty, blockers, invalid-result triggers, and disagreement reasons in reviewer notes.
+9. Do not use this rubric to claim quality, superiority, readiness, or benchmark performance.
+10. Respect Level 5 control over whether and how this rubric is used.
+
+## Reviewer independence
+
+Future reviewer instructions should prevent reviewers from copying another reviewer's score before recording their own initial judgment. Shared calibration may happen before or after scoring only when the approved Level 5 protocol allows it.

--- a/docs/evals/runs/alpha-solver-post-level-3-quality-eval-scoring-rubric/scale-definitions.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-quality-eval-scoring-rubric/scale-definitions.md
@@ -1,0 +1,20 @@
+# Scale Definitions
+
+These scale definitions are a proposed common language for future reviewers. They do not score real outputs and do not run benchmarks.
+
+## Five-point scale
+
+- **5 - Fully satisfies the dimension**: the result is complete, bounded, traceable, internally consistent, and contains no material omissions for the dimension.
+- **4 - Mostly satisfies the dimension**: the result is substantially correct with only minor wording, organization, or citation gaps that do not change the decision boundary.
+- **3 - Partially satisfies the dimension**: the result addresses the dimension but has material incompleteness, ambiguity, or weak traceability that a reviewer must resolve before relying on it.
+- **2 - Minimally satisfies the dimension**: the result contains a recognizable attempt but misses important required elements, contains boundary ambiguity, or requires substantial correction.
+- **1 - Does not satisfy the dimension**: the result is absent, contradictory, unsupported, or materially outside the authorized lane.
+- **Invalid - Not scoreable**: the result triggers an invalid-result rule and must be rejected or repaired before scoring.
+
+## Reviewer calibration rule
+
+Future reviewers should score the observable artifact, not intent. If a claim is not present, traceable, and permitted, reviewers should not infer it in the artifact's favor.
+
+## Scale-use limits
+
+These scale definitions are supporting reference material only. Level 5 controls whether and how this scale is used, including whether to change the number of points, add weighting, or replace scoring with checklist gates.

--- a/docs/evals/runs/alpha-solver-post-level-3-quality-eval-scoring-rubric/scoring-dimensions.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-quality-eval-scoring-rubric/scoring-dimensions.md
@@ -1,0 +1,19 @@
+# Scoring Dimensions
+
+These scoring dimensions are definitions for future quality evaluation design only. They do not score outputs and do not run benchmarks.
+
+## Dimension list
+
+1. **Instruction preservation**: whether the future result preserves the user's explicit task, allowed scope, forbidden scope, requested return format, and required decision markers.
+2. **Evidence-boundary safety**: whether the future result stays within the authorized evidence boundary and avoids converting docs-only artifacts into execution evidence.
+3. **Source-grounding**: whether claims in the future result are traceable to permitted source evidence, packet files, checked commands, or explicitly marked assumptions.
+4. **Claim discipline**: whether the future result avoids quality, superiority, readiness, production, API, dashboard, billing, provider, or benchmark claims that are not authorized by the lane.
+5. **Lane-continuity correctness**: whether selected-next state, blocker fallback state, prior accepted decisions, and no-further-lanes markers remain coherent and non-contradictory.
+6. **Artifact completeness**: whether the future packet contains all required files, required markers, evidence-boundary statements, checks-run notes, and explicit non-actions.
+7. **Failure-mode recognition**: whether the future result identifies blockers, invalid-result triggers, stale evidence risks, contradiction risks, missing-file risks, and forbidden-action risks.
+8. **Actionable next step quality**: whether the future result records a single bounded next action or no-further-lanes decision that is specific, safe, and aligned with the lane decision boundary.
+9. **Unsupported-claim avoidance**: whether the future result avoids implying that unrun tests, unexecuted benchmarks, uncalled providers, unexposed APIs, or unevaluated outputs prove anything.
+
+## Dimension-use limits
+
+The dimensions are not weights, not pass/fail gates, and not benchmark metrics until a later approved Level 5 decision adopts them. Future evaluators must not treat this file as evidence that Alpha Solver quality has been measured.

--- a/docs/evals/runs/alpha-solver-post-level-3-quality-eval-scoring-rubric/selected-next-action.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-quality-eval-scoring-rubric/selected-next-action.md
@@ -1,0 +1,13 @@
+# Selected Next Action
+
+Selected next action:
+
+`NO_FURTHER_QUALITY_EVAL_SCORING_RUBRIC_LANES_SELECTED`
+
+## Rationale
+
+No further quality-eval scoring-rubric lanes are selected because this packet is complete as a supporting reference only. It does not start scoring, does not run benchmarks, and does not authorize downstream execution.
+
+## Level 5 control
+
+Level 5 controls whether and how this rubric is used. A later approved Level 5 lane may accept, revise, reject, or supersede this supporting reference.

--- a/docs/evals/runs/alpha-solver-post-level-3-quality-eval-scoring-rubric/source-evidence-reviewed.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-quality-eval-scoring-rubric/source-evidence-reviewed.md
@@ -1,0 +1,18 @@
+# Source Evidence Reviewed
+
+## Reviewed repo evidence
+
+This packet reviewed only existing repository documentation and static packet requirements relevant to Alpha Solver post-Level-3 documentation continuity:
+
+- repo-level agent instructions in `AGENTS.md`;
+- the existing post-Level-3 docs packet pattern under `docs/evals/runs/alpha-solver-post-level-3-level-4-pre-product-surface-requirements/`;
+- the local packet consistency checker contract in `scripts/check_local_llm_packet_consistency.py`;
+- the guardrail target in `Makefile`.
+
+## Evidence-use limits
+
+The reviewed evidence was used only to shape a docs-only scoring-rubric reference. It was not used to score real outputs, execute evaluations, run benchmarks, run models, call providers, claim quality, claim superiority, promote evidence, or select product-surface work.
+
+## Supporting-reference status
+
+This rubric is a supporting reference only. Level 5 controls whether and how this rubric is used, including whether any dimension, scale, or reviewer procedure is accepted, revised, rejected, or replaced.


### PR DESCRIPTION
### Motivation

- Provide a documented, repo-bound scoring-rubric reference for future Alpha Solver quality-eval design so Level 5 can adopt or revise a consistent set of dimensions, scales, reviewer rules, and failure/claim boundaries. 
- Capture decision continuity (selected next action and blocker fallback) and strict evidence boundaries so the packet cannot be mistaken for execution, scoring, or benchmarking work.

### Description

- Added a docs-only packet at `docs/evals/runs/alpha-solver-post-level-3-quality-eval-scoring-rubric/` with the following files: `README.md`, `source-evidence-reviewed.md`, `scoring-dimensions.md`, `scale-definitions.md`, `reviewer-rules.md`, `disagreement-handling.md`, `invalid-result-rules.md`, `claim-boundary-limits.md`, `non-actions.md`, `selected-next-action.md`, `blocker-fallback-lane.md`, and `checks-run.md`. 
- Defined scoring dimensions including `instruction preservation`, `evidence-boundary safety`, `source-grounding`, `claim discipline`, `lane-continuity correctness`, `artifact completeness`, `failure-mode recognition`, `actionable next step quality`, and `unsupported-claim avoidance`. 
- Provided a proposed five-point scale plus an `Invalid - Not scoreable` state, reviewer conduct and independence rules, a disagreement-handling procedure that elevates invalid-result triggers, and explicit invalid-result rules and claim-boundary limits. 
- Recorded the mandated decision markers: Selected next action `NO_FURTHER_QUALITY_EVAL_SCORING_RUBRIC_LANES_SELECTED` and blocker fallback lane `ALPHA-SOLVER-POST-LEVEL-3-QUALITY-EVAL-SCORING-RUBRIC-FIX-001`, and emphasized that this packet is a supporting reference only and Level 5 controls whether/how it is used.

### Testing

- Ran the required static checks which all passed: `git status --short`, `git diff --name-only`, and `git diff --check` (no whitespace issues). 
- Passed guardrail and packet checks: `make check-local-llm-orchestration-guardrails` completed successfully and `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-quality-eval-scoring-rubric` returned success. 
- Searched and validated required markers with `rg` for `NO_FURTHER_QUALITY_EVAL_SCORING_RUBRIC_LANES_SELECTED`, `ALPHA-SOLVER-POST-LEVEL-3-QUALITY-EVAL-SCORING-RUBRIC-FIX-001`, and rubric keywords and confirmed results were found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25f7c1f8f4832981603ac89c21e3f2)