### PR TITLE
Add provider fallback fail-closed policy packet (docs-only)

### DIFF
--- a/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/README.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/README.md
@@ -1,0 +1,25 @@
+# Provider fallback fail-closed policy packet
+
+Lane: `ALPHA-SOLVER-POST-LEVEL-3-PROVIDER-FALLBACK-FAIL-CLOSED-POLICY-PACKET-001`
+
+This packet is a docs-only supporting reference for future Alpha Solver provider orchestration work. It replaces closed PR #415 with a clean policy packet and records fallback boundaries before any future provider fallback implementation is considered.
+
+## Accepted prior state
+
+- Level 2 controlled usage is closed as local operator usability evidence only.
+- Level 3 validation execution is closed as artifact-complete, non-promotional local orchestration evidence only.
+- Level 4 pre-product-surface requirements are accepted.
+- Level 5 quality evaluation design is accepted.
+- Level 6 product-surface design is accepted.
+- Level 7 provider orchestration design is accepted through `ALPHA-SOLVER-POST-LEVEL-3-LEVEL-7-PROVIDER-ORCHESTRATION-DESIGN-PACKET-001`.
+- Level 7 selected `ALPHA-SOLVER-POST-LEVEL-3-LEVEL-8-MVP-READINESS-REVIEW-PACKET-001` as the next lane.
+
+## Packet role
+
+This packet defines a default-forbidden fallback stance, no-hosted-fallback defaults, fail-closed requirements, explicit opt-in requirements, blocked states, audit requirements, stop conditions, and non-actions.
+
+Level 7 controls whether and how this packet is used, revised, rejected, or superseded. This packet is a supporting reference only. It does not start Level 8.
+
+## Evidence boundary
+
+Docs-only fallback and fail-closed policy design. This does not add fallback, does not enable hosted fallback, does not call providers, does not modify runtime/provider/API/dashboard files, does not expose `/v1/solve`, does not run local models, does not run hosted models, does not run Ollama, does not run benchmarks, does not perform billing work, and does not promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/blocked-fallback-states.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/blocked-fallback-states.md
@@ -1,0 +1,25 @@
+# Blocked fallback states
+
+Fallback is blocked and must fail closed when any of the following states exists:
+
+- missing provider provenance;
+- missing credential boundary;
+- missing cost boundary;
+- ambiguous authorization;
+- unsafe claim boundary;
+- stale evidence;
+- missing audit fields;
+- unclear local-vs-hosted state;
+- unknown provider identity;
+- unknown model identity;
+- unregistered capability boundary;
+- unreviewed credential or secret handling;
+- unavailable cost estimate or budget enforcement;
+- circuit-breaker state that cannot be reconstructed;
+- retry state that could duplicate provider work without operator approval;
+- timeout state that could hide partial provider work;
+- output safety state that cannot be tied to the selected provider path;
+- product-surface state that could imply readiness or promotion;
+- any requested fallback outside the accepted future lane scope.
+
+A blocked fallback state must not be bypassed by convenience, availability, latency, quality expectations, credential presence, or operator urgency.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/blocker-fallback-lane.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/blocker-fallback-lane.md
@@ -1,0 +1,7 @@
+# Blocker fallback lane
+
+`ALPHA-SOLVER-POST-LEVEL-3-PROVIDER-FALLBACK-FAIL-CLOSED-POLICY-FIX-001`
+
+Use this blocker fallback lane only if this packet is found incomplete, inconsistent with accepted Level 7 boundaries, or too ambiguous to serve as a supporting reference.
+
+The blocker fallback lane must remain docs-only unless separately authorized by a future accepted lane.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/checks-run.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/checks-run.md
@@ -1,0 +1,12 @@
+# Checks run
+
+The following checks were run for this docs-only provider fallback fail-closed policy packet:
+
+- `git status --short`
+- `git diff --name-only`
+- `git diff --check`
+- `make check-local-llm-orchestration-guardrails`
+- `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy`
+- `rg "docs/evals/runs/alpha-solver-post-level-3-level-7-provider-orchestration-design|docs/local_llm_solver_orchestration_guardrails|scripts/check_local_llm_packet_consistency.py|NO_FURTHER_PROVIDER_FALLBACK_FAIL_CLOSED_POLICY_LANES_SELECTED|ALPHA-SOLVER-POST-LEVEL-3-PROVIDER-FALLBACK-FAIL-CLOSED-POLICY-FIX-001|does not add fallback|does not call providers|fail-closed|no-hosted-fallback" docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy`
+
+All checks passed before commit.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/explicit-opt-in-rules.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/explicit-opt-in-rules.md
@@ -1,0 +1,17 @@
+# Explicit opt-in rules
+
+Any future fallback behavior requires explicit operator opt-in before it can be used.
+
+Minimum opt-in requirements for a future authorized lane:
+
+- name the exact fallback transition being allowed;
+- name whether the transition is local-to-local, local-to-hosted, hosted-to-hosted, or hosted-to-local;
+- name the provider identities and capability boundaries involved;
+- record credential boundary acknowledgement before provider use;
+- record cost boundary acknowledgement before provider use;
+- record provenance and audit fields required for reconstruction;
+- record safety and claim-gate boundaries for outputs produced after fallback;
+- record stop conditions that override the opt-in;
+- require opt-in to be current, scoped, revocable, and auditable.
+
+A broad setting, environment variable, provider registry entry, available API key, dashboard preference, CLI flag, or prior evidence packet must not count as opt-in unless a future authorized lane explicitly defines and accepts that mechanism.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/fail-closed-requirements.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/fail-closed-requirements.md
@@ -1,0 +1,17 @@
+# Fail-closed requirements
+
+Fail-closed means the system stops safely rather than selecting or invoking another provider path when fallback authorization, safety, provenance, cost, credentials, or audit conditions are incomplete.
+
+A future fallback-capable design must fail closed when:
+
+- fallback authorization is missing, stale, ambiguous, or outside the current lane scope;
+- provider provenance is missing or cannot distinguish the selected provider path;
+- credential boundaries are missing, unclear, or not operator-approved;
+- cost boundaries are missing, exceeded, or cannot be enforced before provider use;
+- local-vs-hosted state is unclear;
+- safety and claim gates do not authorize the proposed output or provider path;
+- audit fields needed to reconstruct the attempted route are unavailable;
+- evidence is stale or cannot be tied to the current packet/lane;
+- stop conditions are met.
+
+Safe failure behavior must be explicit, bounded, and non-promotional. It should produce a blocked/failed state for operator review rather than call providers, expose `/v1/solve`, run local models, run hosted models, run Ollama, run benchmarks, perform billing work, or promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/fallback-audit-requirements.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/fallback-audit-requirements.md
@@ -1,0 +1,20 @@
+# Fallback audit requirements
+
+Any future authorized fallback design must define audit records before fallback can be used.
+
+Required audit fields for a future design include:
+
+- lane or packet authorizing fallback;
+- operator opt-in identifier and timestamp;
+- requested route and selected route;
+- source provider, target provider, model identities, and capability boundaries;
+- local-vs-hosted classification before and after fallback;
+- credential boundary acknowledgement;
+- cost boundary acknowledgement, budget state, and estimated cost exposure;
+- timeout, retry, and circuit-breaker states;
+- safety and claim-gate state;
+- blocked-state checks performed;
+- final outcome: selected, blocked, failed closed, or stopped;
+- evidence packet references used for the decision.
+
+Audit gaps are blocked fallback states. A future design must prefer no provider call over incomplete audit reconstruction.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/fallback-policy-overview.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/fallback-policy-overview.md
@@ -1,0 +1,22 @@
+# Fallback policy overview
+
+Fallback means any automatic, semi-automatic, or operator-assisted movement from one provider path, model path, hosted path, local path, credential context, or routing decision to another after an attempted solve path is unavailable, blocked, timed out, rejected, budget-limited, circuit-open, unsafe, or otherwise not selected.
+
+## Default stance
+
+Provider fallback is default-forbidden unless a future authorized lane explicitly permits it. Absence of a prohibition is not permission. Ambiguous authorization is a blocked fallback state.
+
+## Boundary principles
+
+- Fallback must not be inferred from provider availability.
+- Fallback must not be inferred from timeout, retry, or circuit-breaker design.
+- Fallback must not be inferred from registry presence or capability metadata.
+- Fallback must not be inferred from credentials being configured.
+- Fallback must not be inferred from cost-control design.
+- Fallback must not be inferred from provenance or observability design.
+- Fallback must not be inferred from safety or claim-gate design.
+- Fallback must not cross local-hosted boundaries unless a future authorized lane explicitly permits the exact transition and records explicit operator opt-in.
+
+## Level 7 control
+
+Level 7 controls whether and how this packet is used, revised, rejected, or superseded. This packet is a supporting reference only. It does not start Level 8.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/no-hosted-fallback-defaults.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/no-hosted-fallback-defaults.md
@@ -1,0 +1,16 @@
+# No-hosted-fallback defaults
+
+Hosted fallback is not enabled by this packet.
+
+Default requirements:
+
+- No hosted fallback is allowed by default.
+- No local-to-hosted fallback is allowed by default.
+- No hosted-to-hosted fallback is allowed by default.
+- No hosted-to-local fallback is allowed by default unless a future authorized lane explicitly defines that transition.
+- No provider call may occur merely because a hosted provider is configured, reachable, cheaper, faster, or believed to be higher quality.
+- No credential presence may be treated as hosted fallback opt-in.
+- No timeout, retry, or circuit-breaker event may auto-promote a hosted fallback path.
+- No UI, API, CLI, or dashboard affordance may imply hosted fallback readiness without an accepted future lane.
+
+Any future hosted fallback proposal must start from a fail-closed default and require explicit operator opt-in before use.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/non-actions.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/non-actions.md
@@ -1,0 +1,28 @@
+# Non-actions
+
+This packet does not add fallback.
+
+This packet does not:
+
+- enable hosted fallback;
+- call providers;
+- configure credentials or secrets;
+- modify runtime code;
+- modify provider code;
+- modify API files;
+- modify dashboard files;
+- modify CLI files;
+- modify checker scripts;
+- modify tests;
+- modify `Makefile`;
+- modify `.github/workflows/ci.yml`;
+- modify source-artifact files;
+- expose or call `/v1/solve`;
+- expose dashboards;
+- run local models;
+- run hosted models;
+- run Ollama;
+- run benchmarks;
+- perform billing work;
+- promote evidence;
+- start Level 8.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/selected-next-action.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/selected-next-action.md
@@ -1,0 +1,7 @@
+# Selected next action
+
+`NO_FURTHER_PROVIDER_FALLBACK_FAIL_CLOSED_POLICY_LANES_SELECTED`
+
+No further provider fallback fail-closed policy lanes are selected by this packet.
+
+Level 7 controls whether and how this packet is used, revised, rejected, or superseded. This packet is a supporting reference only. It does not start Level 8.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/source-evidence-reviewed.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/source-evidence-reviewed.md
@@ -1,0 +1,19 @@
+# Source evidence reviewed
+
+The following concrete source paths were verified or reviewed for this docs-only packet:
+
+- `docs/evals/runs/alpha-solver-post-level-3-level-7-provider-orchestration-design/`
+- `docs/evals/runs/alpha-solver-post-level-3-provider-registry-capability-schema/`
+- `docs/evals/runs/alpha-solver-post-level-3-provider-credentials-secrets-boundary/`
+- `docs/evals/runs/alpha-solver-post-level-3-provider-routing-selection-policy/`
+- `docs/evals/runs/alpha-solver-post-level-3-provider-timeout-retry-circuit-breaker/`
+- `docs/evals/runs/alpha-solver-post-level-3-provider-provenance-observability-cost-control/`
+- `docs/evals/runs/alpha-solver-post-level-3-provider-safety-claim-gates/`
+- `docs/evals/runs/alpha-solver-post-level-3-level-6-product-surface-design/`
+- `docs/local_llm_solver_orchestration_guardrails/`
+- `scripts/check_local_llm_evidence_boundaries.py`
+- `scripts/check_local_llm_doc_paths.py`
+- `scripts/check_local_llm_packet_consistency.py`
+- `Makefile`
+
+These paths were used only to preserve existing evidence boundaries and packet consistency. No runtime behavior, provider behavior, API behavior, dashboard behavior, tests, checker scripts, workflows, or source artifacts were changed.

--- a/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/stop-conditions.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/stop-conditions.md
@@ -1,0 +1,18 @@
+# Stop conditions
+
+Fallback review or execution must stop when:
+
+- the accepted Level 7 provider orchestration design packet is missing;
+- the requested change would add fallback behavior in this docs-only packet;
+- the requested change would enable hosted fallback;
+- the requested change would call providers;
+- the requested change would configure credentials or secrets;
+- the requested change would modify runtime, provider, API, dashboard, CLI, checker-script, workflow, test, Makefile, or source-artifact files;
+- the requested change would expose or call `/v1/solve`;
+- the requested change would run local models, hosted models, Ollama, benchmarks, or billing work;
+- fallback authorization is ambiguous or outside the future authorized lane;
+- required provenance, credential, cost, safety, or audit boundaries are missing;
+- local-vs-hosted state is unclear;
+- evidence is stale or promotional.
+
+When a stop condition is met, the safe result is no fallback and fail-closed operator review.


### PR DESCRIPTION
### Motivation

- Provide a clean docs-only policy packet that defines default-forbidden provider fallback, no-hosted-fallback defaults, fail-closed behavior, explicit operator opt-in rules, blocked states, audit requirements, stop conditions, and non-actions for future provider orchestration work. 
- Replace closed PR #415 with a fresh, narrowly-scoped supporting reference that preserves evidence boundaries and defers any implementation or Level 8 work to Level 7 decisions. 

### Description

- Added a new docs-only packet at `docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/` containing `README.md`, `source-evidence-reviewed.md`, `fallback-policy-overview.md`, `fail-closed-requirements.md`, `no-hosted-fallback-defaults.md`, `explicit-opt-in-rules.md`, `blocked-fallback-states.md`, `fallback-audit-requirements.md`, `stop-conditions.md`, `non-actions.md`, `selected-next-action.md`, `blocker-fallback-lane.md`, and `checks-run.md`. 
- `source-evidence-reviewed.md` cites the required concrete source paths (Level 7 orchestration design, provider support packets, `docs/local_llm_solver_orchestration_guardrails/`, `scripts/check_local_llm_packet_consistency.py`, and `Makefile`). 
- Policy content explicitly defines: fallback as default-forbidden unless a future authorized lane permits it; fail-closed triggers and safe failure behavior; no-hosted-fallback defaults; operator opt-in minimums; blocked fallback states and required audit fields; stop conditions; and explicit non-actions that forbid runtime/provider/dashboard/CLI changes, model runs, provider calls, billing, or evidence promotion. 
- Selected next action is `NO_FURTHER_PROVIDER_FALLBACK_FAIL_CLOSED_POLICY_LANES_SELECTED`, and blocker fallback lane is `ALPHA-SOLVER-POST-LEVEL-3-PROVIDER-FALLBACK-FAIL-CLOSED-POLICY-FIX-001`. 
- Confirmed this is docs-only and does not change runtime code, provider code, APIs, dashboards, CLI, tests, `Makefile`, workflows, checker scripts, or any execution or billing behavior. 

### Testing

- Ran repository checks and static packet validators: `git status --short`, `git diff --name-only`, `git diff --check`, and `git diff --cached --check` which produced no problems. 
- Ran `make check-local-llm-orchestration-guardrails`, `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy`, and `rg` evidence checks; all checks passed and the packet consistency check reported success (packet directories scanned: 1). 
- Committed the changes on branch `alpha-solver-provider-fallback-fail-closed-policy` and verified the final changed-file scope is only `docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2637af47c48329b732ebf28b58752a)