### PR TITLE
Add provider credentials & secrets boundary packet

### DIFF
--- a/docs/evals/runs/alpha-solver-post-level-3-provider-credentials-secrets-boundary/README.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-credentials-secrets-boundary/README.md
@@ -1,0 +1,43 @@
+# Provider Credentials and Secrets Boundary Packet
+
+Lane:
+`ALPHA-SOLVER-POST-LEVEL-3-PROVIDER-CREDENTIALS-SECRETS-BOUNDARY-PACKET-001`
+
+## Purpose
+
+This docs-only packet defines the provider credentials and secrets boundary for future Alpha Solver provider orchestration work. It records how future work should treat API keys, tokens, environment variables, secret references, redaction, logging restrictions, local-only settings, hosted-provider credentials, operator confirmation gates, and stop conditions before any provider implementation is authorized.
+
+The packet is a planning and review artifact only. It does not create, request, store, rotate, expose, validate, or configure credentials. It does not call providers, modify provider code, add fallback, expose `/v1/solve`, run models, run benchmarks, perform billing work, or promote evidence.
+
+## Scope boundary
+
+This packet is limited to documentation under this directory. It preserves the post-Level-3 evidence boundary and does not change runtime behavior, provider behavior, API behavior, dashboard behavior, CLI behavior, checker behavior, test behavior, Makefile behavior, CI behavior, or source-artifact content.
+
+Level 7 controls whether and how this packet is used. Future provider orchestration, credential handling, secret reference, provider fallback, hosted-provider, or billing work must be separately authorized by Level 7 and must not treat this packet as implementation approval.
+
+## Files in this packet
+
+- `source-evidence-reviewed.md` records source evidence reviewed for the boundary packet.
+- `secret-boundary-overview.md` summarizes the credential and secret trust boundary.
+- `credential-storage-rules.md` records storage and reference rules for credentials.
+- `environment-variable-rules.md` records environment variable rules.
+- `redaction-and-logging-rules.md` records redaction and logging restrictions.
+- `local-vs-hosted-secret-boundaries.md` records local-only and hosted-provider credential boundaries.
+- `operator-confirmation-gates.md` records operator confirmation gates.
+- `stop-conditions.md` records stop conditions for future work.
+- `non-actions.md` records explicit actions not taken by this docs-only packet.
+- `selected-next-action.md` records the selected next action.
+- `blocker-fallback-lane.md` records the blocker fallback lane.
+- `checks-run.md` records required checks and results.
+
+## Selected next action
+
+`NO_FURTHER_PROVIDER_CREDENTIALS_SECRETS_BOUNDARY_LANES_SELECTED`
+
+## Blocker fallback lane
+
+`ALPHA-SOLVER-POST-LEVEL-3-PROVIDER-CREDENTIALS-SECRETS-BOUNDARY-FIX-001`
+
+## Evidence boundary
+
+This packet is docs-only credentials/secrets boundary design. It does not create, request, store, rotate, expose, validate, or configure credentials. It does not call providers, modify provider code, add fallback, expose `/v1/solve`, run models, run benchmarks, perform billing work, or promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-credentials-secrets-boundary/blocker-fallback-lane.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-credentials-secrets-boundary/blocker-fallback-lane.md
@@ -1,0 +1,13 @@
+# Blocker Fallback Lane
+
+Blocker fallback lane:
+
+`ALPHA-SOLVER-POST-LEVEL-3-PROVIDER-CREDENTIALS-SECRETS-BOUNDARY-FIX-001`
+
+## Use condition
+
+Use this fallback lane only if the docs-only provider credentials/secrets boundary packet is incomplete, contradictory, unsafe, or missing required evidence-boundary language.
+
+## Boundary
+
+The fallback lane is for fixing this documentation packet. It is not approval to create, request, store, rotate, expose, validate, or configure credentials; call providers; modify provider code; add fallback; expose `/v1/solve`; run models; run benchmarks; perform billing work; or promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-credentials-secrets-boundary/checks-run.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-credentials-secrets-boundary/checks-run.md
@@ -1,0 +1,24 @@
+# Checks Run
+
+The required checks for this docs-only packet are:
+
+- `git status --short`
+- `git diff --name-only`
+- `git diff --check`
+- `make check-local-llm-orchestration-guardrails`
+- `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-provider-credentials-secrets-boundary`
+- `rg "NO_FURTHER_PROVIDER_CREDENTIALS_SECRETS_BOUNDARY_LANES_SELECTED|ALPHA-SOLVER-POST-LEVEL-3-PROVIDER-CREDENTIALS-SECRETS-BOUNDARY-FIX-001|credentials|secrets|redaction|does not create|does not configure|does not call providers" docs/evals/runs/alpha-solver-post-level-3-provider-credentials-secrets-boundary`
+
+## Expected boundary confirmation
+
+The checks should confirm that this packet is docs-only and that no runtime, provider, API, dashboard, CLI, checker, test, Makefile, CI, or source-artifact files changed.
+
+## Results
+
+- `git status --short` showed only the new docs-only packet directory before staging.
+- `git diff --name-only` showed no tracked-file modifications before staging because the packet files were still untracked.
+- `git diff --check` passed with no whitespace errors.
+- `make check-local-llm-orchestration-guardrails` passed.
+- `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-provider-credentials-secrets-boundary` passed.
+- The required `rg` command found the selected next action, blocker fallback lane, credentials/secrets/redaction language, and required non-action boundary phrases.
+- No runtime, provider, API, dashboard, CLI, checker, test, Makefile, CI, or source-artifact files were changed.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-credentials-secrets-boundary/credential-storage-rules.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-credentials-secrets-boundary/credential-storage-rules.md
@@ -1,0 +1,25 @@
+# Credential Storage Rules
+
+## Rules for future work
+
+- Do not store API keys, tokens, service account material, or hosted-provider credentials in repository files.
+- Do not add placeholder values that resemble real secrets, test keys, bearer tokens, private keys, or provider-specific credential formats.
+- Do not store credentials in docs, source artifacts, run packets, benchmark outputs, screenshots, dashboard snapshots, logs, or captured terminal output.
+- Prefer secret references over secret values when future Level 7-approved work needs to document a binding.
+- Treat any credential rotation, revocation, validation, or migration as separate Level 7-controlled implementation work.
+
+## Allowed documentation vocabulary
+
+Future docs may name generic concepts such as `API key`, `token`, `secret reference`, `environment variable name`, or `managed secret reference`. They must not include real credential values or realistic key-shaped examples.
+
+## Disallowed storage patterns
+
+- Inline credentials in source or docs.
+- Committed `.env` files containing secrets.
+- Hard-coded provider tokens in tests, fixtures, examples, or generated artifacts.
+- Credential values in issue notes, PR bodies, check logs, or evidence packets.
+- Secret payloads copied from hosted secret managers into local packet files.
+
+## Non-implementation status
+
+This document does not create, request, store, rotate, expose, validate, or configure credentials.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-credentials-secrets-boundary/environment-variable-rules.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-credentials-secrets-boundary/environment-variable-rules.md
@@ -1,0 +1,23 @@
+# Environment Variable Rules
+
+## Environment variable names
+
+Future Level 7-approved work may define environment variable names for provider orchestration only through an authorized spec or implementation lane. Variable names should describe purpose without embedding provider secrets or credential values.
+
+## Environment variable values
+
+- Environment variable values that contain API keys, tokens, credentials, or secret references must be treated as secret material.
+- Future tooling must not print full values to stdout, stderr, logs, dashboards, packet captures, or evidence artifacts.
+- Future diagnostics should report presence, absence, source category, or validation state without exposing values.
+- Any validation of environment variable values is implementation work and is outside this docs-only packet.
+
+## Local files and examples
+
+- Do not commit `.env` files with credentials.
+- Do not add realistic key-shaped sample values.
+- Do not instruct operators to paste secrets into docs, run packets, shell transcripts, screenshots, or PR descriptions.
+- If future Level 7 work needs examples, examples should use clearly non-secret labels rather than provider-shaped key material.
+
+## Non-implementation status
+
+This packet does not configure environment variables, does not validate environment variable values, does not call providers, and does not modify environment checking scripts.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-credentials-secrets-boundary/local-vs-hosted-secret-boundaries.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-credentials-secrets-boundary/local-vs-hosted-secret-boundaries.md
@@ -1,0 +1,23 @@
+# Local Versus Hosted Secret Boundaries
+
+## Local-only settings
+
+Local-only settings are scoped to developer or operator machines and must not be treated as approval for hosted-provider usage. A local secret reference must not be promoted into hosted execution, dashboards, shared evidence, CI, or benchmark runs without a Level 7-approved lane.
+
+## Hosted-provider credentials
+
+Hosted-provider credentials are sensitive production or managed-environment material. Future work must not copy hosted-provider credentials into local docs, local `.env` files, packet artifacts, screenshots, shell transcripts, source artifacts, or PR messages.
+
+## Boundary transitions
+
+Any transition between local-only settings and hosted-provider credentials must be explicitly authorized. Future work should require separate confirmation for:
+
+- moving from local-only configuration to hosted-provider configuration;
+- enabling provider calls from hosted infrastructure;
+- adding or changing secret manager references;
+- enabling billing-capable provider paths;
+- allowing benchmark or evidence workflows to use provider credentials.
+
+## Non-implementation status
+
+This document does not configure local settings, does not configure hosted-provider credentials, does not call providers, and does not perform billing work.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-credentials-secrets-boundary/non-actions.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-credentials-secrets-boundary/non-actions.md
@@ -1,0 +1,24 @@
+# Non-Actions
+
+This docs-only credentials/secrets boundary packet does not take any of the following actions:
+
+- Does not create credentials.
+- Does not request credentials.
+- Does not store credentials.
+- Does not rotate credentials.
+- Does not expose credentials.
+- Does not validate credentials.
+- Does not configure credentials.
+- Does not configure environment variables.
+- Does not add secrets, secret placeholders, example real keys, or provider-shaped key examples.
+- Does not call providers.
+- Does not modify provider code.
+- Does not add fallback.
+- Does not expose `/v1/solve`.
+- Does not run models.
+- Does not run benchmarks.
+- Does not perform billing work.
+- Does not promote evidence.
+- Does not modify runtime, provider, API, dashboard, CLI, checker, test, Makefile, CI, or source-artifact files.
+
+Level 7 controls whether and how this packet is used.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-credentials-secrets-boundary/operator-confirmation-gates.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-credentials-secrets-boundary/operator-confirmation-gates.md
@@ -1,0 +1,26 @@
+# Operator Confirmation Gates
+
+## Required future confirmations
+
+Future Level 7-approved provider orchestration work should require explicit operator confirmation before any of the following actions occur:
+
+- creating, importing, rotating, deleting, or validating a credential;
+- adding or changing a secret reference;
+- enabling provider calls with a configured credential reference;
+- enabling hosted-provider execution;
+- enabling fallback behavior that could call a provider;
+- running benchmarks or evidence workflows that could consume provider credentials;
+- exposing an API or dashboard path that could reveal credential state;
+- performing billing-relevant provider work.
+
+## Confirmation content
+
+A safe confirmation should identify the intended action, environment scope, provider scope, billing implication, redaction expectation, and stop condition. It should not display the secret value.
+
+## Default-deny posture
+
+If a future lane cannot prove that confirmation, redaction, and storage rules are satisfied, it should default to no provider call, no credential change, no benchmark execution, no evidence promotion, and no billing work.
+
+## Non-implementation status
+
+This packet does not request operator confirmation, does not validate credentials, does not call providers, and does not modify any confirmation UI or CLI path.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-credentials-secrets-boundary/redaction-and-logging-rules.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-credentials-secrets-boundary/redaction-and-logging-rules.md
@@ -1,0 +1,21 @@
+# Redaction and Logging Rules
+
+## Redaction principles
+
+Future provider orchestration work must redact secrets before any value can reach logs, dashboards, errors, traces, metrics, evidence packets, screenshots, or operator-facing summaries. Redaction must be applied to API keys, tokens, secret references when sensitive, provider request headers, authorization metadata, and any derived credential material.
+
+## Logging restrictions
+
+- Do not log raw credentials, credential substrings, bearer headers, provider tokens, service account payloads, or environment variable values.
+- Do not log provider request bodies or response bodies if they may contain credential material.
+- Do not use debug logs as an exception to secret redaction.
+- Do not add fallback paths that log credentials after a provider error.
+- Do not capture credentials in benchmark artifacts, model-run packets, or billing evidence.
+
+## Safe diagnostic shape for future work
+
+Future diagnostics may report non-sensitive states such as `credential reference configured`, `credential reference missing`, `redacted`, or `operator confirmation required`. The diagnostic must avoid secret values and avoid realistic key-shaped examples.
+
+## Non-implementation status
+
+This packet defines redaction and logging restrictions only. It does not implement redaction code, modify logging code, call providers, run models, or generate provider diagnostics.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-credentials-secrets-boundary/secret-boundary-overview.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-credentials-secrets-boundary/secret-boundary-overview.md
@@ -1,0 +1,22 @@
+# Secret Boundary Overview
+
+## Boundary statement
+
+Future provider orchestration work must treat API keys, bearer tokens, refresh tokens, service account material, hosted-provider credentials, environment variable values, secret manager payloads, and any derived authorization artifacts as secrets unless a later Level 7-approved spec explicitly classifies a value as non-secret.
+
+## Secret references versus secret values
+
+- Secret references may identify where a credential lives, such as a local environment variable name or a managed-secret identifier.
+- Secret values are the credential payloads themselves and must not be committed, logged, rendered in dashboards, embedded in docs, echoed in command output, or copied into evidence packets.
+- A future implementation may use references only after Level 7 authorizes the storage, retrieval, validation, logging, and operator-confirmation behavior.
+
+## Trust-boundary themes
+
+- Local development settings are not automatically safe for hosted execution.
+- Hosted-provider credentials are not automatically safe for local tooling, screenshots, packet evidence, or benchmark artifacts.
+- Provider orchestration code must not infer permission to call providers merely because a credential reference is present.
+- Evidence packets must not include credentials or unredacted secrets.
+
+## Non-implementation status
+
+This packet defines boundary rules only. It does not create credentials, does not configure credentials, does not call providers, and does not modify provider orchestration behavior.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-credentials-secrets-boundary/selected-next-action.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-credentials-secrets-boundary/selected-next-action.md
@@ -1,0 +1,13 @@
+# Selected Next Action
+
+Selected next action:
+
+`NO_FURTHER_PROVIDER_CREDENTIALS_SECRETS_BOUNDARY_LANES_SELECTED`
+
+## Decision
+
+No further provider credentials/secrets boundary lanes are selected by this packet. The packet is closed as docs-only boundary design.
+
+## Level control
+
+Level 7 controls whether and how this packet is used. This selected next action does not authorize implementation, provider orchestration, credential configuration, provider calls, fallback, benchmarks, billing work, or evidence promotion.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-credentials-secrets-boundary/source-evidence-reviewed.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-credentials-secrets-boundary/source-evidence-reviewed.md
@@ -1,0 +1,16 @@
+# Source Evidence Reviewed
+
+## Reviewed repository evidence
+
+- Repo-level agent instructions for Alpha Solver scope, source-of-truth expectations, safety constraints, and validation expectations.
+- Existing post-Level-3 docs-only packet structure under `docs/evals/runs/alpha-solver-post-level-3-*`.
+- Existing environment expectation documentation and scripts were considered only as evidence of where future work may need separate authorization; this packet does not modify or configure those files.
+- Existing provider and local LLM orchestration specs were considered only to identify sensitive boundary themes; this packet does not update specs or provider code.
+
+## Evidence boundary
+
+This review is docs-only credentials/secrets boundary design. It does not create, request, store, rotate, expose, validate, or configure credentials. It does not call providers, run models, run benchmarks, perform billing work, or promote evidence.
+
+## Level control
+
+Level 7 controls whether and how this packet is used. This source-evidence review is not approval to implement provider orchestration, credential storage, secret validation, provider fallback, hosted-provider configuration, billing, or evidence promotion.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-credentials-secrets-boundary/stop-conditions.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-credentials-secrets-boundary/stop-conditions.md
@@ -1,0 +1,20 @@
+# Stop Conditions
+
+Future provider orchestration work must stop and avoid provider calls, credential changes, benchmark execution, evidence promotion, and billing work when any of the following conditions are present:
+
+- a credential value appears in a repository file, packet artifact, log, screenshot, dashboard, source artifact, PR body, or terminal capture;
+- a provider key, token, bearer header, or service account payload would be printed or stored;
+- a secret reference is ambiguous between local-only and hosted-provider scope;
+- operator confirmation is missing for credential configuration, provider calls, fallback, benchmarks, billing, hosted execution, or evidence usage;
+- redaction behavior is absent, untested, or unable to cover relevant logs and artifacts;
+- future work would configure environment variables or hosted secret references without Level 7 authorization;
+- a runtime, provider, API, dashboard, CLI, checker, test, Makefile, CI, or source-artifact change is proposed outside its approved lane;
+- a provider call, model run, fallback path, benchmark, billing action, or evidence promotion would occur under a docs-only lane.
+
+## Required fallback
+
+If this packet is found incomplete, contradictory, or unsafe, use blocker fallback lane `ALPHA-SOLVER-POST-LEVEL-3-PROVIDER-CREDENTIALS-SECRETS-BOUNDARY-FIX-001` rather than implementing credential or provider behavior.
+
+## Non-implementation status
+
+These stop conditions are documentation only. They do not configure credentials, do not call providers, and do not implement runtime enforcement.


### PR DESCRIPTION
### Motivation

- Define a clear, docs-only boundary for how future provider orchestration work must treat credentials, secret references, environment variables, redaction, logging, local-vs-hosted secrets, operator confirmations, and stop conditions.
- Prevent accidental credential exposure by prescribing storage, logging, and redaction rules and by prohibiting credential values or realistic key-shaped examples in repository artifacts.
- Preserve the post-Level-3 evidence boundary and require Level 7 authorization before any implementation, credential handling, provider calls, billing, or evidence promotion occurs.

### Description

- Add a new docs-only packet at `docs/evals/runs/alpha-solver-post-level-3-provider-credentials-secrets-boundary/` containing focused files: `README.md`, `source-evidence-reviewed.md`, `secret-boundary-overview.md`, `credential-storage-rules.md`, `environment-variable-rules.md`, `redaction-and-logging-rules.md`, `local-vs-hosted-secret-boundaries.md`, `operator-confirmation-gates.md`, `stop-conditions.md`, `non-actions.md`, `selected-next-action.md`, `blocker-fallback-lane.md`, and `checks-run.md`.
- Each file records policy and boundary guidance only (how to treat secrets, allowed vocab, prohibited storage patterns, diagnostics shapes, operator confirmation expectations, and stop/fallback conditions) and explicitly states non-implementation status.
- Declare the selected next action as `NO_FURTHER_PROVIDER_CREDENTIALS_SECRETS_BOUNDARY_LANES_SELECTED` and the blocker fallback lane as `ALPHA-SOLVER-POST-LEVEL-3-PROVIDER-CREDENTIALS-SECRETS-BOUNDARY-FIX-001` and state that Level 7 controls use of this packet.
- Constrain the change set to documentation only and explicitly note that no runtime, provider, API, dashboard, CLI, checker, test, Makefile, CI, or source-artifact files were changed by this packet.

### Testing

- Ran the required checks: `git status --short`, `git diff --name-only`, and `git diff --check`, and they reported no tracked-file issues or whitespace errors prior to committing.
- Ran `make check-local-llm-orchestration-guardrails` and static doc checks including `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-provider-credentials-secrets-boundary` and the local LLM evidence-boundary and doc-path checks, and they all passed.
- Ran the `rg` search for the expected tokens and boundary language inside the new packet and it found the selected next action, blocker fallback lane, credentials/secrets/redaction language, and required non-action phrases.
- Confirmed via the packet consistency checks that the new packet is a valid docs-only packet and that no implementation or runtime files were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26251b29748329af3ba0a4160196bf)