### PR TITLE
Add docs-only provider timeout/retry/circuit-breaker packet

### DIFF
--- a/docs/evals/runs/alpha-solver-post-level-3-provider-timeout-retry-circuit-breaker/README.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-timeout-retry-circuit-breaker/README.md
@@ -1,0 +1,36 @@
+# Alpha Solver post-Level-3 provider timeout/retry/circuit-breaker packet
+
+Lane: `ALPHA-SOLVER-POST-LEVEL-3-PROVIDER-TIMEOUT-RETRY-CIRCUIT-BREAKER-PACKET-001`
+
+## Objective
+
+This docs-only packet defines a future provider timeout, retry, and circuit-breaker design boundary for Alpha Solver. It records the policy questions that must be settled before any provider orchestration implementation can be selected.
+
+The packet covers:
+
+- future timeout budgets;
+- retry limits;
+- circuit-breaker behavior;
+- fail-closed behavior;
+- operator-visible status;
+- budget and cost guardrails;
+- failure and stop conditions;
+- explicit non-actions.
+
+## Decision state
+
+Selected next action:
+
+`NO_FURTHER_PROVIDER_TIMEOUT_RETRY_CIRCUIT_BREAKER_LANES_SELECTED`
+
+Blocker fallback lane:
+
+`ALPHA-SOLVER-POST-LEVEL-3-PROVIDER-TIMEOUT-RETRY-CIRCUIT-BREAKER-FIX-001`
+
+Level 7 controls whether and how this packet is used. This packet does not authorize implementation by itself.
+
+## Evidence boundary
+
+This packet is docs-only timeout/retry/circuit-breaker design. It does not implement timeouts, retries, circuit breakers, provider calls, fallback, runtime changes, model inference, benchmarks, billing, or evidence promotion.
+
+It does not call providers and does not create provider behavior evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-timeout-retry-circuit-breaker/blocker-fallback-lane.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-timeout-retry-circuit-breaker/blocker-fallback-lane.md
@@ -1,0 +1,9 @@
+# Blocker fallback lane
+
+If this packet is found incomplete, inconsistent, or insufficient for Level 7 review, the blocker fallback lane is:
+
+`ALPHA-SOLVER-POST-LEVEL-3-PROVIDER-TIMEOUT-RETRY-CIRCUIT-BREAKER-FIX-001`
+
+## Fallback scope
+
+The fallback lane may only repair this docs-only packet unless separately authorized. It must preserve the evidence boundary and must not implement provider calls, timeouts, retries, circuit breakers, fallback, runtime changes, benchmarks, billing, or evidence promotion.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-timeout-retry-circuit-breaker/budget-and-cost-guards.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-timeout-retry-circuit-breaker/budget-and-cost-guards.md
@@ -1,0 +1,29 @@
+# Budget and cost guards
+
+## Policy intent
+
+Future timeout, retry, and circuit-breaker behavior must be constrained by budget and cost guardrails before provider orchestration can run. Cost controls must be defined before any retry expansion increases provider spend.
+
+## Required future guardrails
+
+A future implementation must define:
+
+- per-request maximum provider attempts;
+- per-request estimated maximum token budget;
+- per-request estimated maximum provider cost;
+- per-tenant or per-operator spend controls, if the future lane supports tenancy;
+- behavior when estimated cost is unknown;
+- accounting fields for attempts, retry count, timeout status, breaker state, and final status;
+- stop behavior when a cost or budget guard is exceeded.
+
+## Unknown-cost behavior
+
+Unknown cost must not be fabricated. If a future request cannot estimate or record the required budget fields safely, the implementation must either omit unknown values in explicit allowlisted records or fail closed when the missing value is required for a pre-call guard.
+
+## Retry cost interaction
+
+Retry policy must count all attempts against budget. A later implementation must not treat retries as free, invisible, or outside budget accounting.
+
+## Billing boundary
+
+This packet does not perform billing work, does not query billing APIs, does not create spend dashboards, does not persist budget ledgers, and does not promote any cost evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-timeout-retry-circuit-breaker/checks-run.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-timeout-retry-circuit-breaker/checks-run.md
@@ -1,0 +1,14 @@
+# Checks run
+
+## Completed checks
+
+- `git status --short` — passed; only this docs-only packet directory was untracked before commit.
+- `git diff --name-only` — passed; no tracked-file diff was present before adding the new docs-only packet.
+- `git diff --check` — passed with no whitespace errors.
+- `make check-local-llm-orchestration-guardrails` — passed.
+- `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-provider-timeout-retry-circuit-breaker` — passed for this packet directory.
+- `rg "NO_FURTHER_PROVIDER_TIMEOUT_RETRY_CIRCUIT_BREAKER_LANES_SELECTED|ALPHA-SOLVER-POST-LEVEL-3-PROVIDER-TIMEOUT-RETRY-CIRCUIT-BREAKER-FIX-001|timeout|retry|circuit-breaker|budget|does not implement|does not call providers" docs/evals/runs/alpha-solver-post-level-3-provider-timeout-retry-circuit-breaker` — passed and found the required decision, fallback, boundary, and policy terms.
+
+## Runtime/provider/API/dashboard confirmation
+
+No runtime, provider, API, dashboard, CLI, checker, test, Makefile, CI, or source-artifact files were changed by this docs-only packet.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-timeout-retry-circuit-breaker/circuit-breaker-policy.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-timeout-retry-circuit-breaker/circuit-breaker-policy.md
@@ -1,0 +1,42 @@
+# Circuit-breaker policy
+
+## Policy intent
+
+Future provider orchestration must define circuit-breaker behavior before enabling repeated provider calls across requests. The breaker must protect users, operators, and budgets from repeated failing provider interactions.
+
+## Required breaker states
+
+A future implementation must define stable state labels equivalent to:
+
+- `closed`: provider attempts are allowed subject to normal guards;
+- `open`: provider attempts are blocked and fail closed;
+- `half_open`: a bounded probe may be allowed only if explicitly authorized by the future implementation lane.
+
+## Required opening conditions
+
+A future implementation must define quantitative thresholds for opening the circuit, such as:
+
+- consecutive retry-exhausted provider failures;
+- rolling-window timeout rate;
+- rolling-window provider error rate;
+- rolling-window budget guard failures;
+- provider safety or SAFE-OUT rejection rate when applicable;
+- operator-forced open state.
+
+## Required closing and probing conditions
+
+A future implementation must define:
+
+- cool-down duration before any half-open probe;
+- maximum half-open probes;
+- success criteria to return to closed;
+- failure criteria to return to open;
+- whether breaker state is process-local, persistent, tenant-scoped, provider-scoped, model-scoped, or route-scoped.
+
+## Fail-closed requirement
+
+When breaker state is missing, corrupted, stale beyond an accepted window, or impossible to evaluate safely, provider orchestration must fail closed. It must not silently ignore breaker state or route to another provider as fallback.
+
+## Evidence boundary
+
+This circuit-breaker policy is docs-only. It does not add circuit-breaker state, provider calls, retries, fallback, runtime behavior, dashboards, tests, benchmarks, billing, or evidence promotion.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-timeout-retry-circuit-breaker/failure-and-stop-conditions.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-timeout-retry-circuit-breaker/failure-and-stop-conditions.md
@@ -1,0 +1,36 @@
+# Failure and stop conditions
+
+## Stop conditions before provider orchestration
+
+Future provider orchestration must not start when:
+
+- provider mode is not explicitly enabled by an approved future implementation lane;
+- required timeout budgets are absent or invalid;
+- required retry limits are absent or invalid;
+- circuit-breaker state is open;
+- circuit-breaker state cannot be evaluated safely;
+- provider credentials are absent, invalid, or unsafe to use;
+- budget guardrails reject the request;
+- request shape is malformed or unsafe;
+- safety policy blocks the request;
+- operator policy has disabled the provider route.
+
+## Stop conditions during attempts
+
+A future implementation must stop attempts when:
+
+- the overall request timeout would be exceeded;
+- retry limits are exhausted;
+- the circuit breaker opens;
+- budget or cost guards are exceeded;
+- a non-retryable provider error occurs;
+- provider output is unsafe or cannot be normalized safely;
+- required operator-visible status cannot be produced safely.
+
+## Final fail-closed behavior
+
+Fail-closed outcomes must be explicit and must not masquerade as successful model answers. Fail-closed status must be operator-visible through allowlisted fields and must not expose raw provider payloads or secrets.
+
+## Evidence boundary
+
+This failure-and-stop policy is docs-only. It does not implement runtime stop conditions, provider calls, provider fallback, retries, circuit breakers, timeout enforcement, billing, benchmarks, or evidence promotion.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-timeout-retry-circuit-breaker/non-actions.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-timeout-retry-circuit-breaker/non-actions.md
@@ -1,0 +1,33 @@
+# Non-actions
+
+This packet intentionally does not perform any implementation work.
+
+## Explicit non-actions
+
+This packet does not:
+
+- implement timeouts;
+- implement retries;
+- implement circuit breakers;
+- call providers;
+- add provider fallback;
+- change runtime code;
+- change provider code;
+- change API behavior;
+- change dashboard behavior;
+- change CLI behavior;
+- change checker behavior;
+- change tests;
+- change Makefile or CI behavior;
+- run models;
+- run benchmarks;
+- perform billing work;
+- query billing APIs;
+- create source artifacts;
+- promote evidence;
+- claim production readiness;
+- claim provider orchestration readiness.
+
+## Governance boundary
+
+Level 7 controls whether and how this packet is used. No implementation lane is selected by this packet.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-timeout-retry-circuit-breaker/operator-visible-status.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-timeout-retry-circuit-breaker/operator-visible-status.md
@@ -1,0 +1,32 @@
+# Operator-visible status
+
+## Policy intent
+
+Operators must be able to determine whether provider orchestration is disabled, timed out, retry-exhausted, circuit-open, budget-blocked, or fail-closed without seeing secrets or raw provider payloads.
+
+## Required future status fields
+
+A future implementation must define stable, allowlisted status fields for:
+
+- provider identifier;
+- model identifier;
+- route or mode;
+- timeout budget selected;
+- attempt count;
+- retry count;
+- retry-exhausted status;
+- circuit-breaker state;
+- circuit-breaker reason;
+- budget status;
+- fail-closed reason;
+- final operator-visible outcome.
+
+## Redaction and allowlist rules
+
+Operator-visible status must not include API keys, authorization headers, bearer tokens, raw prompts, raw system prompts, raw request bodies, raw provider response bodies, tracebacks, raw exception strings, raw metadata dumps, environment dumps, billing account identifiers, or secret-bearing config values.
+
+The future implementation must build status records from an explicit allowlist rather than capturing broad objects and redacting after the fact.
+
+## Evidence boundary
+
+This status policy is docs-only. It does not add telemetry, logs, dashboards, API fields, CLI output, runtime calls, provider calls, retries, circuit breakers, billing, or evidence promotion.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-timeout-retry-circuit-breaker/retry-policy.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-timeout-retry-circuit-breaker/retry-policy.md
@@ -1,0 +1,38 @@
+# Retry policy
+
+## Policy intent
+
+Future provider orchestration must use bounded retries only for retryable provider failures. Retries must be opt-in through the future implementation authority and must never create unbounded loops.
+
+## Required future retry limits
+
+Before implementation, a future lane must define:
+
+- maximum attempts per provider request, including the first attempt;
+- maximum retry count after the first failed attempt;
+- retryable status or error categories;
+- non-retryable status or error categories;
+- backoff schedule and jitter rules, if any;
+- retry budget interaction with request timeout and cost ceilings;
+- stable operator-visible retry status fields;
+- deterministic stop behavior when retry limits are exhausted.
+
+## Required retry exclusions
+
+A future implementation must not retry:
+
+- authentication or authorization failures;
+- malformed requests;
+- policy or safety denials;
+- budget-exceeded decisions;
+- non-idempotent calls unless a future spec proves the request is safe to retry;
+- provider responses that are already accepted as final;
+- failures where retry would exceed the request timeout or cost budget.
+
+## Cost and visibility requirements
+
+Every attempted provider call must be accountable to operator-visible status and cost guardrails. Retry count must be visible as metadata or telemetry without exposing secrets, prompts, raw payloads, or raw exception strings.
+
+## Evidence boundary
+
+This retry policy is docs-only. It does not implement retries, backoff, jitter, provider calls, provider fallback, runtime changes, model inference, benchmarks, billing, or evidence promotion.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-timeout-retry-circuit-breaker/selected-next-action.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-timeout-retry-circuit-breaker/selected-next-action.md
@@ -1,0 +1,11 @@
+# Selected next action
+
+Selected next action:
+
+`NO_FURTHER_PROVIDER_TIMEOUT_RETRY_CIRCUIT_BREAKER_LANES_SELECTED`
+
+## Interpretation
+
+No further provider timeout/retry/circuit-breaker lanes are selected by this packet.
+
+Level 7 controls whether and how this packet is used. This selected action does not authorize provider orchestration implementation.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-timeout-retry-circuit-breaker/source-evidence-reviewed.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-timeout-retry-circuit-breaker/source-evidence-reviewed.md
@@ -1,0 +1,22 @@
+# Source evidence reviewed
+
+## Reviewed source-of-truth materials
+
+The packet was drafted against the repository's existing documentation and specification boundaries, including:
+
+- repo-level agent instructions requiring narrow scoped changes and docs/spec review before behavior changes;
+- provider budget documentation that treats provider accounting as post-call and explicitly separates accounting from hard budget enforcement;
+- provider expert-pass documentation that preserves bounded calls, no loops, no fallback, explicit opt-in, and no production-readiness claims;
+- provider SAFE-OUT documentation that requires fail-closed treatment for unsafe provider output;
+- local LLM solver orchestration documentation that preserves finite timeout, default-off, no-hosted-fallback, and fail-closed boundaries;
+- Level 3 closeout/operator materials that leave downstream use controlled by later governance.
+
+## Evidence interpretation
+
+The reviewed materials support a docs-only packet that defines constraints before provider orchestration work. They do not provide runtime proof of provider timeout, retry, circuit-breaker, fallback, billing, or benchmark behavior.
+
+## Boundary preserved
+
+This review does not implement timeout, retry, circuit-breaker, budget enforcement, provider fallback, runtime routing, API behavior, dashboard behavior, CLI behavior, model inference, benchmark execution, billing integration, or evidence promotion.
+
+This packet does not call providers.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-timeout-retry-circuit-breaker/timeout-policy.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-timeout-retry-circuit-breaker/timeout-policy.md
@@ -1,0 +1,33 @@
+# Timeout policy
+
+## Policy intent
+
+Future provider orchestration must use finite timeout budgets for every provider interaction. No provider call may wait indefinitely, and no retry sequence may exceed the request-level time budget selected by the future implementation authority.
+
+## Required future budget layers
+
+A future implementation must define all of the following before provider orchestration can be enabled:
+
+1. **Per-call connect timeout**: maximum time allowed to establish the provider connection.
+2. **Per-call read timeout**: maximum time allowed to wait for provider response bytes after connection.
+3. **Per-call total timeout**: maximum wall-clock budget for a single provider attempt.
+4. **Overall request timeout**: maximum wall-clock budget across all attempts, retry delay, safety checks, and final response shaping.
+5. **Operator-visible timeout reason**: stable reason code when timeout causes a fail-closed result.
+
+## Candidate constraints for later implementation
+
+A future implementation should prefer conservative defaults:
+
+- exact budgets must be explicit configuration, not implicit library defaults;
+- lower environments may use shorter budgets than production-like controlled runs;
+- retry delay must count against the overall request timeout;
+- provider timeout errors must not be hidden as successful answers;
+- timeout status must be observable without exposing prompts, raw provider payloads, headers, secrets, or stack traces.
+
+## Fail-closed requirement
+
+If any required timeout budget is missing, unbounded, non-numeric, or impossible to enforce, provider orchestration must remain disabled or fail closed. A timeout must not trigger hosted fallback, model substitution, or unbounded retry.
+
+## Evidence boundary
+
+This timeout policy is a design packet only. It does not implement timeout enforcement, runtime configuration, provider calls, provider fallback, retries, circuit-breaker logic, or billing behavior.


### PR DESCRIPTION
### Motivation

- Establish a docs-only design packet that records the required timeout budgets, retry limits, circuit-breaker behavior, fail-closed rules, operator-visible status, cost guardrails, and stop conditions before any provider orchestration is implemented. 
- Preserve a strict evidence boundary so that this lane specifies policy but does not change runtime, provider, billing, or CI behavior. 
- Surface decision requirements and a blocker fallback so Level 7 governance can decide whether and how to use the packet. 

### Description

- Add a new packet at `docs/evals/runs/alpha-solver-post-level-3-provider-timeout-retry-circuit-breaker/` containing `README.md`, `source-evidence-reviewed.md`, `timeout-policy.md`, `retry-policy.md`, `circuit-breaker-policy.md`, `budget-and-cost-guards.md`, `operator-visible-status.md`, `failure-and-stop-conditions.md`, `non-actions.md`, `selected-next-action.md`, `blocker-fallback-lane.md`, and `checks-run.md` that together define the design boundary. 
- Record required policy artifacts including per-call connect/read/total timeout layers, overall request timeout, explicit retry limits and exclusions, circuit-breaker states and thresholds, budget/cost guardrails, operator-visible allowlisted status fields, and deterministic stop/fail-closed behavior. 
- Declare the selected next action as `NO_FURTHER_PROVIDER_TIMEOUT_RETRY_CIRCUIT_BREAKER_LANES_SELECTED` and the blocker fallback lane as `ALPHA-SOLVER-POST-LEVEL-3-PROVIDER-TIMEOUT-RETRY-CIRCUIT-BREAKER-FIX-001`, and state that Level 7 controls whether and how this packet is used. 
- Explicitly document non-actions and the evidence boundary: this packet does not implement timeouts, retries, circuit breakers, provider calls, fallback, runtime changes, model inference, benchmarks, billing, or evidence promotion. 

### Testing

- Ran `git status --short`, `git diff --name-only`, and `git diff --check` to validate workspace state and whitespace (checks passed). 
- Ran `make check-local-llm-orchestration-guardrails`, which executes the repo's static doc/packet checks and returned success. 
- Ran `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-provider-timeout-retry-circuit-breaker`, which validated packet consistency (passed). 
- Ran `rg` for required decision/fallback/policy terms in the packet directory and confirmed the presence of `NO_FURTHER_PROVIDER_TIMEOUT_RETRY_CIRCUIT_BREAKER_LANES_SELECTED`, `ALPHA-SOLVER-POST-LEVEL-3-PROVIDER-TIMEOUT-RETRY-CIRCUIT-BREAKER-FIX-001`, and policy keywords (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a262536d45083298839ca2525f1bcea)