### PR TITLE
Add product-surface observability & audit packet (docs-only)

### DIFF
--- a/docs/evals/runs/alpha-solver-post-level-3-product-surface-observability-audit/README.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-product-surface-observability-audit/README.md
@@ -1,0 +1,35 @@
+# Product Surface Observability and Audit Packet
+
+Lane:
+`ALPHA-SOLVER-POST-LEVEL-3-PRODUCT-SURFACE-OBSERVABILITY-AUDIT-PACKET-001`
+
+## Purpose
+
+This docs-only packet defines the observability and audit expectations that must be reviewable before any Alpha Solver product surface is implemented. It covers run ID requirements, request ID requirements, trace records, decision logs, error logs, evidence references, retention boundaries, redaction requirements, and reviewability requirements.
+
+## Current accepted state
+
+The accepted upstream state remains bounded by post-Level-3 planning and design artifacts. This packet does not add execution evidence, product readiness evidence, dashboard readiness evidence, API readiness evidence, provider readiness evidence, billing readiness evidence, or MVP readiness evidence.
+
+## Level 6 control
+
+Level 6 controls whether and how this packet is used. Future Level 6 review must decide whether these observability and audit requirements are accepted, amended, superseded, or held as non-binding reference material before product-surface work relies on them.
+
+## Evidence boundary
+
+This is docs-only observability and audit design. It does not implement logging, alter runtime behavior, expose routes, call providers, run models, run benchmarks, perform billing work, or promote evidence.
+
+## Packet files
+
+- `source-evidence-reviewed.md` records the local source evidence reviewed for this packet.
+- `observability-principles.md` defines audit-first observability principles.
+- `trace-fields.md` defines the required trace record field families.
+- `decision-log-requirements.md` defines decision log requirements.
+- `error-log-requirements.md` defines error log requirements.
+- `evidence-reference-rules.md` defines evidence-reference rules.
+- `retention-and-redaction.md` defines retention boundaries and redaction requirements.
+- `reviewability-requirements.md` defines reviewer expectations.
+- `non-actions.md` preserves explicit non-actions.
+- `selected-next-action.md` records the selected next action.
+- `blocker-fallback-lane.md` records the blocker fallback lane.
+- `checks-run.md` records validation commands.

--- a/docs/evals/runs/alpha-solver-post-level-3-product-surface-observability-audit/blocker-fallback-lane.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-product-surface-observability-audit/blocker-fallback-lane.md
@@ -1,0 +1,7 @@
+# Blocker Fallback Lane
+
+If this packet is incomplete, inconsistent, unsafe, stale, overbroad, insufficiently reviewable, or unable to preserve the evidence boundary, use blocker fallback lane:
+
+`ALPHA-SOLVER-POST-LEVEL-3-PRODUCT-SURFACE-OBSERVABILITY-AUDIT-FIX-001`
+
+The fallback lane is for documentation repair only unless a later accepted governing packet explicitly authorizes a broader scope.

--- a/docs/evals/runs/alpha-solver-post-level-3-product-surface-observability-audit/checks-run.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-product-surface-observability-audit/checks-run.md
@@ -1,0 +1,22 @@
+# Checks Run
+
+This file records the checks for `ALPHA-SOLVER-POST-LEVEL-3-PRODUCT-SURFACE-OBSERVABILITY-AUDIT-PACKET-001`.
+
+## Commands and results
+
+- Passed: `git status --short`
+  - Showed only added docs files under `docs/evals/runs/alpha-solver-post-level-3-product-surface-observability-audit/` after intent-to-add.
+- Passed: `git diff --name-only`
+  - Showed only files under `docs/evals/runs/alpha-solver-post-level-3-product-surface-observability-audit/` after intent-to-add.
+- Passed: `git diff --check`
+  - No whitespace errors reported.
+- Passed: `make check-local-llm-orchestration-guardrails`
+  - Local LLM evidence-boundary static check passed.
+  - Local LLM doc path/link check passed.
+  - Local LLM packet consistency check passed.
+- Passed: `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-product-surface-observability-audit`
+  - Local LLM packet consistency check passed for this packet directory.
+- Passed: `rg "NO_FURTHER_PRODUCT_SURFACE_OBSERVABILITY_AUDIT_LANES_SELECTED|ALPHA-SOLVER-POST-LEVEL-3-PRODUCT-SURFACE-OBSERVABILITY-AUDIT-FIX-001|run ID|request ID|trace|decision log|redaction|does not implement" docs/evals/runs/alpha-solver-post-level-3-product-surface-observability-audit`
+  - Confirmed required decision, fallback, observability, redaction, and non-implementation terms are present.
+- Passed: Confirm no runtime/provider/dashboard/API files changed.
+  - `git diff --name-only -- . ':!docs/evals/runs/alpha-solver-post-level-3-product-surface-observability-audit/**'` produced no changed files.

--- a/docs/evals/runs/alpha-solver-post-level-3-product-surface-observability-audit/decision-log-requirements.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-product-surface-observability-audit/decision-log-requirements.md
@@ -1,0 +1,27 @@
+# Decision Log Requirements
+
+## Purpose
+
+A decision log records why a future product-surface request was allowed, blocked, routed, retried, escalated, rejected, or marked reviewer-blocked.
+
+## Required fields
+
+- Decision log entry ID.
+- run ID when the request is part of a run-scoped packet.
+- request ID.
+- trace ID.
+- decision type.
+- decision outcome.
+- policy or gate consulted.
+- bounded rationale suitable for reviewer inspection.
+- evidence reference when the decision relies on a reviewed artifact.
+- reviewer state when human review is required.
+- redaction status.
+- UTC timestamp.
+
+## Requirements
+
+- Decision logs must not include raw secrets, raw credentials, provider tokens, payment data, or unredacted personal data.
+- Decision logs should identify blocked claims separately from blocked execution.
+- Decision logs should distinguish automated decisions from reviewer decisions.
+- Decision logs should be reviewable without running models, calling providers, or reproducing billing events.

--- a/docs/evals/runs/alpha-solver-post-level-3-product-surface-observability-audit/error-log-requirements.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-product-surface-observability-audit/error-log-requirements.md
@@ -1,0 +1,44 @@
+# Error Log Requirements
+
+## Purpose
+
+An error log records failure conditions for future product-surface requests without turning failures into promotional evidence or exposing sensitive payloads.
+
+## Required fields
+
+- Error log entry ID.
+- run ID when applicable.
+- request ID.
+- trace ID.
+- error category.
+- severity.
+- bounded message.
+- component or surface category.
+- detected-at UTC timestamp.
+- recovery or fallback state.
+- related decision log reference, if any.
+- evidence reference, if any.
+- redaction status.
+- retention class.
+
+## Error categories
+
+Future implementation design should distinguish at least:
+
+- validation failure;
+- policy or safety block;
+- authentication or authorization failure;
+- provider unavailable;
+- provider timeout;
+- local runtime unavailable;
+- route unavailable;
+- dashboard surface unavailable;
+- malformed request;
+- reviewer-blocked state;
+- retention or redaction violation.
+
+## Requirements
+
+- Error logs must not include raw prompt content unless a later accepted policy explicitly allows and redacts it.
+- Error logs must not include secrets, provider keys, billing account identifiers, session tokens, or raw personal data.
+- Error logs must be sufficient for reviewers to determine whether the issue is product-surface behavior, provider behavior, local runtime behavior, policy behavior, or documentation-only blocker state.

--- a/docs/evals/runs/alpha-solver-post-level-3-product-surface-observability-audit/evidence-reference-rules.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-product-surface-observability-audit/evidence-reference-rules.md
@@ -1,0 +1,29 @@
+# Evidence Reference Rules
+
+## Purpose
+
+Evidence references let reviewers connect a run ID, request ID, trace record, decision log, or error log to bounded artifacts without promoting evidence beyond its accepted boundary.
+
+## Rules
+
+1. Evidence references must identify a bounded artifact location, artifact type, and review state.
+2. Evidence references must distinguish design documents from execution evidence.
+3. Evidence references must not claim product readiness, API readiness, dashboard readiness, provider readiness, billing readiness, benchmark results, or model quality unless a later accepted packet explicitly supports that claim.
+4. Evidence references should include enough metadata for reviewers to find the artifact without duplicating sensitive content in logs.
+5. Evidence references must preserve redaction state and retention class.
+6. Evidence references must not point to private credentials, raw provider payloads, raw billing data, or unredacted personal data.
+7. Evidence references should state when an artifact is superseded, blocked, stale, or review-only.
+
+## Required reference shape
+
+A future reference should include:
+
+- evidence reference ID;
+- artifact path or controlled storage pointer;
+- artifact type;
+- run ID, if applicable;
+- request ID, if applicable;
+- review state;
+- redaction state;
+- retention class;
+- claim boundary.

--- a/docs/evals/runs/alpha-solver-post-level-3-product-surface-observability-audit/non-actions.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-product-surface-observability-audit/non-actions.md
@@ -1,0 +1,9 @@
+# Non-Actions
+
+This packet is docs-only observability and audit design.
+
+It does not implement logging, alter runtime behavior, expose routes, call providers, run models, run benchmarks, perform billing work, promote evidence, update dashboards, update APIs, modify CLI behavior, modify provider routing, modify checker scripts, modify tests, modify CI, or modify Makefiles.
+
+It does not create logs, telemetry stores, trace emitters, decision-log writers, error-log writers, evidence stores, billing events, provider calls, dashboard panels, API routes, or product-surface controls.
+
+It does not select a further product-surface observability audit lane. Level 6 controls whether and how this packet is used.

--- a/docs/evals/runs/alpha-solver-post-level-3-product-surface-observability-audit/observability-principles.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-product-surface-observability-audit/observability-principles.md
@@ -1,0 +1,20 @@
+# Observability Principles
+
+## Audit-first before product surface
+
+Any future product-surface implementation should be reviewable from stable identifiers, bounded records, and evidence references before it is exposed to users. Observability must support reconstruction of what happened without collecting unnecessary sensitive content.
+
+## Required principles
+
+1. Every product-surface attempt should be associated with a run ID when it belongs to an evaluation, review, release-readiness, or operator-controlled run.
+2. Every externally meaningful user or operator attempt should be associated with a request ID.
+3. Trace records should connect run ID, request ID, decision log entries, error log entries, and evidence references without requiring reviewers to inspect raw sensitive payloads.
+4. Logs should preserve enough context for reviewability while respecting redaction and retention boundaries.
+5. Decision logs should explain why a routed, blocked, allowed, retried, or escalated outcome occurred.
+6. Error logs should distinguish system failures, validation failures, policy blocks, provider failures, timeout conditions, and reviewer-blocked states.
+7. Evidence references should point to bounded artifacts and should not become evidence promotion claims by themselves.
+8. Level 6 controls whether and how this packet is used.
+
+## Non-goal
+
+This document does not implement logging or alter runtime behavior.

--- a/docs/evals/runs/alpha-solver-post-level-3-product-surface-observability-audit/retention-and-redaction.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-product-surface-observability-audit/retention-and-redaction.md
@@ -1,0 +1,25 @@
+# Retention and Redaction
+
+## Retention boundaries
+
+Future product-surface observability should assign a retention class before storing trace records, decision logs, error logs, or evidence references.
+
+Suggested retention classes for later Level 6 acceptance or revision:
+
+- `ephemeral_diagnostic`: temporary troubleshooting record with short retention.
+- `run_packet_review`: bounded review artifact tied to a run ID.
+- `release_readiness_review`: bounded artifact retained for release-readiness decisions.
+- `blocked_sensitive`: record blocked from normal retention because it contains or may contain sensitive content.
+- `legal_or_security_hold`: explicitly approved retention override.
+
+## Redaction requirements
+
+- Redaction must occur before logs are used for broad review whenever sensitive content could be present.
+- Raw secrets, API keys, provider credentials, session tokens, payment data, billing account data, and private user identifiers must not be stored in trace records, decision logs, or error logs.
+- Prompt or response content should be summarized, hashed, omitted, or redacted unless a later accepted policy explicitly allows collection.
+- Redaction state must be recorded on trace records, decision logs, error logs, and evidence references.
+- Reviewers must be able to tell whether data is absent, redacted, summarized, blocked, or approved for retention.
+
+## Level 6 control
+
+Level 6 controls whether and how these retention and redaction classes are used, replaced, or rejected.

--- a/docs/evals/runs/alpha-solver-post-level-3-product-surface-observability-audit/reviewability-requirements.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-product-surface-observability-audit/reviewability-requirements.md
@@ -1,0 +1,22 @@
+# Reviewability Requirements
+
+## Reviewer expectations
+
+Before any product surface relies on this packet, reviewers should be able to verify:
+
+- which run ID applies, or that no run-scoped packet applies;
+- which request ID identifies the attempted request;
+- which trace records exist for the request path;
+- which decision log entries explain allow, block, route, retry, escalation, or rejection outcomes;
+- which error log entries identify failure categories and recovery state;
+- which evidence references support review without promoting claims;
+- which retention boundary applies;
+- which redaction state applies;
+- whether Level 6 accepted, amended, superseded, or rejected use of this packet.
+
+## Reviewability requirements
+
+- Records must be internally linkable by run ID, request ID, trace ID, decision log reference, error log reference, and evidence reference.
+- Review must be possible without calling providers, running models, running benchmarks, or performing billing work.
+- Review must identify missing, stale, contradictory, or overbroad observability artifacts as blockers.
+- Review must preserve the distinction between documentation design and implemented runtime behavior.

--- a/docs/evals/runs/alpha-solver-post-level-3-product-surface-observability-audit/selected-next-action.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-product-surface-observability-audit/selected-next-action.md
@@ -1,0 +1,9 @@
+# Selected Next Action
+
+Selected next action:
+
+`NO_FURTHER_PRODUCT_SURFACE_OBSERVABILITY_AUDIT_LANES_SELECTED`
+
+No further product-surface observability audit lanes are selected by this packet.
+
+Level 6 controls whether and how this packet is used.

--- a/docs/evals/runs/alpha-solver-post-level-3-product-surface-observability-audit/source-evidence-reviewed.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-product-surface-observability-audit/source-evidence-reviewed.md
@@ -1,0 +1,13 @@
+# Source Evidence Reviewed
+
+## Reviewed local evidence
+
+This packet reviewed the repo-level agent instructions, prior post-Level-3 packet structure, and local packet-consistency checker expectations. The review was limited to local documentation and checker contracts needed to create a docs-only observability packet.
+
+## Evidence boundary preserved
+
+The review did not create runtime logs, ingest external telemetry, call providers, run models, run benchmarks, inspect billing systems, modify dashboards, modify APIs, or promote evidence.
+
+## Upstream state acknowledged
+
+The packet acknowledges that prior Level 3 evidence remains non-promotional local orchestration evidence and that Level 6 controls whether and how this packet is used.

--- a/docs/evals/runs/alpha-solver-post-level-3-product-surface-observability-audit/trace-fields.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-product-surface-observability-audit/trace-fields.md
@@ -1,0 +1,28 @@
+# Trace Fields
+
+## Required trace field families
+
+Future product-surface trace records should be designed around these field families before implementation:
+
+| Field family | Requirement |
+| --- | --- |
+| `run_id` | Stable run ID for an evaluation, readiness review, operator-controlled session, or release-readiness packet when applicable. |
+| `request_id` | Stable request ID for a single product-surface attempt, generated without embedding user content. |
+| `trace_id` | Stable trace identifier that links trace records for one request path. |
+| `parent_trace_id` | Optional parent trace identifier for nested, retried, replayed, or delegated work. |
+| `timestamp_utc` | UTC timestamp for record creation. |
+| `surface` | Product surface name or placeholder category, such as API, dashboard, CLI bridge, or operator tool. |
+| `actor_type` | Bounded actor category, such as operator, reviewer, service, or unauthenticated user, without personal identifiers unless approved. |
+| `decision_log_ref` | Reference to any decision log entry produced for the request. |
+| `error_log_ref` | Reference to any error log entry produced for the request. |
+| `evidence_ref` | Reference to bounded evidence artifacts, if any, using the evidence-reference rules. |
+| `redaction_state` | Status indicating whether sensitive content was absent, redacted, summarized, or blocked from capture. |
+| `retention_class` | Retention boundary category assigned before storage. |
+| `review_state` | Reviewability status, such as pending review, reviewed, blocked, or superseded. |
+
+## Identifier rules
+
+- A run ID must not encode user content, secrets, prompt text, provider credentials, billing data, or private operator notes.
+- A request ID must be unique enough for review and correlation without exposing sensitive content.
+- A trace record must not rely on raw payload capture as its only review mechanism.
+- If no run ID applies, the trace record should explicitly state that the request was not part of a run-scoped packet.


### PR DESCRIPTION
### Motivation

- Provide a docs-only observability and audit packet that defines the required identifiers, trace records, decision and error logs, evidence references, retention and redaction rules, and reviewability requirements before any product surface is implemented.
- Ensure future product-surface work is reviewable and bounded (run ID, request ID, trace links, decision log refs, error log refs, redaction state, retention class) without collecting or promoting execution evidence.
- Preserve the existing post-Level-3 evidence boundary and defer any enforcement/usage decisions to Level 6 control.

### Description

- Added a new docs-only packet at `docs/evals/runs/alpha-solver-post-level-3-product-surface-observability-audit/` with the files: `README.md`, `source-evidence-reviewed.md`, `observability-principles.md`, `trace-fields.md`, `decision-log-requirements.md`, `error-log-requirements.md`, `evidence-reference-rules.md`, `retention-and-redaction.md`, `reviewability-requirements.md`, `non-actions.md`, `selected-next-action.md`, `blocker-fallback-lane.md`, and `checks-run.md`.
- Defined required trace field families (`run_id`, `request_id`, `trace_id`, `parent_trace_id`, `timestamp_utc`, `surface`, `actor_type`, `decision_log_ref`, `error_log_ref`, `evidence_ref`, `redaction_state`, `retention_class`, `review_state`) and identifier rules in `trace-fields.md`.
- Specified decision log and error log required fields and constraints, evidence-reference shape and rules, retention classes and redaction requirements, and reviewer expectations for reviewability, and recorded explicit non-actions to keep the packet docs-only.
- Recorded selected next action `NO_FURTHER_PRODUCT_SURFACE_OBSERVABILITY_AUDIT_LANES_SELECTED` and blocker fallback lane `ALPHA-SOLVER-POST-LEVEL-3-PRODUCT-SURFACE-OBSERVABILITY-AUDIT-FIX-001`, and stated that Level 6 controls whether/how the packet is used.

### Testing

- Ran `git status --short`, `git diff --name-only`, and `git diff --check` to confirm only the intended docs were staged and no whitespace errors were present, and these checks passed.
- Ran `make check-local-llm-orchestration-guardrails` which ran the repo doc/path/evidence-boundary static checks and the packet-consistency checks and all guardrail checks passed.
- Ran `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-product-surface-observability-audit` which passed for this packet directory.
- Ran `rg` to confirm presence of the required decision/fallback/observability/redaction/non-implementation terms and confirmed no runtime/provider/dashboard/API files were changed, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a260159f9f883298dd2fe4a3aad85bc)