### PR TITLE
Add provider routing and selection policy docs packet

### DIFF
--- a/docs/evals/runs/alpha-solver-post-level-3-provider-routing-selection-policy/README.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-routing-selection-policy/README.md
@@ -1,0 +1,34 @@
+# Alpha Solver Post-Level-3 Provider Routing Selection Policy Packet
+
+## Lane
+
+`ALPHA-SOLVER-POST-LEVEL-3-PROVIDER-ROUTING-SELECTION-POLICY-PACKET-001`
+
+## Objective
+
+This docs-only packet defines the future provider routing and selection policy requirements for Alpha Solver. It describes what future routing work must account for before any runtime/provider/API/dashboard implementation is proposed, enabled, shipped, or exposed.
+
+The packet covers future routing requirements, selection inputs, disallowed implicit routing, operator-visible routing decisions, capability matching, safety-first selection, and stop conditions.
+
+## Decision authority
+
+Level 7 controls whether and how this packet is used. This packet is a design packet only and does not approve, implement, activate, or operationalize provider routing or provider selection.
+
+## Evidence boundary
+
+This is docs-only routing and selection policy design. It does not implement routing, call providers, select providers at runtime, add fallback, modify runtime/provider/API/dashboard files, expose `/v1/solve`, run models, run benchmarks, perform billing work, or promote evidence.
+
+## Packet files
+
+- `source-evidence-reviewed.md` records the local repo evidence reviewed before drafting this packet.
+- `routing-policy-overview.md` defines the overall future routing policy requirements.
+- `selection-inputs.md` defines future provider-selection inputs.
+- `capability-matching.md` defines capability matching requirements.
+- `operator-visible-routing-decisions.md` defines operator-visible decision requirements.
+- `disallowed-implicit-routing.md` defines routing behavior that must not happen implicitly.
+- `safety-first-selection-rules.md` defines safety-first selection rules.
+- `stop-conditions.md` defines conditions that must stop future routing or selection.
+- `non-actions.md` records explicit non-actions and evidence limits.
+- `selected-next-action.md` records the selected next action.
+- `blocker-fallback-lane.md` records the blocker fallback lane.
+- `checks-run.md` records checks for this docs-only packet.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-routing-selection-policy/blocker-fallback-lane.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-routing-selection-policy/blocker-fallback-lane.md
@@ -1,0 +1,7 @@
+# Blocker Fallback Lane
+
+`ALPHA-SOLVER-POST-LEVEL-3-PROVIDER-ROUTING-SELECTION-POLICY-FIX-001`
+
+If this docs-only provider routing and selection policy packet is found incomplete, contradictory, outside the evidence boundary, or incompatible with Level 7 direction, use the blocker fallback lane above for a narrow docs-only fix.
+
+The blocker fallback lane must not implement routing, call providers, select providers at runtime, add fallback, expose `/v1/solve`, run models, run benchmarks, perform billing work, or promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-routing-selection-policy/capability-matching.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-routing-selection-policy/capability-matching.md
@@ -1,0 +1,40 @@
+# Capability Matching
+
+## Purpose
+
+Capability matching ensures that provider selection follows task requirements and safety requirements rather than convenience, availability, or implicit defaults.
+
+## Capability matching requirements
+
+A future provider selection policy must define a capability matrix before runtime use. The matrix should include:
+
+- supported task families;
+- supported input and output formats;
+- context-window limits;
+- structured-output guarantees;
+- tool-use permissions and prohibitions;
+- data-locality and egress characteristics;
+- deterministic or reproducibility controls;
+- logging and retention behavior;
+- safety filtering and refusal behavior;
+- rate-limit and quota constraints;
+- cost/billing profile;
+- operational maturity and known limitations.
+
+## Match outcomes
+
+Capability matching should produce one of these outcomes:
+
+1. **Eligible**: all mandatory task, safety, operator, and budget requirements are met.
+2. **Eligible with constraints**: requirements are met only with recorded constraints that the operator can review before execution.
+3. **Ineligible**: one or more mandatory requirements are not met.
+4. **Unknown**: required capability evidence is absent, stale, or unverifiable.
+5. **Stop**: no provider is safely selectable.
+
+## Unknown capability rule
+
+Unknown capability must not be treated as eligible capability. If a task requires a capability and the provider capability is unknown, the safe outcome is ineligible or stop, not optimistic routing.
+
+## No capability bypass
+
+Capability matching must not be bypassed by provider availability, cached success, manual convenience, or hidden fallback. Any future override must be explicit, operator-visible, bounded, and auditable.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-routing-selection-policy/checks-run.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-routing-selection-policy/checks-run.md
@@ -1,0 +1,13 @@
+# Checks Run
+
+The following checks are required for this docs-only packet:
+
+- `git status --short`
+- `git diff --name-only`
+- `git diff --check`
+- `make check-local-llm-orchestration-guardrails`
+- `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-provider-routing-selection-policy`
+- `rg "NO_FURTHER_PROVIDER_ROUTING_SELECTION_POLICY_LANES_SELECTED|ALPHA-SOLVER-POST-LEVEL-3-PROVIDER-ROUTING-SELECTION-POLICY-FIX-001|routing|selection|capability matching|implicit routing|does not implement|does not call providers" docs/evals/runs/alpha-solver-post-level-3-provider-routing-selection-policy`
+- Confirm no runtime/provider/API/dashboard files changed.
+
+Results are recorded in the PR summary rather than as generated logs in this packet.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-routing-selection-policy/disallowed-implicit-routing.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-routing-selection-policy/disallowed-implicit-routing.md
@@ -1,0 +1,32 @@
+# Disallowed Implicit Routing
+
+## Purpose
+
+Provider routing must not happen implicitly. Any future provider selection must be explicit, policy-governed, operator-visible, and bounded by stop conditions.
+
+## Disallowed implicit routing behaviors
+
+Future work must not select or call a provider based on:
+
+- provider import order;
+- first provider found in configuration;
+- first endpoint that responds;
+- silent fallback after provider failure;
+- local environment variables alone;
+- credential presence alone;
+- dashboard or API default values alone;
+- runtime convenience paths;
+- hidden model aliases;
+- stale previous run metadata;
+- benchmark scores without safety and operator gates;
+- billing availability alone;
+- cost or speed alone;
+- broad provider class labels without capability matching.
+
+## Disallowed hidden fallback
+
+Fallback must not be implicit. If future fallback is ever proposed, it must be separately authorized, operator-visible, bounded, logged, and subject to the same capability matching, safety-first selection, budget, and stop-condition requirements as primary selection.
+
+## Disallowed runtime activation
+
+This packet does not implement routing and does not call providers. It does not authorize runtime/provider/API/dashboard files to select providers, expose `/v1/solve`, add fallback, run models, run benchmarks, perform billing work, or promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-routing-selection-policy/non-actions.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-routing-selection-policy/non-actions.md
@@ -1,0 +1,21 @@
+# Non-Actions
+
+This packet is docs-only routing and selection policy design.
+
+It does not implement routing.
+
+It does not call providers.
+
+It does not select providers at runtime.
+
+It does not add fallback, retry, load balancing, model aliasing, or provider preference logic.
+
+It does not modify runtime, provider, API, dashboard, CLI, checker, test, Makefile, CI, or source-artifact files.
+
+It does not expose `/v1/solve` or any product surface.
+
+It does not run models, run benchmarks, perform billing work, create provider credentials, or change environment expectations.
+
+It does not promote evidence, approve evidence for product claims, or change the status of any existing eval result.
+
+Level 7 controls whether and how this packet is used.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-routing-selection-policy/operator-visible-routing-decisions.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-routing-selection-policy/operator-visible-routing-decisions.md
@@ -1,0 +1,34 @@
+# Operator-Visible Routing Decisions
+
+## Operator visibility principle
+
+Future routing decisions must be visible to operators before provider execution when the decision can affect data egress, cost, safety posture, evidence status, runtime behavior, or product-surface exposure.
+
+## Minimum visible fields
+
+A future operator-visible routing decision should display or log:
+
+- selected route state: selected provider, no-provider stop, or blocked;
+- provider and model identifier when applicable;
+- request/task class;
+- environment and surface where the decision applies;
+- eligible providers considered;
+- providers excluded and exclusion reasons;
+- selected provider reason;
+- capability matching result;
+- safety gate result;
+- budget/spend gate result;
+- data-egress posture;
+- fallback/retry authorization state;
+- evidence status and promotion boundary;
+- operator confirmation status;
+- stop condition if no provider is selected.
+
+## Before/after visibility
+
+- **Before execution**: operators should see the selected route state, data egress posture, budget gate, safety gate, and fallback/retry authorization.
+- **After execution**: operators should see the actual provider used, whether any fallback/retry occurred, final evidence status, and any stop/override reason.
+
+## Explainability requirement
+
+Future routing must produce a concise explanation that a non-implementing operator can understand. The explanation should distinguish capability fit, safety gate results, budget gate results, operator authorization, and availability.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-routing-selection-policy/routing-policy-overview.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-routing-selection-policy/routing-policy-overview.md
@@ -1,0 +1,37 @@
+# Routing Policy Overview
+
+## Policy purpose
+
+Future provider routing must be explicit, explainable, operator-visible, and safety-bounded. Routing must be treated as a policy decision, not as an incidental implementation detail hidden inside runtime/provider/API/dashboard code.
+
+## Future routing requirements
+
+Any future routing implementation proposal must define:
+
+1. **Decision authority**: which Level 7 approval or downstream implementation contract authorizes use of this packet.
+2. **Routing scope**: which request classes, provider classes, environments, and product surfaces are in scope.
+3. **Selection inputs**: the exact inputs used to choose a provider or stop selection.
+4. **Capability matching**: the required mapping from task needs to provider/model capabilities.
+5. **Safety-first rules**: conditions that prefer safe stop over provider selection.
+6. **Operator visibility**: the routing decision fields visible to operators before and after execution.
+7. **No implicit routing**: a guarantee that provider choice is not inferred from ambient configuration, import order, availability alone, or hidden fallback.
+8. **Stop conditions**: explicit conditions that prevent selection, execution, fallback, or retry.
+
+## Required future route decision shape
+
+A future route decision should be represented as a structured decision record before execution. At minimum, it should identify:
+
+- request class;
+- operator-approved environment;
+- eligible provider set;
+- excluded provider set with reasons;
+- selected provider or stop state;
+- required capability match;
+- safety and budget gates evaluated;
+- fallback/retry authorization state;
+- operator-visible explanation;
+- evidence boundary and promotion status.
+
+## Level 7 control
+
+Level 7 controls whether and how this packet is used. Nothing in this packet activates routing, chooses a provider, approves provider calls, or authorizes exposure of a product/API/dashboard surface.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-routing-selection-policy/safety-first-selection-rules.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-routing-selection-policy/safety-first-selection-rules.md
@@ -1,0 +1,29 @@
+# Safety-First Selection Rules
+
+## Principle
+
+Future provider selection must prefer a safe stop over an unsafe, unclear, unaudited, or unauthorized provider call.
+
+## Safety-first rules
+
+Future selection must stop when:
+
+- operator authorization is absent or ambiguous;
+- data sensitivity is unknown or incompatible with provider/data-egress policy;
+- required capability matching is absent, stale, unknown, or failed;
+- budget/spend limits are absent, exceeded, or unverifiable;
+- provider logging/retention behavior conflicts with the task;
+- the request requires local-only processing but only hosted providers are eligible;
+- the request could promote evidence without a separate promotion decision;
+- the provider route would expose a product/API/dashboard surface without approval;
+- fallback/retry would occur without explicit authorization;
+- safety classification is missing, contradictory, or outside policy;
+- the route decision cannot be explained to an operator.
+
+## Safety cannot be outweighed by convenience
+
+Cost, speed, provider availability, cached success, operator convenience, or implementation simplicity must not override missing safety gates. Safety gate failure results in stop, not degraded implicit routing.
+
+## Evidence safety
+
+Routing output is not promoted evidence by default. Any future evidence promotion must be decided by the appropriate downstream authority and must not be inferred from successful provider execution.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-routing-selection-policy/selected-next-action.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-routing-selection-policy/selected-next-action.md
@@ -1,0 +1,7 @@
+# Selected Next Action
+
+`NO_FURTHER_PROVIDER_ROUTING_SELECTION_POLICY_LANES_SELECTED`
+
+No further provider routing selection policy lanes are selected by this packet.
+
+Level 7 controls whether and how this packet is used. This selected next action does not authorize implementation, runtime provider selection, provider calls, fallback, API/dashboard exposure, model runs, benchmarks, billing work, or evidence promotion.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-routing-selection-policy/selection-inputs.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-routing-selection-policy/selection-inputs.md
@@ -1,0 +1,37 @@
+# Selection Inputs
+
+## Required explicit inputs
+
+Future provider selection must use only explicit, reviewable inputs. At minimum, a proposed implementation contract must identify whether each input is required, optional, operator supplied, policy supplied, or derived.
+
+Required future input categories:
+
+- **Task intent**: the task family, expected output type, and whether the task is evaluation, operator-assist, production-facing, or diagnostic.
+- **Capability requirements**: model/provider capabilities required for the task, including context length, tool permissions, structured output support, determinism controls, locality expectations, and safety controls.
+- **Data sensitivity**: whether the input includes private, regulated, customer, credential, source, evaluation, or embargoed evidence.
+- **Environment**: local-only, hosted-provider-allowed, offline, CI, manual-operator, or production-like context.
+- **Operator authorization**: explicit operator approval state for provider class, network use, spend, data egress, and evidence promotion.
+- **Budget constraints**: maximum spend, token/compute caps, retry limits, and billing status.
+- **Availability state**: provider health and readiness only as a gating input, never as the sole selection input.
+- **Safety gates**: prohibited data, missing consent, unsafe prompt class, missing capability proof, or unreviewed evidence.
+- **Evidence status**: whether the route is producing draft output, non-promotional evidence, or reviewed evidence eligible for a later promotion decision.
+
+## Inputs that must not select providers by themselves
+
+The following must not independently select a provider:
+
+- first configured provider;
+- first importable adapter;
+- first reachable endpoint;
+- lowest cost alone;
+- fastest response alone;
+- largest context window alone;
+- provider popularity;
+- environment variable presence alone;
+- previous successful run alone;
+- dashboard default alone;
+- hidden fallback from a failed provider.
+
+## Input recording requirement
+
+Future implementations must record the inputs used for a routing decision in an operator-readable form. If an input is unavailable, stale, contradictory, or outside policy, selection must stop rather than infer a provider.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-routing-selection-policy/source-evidence-reviewed.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-routing-selection-policy/source-evidence-reviewed.md
@@ -1,0 +1,16 @@
+# Source Evidence Reviewed
+
+## Purpose
+
+This file records the local repo evidence reviewed for the docs-only provider routing and selection policy packet.
+
+## Evidence reviewed
+
+- `AGENTS.md` was reviewed for repo-level workflow, validation, source-of-truth, and safety instructions.
+- Existing post-Level-3 packets under `docs/evals/runs/alpha-solver-post-level-3-*` were reviewed for packet structure, decision-authority wording, evidence-boundary wording, selected-next-action usage, blocker-fallback-lane usage, and checks-run style.
+- Existing local LLM/provider-oriented packets under `docs/evals/runs/20260604-alpha-local-llm-provider-*`, `docs/evals/runs/20260605-alpha-local-llm-provider-*`, and `docs/evals/runs/20260605-alpha-local-llm-solver-orchestration-*` were reviewed as context only.
+- `scripts/check_local_llm_packet_consistency.py` was reviewed to keep packet markers, selected-next-action, blocker fallback, and non-actions compatible with repo packet checks.
+
+## Evidence limits
+
+This review was inspect-only. It did not implement routing, does not call providers, does not select providers at runtime, does not add fallback behavior, does not expose `/v1/solve`, does not run models, does not run benchmarks, does not perform billing work, and does not promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-routing-selection-policy/stop-conditions.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-routing-selection-policy/stop-conditions.md
@@ -1,0 +1,28 @@
+# Stop Conditions
+
+## Stop-condition purpose
+
+Stop conditions define when future provider routing or selection must not proceed.
+
+## Required stop conditions
+
+Future routing and selection must stop when any of the following applies:
+
+1. Level 7 has not authorized use of this packet or a downstream implementation contract.
+2. The request class is outside the approved routing scope.
+3. The provider set is undefined, ambiguous, or not operator-approved.
+4. Required selection inputs are missing, stale, contradictory, or unverifiable.
+5. Required capability matching fails or returns unknown for a mandatory capability.
+6. Data sensitivity conflicts with provider locality, logging, retention, or egress policy.
+7. Budget, spend, billing, retry, or quota controls are absent or exceeded.
+8. Operator confirmation is required but missing.
+9. A provider would be selected by implicit default, hidden fallback, configuration order, credential presence, availability alone, cost alone, or speed alone.
+10. A fallback or retry would occur without explicit authorization.
+11. Execution would expose `/v1/solve` or any product/API/dashboard surface without separate approval.
+12. Execution would run a model, benchmark, provider call, or billing workflow outside the approved implementation scope.
+13. Execution would promote evidence or change evidence status without a separate promotion decision.
+14. The route decision cannot be logged or shown to the operator in an understandable form.
+
+## Stop outcome
+
+A stop is a valid routing outcome. Future systems should record the stop reason rather than silently choosing another provider or continuing through a hidden path.


### PR DESCRIPTION
### Motivation

- Define a docs-only policy packet that records future requirements and guardrails for provider routing and selection, ensuring routing is explicit, operator-visible, and safety-first before any runtime or product work is proposed.
- Provide a canonical evidence-boundary and non-actions list so downstream implementation proposals cannot implicitly activate routing, provider calls, or evidence promotion without Level 7 authorization.

### Description

- Added a new docs-only packet `ALPHA-SOLVER-POST-LEVEL-3-PROVIDER-ROUTING-SELECTION-POLICY-PACKET-001` under `docs/evals/runs/alpha-solver-post-level-3-provider-routing-selection-policy/` containing 13 markdown files (`README.md`, `source-evidence-reviewed.md`, `routing-policy-overview.md`, `selection-inputs.md`, `capability-matching.md`, `operator-visible-routing-decisions.md`, `disallowed-implicit-routing.md`, `safety-first-selection-rules.md`, `stop-conditions.md`, `non-actions.md`, `selected-next-action.md`, `blocker-fallback-lane.md`, `checks-run.md`).
- The packet records Level 7 as the decision authority, sets the selected next action to `NO_FURTHER_PROVIDER_ROUTING_SELECTION_POLICY_LANES_SELECTED`, and designates the blocker fallback lane `ALPHA-SOLVER-POST-LEVEL-3-PROVIDER-ROUTING-SELECTION-POLICY-FIX-001` for narrow docs-only fixes.
- Key policy content: explicit selection inputs required, capability-matching matrix and outcomes, operator-visible decision fields and explainability, disallowed implicit routing / hidden fallbacks, safety-first rules preferring stop over unsafe selection, and concrete stop conditions.
- Evidence boundary and non-actions are explicit: this is docs-only and does not implement routing, call providers, select providers at runtime, add fallback, expose `/v1/solve`, run models/benchmarks, perform billing work, or promote evidence.

### Testing

- Ran repository guardrail and packet checks which all passed: `git status --short`, `git diff --name-only`, `git diff --check`, `make check-local-llm-orchestration-guardrails`, and `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-provider-routing-selection-policy` (all succeeded).
- Ran a targeted grep to confirm required markers and phrases: `rg "NO_FURTHER_PROVIDER_ROUTING_SELECTION_POLICY_LANES_SELECTED|ALPHA-SOLVER-POST-LEVEL-3-PROVIDER-ROUTING-SELECTION-POLICY-FIX-001|routing|selection|capability matching|implicit routing|does not implement|does not call providers" docs/evals/runs/alpha-solver-post-level-3-provider-routing-selection-policy` (succeeded).
- Confirmed only the new docs packet files under `docs/evals/runs/alpha-solver-post-level-3-provider-routing-selection-policy/` were changed and no runtime/provider/API/dashboard/CLI/checker/test/Makefile/CI/source-artifact files were modified (check passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a262525ead48329970a9cc2df547072)