### PR TITLE
Add docs-only product-surface dashboard design packet

### DIFF
--- a/docs/evals/runs/alpha-solver-post-level-3-product-surface-dashboard-design/README.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-product-surface-dashboard-design/README.md
@@ -1,0 +1,52 @@
+# Product Surface Dashboard Design Packet
+
+Lane:
+`ALPHA-SOLVER-POST-LEVEL-3-PRODUCT-SURFACE-DASHBOARD-DESIGN-PACKET-001`
+
+## Purpose
+
+This docs-only packet defines a future Alpha Solver dashboard surface design boundary. It describes dashboard purpose, candidate views, evidence boundaries, operator controls, audit displays, error and blocked states, claim-boundary display rules, non-actions, selected next action, blocker fallback lane, and release gates that must be satisfied before any dashboard route or UI implementation.
+
+This packet defines future dashboard views without building them. It does not create dashboard routes, expose dashboards, modify frontend code, modify backend code, call providers, run models, run benchmarks, perform billing work, expose `/v1/solve`, or promote evidence.
+
+## Current accepted state
+
+The accepted prior state carried into this packet is:
+
+- Level 2 controlled usage is closed as local operator usability evidence only.
+- Level 3 validation execution is closed as artifact-complete, non-promotional local orchestration evidence only.
+- Final accepted Level 3 decision: `LEVEL_3_VALIDATION_EXECUTION_ACCEPTED_AS_ARTIFACT_COMPLETE_NON_PROMOTIONAL_LOCAL_ORCHESTRATION_EVIDENCE`.
+- Level 3 closeout selected: `NO_FURTHER_LEVEL_3_VALIDATION_LANES_SELECTED`.
+- The release-readiness ladder is accepted as the post-Level-3 sequencing model.
+- The Level 5 quality evaluation design packet exists in this checkout and remains design-only quality-evaluation guidance.
+- The guardrail runbook exists in this checkout and remains documentation-only guardrail operating guidance.
+
+## Design-only boundary
+
+This packet is dashboard design documentation only. It does not establish dashboard readiness, product readiness, MVP readiness, production readiness, provider readiness, billing readiness, `/v1/solve` readiness, benchmark evidence, local model quality evidence, Alpha superiority, or evidence-model promotion.
+
+## Release-gate summary
+
+No dashboard route or UI implementation may start from this packet alone. A future implementation lane must first pass all release gates defined in `candidate-views.md`, `operator-controls.md`, `audit-and-traceability.md`, `error-and-blocked-states.md`, and `claim-boundary-display-rules.md`. Level 6 controls whether this design is used.
+
+## Selected next action
+
+`NO_FURTHER_PRODUCT_SURFACE_DASHBOARD_DESIGN_LANES_SELECTED`
+
+## Blocker fallback lane
+
+`ALPHA-SOLVER-POST-LEVEL-3-PRODUCT-SURFACE-DASHBOARD-DESIGN-FIX-001`
+
+## Files in this packet
+
+- `source-evidence-reviewed.md` records source evidence reviewed and preflight confirmations.
+- `dashboard-purpose.md` defines the intended dashboard purpose and non-purpose.
+- `candidate-views.md` defines possible future views without building routes or UI.
+- `operator-controls.md` defines operator controls and default-off behavior.
+- `audit-and-traceability.md` defines audit trail display requirements.
+- `error-and-blocked-states.md` defines dashboard error and blocked states.
+- `claim-boundary-display-rules.md` defines evidence and claim-boundary display rules.
+- `non-actions.md` records explicit non-actions and forbidden interpretations.
+- `selected-next-action.md` records the selected next action.
+- `blocker-fallback-lane.md` records the blocker fallback lane.
+- `checks-run.md` records required checks for this packet.

--- a/docs/evals/runs/alpha-solver-post-level-3-product-surface-dashboard-design/audit-and-traceability.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-product-surface-dashboard-design/audit-and-traceability.md
@@ -1,0 +1,28 @@
+# Audit and Traceability Requirements
+
+## Audit trail display requirements
+
+A future dashboard audit display must show:
+
+- Packet lane identifier.
+- Packet path.
+- Source artifact links.
+- Selected next action or selected next lane.
+- Blocker fallback lane.
+- Evidence boundary summary.
+- Non-actions summary.
+- Checks recorded for the packet.
+- Commit or artifact provenance when available.
+- Whether the displayed state is accepted, draft, historical, closed, or blocked.
+
+## Traceability requirements
+
+Every dashboard statement must trace to a file, packet, or accepted source artifact. If a dashboard cannot trace a statement to an authoritative source, it must display the statement as unavailable or blocked rather than infer it.
+
+## Historical-state preservation
+
+A future dashboard must preserve historical closed decisions. It must not replace a closed `NO_FURTHER_*_LANES_SELECTED` action with a later planning lane unless the source artifact explicitly records that transition.
+
+## Audit mutation boundary
+
+This packet defines display requirements only. It does not create audit-write APIs, dashboard routes, UI code, mutation controls, runtime hooks, provider calls, model calls, benchmark runs, billing work, `/v1/solve` exposure, or evidence promotion.

--- a/docs/evals/runs/alpha-solver-post-level-3-product-surface-dashboard-design/blocker-fallback-lane.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-product-surface-dashboard-design/blocker-fallback-lane.md
@@ -1,0 +1,5 @@
+# Blocker Fallback Lane
+
+`ALPHA-SOLVER-POST-LEVEL-3-PRODUCT-SURFACE-DASHBOARD-DESIGN-FIX-001`
+
+Use this blocker fallback lane if this packet is incomplete, inconsistent, stale, overbroad, contradictory, unable to preserve evidence boundaries, or unable to keep dashboard design separate from dashboard implementation.

--- a/docs/evals/runs/alpha-solver-post-level-3-product-surface-dashboard-design/candidate-views.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-product-surface-dashboard-design/candidate-views.md
@@ -1,0 +1,65 @@
+# Candidate Views
+
+This file defines possible future dashboard views without creating routes, UI code, API endpoints, frontend components, backend handlers, or data loaders.
+
+## View 1: Evidence packet index
+
+A future view may list accepted or draft packet directories with:
+
+- Packet lane identifier.
+- Packet title.
+- Selected next action or selected next lane.
+- Blocker fallback lane.
+- Evidence boundary summary.
+- Links to authoritative packet files.
+
+Release gates before implementation:
+
+- A source-of-truth packet index must be designated.
+- The view must distinguish accepted packets from draft or historical packets.
+- The view must show that displayed evidence does not create dashboard readiness or `/v1/solve` readiness.
+- Level 6 must approve use of this design before any route or UI is created.
+
+## View 2: Guardrail status view
+
+A future view may display static guardrail checker names, expected commands, last recorded docs-only check results, and links to runbook pages.
+
+Release gates before implementation:
+
+- The implementation must not run checkers automatically unless separately authorized.
+- The implementation must not weaken checker scripts, Makefile targets, tests, or CI.
+- The view must label check results as static documentation/check evidence only.
+- The view must not imply model quality, provider readiness, benchmark readiness, or production readiness.
+
+## View 3: Claim-boundary view
+
+A future view may present blocked claims, allowed language, risky phrases, and required nearby boundary language for operators reviewing evidence.
+
+Release gates before implementation:
+
+- The claim taxonomy must be accepted in an authoritative spec or packet.
+- Risky claim detection must not be treated as proof that unflagged text is safe.
+- The view must include explicit "does not create" and "does not expose" boundary statements.
+- Level 6 controls whether this design is used.
+
+## View 4: Audit trail view
+
+A future view may display packet lineage, lane transitions, selected next actions, blocker fallback lanes, and checks run.
+
+Release gates before implementation:
+
+- The audit source must be immutable or explicitly versioned for the displayed snapshot.
+- The view must show commit or artifact provenance when available.
+- The view must preserve historical closed states and must not overwrite them with current selections.
+- The view must not provide controls that mutate audit records unless a separate audited mutation design is accepted.
+
+## View 5: Operator decision checklist
+
+A future view may display default-off operator controls, required confirmations, and stop conditions before an operator proceeds to a later lane.
+
+Release gates before implementation:
+
+- All controls must be default-off.
+- Any enabled control must require explicit operator intent and visible evidence boundary acceptance.
+- Controls must not invoke providers, run models, expose routes, or modify runtime behavior in this design.
+- Any future control that can execute work must be specified and accepted in a separate implementation lane.

--- a/docs/evals/runs/alpha-solver-post-level-3-product-surface-dashboard-design/checks-run.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-product-surface-dashboard-design/checks-run.md
@@ -1,0 +1,17 @@
+# Checks Run
+
+This file records checks for the docs-only product-surface dashboard design packet.
+
+## Required checks
+
+- `git status --short`
+- `git diff --name-only`
+- `git diff --check`
+- `make check-local-llm-orchestration-guardrails`
+- `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-product-surface-dashboard-design`
+- `rg "NO_FURTHER_PRODUCT_SURFACE_DASHBOARD_DESIGN_LANES_SELECTED|ALPHA-SOLVER-POST-LEVEL-3-PRODUCT-SURFACE-DASHBOARD-DESIGN-FIX-001|dashboard|does not create|does not expose|operator controls|audit" docs/evals/runs/alpha-solver-post-level-3-product-surface-dashboard-design`
+- Confirm no runtime/provider/dashboard/API files changed.
+
+## Boundary of checks
+
+These checks are documentation and static checker commands only. They do not run local model inference, start Ollama, rerun validation, rerun smoke, call hosted providers, expose `/v1/solve`, expose dashboard routes, add provider fallback, add hosted fallback, run benchmarks, score outputs, perform billing work, update Google Sheets or backlog workbooks, or promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-product-surface-dashboard-design/claim-boundary-display-rules.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-product-surface-dashboard-design/claim-boundary-display-rules.md
@@ -1,0 +1,48 @@
+# Claim-Boundary Display Rules
+
+## Evidence display rule
+
+A future dashboard may display only claims supported by the cited source artifact. If the claim is not directly supported, the dashboard must either omit it or display it as blocked.
+
+## Required boundary labels
+
+Dashboard displays must label evidence as one of:
+
+- Documentation-only design.
+- Static guardrail check evidence.
+- Local operator usability evidence.
+- Artifact-complete non-promotional local orchestration evidence.
+- Draft or unaccepted evidence.
+- Blocked or unsupported claim.
+
+## Required nearby boundary language
+
+Any future display using terms such as dashboard, product surface, readiness, quality evidence, benchmark, provider, billing, `/v1/solve`, production, MVP, Alpha superiority, or promotion must show nearby boundary language explaining what the source does and does not establish.
+
+Required phrases for this packet's descendants include:
+
+- This docs-only dashboard design does not create dashboard routes.
+- This docs-only dashboard design does not expose dashboards.
+- This docs-only dashboard design does not expose `/v1/solve`.
+- This docs-only dashboard design does not call providers, run models, run benchmarks, perform billing work, or promote evidence.
+- Level 6 controls whether this design is used.
+
+## Prohibited display claims
+
+A future dashboard must not claim or imply:
+
+- Dashboard readiness.
+- Product-surface readiness.
+- MVP readiness.
+- Production readiness.
+- `/v1/solve` readiness.
+- Provider readiness.
+- Billing readiness.
+- Benchmark success.
+- Local model quality.
+- Alpha superiority.
+- Evidence-model promotion.
+
+## Release gate before display
+
+Before any dashboard display is implemented, a later authorized lane must prove that the display can preserve these claim-boundary rules without changing checker scripts, tests, Makefile targets, CI, runtime code, provider behavior, API exposure, or evidence artifacts.

--- a/docs/evals/runs/alpha-solver-post-level-3-product-surface-dashboard-design/dashboard-purpose.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-product-surface-dashboard-design/dashboard-purpose.md
@@ -1,0 +1,27 @@
+# Dashboard Purpose
+
+## Intended purpose
+
+A future Alpha Solver dashboard may help operators inspect bounded evidence, lane status, guardrail outcomes, and traceability for local LLM solver orchestration work. Its purpose is to make already-accepted documentation artifacts easier to review without changing their meaning.
+
+The dashboard should be an evidence-navigation surface, not an evidence-producing surface. It may summarize links, statuses, packet boundaries, checks, and audit trails that already exist in accepted docs. It must not turn documentation into runtime readiness, model-quality evidence, provider-readiness evidence, benchmark evidence, billing evidence, `/v1/solve` readiness, dashboard readiness, or production readiness.
+
+## Non-purpose
+
+A future dashboard must not:
+
+- Execute solver requests.
+- Expose or call `/v1/solve`.
+- Call hosted providers or local model providers.
+- Run local model inference.
+- Start Ollama.
+- Run benchmarks.
+- Score outputs.
+- Perform billing work.
+- Modify evidence artifacts.
+- Promote evidence boundaries.
+- Assert Alpha superiority.
+
+## Design principle
+
+Every dashboard element must answer: "What accepted artifact, boundary, check, or operator decision is being displayed?" If an element cannot identify its source artifact and evidence boundary, it must be blocked before implementation.

--- a/docs/evals/runs/alpha-solver-post-level-3-product-surface-dashboard-design/error-and-blocked-states.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-product-surface-dashboard-design/error-and-blocked-states.md
@@ -1,0 +1,31 @@
+# Error and Blocked States
+
+## Required blocked states
+
+A future dashboard must block display or action when:
+
+- The source packet is missing.
+- The source packet has no evidence boundary or equivalent non-actions file.
+- The source packet has contradictory selected-next state.
+- The selected next action and blocker fallback lane are missing.
+- A claim would imply dashboard readiness, `/v1/solve` readiness, production readiness, MVP readiness, benchmark evidence, provider readiness, billing readiness, local model quality evidence, Alpha superiority, or evidence promotion without an accepted source.
+- Level 6 has not authorized use of this design for implementation.
+
+## Required error states
+
+A future dashboard must distinguish:
+
+- `SOURCE_NOT_FOUND`: source artifact cannot be resolved.
+- `BOUNDARY_MISSING`: evidence boundary or non-actions are absent.
+- `CONTRADICTORY_STATE`: selected-next state conflicts with no-further-lanes state.
+- `UNSUPPORTED_CLAIM`: display text would exceed accepted evidence.
+- `IMPLEMENTATION_NOT_AUTHORIZED`: a route, UI, or control is requested before release gates are met.
+- `RUNTIME_ACTION_BLOCKED`: requested action would call providers, run models, expose `/v1/solve`, expose dashboards, run benchmarks, perform billing work, or promote evidence.
+
+## Operator-facing language
+
+Blocked states must use plain language. Example: "This dashboard cannot display a readiness claim because the source artifact does not establish readiness evidence."
+
+## Non-action boundary
+
+Defining blocked states does not build blocked-state UI. This packet does not create dashboard routes, UI components, API behavior, provider calls, model runs, benchmark runs, billing behavior, `/v1/solve` exposure, or evidence promotion.

--- a/docs/evals/runs/alpha-solver-post-level-3-product-surface-dashboard-design/non-actions.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-product-surface-dashboard-design/non-actions.md
@@ -1,0 +1,28 @@
+# Non-Actions
+
+This packet is documentation only.
+
+It does not:
+
+- Modify runtime code.
+- Add dashboard routes.
+- Add UI code.
+- Expose a dashboard.
+- Expose `/v1/solve`.
+- Modify frontend code.
+- Modify backend code.
+- Modify provider code.
+- Call providers.
+- Run local model inference.
+- Start Ollama.
+- Run benchmarks.
+- Score model outputs.
+- Perform billing work.
+- Modify checker scripts.
+- Modify tests.
+- Modify Makefile targets.
+- Modify CI.
+- Modify backlog workbooks.
+- Promote evidence.
+
+This packet does not establish dashboard readiness, product-surface readiness, MVP readiness, production readiness, provider readiness, billing readiness, `/v1/solve` readiness, benchmark evidence, local model quality evidence, Alpha superiority, or evidence-model promotion.

--- a/docs/evals/runs/alpha-solver-post-level-3-product-surface-dashboard-design/operator-controls.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-product-surface-dashboard-design/operator-controls.md
@@ -1,0 +1,30 @@
+# Operator Controls
+
+## Control posture
+
+All future dashboard operator controls must be default-off. A dashboard page may display read-only evidence by default only after Level 6 authorizes the design and a later implementation lane creates the route or UI.
+
+## Required default-off controls
+
+Potential future controls must remain disabled until separately authorized:
+
+- Refresh evidence snapshot.
+- Run guardrail checks.
+- Export audit summary.
+- Acknowledge a claim boundary.
+- Mark a packet as reviewed.
+- Start a follow-on lane.
+
+## Required confirmation pattern
+
+If a future implementation adds any control, the control must require:
+
+1. Explicit operator selection.
+2. Display of the source artifact being acted on.
+3. Display of the claim and evidence boundary.
+4. Display of the non-actions that remain true.
+5. A confirmation that the control does not expose dashboards beyond the authorized surface and does not expose `/v1/solve`.
+
+## Forbidden control behavior in this design
+
+This design does not create controls that call providers, run models, run benchmarks, perform billing work, mutate runtime configuration, expose dashboard routes, expose `/v1/solve`, or promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-product-surface-dashboard-design/selected-next-action.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-product-surface-dashboard-design/selected-next-action.md
@@ -1,0 +1,5 @@
+# Selected Next Action
+
+`NO_FURTHER_PRODUCT_SURFACE_DASHBOARD_DESIGN_LANES_SELECTED`
+
+No follow-on dashboard design lane is selected by this packet. Level 6 controls whether this design is used, and any future dashboard route or UI implementation requires a separate authorized lane after release gates are satisfied.

--- a/docs/evals/runs/alpha-solver-post-level-3-product-surface-dashboard-design/source-evidence-reviewed.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-product-surface-dashboard-design/source-evidence-reviewed.md
@@ -1,0 +1,28 @@
+# Source Evidence Reviewed
+
+## Preflight verification
+
+This packet reviewed the current checkout for the accepted Level 5 quality evaluation design packet and the guardrail runbook before creating dashboard design documentation.
+
+Reviewed evidence:
+
+- `docs/evals/runs/alpha-solver-post-level-3-level-5-quality-evaluation-design/README.md`
+- `docs/evals/runs/alpha-solver-post-level-3-level-5-quality-evaluation-design/checks-run.md`
+- `docs/local_llm_solver_orchestration_guardrails/README.md`
+- `docs/local_llm_solver_orchestration_guardrails/checker-inventory.md`
+- `docs/local_llm_solver_orchestration_guardrails/how-to-run.md`
+- `docs/local_llm_solver_orchestration_guardrails/non-actions.md`
+
+Preflight result:
+
+- The Level 5 quality evaluation design packet is present in the checkout and states it is docs-only design work that does not run quality evaluation, benchmarks, local model inference, scoring, product-surface implementation, or evidence promotion.
+- The guardrail runbook is present in the checkout and documents the `make check-local-llm-orchestration-guardrails` suite plus evidence-boundary, packet-consistency, and path/link checks.
+- The repository remote named `origin` was not configured in this environment, so remote `main` could not be fetched. This packet therefore records local checkout verification only and does not claim a new remote-main verification artifact.
+
+## Evidence boundary inherited by this packet
+
+The reviewed evidence is used only to bound this docs-only dashboard design. It does not create dashboard routes, expose dashboards, modify frontend or backend code, call providers, run models, run benchmarks, perform billing work, expose `/v1/solve`, or promote evidence.
+
+## Non-promotional interpretation
+
+The presence of Level 5 and the guardrail runbook does not mean a dashboard can be built or exposed. Any future product-surface implementation remains controlled by Level 6 and by separate release gates.


### PR DESCRIPTION
### Motivation

- Provide a docs-only design packet that defines a safe, evidence-bound dashboard surface for future Alpha Solver product-surface work without implementing routes or UI. 
- Preserve the existing Level 2/Level 3 evidence boundary and guardrails and require stricter release gates before any implementation. 
- Ensure operator-facing controls are default-off and audit/tracing/display rules prevent inadvertent evidence promotion.

### Description

- Add a new docs-only packet at `docs/evals/runs/alpha-solver-post-level-3-product-surface-dashboard-design/` containing `README.md`, `source-evidence-reviewed.md`, `dashboard-purpose.md`, `candidate-views.md`, `operator-controls.md`, `audit-and-traceability.md`, `error-and-blocked-states.md`, `claim-boundary-display-rules.md`, `non-actions.md`, `selected-next-action.md`, `blocker-fallback-lane.md`, and `checks-run.md` describing the future dashboard design surface.
- Define candidate views (evidence packet index, guardrail status, claim-boundary view, audit trail, operator decision checklist), operator controls (default-off + explicit confirmation pattern), audit & traceability display requirements, explicit error/blocked states and plain-language operator messaging, and claim-boundary display rules that block unsupported claims.
- Record preflight verification that the Level 5 quality evaluation design packet and guardrail runbook exist in the checkout and note that a remote `origin` was not configured in this environment (local checkout verification only).
- Record decisions: selected next action is `NO_FURTHER_PRODUCT_SURFACE_DASHBOARD_DESIGN_LANES_SELECTED` and blocker fallback lane is `ALPHA-SOLVER-POST-LEVEL-3-PRODUCT-SURFACE-DASHBOARD-DESIGN-FIX-001`, and require Level 6 authorization before any implementation.

### Testing

- Ran repository checks: `git status --short`, `git diff --name-only`, and `git diff --check` with no blocking issues. 
- Ran guardrail suite via `make check-local-llm-orchestration-guardrails` which runs `check_local_llm_evidence_boundaries.py`, `check_local_llm_doc_paths.py`, and `check_local_llm_packet_consistency.py`; all passed. 
- Ran the packet consistency check for the new packet with `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-product-surface-dashboard-design` which passed, and ran an `rg` search to confirm required tokens/phrases are present. 
- Confirmed changed files are limited to the new docs directory and no runtime, provider, dashboard, API, frontend, backend, checker, test, Makefile, or CI files were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26014d2ac88329916e6a26a033022e)