### PR TITLE
Add provider registry capability schema packet (docs-only)

### DIFF
--- a/docs/evals/runs/alpha-solver-post-level-3-provider-registry-capability-schema/README.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-registry-capability-schema/README.md
@@ -1,0 +1,54 @@
+# Provider Registry Capability Schema Packet
+
+Lane: `ALPHA-SOLVER-POST-LEVEL-3-PROVIDER-REGISTRY-CAPABILITY-SCHEMA-PACKET-001`
+
+## Objective
+
+This docs-only packet defines a supporting provider registry and capability schema reference for future Alpha Solver provider orchestration work.
+
+It records design requirements for:
+
+- provider identity fields;
+- capability labels;
+- supported modes and surface compatibility;
+- safety constraints;
+- provenance requirements;
+- local-vs-hosted labels;
+- cost and quota labels; and
+- disabled/default-off state requirements.
+
+## Required preflight result
+
+Current `main` contains the accepted Level 6 product-surface design packet in `docs/evals/runs/alpha-solver-post-level-3-level-6-product-surface-design/`.
+That packet selected `ALPHA-SOLVER-POST-LEVEL-3-LEVEL-7-PROVIDER-ORCHESTRATION-DESIGN-PACKET-001` as the next design lane.
+
+## Design status
+
+This packet is a supporting reference only. It does not create a registry and does not decide provider orchestration behavior. Level 7 controls whether this reference is used, ignored, narrowed, or replaced.
+
+## Evidence boundary
+
+This packet is docs-only provider registry/capability schema design. It does not create a registry, modify provider code, call providers, configure credentials, add routing, add fallback, expose `/v1/solve`, expose dashboards, run models, run benchmarks, perform billing work, or promote evidence.
+
+## Selected next action
+
+`NO_FURTHER_PROVIDER_REGISTRY_CAPABILITY_SCHEMA_LANES_SELECTED`
+
+## Blocker fallback lane
+
+`ALPHA-SOLVER-POST-LEVEL-3-PROVIDER-REGISTRY-CAPABILITY-SCHEMA-FIX-001`
+
+## Files in this packet
+
+- `source-evidence-reviewed.md` records the preflight evidence reviewed.
+- `registry-overview.md` summarizes the reference schema.
+- `provider-identity-fields.md` defines provider identity fields.
+- `capability-labels.md` defines capability labels.
+- `mode-and-surface-compatibility.md` defines supported modes and surface compatibility labels.
+- `local-vs-hosted-boundaries.md` defines local-vs-hosted boundaries.
+- `cost-and-quota-labels.md` defines cost and quota labels.
+- `disabled-default-off-state.md` defines default-off and disabled-state requirements.
+- `non-actions.md` records explicit non-actions.
+- `selected-next-action.md` records the closed selected next action.
+- `blocker-fallback-lane.md` records the fallback lane.
+- `checks-run.md` records validation commands.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-registry-capability-schema/blocker-fallback-lane.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-registry-capability-schema/blocker-fallback-lane.md
@@ -1,0 +1,7 @@
+# Blocker Fallback Lane
+
+If this packet is incomplete, inconsistent, stale, overbroad, unsafe by default, unclear about default-off state, or inconsistent with Level 6 or Level 7 boundaries, use blocker fallback lane:
+
+`ALPHA-SOLVER-POST-LEVEL-3-PROVIDER-REGISTRY-CAPABILITY-SCHEMA-FIX-001`
+
+The fallback lane may repair this docs-only supporting reference. It must not create a registry, modify provider code, call providers, configure credentials, add routing, add fallback, expose `/v1/solve`, expose dashboards, run models, run benchmarks, perform billing work, or promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-registry-capability-schema/capability-labels.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-registry-capability-schema/capability-labels.md
@@ -1,0 +1,31 @@
+# Capability Labels
+
+## Capability label goals
+
+Capability labels should describe declared provider abilities without claiming runtime readiness. They are planning metadata for Level 7 provider orchestration design only.
+
+## Recommended capability labels
+
+| Label | Meaning |
+| --- | --- |
+| `text_generation` | Provider is intended to produce natural-language output. |
+| `structured_output_candidate` | Provider may support structured output in a future authorized implementation. |
+| `tool_use_candidate` | Provider may support tool-use patterns, but this packet does not authorize tool use. |
+| `local_runtime_candidate` | Provider may run through a local runtime boundary. |
+| `hosted_api_candidate` | Provider may require a hosted API boundary. |
+| `streaming_candidate` | Provider may support streamed output in future design. |
+| `batch_candidate` | Provider may support batch execution in future design. |
+| `eval_only_candidate` | Provider may be limited to evaluation contexts if later authorized. |
+| `operator_review_required` | Operator review is required before use. |
+| `evidence_restricted` | Output must not be promoted beyond its accepted evidence boundary. |
+
+## Capability constraints
+
+- Capability labels are not proof that a provider works.
+- Capability labels are not permission to call providers.
+- Capability labels do not authorize routing, fallback, hosted calls, local model execution, benchmarks, billing work, API exposure, dashboard exposure, or evidence promotion.
+- Capability labels must be auditable and tied to provenance requirements.
+
+## Unknown capabilities
+
+Unknown, missing, stale, or contradictory capability labels should fail closed. A future registry should treat unknown capability data as disabled/default-off until Level 7 or a later authorized lane resolves it.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-registry-capability-schema/checks-run.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-registry-capability-schema/checks-run.md
@@ -1,0 +1,15 @@
+# Checks Run
+
+## Results
+
+- PASS: `git status --short` showed only new docs under `docs/evals/runs/alpha-solver-post-level-3-provider-registry-capability-schema/`.
+- PASS: `git diff --name-only` showed only files in this packet directory.
+- PASS: `git diff --check` reported no whitespace errors.
+- PASS: `make check-local-llm-orchestration-guardrails` passed evidence-boundary, doc path/link, and packet consistency checks.
+- PASS: `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-provider-registry-capability-schema` passed with one packet directory scanned.
+- PASS: `rg "NO_FURTHER_PROVIDER_REGISTRY_CAPABILITY_SCHEMA_LANES_SELECTED|ALPHA-SOLVER-POST-LEVEL-3-PROVIDER-REGISTRY-CAPABILITY-SCHEMA-FIX-001|provider registry|capability labels|default-off|does not create|does not call providers" docs/evals/runs/alpha-solver-post-level-3-provider-registry-capability-schema` found the required decision, fallback, schema, default-off, and boundary phrases.
+- PASS: no runtime, provider, API, dashboard, CLI, checker, test, Makefile, CI, or source-artifact files were changed.
+
+## Evidence boundary for checks
+
+No check called providers, ran models, configured secrets, added routing, added fallback, exposed `/v1/solve`, exposed dashboards, ran benchmarks, performed billing work, or promoted evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-registry-capability-schema/cost-and-quota-labels.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-registry-capability-schema/cost-and-quota-labels.md
@@ -1,0 +1,31 @@
+# Cost and Quota Labels
+
+## Cost labels
+
+A future provider registry entry should include a conservative cost label:
+
+| Cost label | Meaning |
+| --- | --- |
+| `no_cost_docs_only` | Documentation-only entry with no provider calls. |
+| `local_resource_cost_candidate` | May consume local compute resources if later authorized. |
+| `hosted_billable_candidate` | May create hosted-provider costs if later authorized. |
+| `unknown_cost` | Cost is unresolved and must remain disabled/default-off. |
+
+## Quota labels
+
+A future entry should include a quota label:
+
+| Quota label | Meaning |
+| --- | --- |
+| `no_quota_docs_only` | Documentation-only entry with no quota use. |
+| `local_resource_limit_required` | Future local use requires explicit resource limits. |
+| `hosted_rate_limit_required` | Future hosted use requires rate-limit policy. |
+| `budget_guard_required` | Future use requires budget guard design before invocation. |
+| `unknown_quota` | Quota is unresolved and must remain disabled/default-off. |
+
+## Cost and quota constraints
+
+- A provider entry must not be enabled unless cost and quota labels are known and reviewed.
+- Hosted billable candidates must remain disabled/default-off without accepted budget, rate-limit, credential, and operator opt-in controls.
+- Local resource candidates must remain disabled/default-off without accepted timeout, concurrency, resource-limit, and stop-condition controls.
+- Cost labels are not billing evidence and do not perform billing work.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-registry-capability-schema/disabled-default-off-state.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-registry-capability-schema/disabled-default-off-state.md
@@ -1,0 +1,33 @@
+# Disabled and Default-Off State
+
+## Required default
+
+Every future provider registry entry must be disabled/default-off unless a later accepted Level 7 or implementation lane explicitly authorizes a narrower state.
+
+## State labels
+
+| State label | Meaning |
+| --- | --- |
+| `disabled_default_off` | Required default for all entries. |
+| `docs_reference_only` | Entry is reference material only. |
+| `blocked_pending_level_7` | Entry cannot be used until Level 7 decides whether it is in scope. |
+| `blocked_pending_credentials_policy` | Hosted candidate cannot be used without credential policy. |
+| `blocked_pending_cost_policy` | Candidate cannot be used without cost and quota policy. |
+| `blocked_pending_safety_review` | Candidate cannot be used without safety review. |
+
+## Fail-closed requirements
+
+A future registry should fail closed when:
+
+- a required identity field is missing;
+- a capability label is unknown or contradictory;
+- local-vs-hosted boundary is unknown;
+- cost or quota labels are unknown;
+- provenance is missing;
+- safety constraints are missing;
+- a provider is not explicitly enabled by an accepted lane; or
+- operator opt-in is absent.
+
+## No implicit enablement
+
+No label in this packet authorizes provider calls. No future registry entry should become callable through default configuration, environment variables, installed dependencies, discovered local runtimes, available provider keys, dashboard selection, API request fields, CLI flags, or fallback behavior unless later accepted work explicitly authorizes that behavior.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-registry-capability-schema/local-vs-hosted-boundaries.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-registry-capability-schema/local-vs-hosted-boundaries.md
@@ -1,0 +1,28 @@
+# Local-vs-Hosted Boundaries
+
+## Boundary labels
+
+A future registry should label each entry with exactly one primary boundary:
+
+| Boundary label | Meaning |
+| --- | --- |
+| `local_only` | Provider is intended to run only through local runtime boundaries if later authorized. |
+| `hosted_only` | Provider requires a hosted service if later authorized. |
+| `hybrid_candidate` | Provider may have local and hosted variants, but they must be represented as separate callable paths if later authorized. |
+| `unknown_boundary` | Boundary is unresolved and must remain disabled/default-off. |
+
+## Local boundary requirements
+
+A local-labeled entry must preserve local-only safety constraints until a later accepted lane changes them. It must not require, accept, read, validate, forward, or depend on hosted provider credentials for local mode.
+
+## Hosted boundary requirements
+
+A hosted-labeled entry must remain disabled/default-off until a later authorized lane defines credential policy, quota policy, cost controls, operator opt-in, logging limits, provenance requirements, and stop conditions.
+
+## Hybrid boundary requirements
+
+A `hybrid_candidate` label must not blur local and hosted paths. Future design should split local and hosted behavior into separately auditable entries or subentries so hosted fallback cannot be implied by local failure.
+
+## Boundary constraint
+
+This packet does not call providers, configure secrets, enable hosted fallback, enable provider fallback, or authorize any local or hosted model execution.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-registry-capability-schema/mode-and-surface-compatibility.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-registry-capability-schema/mode-and-surface-compatibility.md
@@ -1,0 +1,33 @@
+# Mode and Surface Compatibility
+
+## Supported mode labels
+
+A future provider registry entry should use explicit mode labels instead of inferring behavior:
+
+| Mode label | Meaning |
+| --- | --- |
+| `docs_only` | Entry exists only as documentation and cannot be invoked. |
+| `local_manual_candidate` | Candidate for manually invoked local workflows if later authorized. |
+| `local_operator_candidate` | Candidate for local operator workflows if later authorized. |
+| `hosted_candidate` | Candidate for hosted-provider workflows if later authorized. |
+| `eval_candidate` | Candidate for future eval-only workflows if later authorized. |
+| `production_blocked` | Not eligible for production use. |
+
+## Product surface labels
+
+Surface labels should be separate from mode labels:
+
+| Surface label | Requirement |
+| --- | --- |
+| `no_surface` | Default label; no product surface may use this provider. |
+| `api_candidate` | Candidate for future API design only; does not expose `/v1/solve`. |
+| `dashboard_candidate` | Candidate for future dashboard design only; does not expose dashboards. |
+| `cli_candidate` | Candidate for future CLI design only; does not modify CLI behavior. |
+| `eval_surface_candidate` | Candidate for future evaluation-only workflows. |
+
+## Compatibility rules
+
+- `docs_only` and `no_surface` should be the default state for every registry entry.
+- A provider must not become callable because it has an `api_candidate`, `dashboard_candidate`, `cli_candidate`, or `eval_surface_candidate` label.
+- Surface compatibility must remain subordinate to accepted Level 6 product-surface gates and Level 7 provider orchestration decisions.
+- Missing compatibility labels must fail closed.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-registry-capability-schema/non-actions.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-registry-capability-schema/non-actions.md
@@ -1,0 +1,31 @@
+# Non-Actions
+
+This packet is docs-only provider registry/capability schema design.
+
+It explicitly does not:
+
+- create a provider registry;
+- modify runtime code;
+- modify provider code;
+- modify API code;
+- modify dashboard code;
+- modify CLI code;
+- modify checker code;
+- modify test code;
+- modify Makefile or CI behavior;
+- modify source-artifact files;
+- call providers;
+- run models;
+- configure secrets or credentials;
+- add routing;
+- add fallback;
+- expose `/v1/solve`;
+- expose dashboards;
+- run benchmarks;
+- perform billing work;
+- promote evidence;
+- claim provider readiness;
+- claim product readiness; or
+- start Level 7 provider orchestration design.
+
+This is a supporting reference only. Level 7 controls whether it is used.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-registry-capability-schema/provider-identity-fields.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-registry-capability-schema/provider-identity-fields.md
@@ -1,0 +1,32 @@
+# Provider Identity Fields
+
+## Required identity fields
+
+A future provider registry entry should require these identity fields:
+
+| Field | Requirement |
+| --- | --- |
+| `provider_id` | Stable machine-readable identifier, unique within the registry. |
+| `display_name` | Human-readable provider name for operator review. |
+| `provider_family` | Provider family or adapter family, such as local runtime, hosted API, or bridge adapter. |
+| `integration_owner` | Responsible maintainer or owning lane; may be `unassigned` until implementation is authorized. |
+| `registry_version` | Schema version used by the entry. |
+| `entry_status` | One of `draft`, `review_only`, `disabled`, `eligible_for_future_review`, or another Level-7-approved state. |
+| `source_packet` | Packet or spec that authorized the entry. |
+| `last_reviewed_at` | Date of last docs review; must not imply runtime validation. |
+
+## Optional identity fields
+
+A future entry may include optional labels only if Level 7 authorizes them:
+
+- `adapter_module` for an existing adapter path, if code already exists;
+- `provider_docs_url` for external documentation reference;
+- `credential_profile_name` for a future credential-policy label, not a secret value;
+- `model_catalog_reference` for a docs-only model catalog pointer; and
+- `deprecation_note` for retired or blocked providers.
+
+## Identity constraints
+
+- Identity fields must not contain secrets, API keys, tokens, account IDs, private endpoints, or billing credentials.
+- Identity fields must not imply that the provider can be called.
+- Identity fields must not imply readiness for provider orchestration, fallback, `/v1/solve`, dashboard exposure, benchmarks, billing, or evidence promotion.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-registry-capability-schema/registry-overview.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-registry-capability-schema/registry-overview.md
@@ -1,0 +1,34 @@
+# Registry Overview
+
+## Purpose
+
+A future provider registry, if Level 7 chooses to use one, should be a declarative inventory of candidate provider integrations and capabilities. The registry should help future orchestration code answer narrowly scoped questions such as:
+
+- What provider identity is being described?
+- Is the provider local or hosted?
+- Which capability labels are declared?
+- Which modes and product surfaces are compatible?
+- Which safety, provenance, cost, and quota constraints apply?
+- Is the provider disabled by default?
+
+## Reference-only schema shape
+
+This packet recommends the following conceptual record sections:
+
+1. `identity`: stable provider identity fields.
+2. `location`: local-vs-hosted boundary labels.
+3. `capabilities`: capability labels and evidence limitations.
+4. `modes`: supported execution modes.
+5. `surfaces`: allowed future surfaces, if separately authorized.
+6. `safety`: safety constraints and stop conditions.
+7. `provenance`: required evidence and attribution metadata.
+8. `cost_quota`: cost, quota, budget, and rate-limit labels.
+9. `state`: disabled/default-off requirements.
+
+## Required defaults
+
+Every future provider registry entry should default to disabled unless a later accepted Level 7 or implementation lane explicitly enables it. Missing fields should fail closed, not enable implicit provider routing.
+
+## Evidence boundary
+
+This reference does not create a registry, modify provider code, add routing, add fallback, call providers, configure credentials, run models, run benchmarks, expose `/v1/solve`, expose dashboards, perform billing work, or promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-registry-capability-schema/selected-next-action.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-registry-capability-schema/selected-next-action.md
@@ -1,0 +1,9 @@
+# Selected Next Action
+
+Exactly one selected next action is recorded:
+
+`NO_FURTHER_PROVIDER_REGISTRY_CAPABILITY_SCHEMA_LANES_SELECTED`
+
+No further provider registry capability schema lanes are selected by this packet.
+
+This packet is a supporting reference only. Level 7 controls whether it is used.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-registry-capability-schema/source-evidence-reviewed.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-registry-capability-schema/source-evidence-reviewed.md
@@ -1,0 +1,19 @@
+# Source Evidence Reviewed
+
+## Required preflight
+
+Current `main` was inspected before authoring this packet.
+
+| Evidence | Path | Reviewed state |
+| --- | --- | --- |
+| Accepted Level 6 product-surface design packet | `docs/evals/runs/alpha-solver-post-level-3-level-6-product-surface-design/README.md` | Records `ALPHA-SOLVER-POST-LEVEL-3-LEVEL-6-PRODUCT-SURFACE-DESIGN-PACKET-001` and accepted prior state. |
+| Level 6 selected next lane | `docs/evals/runs/alpha-solver-post-level-3-level-6-product-surface-design/selected-next-lane.md` | Selects `ALPHA-SOLVER-POST-LEVEL-3-LEVEL-7-PROVIDER-ORCHESTRATION-DESIGN-PACKET-001`. |
+| Level 6 product-surface boundary | `docs/evals/runs/alpha-solver-post-level-3-level-6-product-surface-design/product-surface-design-boundary.md` | Requires future product-surface work to cite an accepted packet and readiness gate. |
+| Level 6 deferred Level 7 context | `docs/evals/runs/alpha-solver-post-level-3-level-6-product-surface-design/deferred-work.md` | Defers Level 7 provider orchestration design until Level 6 boundaries are accepted. |
+| Level 6 non-actions and blocked claims | `docs/evals/runs/alpha-solver-post-level-3-level-6-product-surface-design/non-actions.md` and `blocked-claims.md` | Blocks provider readiness, hosted fallback, provider fallback, API, dashboard, billing, benchmark, and evidence-promotion claims. |
+
+## Boundary inherited for this packet
+
+The reviewed evidence supports only a docs-only supporting reference for future provider orchestration design. This packet does not create a registry and does not call providers. It does not claim provider readiness, API readiness, dashboard readiness, product readiness, billing readiness, benchmark performance, model quality, or evidence promotion.
+
+Level 7 controls whether this reference is used.


### PR DESCRIPTION
### Motivation

- Provide a focused, docs-only reference for a future provider registry and capability schema to guide Level 7 provider orchestration design. 
- Capture required identity, capability, safety, provenance, cost, boundary, and default-off rules so future implementation lanes inherit clear constraints. 
- Verify preflight evidence that `main` contains the accepted Level 6 product-surface design packet and that Level 6 selected the Level 7 provider orchestration design lane. 

### Description

- Add a docs-only packet `ALPHA-SOLVER-POST-LEVEL-3-PROVIDER-REGISTRY-CAPABILITY-SCHEMA-PACKET-001` under `docs/evals/runs/alpha-solver-post-level-3-provider-registry-capability-schema/` containing a `README.md`, `source-evidence-reviewed.md`, `registry-overview.md`, `provider-identity-fields.md`, `capability-labels.md`, `mode-and-surface-compatibility.md`, `local-vs-hosted-boundaries.md`, `cost-and-quota-labels.md`, `disabled-default-off-state.md`, `non-actions.md`, `selected-next-action.md`, `blocker-fallback-lane.md`, and `checks-run.md`. 
- Define required provider identity fields (e.g. `provider_id`, `display_name`, `provider_family`, `integration_owner`, `registry_version`, `entry_status`, `source_packet`, `last_reviewed_at`) and constraints prohibiting secrets or readiness claims. 
- Introduce recommended capability labels (e.g. `text_generation`, `structured_output_candidate`, `tool_use_candidate`, `local_runtime_candidate`, `hosted_api_candidate`, `streaming_candidate`, `batch_candidate`, `eval_only_candidate`, `operator_review_required`, `evidence_restricted`), explicit mode and surface labels, local-vs-hosted boundary labels, conservative cost/quota labels, and fail-closed/disabled-default-off state rules. 
- Record evidence boundary and explicit non-actions making clear this packet does not create a registry, change runtime/provider/API/dashboard/CLI/checker/tests/Makefile/CI/source-artifact files, call providers, configure secrets, add routing/fallback, expose `/v1/solve` or dashboards, run models or benchmarks, perform billing work, or promote evidence. 
- Set selected next action to `NO_FURTHER_PROVIDER_REGISTRY_CAPABILITY_SCHEMA_LANES_SELECTED` and blocker fallback lane to `ALPHA-SOLVER-POST-LEVEL-3-PROVIDER-REGISTRY-CAPABILITY-SCHEMA-FIX-001`. 

### Testing

- Ran repository checks: `git status --short`, `git diff --name-only`, and `git diff --check`, which showed only new docs and no whitespace errors (PASS). 
- Ran guardrail and packet checks via `make check-local-llm-orchestration-guardrails` (which invokes `check_local_llm_evidence_boundaries.py`, `check_local_llm_doc_paths.py`, and `check_local_llm_packet_consistency.py`) and `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-provider-registry-capability-schema`, all of which passed (PASS). 
- Searched packet files with `rg` for required markers (selected next action, fallback token, default-off/boundary phrases) and confirmed presence (PASS). 
- Confirmed no runtime/provider/API/dashboard/CLI/checker/test/Makefile/CI/source-artifact files were changed (PASS).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26251270248329975eb4da43cc9fdb)