### PR TITLE
Add product-surface threat & risk model packet (post-Level-3)

### DIFF
--- a/docs/evals/runs/alpha-solver-post-level-3-product-surface-threat-risk-model/README.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-product-surface-threat-risk-model/README.md
@@ -1,0 +1,44 @@
+# Product Surface Threat and Risk Model Packet
+
+Lane:
+`ALPHA-SOLVER-POST-LEVEL-3-PRODUCT-SURFACE-THREAT-RISK-MODEL-PACKET-001`
+
+## Purpose
+
+This docs-only packet records a threat and risk model for future Alpha Solver product-surface work before any implementation is selected. It identifies risks, abuse cases, privacy issues, evidence-promotion risks, unsupported-claim risks, route-exposure risks, dashboard risks, provider/fallback confusion risks, mitigations to consider later, and stop conditions.
+
+The packet is a planning and review artifact only. It does not implement mitigations, modify runtime behavior, expose routes, expose dashboards, call providers, run models, run benchmarks, perform billing work, or promote evidence.
+
+## Scope boundary
+
+This packet is limited to documentation under this directory. It preserves the post-Level-3 evidence boundary and does not change the product surface, provider surface, dashboard surface, API surface, fallback behavior, billing behavior, model execution path, benchmark execution path, or evidence-promotion state.
+
+Level 6 controls whether and how this packet is used. Future product-surface design, implementation, readiness, or release work must be separately authorized by Level 6 and must not treat this packet as implementation approval.
+
+## Files in this packet
+
+- `source-evidence-reviewed.md` records source evidence reviewed for the threat model.
+- `risk-model-overview.md` summarizes asset, actor, trust-boundary, and risk themes.
+- `abuse-cases.md` records abuse cases for future review.
+- `privacy-and-data-risks.md` records privacy and data-handling risks.
+- `evidence-promotion-risks.md` records evidence-promotion and unsupported-claim risks.
+- `route-exposure-risks.md` records risks from future API or route exposure.
+- `dashboard-risks.md` records dashboard risks.
+- `provider-and-fallback-confusion-risks.md` records provider/fallback confusion risks.
+- `mitigations-and-stop-conditions.md` records candidate mitigations and hard stop conditions.
+- `non-actions.md` records explicit actions not taken by this docs-only packet.
+- `selected-next-action.md` records the selected next action.
+- `blocker-fallback-lane.md` records the blocker fallback lane.
+- `checks-run.md` records required checks and results.
+
+## Selected next action
+
+`NO_FURTHER_PRODUCT_SURFACE_THREAT_RISK_MODEL_LANES_SELECTED`
+
+## Blocker fallback lane
+
+`ALPHA-SOLVER-POST-LEVEL-3-PRODUCT-SURFACE-THREAT-RISK-MODEL-FIX-001`
+
+## Evidence boundary
+
+This packet is docs-only threat and risk modeling. It does not implement mitigations, modify runtime, expose routes, expose dashboards, call providers, run models, run benchmarks, perform billing work, or promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-product-surface-threat-risk-model/abuse-cases.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-product-surface-threat-risk-model/abuse-cases.md
@@ -1,0 +1,29 @@
+# Abuse Cases
+
+The abuse cases below are for future product-surface threat modeling only. They do not describe implemented routes or currently authorized product behavior.
+
+## Prompt and content abuse cases
+
+- A user submits prompt-injection text intended to override solver policies, exfiltrate hidden context, or induce unsafe tool use.
+- A user submits private third-party data and later expects deletion or non-retention guarantees that have not been implemented.
+- A user uses generated output for high-impact decisions while believing the product has validated quality, benchmark, or safety claims.
+- A user requests illegal, harmful, privacy-invasive, or deceptive content through a future public route.
+
+## Access and route abuse cases
+
+- An attacker enumerates route exposure for `/v1/solve`, dashboard endpoints, health endpoints, or debug endpoints.
+- An unauthenticated actor submits high-volume requests to cause resource exhaustion or billing spend.
+- A user tampers with request parameters to bypass route, provider, fallback, budget, or local-only constraints.
+- A stale client calls a route after a future product-surface decision changes allowed behavior.
+
+## Evidence and claim abuse cases
+
+- A reviewer promotes local orchestration evidence as product readiness evidence.
+- A dashboard screenshot or packet excerpt is reused as proof of quality, production readiness, or benchmark superiority.
+- A future artifact omits caveats and creates unsupported claims about accuracy, latency, cost, reliability, privacy, or safety.
+
+## Provider and fallback abuse cases
+
+- An operator believes local-only execution is active while a hosted provider or fallback path is used.
+- A fallback path silently changes model behavior, billing exposure, or data residency.
+- A provider failure is hidden behind fallback output, making incident review and user disclosure difficult.

--- a/docs/evals/runs/alpha-solver-post-level-3-product-surface-threat-risk-model/blocker-fallback-lane.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-product-surface-threat-risk-model/blocker-fallback-lane.md
@@ -1,0 +1,16 @@
+# Blocker Fallback Lane
+
+If this packet is incomplete, inconsistent, unsafe, stale, overbroad, contradictory, or unable to preserve the accepted evidence boundary, use this blocker fallback lane:
+
+`ALPHA-SOLVER-POST-LEVEL-3-PRODUCT-SURFACE-THREAT-RISK-MODEL-FIX-001`
+
+## Fallback triggers
+
+Use the fallback lane if:
+
+- Level 6 control over whether and how this packet is used is missing;
+- selected-next state is contradictory;
+- abuse cases, privacy issues, evidence-promotion risks, unsupported-claim risks, route exposure risks, dashboard risks, provider/fallback confusion risks, mitigations, stop conditions, non-actions, or checks are missing;
+- the packet appears to implement mitigations or start product-surface work;
+- runtime, provider, CLI, checker scripts, tests, Makefile, CI, API, dashboard, or source-artifact files would need modification;
+- route exposure, dashboard exposure, provider calls, fallback, billing, model inference, benchmark execution, or evidence promotion is required.

--- a/docs/evals/runs/alpha-solver-post-level-3-product-surface-threat-risk-model/checks-run.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-product-surface-threat-risk-model/checks-run.md
@@ -1,0 +1,27 @@
+# Checks Run
+
+This packet is docs-only. Checks confirm static packet consistency and guardrail compatibility without implementing mitigations, running local model inference, running Ollama, calling hosted providers, running benchmarks, running quality evaluations, scoring outputs, exposing routes, exposing dashboards, adding fallback, performing billing work, or promoting evidence.
+
+## Required checks for this packet
+
+- `git status --short`
+- `git diff --name-only`
+- `git diff --check`
+- `make check-local-llm-orchestration-guardrails`
+- `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-product-surface-threat-risk-model`
+- `rg "NO_FURTHER_PRODUCT_SURFACE_THREAT_RISK_MODEL_LANES_SELECTED|ALPHA-SOLVER-POST-LEVEL-3-PRODUCT-SURFACE-THREAT-RISK-MODEL-FIX-001|abuse cases|privacy|evidence-promotion|route exposure|dashboard risks|does not implement" docs/evals/runs/alpha-solver-post-level-3-product-surface-threat-risk-model`
+- Confirm no runtime/provider/dashboard/API files changed.
+
+## Results recorded for this packet
+
+- PASS: `git status --short` showed only the new docs-only packet directory before staging: `?? docs/evals/runs/alpha-solver-post-level-3-product-surface-threat-risk-model/`.
+- PASS: `git diff --name-only` produced no tracked-file output before staging, confirming no existing tracked files were modified.
+- PASS: `git diff --check` reported no unstaged whitespace errors.
+- PASS: `make check-local-llm-orchestration-guardrails` passed, including evidence-boundary, doc-path/link, and packet-consistency checks.
+- PASS: `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-product-surface-threat-risk-model` passed and reported `1 packet directories scanned`.
+- PASS: `rg "NO_FURTHER_PRODUCT_SURFACE_THREAT_RISK_MODEL_LANES_SELECTED|ALPHA-SOLVER-POST-LEVEL-3-PRODUCT-SURFACE-THREAT-RISK-MODEL-FIX-001|abuse cases|privacy|evidence-promotion|route exposure|dashboard risks|does not implement" docs/evals/runs/alpha-solver-post-level-3-product-surface-threat-risk-model` found the selected next action, blocker fallback lane, abuse case, privacy, evidence-promotion, route exposure, dashboard risk, and does-not-implement boundary language.
+- PASS: `git diff --name-only -- alpha service cli scripts tests Makefile .github/workflows docs/dashboard dashboard api service/app.py` produced no output, confirming no runtime/provider/dashboard/API files, checker scripts, tests, Makefile targets, or CI files changed.
+
+## Interpretation boundary
+
+Passing checks only confirms static documentation consistency within checker scope. It does not establish quality evidence, benchmark evidence, model quality, provider readiness, dashboard readiness, route readiness, billing readiness, MVP readiness, production readiness, or product readiness.

--- a/docs/evals/runs/alpha-solver-post-level-3-product-surface-threat-risk-model/dashboard-risks.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-product-surface-threat-risk-model/dashboard-risks.md
@@ -1,0 +1,24 @@
+# Dashboard Risks
+
+## dashboard risks
+
+- A dashboard may expose prompts, responses, traces, provider metadata, cost metadata, user identifiers, credentials, session values, cookies, CSRF tokens, or operational secrets.
+- Dashboard access may be mistaken for product readiness, route readiness, provider readiness, quality evidence, or production readiness.
+- Screenshots may capture sensitive data or imply unsupported claims if reused in PRs, docs, tickets, or external materials.
+- Request metrics may be interpreted as quality, safety, or benchmark results even when they are operational-only signals.
+
+## Access and session risks
+
+- Missing or weak authentication, authorization, session expiry, secret rotation, CSRF protection, or role boundaries.
+- Overbroad dashboard permissions that allow data export, reruns, replay, provider calls, or billing-impacting actions.
+- Inconsistent local versus hosted dashboard configuration that obscures what data is visible or retained.
+
+## Stop conditions
+
+- Stop if dashboard exposure is required before Level 6 authorizes dashboard scope and controls.
+- Stop if screenshots, logs, or exports may include unredacted sensitive data.
+- Stop if dashboard metrics are used as evidence-promotion or unsupported product-surface claims.
+
+## Boundary
+
+This packet does not expose, call, test, configure, or modify dashboards. It does not implement dashboard mitigations, route behavior, provider calls, fallback, billing, model inference, benchmark execution, or evidence promotion.

--- a/docs/evals/runs/alpha-solver-post-level-3-product-surface-threat-risk-model/evidence-promotion-risks.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-product-surface-threat-risk-model/evidence-promotion-risks.md
@@ -1,0 +1,26 @@
+# Evidence-Promotion Risks
+
+## evidence-promotion risks
+
+- Local orchestration artifacts may be cited as product readiness even though they are non-promotional evidence.
+- Level 2 operator usability evidence may be overextended into quality, route, provider, dashboard, billing, or production claims.
+- Level 3 artifact completeness may be mistaken for validated user-facing behavior.
+- A future product page, dashboard, README, PR, or release note may omit evidence boundaries and imply unsupported readiness.
+
+## Unsupported-claim risks
+
+- Claims about accuracy, quality lift, safety, latency, reliability, privacy, cost, provider readiness, fallback readiness, route readiness, dashboard readiness, MVP readiness, production readiness, or product readiness may appear before authorized evidence exists.
+- A benchmark label may be used without benchmark execution, frozen task sets, scoring rules, review workflow, or artifact preservation.
+- Dashboard metrics may be interpreted as quality evidence when they only show request or operational metadata.
+- Provider success in one path may be presented as general provider or fallback readiness.
+
+## Required interpretation controls for future use
+
+- Preserve explicit boundaries in every future artifact that cites this packet.
+- Separate observed evidence from claims, decisions, recommendations, and implementation status.
+- Require Level 6 authorization before product-surface use.
+- Require a stop if any future artifact turns this packet into evidence promotion or unsupported claims.
+
+## Boundary
+
+This packet does not promote evidence. It is a docs-only threat and risk model and does not run evaluations, run benchmarks, score outputs, call providers, expose routes, expose dashboards, perform billing work, or implement mitigations.

--- a/docs/evals/runs/alpha-solver-post-level-3-product-surface-threat-risk-model/mitigations-and-stop-conditions.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-product-surface-threat-risk-model/mitigations-and-stop-conditions.md
@@ -1,0 +1,28 @@
+# Mitigations and Stop Conditions
+
+The items below are candidate planning controls for future Level 6 use. They are not implemented by this packet.
+
+## Candidate mitigations for future consideration
+
+- Require explicit Level 6 authorization before product-surface design, implementation, route exposure, dashboard exposure, provider calls, fallback behavior, billing work, benchmark execution, model inference, or evidence promotion.
+- Require authentication, authorization, session, CSRF, rate-limit, budget, logging, redaction, retention, and incident-review requirements before any future route or dashboard exposure.
+- Require provider/fallback labels in operator-facing and user-facing artifacts.
+- Require evidence-boundary labels on dashboards, reports, PRs, release notes, and run packets.
+- Require privacy review for prompts, responses, traces, screenshots, exports, logs, and retained artifacts.
+- Require unsupported-claim review before any claim about quality, accuracy, safety, latency, cost, reliability, privacy, provider readiness, route readiness, dashboard readiness, MVP readiness, production readiness, or product readiness.
+
+## Hard stop conditions
+
+Stop future work and use the blocker fallback lane if any of the following are true:
+
+- Level 6 control over packet use is missing or contradicted.
+- Work would modify runtime, provider, CLI, checker scripts, tests, Makefile, CI, API, or dashboard files under this lane.
+- Work would expose routes, expose dashboards, call providers, add fallback, perform billing work, run model inference, run benchmarks, or promote evidence.
+- Evidence-promotion or unsupported claims appear in docs, PR text, dashboard labels, reports, or release materials.
+- Privacy, redaction, retention, credential, session, or provider-account risks cannot be bounded.
+- Provider/fallback status cannot be explained unambiguously.
+- Route exposure or dashboard risks cannot be mitigated before exposure.
+
+## Blocker fallback lane
+
+Use `ALPHA-SOLVER-POST-LEVEL-3-PRODUCT-SURFACE-THREAT-RISK-MODEL-FIX-001` if this packet is incomplete, contradictory, unsafe, stale, overbroad, or unable to preserve the evidence boundary.

--- a/docs/evals/runs/alpha-solver-post-level-3-product-surface-threat-risk-model/non-actions.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-product-surface-threat-risk-model/non-actions.md
@@ -1,0 +1,31 @@
+# Non-Actions
+
+This docs-only threat and risk model does not:
+
+- modify runtime behavior;
+- modify provider behavior;
+- modify CLI behavior;
+- modify checker scripts;
+- modify tests;
+- modify `Makefile`;
+- modify CI;
+- modify API files;
+- modify dashboard files;
+- modify source artifacts;
+- expose routes;
+- expose dashboards;
+- call providers;
+- configure providers;
+- add fallback;
+- run local model inference;
+- run hosted model inference;
+- run Ollama;
+- run benchmarks;
+- run evaluations;
+- score outputs;
+- perform billing work;
+- collect private user data;
+- promote evidence;
+- claim quality, benchmark readiness, provider readiness, route readiness, dashboard readiness, MVP readiness, production readiness, or product readiness;
+- implement mitigations;
+- start product-surface work.

--- a/docs/evals/runs/alpha-solver-post-level-3-product-surface-threat-risk-model/privacy-and-data-risks.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-product-surface-threat-risk-model/privacy-and-data-risks.md
@@ -1,0 +1,24 @@
+# Privacy and Data Risks
+
+## Sensitive data risks
+
+- Future product surfaces may receive personal data, confidential business data, credentials, proprietary prompts, or regulated information.
+- Logs, traces, dashboards, evidence packets, screenshots, and copied artifacts may retain sensitive data longer than intended.
+- Provider metadata, account identifiers, request IDs, billing identifiers, cookies, tokens, session values, and CSRF values could leak through artifacts.
+
+## Data handling risks
+
+- Data-retention behavior may be unclear if local runs, hosted provider calls, fallback calls, and dashboard logging are not separated.
+- Operators may confuse sanitized evidence summaries with raw provider payloads or full request/response traces.
+- Redaction gaps may allow private user content to enter docs, tickets, dashboard screenshots, benchmark reports, or PR descriptions.
+- Future deletion, export, or audit expectations may be unsupported if storage locations are not inventoried before route exposure.
+
+## Privacy stop signals
+
+- Stop if a future packet requires raw unredacted prompts, responses, traces, credentials, cookies, sessions, provider account identifiers, billing identifiers, or private user data in committed docs.
+- Stop if future dashboard risks are reviewed without redaction, retention, access-control, and screenshot-handling rules.
+- Stop if provider/fallback behavior is ambiguous enough that data residency, third-party processing, or billing exposure cannot be explained to an operator.
+
+## Boundary
+
+This packet does not collect, store, inspect, transmit, or process private user data. It does not implement privacy controls, dashboard controls, route controls, provider calls, fallback behavior, billing work, model inference, benchmark execution, or evidence promotion.

--- a/docs/evals/runs/alpha-solver-post-level-3-product-surface-threat-risk-model/provider-and-fallback-confusion-risks.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-product-surface-threat-risk-model/provider-and-fallback-confusion-risks.md
@@ -1,0 +1,24 @@
+# Provider and Fallback Confusion Risks
+
+## Provider confusion risks
+
+- Operators may not know whether a future run uses local-only execution, a hosted provider, a fallback provider, a mock, a replay artifact, or no model inference.
+- Provider names, model names, and environment variables may be logged or displayed inconsistently.
+- A successful local run may be mistaken for hosted provider readiness, and a successful hosted call may be mistaken for general product readiness.
+
+## Fallback confusion risks
+
+- Fallback may silently change model behavior, privacy exposure, cost exposure, latency, or output quality.
+- Failure handling may hide provider errors and prevent accurate incident review.
+- Budget guard, rate-limit, and data-residency expectations may differ between primary and fallback paths.
+- A future UI may display output without clearly labeling provider, fallback, replay, mock, or local-only status.
+
+## Required future clarity
+
+- Any future implementation must make execution mode, provider/fallback status, billing exposure, and data-handling implications explicit.
+- Any future evidence must distinguish local, hosted, fallback, mock, replay, and no-inference artifacts.
+- Any future stop condition must block silent fallback or unlabeled provider behavior.
+
+## Boundary
+
+This packet does not call providers, configure providers, add fallback, run models, run benchmarks, perform billing work, expose routes, expose dashboards, implement mitigations, or promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-product-surface-threat-risk-model/risk-model-overview.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-product-surface-threat-risk-model/risk-model-overview.md
@@ -1,0 +1,38 @@
+# Risk Model Overview
+
+## Protected assets
+
+- User prompts, uploaded context, private operator notes, and any future request metadata.
+- Provider credentials, dashboard credentials, cookies, CSRF tokens, session values, API keys, and billing identifiers.
+- Solver outputs, traces, score sheets, run packets, evidence artifacts, and decision ledgers.
+- Route configuration, provider/fallback configuration, budget limits, and product-readiness status.
+
+## Actors and misuse sources
+
+- Legitimate operators who may misunderstand readiness boundaries.
+- External users if a future surface is exposed before authorization.
+- Internal reviewers who may over-promote evidence or cite unsupported claims.
+- Automated agents that may follow stale docs or infer route/provider/dashboard readiness from packet existence.
+- Attackers seeking prompt data, credentials, billing abuse, route enumeration, or dashboard access.
+
+## Trust boundaries
+
+- Local docs versus runtime behavior.
+- Internal review packets versus public product claims.
+- Operator-only artifacts versus user-facing product surfaces.
+- Local model/provider configuration versus hosted provider calls.
+- Evidence artifacts versus promoted readiness, quality, or benchmark claims.
+
+## Primary risk themes
+
+- Abuse cases and prompt injection risks if future surfaces accept untrusted input.
+- Privacy and data-retention risks if future artifacts include sensitive request content.
+- evidence-promotion risks if Level 2 or Level 3 evidence is treated as product readiness.
+- Unsupported-claim risks if docs imply benchmark, quality, provider, route, dashboard, billing, MVP, production, or product readiness.
+- route exposure risks if `/v1/solve` or related routes are exposed before authentication, authorization, rate limiting, logging, privacy, and stop-condition controls are approved.
+- dashboard risks if a dashboard is reachable without strong session, secret, CSRF, and redaction controls.
+- Provider and fallback confusion risks if local, hosted, fallback, billing, or model-inference paths are ambiguous.
+
+## Level 6 control
+
+Level 6 controls whether and how this packet is used. This packet is not approval to implement product-surface changes, expose routes, expose dashboards, call providers, add fallback, bill users, run benchmarks, run model inference, or promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-product-surface-threat-risk-model/route-exposure-risks.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-product-surface-threat-risk-model/route-exposure-risks.md
@@ -1,0 +1,25 @@
+# Route Exposure Risks
+
+## route exposure risks
+
+- Future `/v1/solve` or related routes could be exposed before authentication, authorization, rate limiting, input validation, output boundaries, privacy controls, and abuse monitoring are approved.
+- Debug, health, metrics, replay, or internal routes could reveal route maps, environment state, provider configuration, request metadata, or operational status.
+- Route behavior may differ between local, preview, and hosted environments, creating false readiness assumptions.
+- Error messages may leak stack traces, provider details, budget state, policy decisions, or sensitive input fragments.
+
+## Abuse paths
+
+- Route enumeration and unauthenticated probing.
+- High-volume request submission causing denial of service or unexpected billing.
+- Parameter tampering to enable provider calls, fallback, debug behavior, or non-default models.
+- Replay of stale requests after configuration or evidence-boundary changes.
+
+## Stop conditions
+
+- Stop if route exposure is required before Level 6 authorizes route scope and controls.
+- Stop if authentication, authorization, rate limiting, privacy, logging, budget, error-message, and incident-review expectations are unspecified.
+- Stop if route evidence is presented as dashboard, provider, benchmark, MVP, production, or product readiness.
+
+## Boundary
+
+This packet does not expose, call, test, or modify routes. It does not implement route mitigations, API behavior, provider calls, fallback, dashboard behavior, billing, model inference, benchmark execution, or evidence promotion.

--- a/docs/evals/runs/alpha-solver-post-level-3-product-surface-threat-risk-model/selected-next-action.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-product-surface-threat-risk-model/selected-next-action.md
@@ -1,0 +1,13 @@
+# Selected Next Action
+
+Exactly one selected next action is recorded for this docs-only threat and risk model packet:
+
+`NO_FURTHER_PRODUCT_SURFACE_THREAT_RISK_MODEL_LANES_SELECTED`
+
+## Rationale
+
+This packet creates a pre-implementation risk model only. It does not need a follow-on threat-risk-model lane because Level 6 controls whether and how this packet is used, revised, superseded, or ignored.
+
+## Non-start boundary
+
+This selected next action does not start product-surface design, product-surface implementation, route exposure, dashboard exposure, provider work, fallback work, billing work, model inference, benchmark execution, quality evaluation execution, MVP review, production readiness review, or evidence promotion.

--- a/docs/evals/runs/alpha-solver-post-level-3-product-surface-threat-risk-model/source-evidence-reviewed.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-product-surface-threat-risk-model/source-evidence-reviewed.md
@@ -1,0 +1,26 @@
+# Source Evidence Reviewed
+
+This packet reviewed repository documentation and guardrail context without modifying preserved source artifacts, closed Level 2 packets, closed Level 3 packets, release-readiness ladder files, runtime files, provider files, CLI files, checker scripts, tests, Makefile targets, API files, dashboard files, or CI files.
+
+## Reviewed source areas
+
+- `AGENTS.md`
+- `.specs/INDEX.md`
+- `docs/evals/runs/README.md`
+- `docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder/`
+- `docs/evals/runs/alpha-solver-post-level-3-level-4-pre-product-surface-requirements/`
+- `docs/evals/runs/alpha-solver-post-level-3-level-5-quality-evaluation-design/`
+- `docs/evals/runs/alpha-solver-post-level-3-quality-eval-task-taxonomy/`
+- `docs/evals/runs/local-llm-solver-orchestration-index/`
+- `docs/local_llm_solver_orchestration_operator_guide/`
+- `docs/local_llm_solver_orchestration_guardrails/`
+- `scripts/check_local_llm_packet_consistency.py`
+- `Makefile`
+
+## Evidence-boundary observations
+
+- Level 2 controlled usage remains local operator usability evidence only.
+- Level 3 validation execution remains artifact-complete, non-promotional local orchestration evidence only.
+- Existing post-Level-3 docs preserve blocked claims around product readiness, route readiness, dashboard readiness, provider readiness, fallback readiness, billing readiness, benchmark readiness, quality claims, and evidence promotion.
+- This packet does not implement product-surface mitigations and does not approve any route, dashboard, provider, fallback, billing, model, benchmark, or evidence-promotion work.
+- Level 6 controls whether and how this packet is used.


### PR DESCRIPTION
### Motivation

- Provide a docs-only, pre-implementation threat and risk model for future Alpha Solver product-surface work that catalogs abuse cases, privacy/data risks, evidence-promotion and unsupported-claim risks, route-exposure risks, dashboard risks, provider/fallback confusion risks, mitigations to consider, and explicit stop conditions. 
- Preserve the post-Level-3 evidence boundary and require Level 6 authorization before any product-surface implementation or exposure is pursued.

### Description

- Add a new docs-only packet at `docs/evals/runs/alpha-solver-post-level-3-product-surface-threat-risk-model/` containing the recommended files: `README.md`, `source-evidence-reviewed.md`, `risk-model-overview.md`, `abuse-cases.md`, `privacy-and-data-risks.md`, `evidence-promotion-risks.md`, `route-exposure-risks.md`, `dashboard-risks.md`, `provider-and-fallback-confusion-risks.md`, `mitigations-and-stop-conditions.md`, `non-actions.md`, `selected-next-action.md`, `blocker-fallback-lane.md`, and `checks-run.md`. 
- Record the selected next action as `NO_FURTHER_PRODUCT_SURFACE_THREAT_RISK_MODEL_LANES_SELECTED` and the blocker fallback lane as `ALPHA-SOLVER-POST-LEVEL-3-PRODUCT-SURFACE-THREAT-RISK-MODEL-FIX-001`. 
- Explicitly state the evidence boundary and non-actions to ensure the packet does not implement mitigations, modify runtime/provider/CLI/tests/Makefile/CI/API/dashboard files, expose routes, call providers, run models/benchmarks/evaluations, perform billing, or promote evidence.

### Testing

- Ran the required static checks including `git status --short`, `git diff --name-only`, and `git diff --check`, and recorded no tracked-file modifications or whitespace errors. 
- Ran guardrail checks `make check-local-llm-orchestration-guardrails` which passed, and `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-product-surface-threat-risk-model` which passed and reported `1 packet directories scanned`. 
- Ran content grep `rg "NO_FURTHER_PRODUCT_SURFACE_THREAT_RISK_MODEL_LANES_SELECTED|ALPHA-SOLVER-POST-LEVEL-3-PRODUCT-SURFACE-THREAT-RISK-MODEL-FIX-001|abuse cases|privacy|evidence-promotion|route exposure|dashboard risks|does not implement"` and confirmed expected markers are present, and confirmed no runtime/provider/dashboard/API/checker/test/Makefile/CI files were changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2601665d948329b71cee22e4fda919)