### PR TITLE
Add docs-only Alpha Solver quality eval artifact schema packet

### DIFF
--- a/docs/evals/runs/alpha-solver-post-level-3-quality-eval-artifact-schema/README.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-quality-eval-artifact-schema/README.md
@@ -1,0 +1,64 @@
+# Alpha Solver Post-Level-3 Quality Eval Artifact Schema Packet
+
+Lane: `ALPHA-SOLVER-POST-LEVEL-3-QUALITY-EVAL-ARTIFACT-SCHEMA-PACKET-001`
+
+## Purpose
+
+This packet defines a docs-only artifact schema for future Alpha Solver quality evaluation execution packets. It describes the files, metadata fields, raw-output preservation rules, reviewer notes, scoring records, invalid-result markers, redaction rules, final decision files, and checks-run files that future eval artifact packets should contain.
+
+## Authority and boundary
+
+This schema is a supporting reference only and does not create eval evidence. Level 5 controls whether and how this schema is used in future quality evaluation lanes.
+
+The schema does not execute an eval, score output, call any provider, expose `/v1/solve`, expose dashboards, add fallback behavior, perform billing work, promote evidence, or create real eval result artifacts.
+
+## Required future artifact files
+
+Future quality eval artifact packets that adopt this schema should include the following files or clearly document why a required file is absent:
+
+- `README.md` — packet purpose, evidence boundary, adopted schema version, and file map.
+- `run-metadata.md` — required metadata fields for the future evaluation execution.
+- `source-evidence-reviewed.md` — source materials reviewed before the future evaluation artifact packet was assembled.
+- `artifact-file-inventory.md` — inventory of raw outputs, derived reviewer notes, scoring sheets, final decisions, and checks.
+- `raw-output-preservation.md` — preservation hash ledger and immutability notes for captured raw outputs.
+- `raw-outputs/` — append-only directory for unmodified raw provider, model, runner, or operator output captures.
+- `reviewer-notes.md` — structured reviewer notes that refer back to raw outputs without replacing them.
+- `scoring-records.md` — scoring records, rubric references, reviewer identity or role fields, and raw-output anchors.
+- `invalid-result-markers.md` — explicit invalid, incomplete, redacted, superseded, and blocked result states.
+- `redaction-log.md` — redaction decisions, redacted-field locations, reason codes, and reviewer signoff.
+- `final-decision.md` — final decision and claim boundaries derived from reviewed evidence.
+- `checks-run.md` — commands and static checks run while assembling the artifact packet.
+- `non-actions.md` — explicit confirmation of eval, provider, runtime, dashboard, billing, and evidence-promotion non-actions.
+
+## Packet files in this schema lane
+
+- `README.md`
+- `source-evidence-reviewed.md`
+- `artifact-file-inventory.md`
+- `metadata-fields.md`
+- `raw-output-preservation.md`
+- `reviewer-notes-schema.md`
+- `scoring-record-schema.md`
+- `invalid-result-markers.md`
+- `redaction-rules.md`
+- `final-decision-files.md`
+- `non-actions.md`
+- `selected-next-action.md`
+- `blocker-fallback-lane.md`
+- `checks-run.md`
+
+## Required claim-boundary language
+
+Future eval artifacts adopting this schema must use claim-boundary language that separates captured evidence from interpretation. Required phrasing:
+
+- "This artifact records evidence captured during the named evaluation run only."
+- "This artifact does not establish production readiness, MVP readiness, benchmark superiority, provider reliability, billing readiness, dashboard readiness, or broad runtime readiness unless a separate Level 5 decision explicitly authorizes that claim."
+- "Scored artifacts refer back to preserved raw outputs and do not replace the raw outputs."
+- "Redacted derivatives are convenience review artifacts; preserved raw outputs remain the source of record unless Level 5 requires redacted-only retention."
+- "Invalid results must remain discoverable and must not be silently deleted or converted into passing evidence."
+
+## Decision state
+
+Selected next action: `NO_FURTHER_QUALITY_EVAL_ARTIFACT_SCHEMA_LANES_SELECTED`
+
+Blocker fallback lane: `ALPHA-SOLVER-POST-LEVEL-3-QUALITY-EVAL-ARTIFACT-SCHEMA-FIX-001`

--- a/docs/evals/runs/alpha-solver-post-level-3-quality-eval-artifact-schema/artifact-file-inventory.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-quality-eval-artifact-schema/artifact-file-inventory.md
@@ -1,0 +1,42 @@
+# Artifact File Inventory Schema
+
+## Purpose
+
+Future quality eval execution packets should include an inventory that makes every artifact discoverable and classifies each file as raw, derived, decision, check, or administrative content.
+
+## Required inventory columns
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `artifact_id` | Yes | Stable unique identifier for the file within the packet. |
+| `relative_path` | Yes | Repo-relative path or packet-relative path to the artifact. |
+| `artifact_type` | Yes | One of `raw_output`, `reviewer_note`, `scoring_record`, `redaction_log`, `final_decision`, `checks_run`, `metadata`, or `non_action`. |
+| `source_raw_output_id` | Conditional | Required for reviewer notes, scoring records, redaction logs, and final decisions that cite specific raw outputs. |
+| `created_by_role` | Yes | Operator, reviewer, scorer, automation, or Level 5 approver role. |
+| `created_at_utc` | Yes | UTC timestamp in ISO 8601 format. |
+| `sha256` | Conditional | Required for immutable raw outputs and recommended for final decision files. |
+| `redaction_state` | Yes | `none`, `redacted_derivative`, `raw_sensitive_restricted`, or `not_applicable`. |
+| `validity_state` | Yes | `valid`, `invalid`, `incomplete`, `superseded`, `blocked`, or `quarantined`. |
+| `notes` | Optional | Short inventory-specific notes; not a substitute for reviewer notes. |
+
+## Required future artifact files
+
+A future packet adopting this schema should inventory at least these file groups:
+
+1. Packet overview and run metadata.
+2. Raw output captures in `raw-outputs/`.
+3. Raw-output preservation ledger.
+4. Reviewer notes.
+5. Scoring records or explicit no-scoring record.
+6. Invalid-result marker ledger.
+7. Redaction log.
+8. Final decision file.
+9. Checks-run file.
+10. Non-actions confirmation.
+
+## Inventory rules
+
+- Raw outputs must be inventoried before scoring records claim them as source material.
+- Derived artifacts must refer to raw outputs by `artifact_id` and path.
+- Invalid and blocked artifacts remain in the inventory with their invalid-result markers.
+- Deleted or replaced files must be recorded as `superseded` rather than disappearing from the inventory.

--- a/docs/evals/runs/alpha-solver-post-level-3-quality-eval-artifact-schema/blocker-fallback-lane.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-quality-eval-artifact-schema/blocker-fallback-lane.md
@@ -1,0 +1,5 @@
+# Blocker Fallback Lane
+
+`ALPHA-SOLVER-POST-LEVEL-3-QUALITY-EVAL-ARTIFACT-SCHEMA-FIX-001`
+
+Use this blocker fallback lane only if the docs-only artifact schema packet is found to be incomplete, internally inconsistent, or missing required boundary language. The fallback lane is not authorization to run evaluations, score outputs, call providers, change runtime behavior, expose `/v1/solve`, expose dashboards, perform billing work, or promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-quality-eval-artifact-schema/checks-run.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-quality-eval-artifact-schema/checks-run.md
@@ -1,0 +1,27 @@
+# Checks Run
+
+This file records checks for the docs-only artifact schema packet. It does not record evaluation execution and does not create eval evidence.
+
+## Required checks
+
+- `git status --short`
+- `git diff --name-only`
+- `git diff --check`
+- `make check-local-llm-orchestration-guardrails`
+- `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-quality-eval-artifact-schema`
+- `rg "NO_FURTHER_QUALITY_EVAL_ARTIFACT_SCHEMA_LANES_SELECTED|ALPHA-SOLVER-POST-LEVEL-3-QUALITY-EVAL-ARTIFACT-SCHEMA-FIX-001|raw-output preservation|metadata fields|final decision files|does not create eval evidence" docs/evals/runs/alpha-solver-post-level-3-quality-eval-artifact-schema`
+- Confirm no preserved source artifact files changed.
+- Confirm no runtime/provider/dashboard/API behavior files changed.
+
+## Checks executed for this PR
+
+Recorded after final checks.
+
+- PASS: `git status --short` showed only the new docs-only artifact schema packet directory before staging.
+- PASS: `git diff --name-only` produced no tracked-file modifications before staging because all changes were new untracked docs files.
+- PASS: `git diff --check` reported no whitespace errors for tracked unstaged changes.
+- PASS: `make check-local-llm-orchestration-guardrails` passed local LLM evidence-boundary, doc path/link, and packet consistency checks.
+- PASS: `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-quality-eval-artifact-schema` passed for the new packet directory.
+- PASS: `rg "NO_FURTHER_QUALITY_EVAL_ARTIFACT_SCHEMA_LANES_SELECTED|ALPHA-SOLVER-POST-LEVEL-3-QUALITY-EVAL-ARTIFACT-SCHEMA-FIX-001|raw-output preservation|metadata fields|final decision files|does not create eval evidence" docs/evals/runs/alpha-solver-post-level-3-quality-eval-artifact-schema` found the required decision, fallback, schema, and boundary language.
+- PASS: preserved source artifact files were not modified.
+- PASS: runtime, provider, dashboard, and API behavior files were not modified.

--- a/docs/evals/runs/alpha-solver-post-level-3-quality-eval-artifact-schema/final-decision-files.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-quality-eval-artifact-schema/final-decision-files.md
@@ -1,0 +1,38 @@
+# Final Decision Files Schema
+
+## Purpose
+
+Final decision files record what a future eval artifact packet concludes. Checks-run files record commands and checks. The two must not be conflated.
+
+## What belongs in final decision files
+
+Future `final-decision.md` files should contain:
+
+- Final decision state: accepted, rejected, blocked, inconclusive, deferred, or superseded.
+- Scope of the decision and adopted schema reference.
+- Raw outputs, reviewer notes, scoring records, invalid markers, and redaction logs considered.
+- Excluded artifacts and the reason for exclusion.
+- Claim-boundary language for the decision.
+- Level 5 authorization or limitation statement.
+- Required follow-up or explicit no-further-action marker.
+- Signoff roles and decision timestamp.
+
+## What belongs in checks-run files
+
+Future `checks-run.md` files should contain:
+
+- Commands run while assembling or validating the artifact packet.
+- Pass, fail, or warning status for each command.
+- Environment limitations for warnings.
+- Paths inspected by static checks.
+- Confirmation that forbidden actions were not run.
+
+## Separation rule
+
+A passing check does not by itself create a final quality decision. A final decision may cite checks-run status, but the decision must be based on the reviewed artifact inventory, raw-output preservation state, scoring records, invalid-result markers, redaction state, and Level 5 authorization.
+
+## Required final decision claim-boundary language
+
+Future final decision files must include:
+
+"This final decision applies only to the artifacts identified in this packet and only within the Level 5 authorization boundary. It does not create eval evidence beyond the preserved raw outputs, reviewed scoring records, and explicitly accepted decision scope."

--- a/docs/evals/runs/alpha-solver-post-level-3-quality-eval-artifact-schema/invalid-result-markers.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-quality-eval-artifact-schema/invalid-result-markers.md
@@ -1,0 +1,27 @@
+# Invalid Result Markers
+
+## Purpose
+
+Future eval packets need explicit invalid result states so incomplete or unusable captures remain visible without being promoted as valid evidence.
+
+## Required invalid result states
+
+| Marker | Meaning | Evidence handling |
+| --- | --- | --- |
+| `VALID_RESULT` | Artifact is valid for its declared purpose. | May be considered by scoring and final decision. |
+| `INVALID_MISSING_RAW_OUTPUT` | A derived note or score has no preserved raw output. | Exclude from scoring and final claims. |
+| `INVALID_MUTATED_RAW_OUTPUT` | Raw output was edited in place or cannot be verified as unmodified. | Quarantine and exclude unless Level 5 accepts a restricted derivative policy. |
+| `INVALID_UNAUTHORIZED_RUN` | Execution occurred without required authorization. | Preserve for audit, exclude from promoted evidence. |
+| `INVALID_SCOPE_VIOLATION` | Artifact reflects a forbidden provider, runtime, API, dashboard, billing, or benchmark action. | Preserve for audit and block promotion. |
+| `INVALID_REDACTION_GAP` | Sensitive data appears without required redaction or restriction. | Restrict access, create redaction log, block public review. |
+| `INVALID_HASH_MISMATCH` | Recorded hash does not match artifact bytes. | Quarantine until resolved. |
+| `INCOMPLETE_CAPTURE` | Capture ended early or lacks required stdout, stderr, status, metadata, or command provenance. | Keep visible and mark incomplete. |
+| `BLOCKED_BY_ENVIRONMENT` | Environment limitation prevented valid execution or checking. | Keep as blocked evidence, not failure evidence. |
+| `SUPERSEDED_BY_RERUN` | Later authorized rerun replaced this result. | Keep in inventory and cite superseding artifact. |
+| `REDACTED_DERIVATIVE_ONLY` | Only a redacted derivative can be reviewed under current policy. | Final decision must state raw-source availability limits. |
+
+## Invalid marker rules
+
+- Invalid results must not be deleted solely because they are invalid.
+- Invalid markers must be visible in inventory, scoring records, and final decision exclusions.
+- A final decision must distinguish invalid, incomplete, blocked, and valid artifacts.

--- a/docs/evals/runs/alpha-solver-post-level-3-quality-eval-artifact-schema/metadata-fields.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-quality-eval-artifact-schema/metadata-fields.md
@@ -1,0 +1,34 @@
+# Metadata Fields Schema
+
+## Purpose
+
+Future quality eval artifacts need consistent metadata fields so reviewers can determine what was run, what was captured, what was not run, and which claims are allowed.
+
+## Required metadata fields
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `schema_packet` | Yes | The schema reference used by the future eval artifact packet. |
+| `eval_packet_id` | Yes | Stable identifier for the future evaluation packet. |
+| `eval_objective` | Yes | Short objective of the future evaluation execution. |
+| `level_5_authorization` | Yes | Link or marker showing whether Level 5 authorized execution and schema use. |
+| `operator_role` | Yes | Role of the person or automation that ran the future eval. |
+| `reviewer_roles` | Yes | Roles assigned to review, scoring, redaction, and final decision. |
+| `started_at_utc` | Conditional | Required if an eval run actually occurred. |
+| `completed_at_utc` | Conditional | Required if an eval run actually completed. |
+| `repository_commit` | Yes | Git commit used when the future packet was assembled. |
+| `working_tree_state` | Yes | Clean, dirty, or documented exception. |
+| `runtime_entrypoint` | Conditional | CLI, script, API route, or operator command used if execution occurred. |
+| `provider_or_model` | Conditional | Provider, local model, hosted model, or none. |
+| `network_state` | Yes | Local-only, hosted-provider, offline, or not applicable. |
+| `input_set_id` | Conditional | Frozen or ad hoc input set identifier if execution occurred. |
+| `raw_output_ids` | Conditional | IDs of raw outputs captured for the future evaluation. |
+| `rubric_id` | Conditional | Rubric or scoring guide used if scoring occurred. |
+| `redaction_policy` | Yes | Redaction rule set used by the future artifact packet. |
+| `claim_boundary` | Yes | Exact claim-boundary language applied to the packet. |
+| `invalid_result_policy` | Yes | Invalid-result marker set used by the packet. |
+| `final_decision_state` | Conditional | Final accepted, rejected, blocked, inconclusive, or deferred state. |
+
+## Metadata fields boundary
+
+Metadata fields describe future artifacts and do not themselves prove model quality. Missing conditional fields must be marked `not_applicable` or `not_run`; they must not be inferred from reviewer expectations.

--- a/docs/evals/runs/alpha-solver-post-level-3-quality-eval-artifact-schema/non-actions.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-quality-eval-artifact-schema/non-actions.md
@@ -1,0 +1,29 @@
+# Non-Actions
+
+This docs-only artifact schema packet does not create eval evidence.
+
+## Explicit non-actions
+
+This packet did not:
+
+- Run local model inference.
+- Run hosted model inference.
+- Run benchmarks.
+- Score outputs.
+- Create eval result artifacts.
+- Call providers.
+- Expose `/v1/solve`.
+- Expose dashboards.
+- Add fallback behavior.
+- Change runtime behavior.
+- Change provider behavior.
+- Perform billing work.
+- Promote evidence.
+- Modify Level 2 packets.
+- Modify Level 3 packets.
+- Modify release-readiness ladder files.
+- Modify source artifacts.
+
+## Boundary statement
+
+This packet is a supporting reference only. Level 5 controls whether and how this schema is used.

--- a/docs/evals/runs/alpha-solver-post-level-3-quality-eval-artifact-schema/raw-output-preservation.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-quality-eval-artifact-schema/raw-output-preservation.md
@@ -1,0 +1,32 @@
+# Raw-Output Preservation Schema
+
+## raw-output preservation requirement
+
+Future eval packets must preserve raw outputs without mutation. Raw provider responses, local model outputs, runner stdout, runner stderr, command transcripts, API responses, and operator captures must be stored exactly as captured whenever retention is allowed.
+
+## Required preservation fields
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `raw_output_id` | Yes | Stable ID referenced by reviewer notes and scoring records. |
+| `relative_path` | Yes | Path under the future packet, usually `raw-outputs/`. |
+| `capture_method` | Yes | CLI redirect, script capture, API transcript, provider export, or operator paste. |
+| `captured_at_utc` | Yes | UTC capture timestamp. |
+| `captured_by_role` | Yes | Operator, automation, or reviewer role. |
+| `bytes` | Yes | File size in bytes. |
+| `sha256` | Yes | Hash of the preserved raw file. |
+| `encoding` | Yes | UTF-8, binary, JSON, text, or documented alternative. |
+| `mutation_state` | Yes | Must be `unmodified_raw` for source-of-record raw outputs. |
+| `sensitivity_state` | Yes | `none_detected`, `sensitive_restricted`, or `redacted_derivative_available`. |
+
+## Preservation rules
+
+- Do not edit raw outputs in place.
+- Do not normalize whitespace, JSON formatting, timestamps, ordering, or error messages in raw outputs.
+- Do not remove failed, partial, invalid, or embarrassing outputs.
+- If sensitive content requires restriction, retain the source-of-record path according to the Level 5 retention decision and create a separate redacted derivative rather than mutating the raw file.
+- If policy requires raw deletion, the future packet must retain a deletion marker with hash, size, redaction reason, approver role, and deletion timestamp.
+
+## Scored artifact references
+
+Scoring records must refer back to raw outputs by `raw_output_id`, path, and, when practical, line range or JSON pointer. A score cannot stand alone as source evidence; it is an interpretation anchored to preserved raw output.

--- a/docs/evals/runs/alpha-solver-post-level-3-quality-eval-artifact-schema/redaction-rules.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-quality-eval-artifact-schema/redaction-rules.md
@@ -1,0 +1,29 @@
+# Redaction Rules
+
+## Purpose
+
+Future quality eval packets may contain sensitive information. Redaction rules protect sensitive content while preserving auditability and raw-output integrity.
+
+## Sensitive information categories
+
+Future packets must identify and protect:
+
+- API keys, access tokens, cookies, session IDs, SSH keys, and credentials.
+- Personal data, private emails, phone numbers, addresses, or account identifiers.
+- Provider billing details, invoices, payment data, and quota identifiers.
+- Proprietary prompts, hidden system prompts, confidential datasets, and private eval inputs when restricted.
+- Internal network names, hostnames, local file paths, or secrets that create operational risk.
+
+## Redaction rules
+
+- Do not mutate raw outputs to redact them in place.
+- Create a redacted derivative with a separate path and artifact ID.
+- Record every redaction in `redaction-log.md` with source path, redacted path, redaction category, reason code, reviewer role, and timestamp.
+- Replace sensitive text with stable placeholders such as `[REDACTED_API_KEY_001]` rather than ambiguous deletion.
+- Preserve enough surrounding context for review without exposing the sensitive value.
+- If raw retention is not allowed, record a deletion or restricted-retention marker approved by the required role.
+- Final decision files must state whether they rely on raw outputs, redacted derivatives, or restricted raw outputs.
+
+## Redaction claim boundary
+
+A redacted derivative supports review convenience only. It does not prove the unredacted raw output was unchanged unless linked to a preservation record, hash, and Level 5-approved retention decision.

--- a/docs/evals/runs/alpha-solver-post-level-3-quality-eval-artifact-schema/reviewer-notes-schema.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-quality-eval-artifact-schema/reviewer-notes-schema.md
@@ -1,0 +1,28 @@
+# Reviewer Notes Schema
+
+## Purpose
+
+Reviewer notes capture human or automation review observations about future eval artifacts. They are derived artifacts and must not replace raw outputs.
+
+## Required reviewer note fields
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `review_note_id` | Yes | Stable note identifier. |
+| `reviewer_role` | Yes | Reviewer role or automation role. |
+| `reviewed_at_utc` | Yes | UTC review timestamp. |
+| `source_raw_output_id` | Conditional | Required when a note discusses a raw output. |
+| `source_path` | Conditional | Required with `source_raw_output_id`. |
+| `source_anchor` | Optional | Line range, JSON pointer, timestamp range, or section marker. |
+| `observation_type` | Yes | `format`, `behavior`, `safety`, `correctness`, `latency`, `error`, `redaction`, `validity`, or `other`. |
+| `observation` | Yes | Concise reviewer observation. |
+| `claim_boundary` | Yes | Boundary statement limiting the observation to the cited source. |
+| `requires_scoring` | Yes | `yes`, `no`, or `not_applicable`. |
+| `invalid_marker` | Conditional | Required if the observation identifies invalid evidence. |
+
+## Note rules
+
+- Notes must distinguish direct observation from inference.
+- Notes must cite preserved raw outputs when discussing outputs.
+- Notes must not silently correct or rewrite model responses.
+- Notes must not promote an observation into broad Alpha Solver quality evidence without the final decision file and Level 5 authorization.

--- a/docs/evals/runs/alpha-solver-post-level-3-quality-eval-artifact-schema/scoring-record-schema.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-quality-eval-artifact-schema/scoring-record-schema.md
@@ -1,0 +1,31 @@
+# Scoring Record Schema
+
+## Purpose
+
+Scoring records document how future eval outputs are scored against an authorized rubric. They are derived artifacts that refer back to raw outputs.
+
+## Required scoring fields
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `scoring_record_id` | Yes | Stable scoring record identifier. |
+| `rubric_id` | Yes | Rubric or scoring guide used. |
+| `scorer_role` | Yes | Scorer role or automation role. |
+| `scored_at_utc` | Yes | UTC scoring timestamp. |
+| `source_raw_output_id` | Yes | Raw output being scored. |
+| `source_path` | Yes | Path to the raw output. |
+| `source_anchor` | Recommended | Line range, JSON pointer, or transcript turn. |
+| `criterion_id` | Yes | Rubric criterion identifier. |
+| `score_value` | Conditional | Score if valid scoring was possible. |
+| `score_scale` | Conditional | Scale such as `0-2`, `pass_fail`, or rubric-defined labels. |
+| `invalid_result_marker` | Conditional | Required when scoring cannot produce a valid result. |
+| `rationale` | Yes | Rationale grounded in the cited raw output. |
+| `review_status` | Yes | `draft`, `reviewed`, `accepted`, `rejected`, or `blocked`. |
+| `claim_boundary` | Yes | Statement that the score applies only to the cited artifact and criterion. |
+
+## Scoring rules
+
+- A scored artifact must refer back to raw output by `source_raw_output_id` and `source_path`.
+- A score must not be created from memory, screenshots alone, summaries alone, or reviewer notes alone when raw output exists.
+- Invalid outputs should receive an invalid-result marker rather than an invented score.
+- Aggregated scores must identify every included scoring record and every excluded invalid record.

--- a/docs/evals/runs/alpha-solver-post-level-3-quality-eval-artifact-schema/selected-next-action.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-quality-eval-artifact-schema/selected-next-action.md
@@ -1,0 +1,5 @@
+# Selected Next Action
+
+`NO_FURTHER_QUALITY_EVAL_ARTIFACT_SCHEMA_LANES_SELECTED`
+
+No follow-on quality eval artifact schema lane is selected by this packet. This selected next action closes the docs-only schema lane without authorizing eval execution, scoring, provider calls, runtime changes, dashboard exposure, billing work, or evidence promotion.

--- a/docs/evals/runs/alpha-solver-post-level-3-quality-eval-artifact-schema/source-evidence-reviewed.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-quality-eval-artifact-schema/source-evidence-reviewed.md
@@ -1,0 +1,16 @@
+# Source Evidence Reviewed
+
+## Reviewed repository guidance
+
+This docs-only schema packet was prepared from the lane request and repository operating constraints. It is a design reference for future quality evaluation artifacts and does not create eval evidence.
+
+## Reviewed scope inputs
+
+- Lane identifier: `ALPHA-SOLVER-POST-LEVEL-3-QUALITY-EVAL-ARTIFACT-SCHEMA-PACKET-001`
+- Allowed location: `docs/evals/runs/alpha-solver-post-level-3-quality-eval-artifact-schema/`
+- Required decision marker: `NO_FURTHER_QUALITY_EVAL_ARTIFACT_SCHEMA_LANES_SELECTED`
+- Required blocker fallback lane: `ALPHA-SOLVER-POST-LEVEL-3-QUALITY-EVAL-ARTIFACT-SCHEMA-FIX-001`
+
+## Evidence boundary
+
+No model output, benchmark output, provider response, dashboard capture, `/v1/solve` response, billing artifact, or runtime trace was reviewed as eval evidence for this packet.


### PR DESCRIPTION
### Motivation

- Provide a canonical docs-only artifact schema for future Alpha Solver Level 3+ quality evaluation execution packets to standardize required files, metadata, preservation rules, reviewer artifacts, and decision boundaries.  
- Capture clear claim-boundary language and non-action constraints so future packets do not inadvertently create eval evidence or run evaluations without Level 5 authorization.  

### Description

- Add a new docs-only packet at `docs/evals/runs/alpha-solver-post-level-3-quality-eval-artifact-schema/` containing a README and schema documents that define required future artifact files, required metadata fields, raw-output preservation rules, reviewer notes schema, scoring record schema, invalid-result markers, redaction rules, final-decision/checks-run separation, and inventory rules.  
- Create the concrete set of docs files: `README.md`, `source-evidence-reviewed.md`, `artifact-file-inventory.md`, `metadata-fields.md`, `raw-output-preservation.md`, `reviewer-notes-schema.md`, `scoring-record-schema.md`, `invalid-result-markers.md`, `redaction-rules.md`, `final-decision-files.md`, `non-actions.md`, `selected-next-action.md`, `blocker-fallback-lane.md`, and `checks-run.md`.  
- Record the selected next action as `NO_FURTHER_QUALITY_EVAL_ARTIFACT_SCHEMA_LANES_SELECTED` and the blocker fallback lane as `ALPHA-SOLVER-POST-LEVEL-3-QUALITY-EVAL-ARTIFACT-SCHEMA-FIX-001`, and explicitly state that this packet is a supporting reference only and does not create eval evidence.  
- Ensure the change is docs-only and does not modify runtime, provider, CLI, checker scripts, tests, Makefile, CI, source artifacts, Level 2/3 packets, or release-readiness ladder files.  

### Testing

- Run static and packet checks with `make check-local-llm-orchestration-guardrails`, which executed `scripts/check_local_llm_evidence_boundaries.py`, `scripts/check_local_llm_doc_paths.py`, and `scripts/check_local_llm_packet_consistency.py`, and reported PASS.  
- Run the packet-level consistency check `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-quality-eval-artifact-schema`, which passed for the new packet directory.  
- Run repository verification commands `git status --short`, `git diff --name-only`, and `git diff --check`, and the required `rg` search for lane/fallback/schema phrases, all of which returned expected matches and no whitespace errors.  
- Confirmed via the checks that preserved source-artifact files were not modified and that no runtime/provider/dashboard/API behavior files were changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25f7c8586c83298763769b7764366a)