### PR TITLE
Add docs-only provider fallback fail-closed policy packet

### DIFF
--- a/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/README.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/README.md
@@ -1,0 +1,35 @@
+# Provider Fallback and Fail-Closed Policy Packet
+
+Lane:
+`ALPHA-SOLVER-POST-LEVEL-3-PROVIDER-FALLBACK-FAIL-CLOSED-POLICY-PACKET-001`
+
+## Purpose
+
+This docs-only packet defines future provider fallback and fail-closed policy boundaries for Alpha Solver after Level 3. It records when fallback is forbidden, explicit operator opt-in requirements, no-hosted-fallback defaults, blocked fallback states, audit requirements, safe failure behavior, stop conditions, and explicit non-actions.
+
+## Current accepted state
+
+The accepted upstream state remains bounded by post-Level-3 local orchestration planning and design artifacts. This packet does not add fallback, does not enable hosted fallback, does not call providers, does not modify runtime/provider/API/dashboard files, does not expose `/v1/solve`, does not run models, does not run benchmarks, does not perform billing work, and does not promote evidence.
+
+## Level 7 control
+
+Level 7 controls whether and how this packet is used. Future Level 7 review must decide whether these provider fallback and fail-closed requirements are accepted, amended, superseded, or held as non-binding reference material before any implementation, runtime policy, provider routing, API behavior, dashboard behavior, hosted fallback, billing, or evidence-promotion work relies on them.
+
+## Evidence boundary
+
+This is docs-only fallback/fail-closed policy design. It does not add fallback, enable hosted fallback, call providers, modify runtime/provider/API/dashboard files, expose `/v1/solve`, run models, run benchmarks, perform billing work, or promote evidence.
+
+## Packet files
+
+- `source-evidence-reviewed.md` records the source evidence reviewed for this packet.
+- `fallback-policy-overview.md` defines future fallback boundaries and default posture.
+- `fail-closed-requirements.md` defines safe failure behavior and fail-closed expectations.
+- `no-hosted-fallback-defaults.md` defines the default no-hosted-fallback posture.
+- `explicit-opt-in-rules.md` defines operator opt-in requirements.
+- `blocked-fallback-states.md` defines states where fallback is forbidden.
+- `fallback-audit-requirements.md` defines future auditability expectations.
+- `stop-conditions.md` defines conditions that stop fallback work or use.
+- `non-actions.md` preserves explicit non-actions and the evidence boundary.
+- `selected-next-action.md` records the selected next action.
+- `blocker-fallback-lane.md` records the blocker fallback lane.
+- `checks-run.md` records validation commands.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/blocked-fallback-states.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/blocked-fallback-states.md
@@ -1,0 +1,19 @@
+# Blocked Fallback States
+
+Fallback is forbidden in these states unless a later Level 7-controlled packet supersedes this list with narrower accepted rules:
+
+- local-only mode is required;
+- no-network mode is required;
+- no-hosted-fallback defaults apply;
+- explicit opt-in is absent, stale, ambiguous, revoked, or out of scope;
+- provider identity, endpoint locality, or hosted/local status is unknown;
+- billing policy, spend cap, account ownership, or payment authorization is unresolved;
+- secrets, credentials, tokens, or sensitive payloads would be exposed;
+- audit logging, decision logging, retention policy, or redaction policy is unavailable;
+- safety policy blocks the request or requires human review;
+- evidence boundary forbids provider calls, model runs, benchmarks, product-readiness claims, provider-readiness claims, billing work, or evidence promotion;
+- runtime, provider, API, dashboard, CLI, checker, test, Makefile, CI, or source-artifact changes are out of scope;
+- fallback would expose `/v1/solve` or alter API/dashboard behavior;
+- fallback would hide, rewrite, or downgrade a failure that should remain visible to reviewers.
+
+When any blocked fallback state is present, the safe outcome is blocked or fail-closed, not retry, hosted fallback, model execution, provider call, benchmark execution, billing work, or evidence promotion.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/blocker-fallback-lane.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/blocker-fallback-lane.md
@@ -1,0 +1,7 @@
+# Blocker Fallback Lane
+
+If this packet is incomplete, inconsistent, unsafe, stale, overbroad, insufficiently reviewable, or unable to preserve the evidence boundary, use blocker fallback lane:
+
+`ALPHA-SOLVER-POST-LEVEL-3-PROVIDER-FALLBACK-FAIL-CLOSED-POLICY-FIX-001`
+
+The fallback lane is for documentation repair only unless a later accepted Level 7-controlled governing packet explicitly authorizes a broader scope.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/checks-run.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/checks-run.md
@@ -1,0 +1,22 @@
+# Checks Run
+
+This file records the checks for `ALPHA-SOLVER-POST-LEVEL-3-PROVIDER-FALLBACK-FAIL-CLOSED-POLICY-PACKET-001`.
+
+## Commands and results
+
+- Passed: `git status --short`
+  - Showed only added docs files under `docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/` after intent-to-add.
+- Passed: `git diff --name-only`
+  - Showed only files under `docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/` after intent-to-add.
+- Passed: `git diff --check`
+  - No whitespace errors reported.
+- Passed: `make check-local-llm-orchestration-guardrails`
+  - Local LLM evidence-boundary static check passed.
+  - Local LLM doc path/link check passed.
+  - Local LLM packet consistency check passed.
+- Passed: `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy`
+  - Local LLM packet consistency check passed for this packet directory.
+- Passed: `rg "NO_FURTHER_PROVIDER_FALLBACK_FAIL_CLOSED_POLICY_LANES_SELECTED|ALPHA-SOLVER-POST-LEVEL-3-PROVIDER-FALLBACK-FAIL-CLOSED-POLICY-FIX-001|fallback|fail-closed|no-hosted-fallback|explicit opt-in|does not add fallback|does not call providers" docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy`
+  - Confirmed required decision, fallback lane, fallback, fail-closed, no-hosted-fallback, explicit opt-in, and non-action terms are present.
+- Passed: Confirm no runtime/provider/API/dashboard files changed.
+  - `git diff --name-only -- . ':!docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/**'` produced no changed files.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/explicit-opt-in-rules.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/explicit-opt-in-rules.md
@@ -1,0 +1,23 @@
+# Explicit Opt-In Rules
+
+## Operator opt-in requirement
+
+Future fallback requires explicit opt-in before any fallback behavior can be considered. Opt-in must be affirmative, scoped, reviewable, and revocable. Silence, default configuration, stale approval, inherited approval, environment drift, provider failure, or runtime convenience must not count as opt-in.
+
+## Required opt-in scope
+
+A future operator opt-in must identify:
+
+- the operator or reviewer role authorizing fallback;
+- the run, request class, or bounded operating window;
+- the allowed source provider or local path;
+- the allowed fallback provider or provider class;
+- whether hosted fallback remains forbidden or is narrowly allowed;
+- billing scope and spend limits, if any;
+- retention, redaction, and audit requirements;
+- stop conditions and revocation conditions;
+- the evidence boundary for outputs and failures.
+
+## Opt-in invalidation
+
+Opt-in is invalid when any scoped condition changes materially, when policy state is stale, when audit capture is unavailable, when billing scope is unresolved, when safety state is blocked, when the request is outside the authorized window, or when Level 7 has not controlled use of this packet.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/fail-closed-requirements.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/fail-closed-requirements.md
@@ -1,0 +1,22 @@
+# Fail-Closed Requirements
+
+## Required fail-closed behavior
+
+Future provider fallback policy must fail closed when authorization, configuration, locality, provider identity, billing scope, auditability, evidence boundary, or safety state is absent, stale, contradictory, or unreviewed.
+
+## Safe failure requirements
+
+A safe failure must:
+
+- avoid calling providers when provider calls are not explicitly authorized;
+- avoid hosted fallback when no-hosted-fallback defaults apply;
+- avoid billing activity unless explicitly authorized by a later governing packet;
+- avoid exposing `/v1/solve` or changing API/dashboard behavior;
+- avoid running models or benchmarks;
+- return or record a blocked/fail-closed state rather than silently degrading;
+- preserve enough bounded metadata for review without storing secrets, credentials, payment data, or raw sensitive payloads;
+- avoid converting a failure into product readiness, provider readiness, benchmark, billing, or promotional evidence.
+
+## Ambiguity handling
+
+Ambiguous fallback eligibility must be treated as ineligible. Ambiguous operator opt-in must be treated as absent. Ambiguous hosted-provider status must be treated as hosted and blocked unless a later Level 7-controlled policy proves otherwise.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/fallback-audit-requirements.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/fallback-audit-requirements.md
@@ -1,0 +1,29 @@
+# Fallback Audit Requirements
+
+## Audit purpose
+
+Future fallback audit records must make fallback decisions reviewable without requiring providers to be called, models to be run, benchmarks to be executed, billing events to be reproduced, or product surfaces to be exposed.
+
+## Required audit fields
+
+A future fallback audit record should include:
+
+- run ID or explicit statement that no run-scoped packet applies;
+- request ID or bounded request reference;
+- original provider/local path considered;
+- fallback provider/path considered;
+- hosted/local classification for each path;
+- explicit opt-in reference and scope;
+- Level 7 packet-use decision reference;
+- blocked fallback state, if any;
+- fail-closed reason, if any;
+- billing authorization state;
+- retention and redaction state;
+- safety policy state;
+- evidence-boundary state;
+- final decision: allowed, blocked, fail-closed, or reviewer-blocked;
+- UTC timestamp.
+
+## Audit boundaries
+
+Audit records must not store raw secrets, raw credentials, provider tokens, payment details, unredacted personal data, or raw sensitive payloads. Auditability must not be used as justification to add fallback, call providers, run models, run benchmarks, perform billing work, expose `/v1/solve`, modify runtime/provider/API/dashboard files, or promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/fallback-policy-overview.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/fallback-policy-overview.md
@@ -1,0 +1,24 @@
+# Fallback Policy Overview
+
+## Default posture
+
+Future provider fallback must be treated as forbidden unless a later Level 7-controlled decision explicitly authorizes a bounded fallback path. No hosted fallback is allowed by default.
+
+## Future fallback boundaries
+
+Any future fallback design must remain bounded by all of the following requirements before implementation can be considered:
+
+- Level 7 must control whether and how this packet is used.
+- Fallback must never be assumed from provider failure alone.
+- Fallback must never be used to bypass local-only, no-network, no-hosted-provider, evidence-boundary, privacy, safety, billing, or operator-review constraints.
+- Fallback must identify the original provider path, attempted fallback path, operator authorization state, audit state, blocked state, and safe failure outcome.
+- Fallback must distinguish routing eligibility from execution authorization.
+- Fallback must fail closed when policy, configuration, consent, auditability, or safety state is missing or contradictory.
+
+## When fallback is forbidden
+
+Fallback is forbidden when the request, environment, operator state, or evidence boundary requires local-only behavior, no hosted providers, no billing activity, no provider calls, no model runs, no `/v1/solve` exposure, no runtime change, no API change, or no dashboard change.
+
+## Safe failure posture
+
+If fallback cannot be proven authorized, bounded, auditable, and safe, the expected policy outcome is to stop and return a blocked or fail-closed state rather than silently retrying, routing to a hosted provider, exposing claims, or promoting evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/no-hosted-fallback-defaults.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/no-hosted-fallback-defaults.md
@@ -1,0 +1,19 @@
+# No-Hosted-Fallback Defaults
+
+## Default rule
+
+No hosted fallback is allowed by default. A local provider failure, timeout, missing model, unsupported route, or policy block must not automatically route to a hosted provider.
+
+## Hosted fallback prohibition
+
+Hosted fallback remains prohibited unless all of the following are true in a future approved scope:
+
+- Level 7 has accepted or amended this packet for use.
+- A later implementation contract explicitly authorizes hosted fallback.
+- The operator has explicitly opted in for the relevant run, request class, provider class, billing class, and retention/audit class.
+- Billing, privacy, safety, evidence, and audit boundaries are defined before any provider call.
+- The request is not in any blocked fallback state.
+
+## Missing configuration
+
+Missing fallback configuration, missing hosted-provider allowlists, missing credentials policy, missing billing policy, missing audit policy, or missing operator opt-in must produce a blocked or fail-closed result. Missing configuration must not produce best-effort hosted fallback.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/non-actions.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/non-actions.md
@@ -1,0 +1,9 @@
+# Non-Actions
+
+This packet is documentation only.
+
+It does not add fallback, does not enable hosted fallback, does not call providers, does not modify runtime/provider/API/dashboard files, does not expose `/v1/solve`, does not run models, does not run benchmarks, does not perform billing work, and does not promote evidence.
+
+It also does not modify runtime, provider, API, dashboard, CLI, checker, test, Makefile, CI, or source-artifact files. It does not add fallback behavior, hosted fallback, provider calls, model runs, benchmark execution, or billing work.
+
+Level 7 controls whether and how this packet is used.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/selected-next-action.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/selected-next-action.md
@@ -1,0 +1,9 @@
+# Selected Next Action
+
+Selected next action:
+
+`NO_FURTHER_PROVIDER_FALLBACK_FAIL_CLOSED_POLICY_LANES_SELECTED`
+
+No further provider fallback/fail-closed policy lanes are selected by this packet.
+
+Level 7 controls whether and how this packet is used.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/source-evidence-reviewed.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/source-evidence-reviewed.md
@@ -1,0 +1,13 @@
+# Source Evidence Reviewed
+
+## Reviewed local evidence
+
+This packet reviewed the repo-level agent instructions, post-Level-3 packet conventions, local orchestration guardrail expectations, and packet-consistency checker expectations needed to create a docs-only provider fallback and fail-closed policy packet.
+
+## Evidence boundary preserved
+
+The review was limited to local documentation and checker contracts. It did not add fallback, enable hosted fallback, call providers, modify runtime/provider/API/dashboard files, expose `/v1/solve`, run models, run benchmarks, perform billing work, or promote evidence.
+
+## Upstream state acknowledged
+
+The packet acknowledges that prior Level 3 evidence remains non-promotional local orchestration evidence. Level 7 controls whether and how this packet is used, accepted, amended, superseded, or rejected.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/stop-conditions.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/stop-conditions.md
@@ -1,0 +1,14 @@
+# Stop Conditions
+
+Fallback policy work or future fallback use must stop when any of the following conditions apply:
+
+- Level 7 has not decided whether and how this packet is used.
+- The requested scope would add fallback behavior in a docs-only lane.
+- Hosted fallback would be enabled by default.
+- Explicit opt-in is missing, stale, ambiguous, revoked, or not reviewable.
+- Any blocked fallback state is present.
+- Provider calls, model runs, benchmark execution, billing work, `/v1/solve` exposure, runtime changes, provider changes, API changes, dashboard changes, CLI changes, checker changes, test changes, Makefile changes, CI changes, or source-artifact changes would be required.
+- The evidence boundary would be weakened or promoted beyond non-promotional local orchestration evidence.
+- Audit, redaction, retention, safety, locality, or billing state cannot be proven before execution.
+
+The expected safe outcome after a stop condition is a blocked or fail-closed result with bounded review metadata, not fallback execution.


### PR DESCRIPTION
### Motivation

- Provide a focused, docs-only policy packet that defines future provider fallback boundaries, forbidden fallback states, explicit operator opt-in requirements, no-hosted-fallback defaults, safe failure/fail-closed behavior, audit/stop conditions, and explicit non-actions to guide any later implementation work.
- Preserve the post-Level-3 evidence boundary and ensure reviewers can decide whether and how the policy is used before any runtime, provider, API, dashboard, billing, or evidence-promotion changes occur.
- Entrust Level 7 with the control decision for whether and how this packet is accepted, amended, superseded, or used in implementation lanes.

### Description

- Added a new docs-only packet at `docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/` containing 13 files including `README.md`, `fallback-policy-overview.md`, `fail-closed-requirements.md`, `no-hosted-fallback-defaults.md`, `explicit-opt-in-rules.md`, `blocked-fallback-states.md`, `fallback-audit-requirements.md`, `stop-conditions.md`, `non-actions.md`, `selected-next-action.md`, `blocker-fallback-lane.md`, `source-evidence-reviewed.md`, and `checks-run.md` that together define the packet content and index.
- Key policy outcomes: default-forbidden fallback posture, `no-hosted-fallback` by default, explicit affirmative and scoped operator opt-in required for any future fallback, ambiguous or missing authorization/configuration/audit/billing/locality/safety state must fail closed, and safe failure must record a blocked/fail-closed outcome rather than silently routing to hosted providers or running models/billing.
- Selected next action is `NO_FURTHER_PROVIDER_FALLBACK_FAIL_CLOSED_POLICY_LANES_SELECTED` and the blocker fallback lane is `ALPHA-SOLVER-POST-LEVEL-3-PROVIDER-FALLBACK-FAIL-CLOSED-POLICY-FIX-001` as recorded in the packet.
- Evidence boundary preserved: the packet is explicitly docs-only and does not add fallback, enable hosted fallback, call providers, modify runtime/provider/API/dashboard files, expose `/v1/solve`, run models or benchmarks, perform billing work, or promote evidence.

### Testing

- Ran repository/docs checks and guardrails: `git status --short` and `git diff --name-only` showed only the new packet files, and `git diff --check` reported no whitespace errors (all passed).
- Ran `make check-local-llm-orchestration-guardrails` and its subchecks (`check_local_llm_evidence_boundaries.py`, `check_local_llm_doc_paths.py`, `check_local_llm_packet_consistency.py`) and they passed for the new packet.
- Ran the targeted packet consistency check `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy` and the `rg` search for required decision/fallback/fail-closed terms and both checks passed.
- Confirmed no non-doc runtime/provider/API/dashboard/CLI/checker/test/Makefile/CI/source-artifact files were changed by checking diffs outside the new docs directory and found no changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26252f219483298ca63bc518f26275)