### PR TITLE
Add Self Operator MVP scope matrix packet (docs-only)

### DIFF
--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-mvp-scope-matrix/README.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-mvp-scope-matrix/README.md
@@ -1,0 +1,44 @@
+# Self Operator MVP Scope Matrix Packet
+
+Lane: `ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-MVP-SCOPE-MATRIX-PACKET-001`
+
+## Purpose
+
+This docs-only packet defines the earliest safe Self Operator MVP scope matrix for Alpha Solver. It separates narrowly allowed MVP design scope from explicit non-goals, operator-only boundaries, and work blocked until later implementation lanes.
+
+The narrow MVP scope is operator-supervised task execution with explicit confirmation gates, local artifact generation, traceability, stop states, and no autonomous external actions.
+
+## Required source evidence
+
+This packet reviewed and cites the required concrete source paths in `source-evidence-reviewed.md`, including the accepted Level 7 provider orchestration design packet at `docs/evals/runs/alpha-solver-post-level-3-level-7-provider-orchestration-design/`.
+
+The accepted Level 7 provider orchestration design packet is present. A standalone provider fallback/fail-closed policy packet was not found as a separate support packet, so this packet records that as a pending dependency rather than failing the lane.
+
+## Evidence boundary
+
+This is docs-only scope design. This packet does not implement Self Operator, run agents, modify runtime, call providers, expose `/v1/solve`, expose dashboard, configure credentials, run models, run benchmarks, perform billing, deploy, or promote evidence.
+
+## Selected next action
+
+`NO_FURTHER_SELF_OPERATOR_MVP_SCOPE_MATRIX_LANES_SELECTED`
+
+No follow-on Self Operator MVP scope matrix lane is selected by this packet.
+
+## Blocker fallback lane
+
+If this packet is incomplete, inconsistent, stale, overbroad, unsafe by default, contradictory with accepted provider/product/operator boundaries, or unclear about what remains operator-only, use blocker fallback lane:
+
+`ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-MVP-SCOPE-MATRIX-FIX-001`
+
+## Files in this packet
+
+- `source-evidence-reviewed.md` records the source evidence and dependency status.
+- `in-scope-mvp.md` defines the narrow earliest safe MVP scope.
+- `out-of-scope-mvp.md` defines explicit MVP exclusions.
+- `operator-only-boundary.md` defines decisions and actions that must remain operator-only.
+- `blocked-until-later.md` defines deferred work that requires later lanes.
+- `dependency-notes.md` records upstream dependencies and pending dependency status.
+- `non-actions.md` records actions explicitly not taken by this docs-only packet.
+- `selected-next-action.md` records the no-further-lanes selected next action.
+- `blocker-fallback-lane.md` records the fallback lane.
+- `checks-run.md` records checks run for this packet.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-mvp-scope-matrix/blocked-until-later.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-mvp-scope-matrix/blocked-until-later.md
@@ -1,0 +1,19 @@
+# Blocked Until Later
+
+Lane: `ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-MVP-SCOPE-MATRIX-PACKET-001`
+
+The following work is blocked until later accepted lanes define requirements, implementation boundaries, tests, rollback plans, and operator approvals:
+
+| Blocked area | Required later-lane prerequisite |
+| --- | --- |
+| Self Operator runtime implementation | Accepted implementation lane with spec, tests, trace schema, stop-state behavior, and rollback plan. |
+| Agent execution | Accepted lane defining agent capabilities, allowed tools, local-only boundaries, audit records, and operator confirmations. |
+| Browser control | Accepted browser-risk lane with site/action allowlists, credential rules, confirmation gates, dry-run behavior, and hard stop states. |
+| Provider calls and routing | Accepted provider implementation lane satisfying Level 7 provider orchestration gates. |
+| Fallback/fail-closed policy implementation | Accepted standalone or incorporated fallback/fail-closed policy lane with explicit fallback graph, operator visibility, provenance, and fail-closed tests. |
+| Credential handling | Accepted credential/secret implementation lane with storage, retrieval, redaction, logging, validation, and operator-confirmation rules. |
+| `/v1/solve` exposure | Accepted API/product lane with authentication, routing, safety, observability, rate-limit, and claim gates. |
+| Dashboard exposure | Accepted dashboard lane with safe rendering, redaction, auditability, and no secret leakage. |
+| Billing or metering | Accepted billing lane with provider cost controls, budget enforcement, reconciliation, and claims boundary. |
+| Autonomous merge/release/deploy | Accepted release/deployment lane with human approval, rollback, audit trail, environment isolation, and production-readiness evidence. |
+| Evidence promotion | Accepted evidence-promotion lane that proves the artifacts meet promotion criteria and do not overclaim provider or product readiness. |

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-mvp-scope-matrix/blocker-fallback-lane.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-mvp-scope-matrix/blocker-fallback-lane.md
@@ -1,0 +1,9 @@
+# Blocker Fallback Lane
+
+Lane: `ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-MVP-SCOPE-MATRIX-PACKET-001`
+
+If this packet is incomplete, inconsistent, stale, overbroad, contradictory, unsafe by default, missing required evidence, missing the accepted Level 7 provider orchestration design dependency, unclear about operator-only boundaries, or unable to preserve the docs-only evidence boundary, use blocker fallback lane:
+
+`ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-MVP-SCOPE-MATRIX-FIX-001`
+
+The fallback lane is corrective only. It does not authorize Self Operator implementation, runtime changes, agents, providers, credentials, `/v1/solve`, dashboard exposure, billing, deployment, autonomous external actions, or evidence promotion.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-mvp-scope-matrix/checks-run.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-mvp-scope-matrix/checks-run.md
@@ -1,0 +1,24 @@
+# Checks Run
+
+Lane: `ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-MVP-SCOPE-MATRIX-PACKET-001`
+
+## Results
+
+- PASS: `git status --short`
+  - Output showed only the new docs packet directory as untracked before commit: `docs/evals/runs/alpha-solver-post-level-7-self-operator-mvp-scope-matrix/`.
+- PASS: `git diff --name-only`
+  - Output was empty because all changed files were untracked at the time of the check.
+- PASS: `git diff --check`
+  - No whitespace errors were reported.
+- PASS: `make check-local-llm-orchestration-guardrails`
+  - `scripts/check_local_llm_evidence_boundaries.py` passed.
+  - `scripts/check_local_llm_doc_paths.py` passed.
+  - `scripts/check_local_llm_packet_consistency.py` passed.
+- PASS: `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-7-self-operator-mvp-scope-matrix`
+  - The new packet passed targeted packet consistency validation.
+- PASS: changed-file scope confirmation.
+  - Changed files were confirmed to be only under `docs/evals/runs/alpha-solver-post-level-7-self-operator-mvp-scope-matrix/`.
+
+## Evidence-boundary confirmation
+
+The checks were static documentation checks only. They did not implement Self Operator, run agents, modify runtime, call providers, expose `/v1/solve`, expose dashboard, configure credentials, run models, run benchmarks, perform billing, deploy, or promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-mvp-scope-matrix/dependency-notes.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-mvp-scope-matrix/dependency-notes.md
@@ -1,0 +1,26 @@
+# Dependency Notes
+
+Lane: `ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-MVP-SCOPE-MATRIX-PACKET-001`
+
+## Accepted dependency
+
+- Accepted Level 7 provider orchestration design packet: `docs/evals/runs/alpha-solver-post-level-3-level-7-provider-orchestration-design/`.
+
+This dependency is present and is the required source for provider orchestration boundaries, provider non-actions, fail-closed requirements, blocked provider claims, and implementation-readiness constraints.
+
+## Supporting references reviewed
+
+- Level 6 product-surface design: `docs/evals/runs/alpha-solver-post-level-3-level-6-product-surface-design/`.
+- Product-surface operator controls: `docs/evals/runs/alpha-solver-post-level-3-product-surface-operator-controls/`.
+- Product-surface observability/audit: `docs/evals/runs/alpha-solver-post-level-3-product-surface-observability-audit/`.
+- Provider credentials/secrets boundary: `docs/evals/runs/alpha-solver-post-level-3-provider-credentials-secrets-boundary/`.
+- Provider routing/selection policy: `docs/evals/runs/alpha-solver-post-level-3-provider-routing-selection-policy/`.
+- Provider safety/claim gates: `docs/evals/runs/alpha-solver-post-level-3-provider-safety-claim-gates/`.
+
+## Pending dependency
+
+A standalone provider fallback/fail-closed policy packet is pending. The Level 7 provider orchestration design packet includes fallback and fail-closed requirements, but later implementation lanes should not treat that as an implemented fallback policy or runtime capability.
+
+## Dependency rule for later lanes
+
+Later Self Operator work must not infer permission from dependency presence alone. Accepted dependencies define boundaries and prerequisites; they do not authorize runtime changes, provider calls, credential use, dashboard exposure, billing, deployments, autonomous external actions, or evidence promotion.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-mvp-scope-matrix/in-scope-mvp.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-mvp-scope-matrix/in-scope-mvp.md
@@ -1,0 +1,27 @@
+# In-Scope MVP
+
+Lane: `ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-MVP-SCOPE-MATRIX-PACKET-001`
+
+## Narrow MVP definition
+
+The earliest safe Self Operator MVP may include only operator-supervised task execution design that stays local, reviewable, reversible before external action, and stopped by default when authority or evidence is unclear.
+
+## Scope matrix
+
+| Area | In-scope MVP definition | Required safety boundary |
+| --- | --- | --- |
+| Task intake | Operator-provided task descriptions, acceptance criteria, and local artifact targets. | No autonomous discovery of external work, secrets, deployments, billing, or production changes. |
+| Plan drafting | Local draft plans, checklists, and task breakdowns for operator review. | Plans are suggestions only until explicitly approved by the operator. |
+| Confirmation gates | Explicit operator confirmation before every material transition, especially file write proposal, test execution, evidence labeling, or handoff recommendation. | Missing, ambiguous, stale, or conflicting confirmation must stop the flow. |
+| Local artifact generation | Docs, reports, matrices, checklists, run notes, and other local files approved by the operator. | Artifacts must stay local and must not claim runtime, provider, production, billing, or deployment readiness. |
+| Traceability | Local trace notes linking task input, operator confirmations, generated artifacts, checks, stop states, and unresolved blockers. | Traceability must use references and summaries, not secrets or unredacted payloads. |
+| Stop states | Clearly named stop states for missing approval, unclear scope, missing dependency, unsafe external action, secret risk, provider/routing ambiguity, failed check, or evidence-boundary conflict. | Stop states require operator review before continuation. |
+| Operator handoff | A final packet summary that tells the operator what was drafted, what was not done, checks run, blockers, and next action state. | The MVP does not perform the handoff action outside the repo or local artifact context. |
+
+## Minimum MVP behavior principles
+
+- The Self Operator MVP is assistive, not autonomous.
+- The operator remains the authority for scope, approval, credentials, external action, merge, deploy, billing, and evidence promotion decisions.
+- Every generated artifact must be locally inspectable before any downstream use.
+- Every uncertain state must prefer stop over inference.
+- Provider, browser, dashboard, API, billing, deployment, and credential behavior is excluded unless a later accepted lane explicitly authorizes it.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-mvp-scope-matrix/non-actions.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-mvp-scope-matrix/non-actions.md
@@ -1,0 +1,21 @@
+# Non-Actions
+
+Lane: `ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-MVP-SCOPE-MATRIX-PACKET-001`
+
+This packet is docs-only scope design. It did not and does not:
+
+- Implement Self Operator.
+- Run agents.
+- Modify runtime behavior.
+- Add or modify provider orchestration, routing, fallback, or failover.
+- Call local, hosted, or third-party providers.
+- Expose `/v1/solve`.
+- Expose dashboard routes or dashboard data.
+- Configure, validate, store, display, log, or use credentials or secrets.
+- Run models.
+- Run benchmarks or scoring.
+- Perform billing, metering, invoice, quota, or payment work.
+- Deploy to any environment.
+- Merge, release, tag, publish, or promote evidence.
+- Perform browser takeover or any autonomous external action.
+- Modify backlog workbooks or external planning ledgers.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-mvp-scope-matrix/operator-only-boundary.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-mvp-scope-matrix/operator-only-boundary.md
@@ -1,0 +1,39 @@
+# Operator-Only Boundary
+
+Lane: `ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-MVP-SCOPE-MATRIX-PACKET-001`
+
+## Operator-only decisions
+
+The following decisions must remain operator-only in the earliest safe Self Operator MVP:
+
+- Approving task scope, acceptance criteria, and evidence labels.
+- Deciding whether a generated artifact is accurate, sufficient, or accepted.
+- Authorizing any file creation or modification beyond an explicitly approved local docs/artifact scope.
+- Authorizing tests or checks with side effects beyond local deterministic validation.
+- Providing, changing, validating, or using credentials, tokens, secrets, or environment variables.
+- Selecting or enabling providers, model routes, fallback paths, hosted execution, or `/v1/solve` exposure.
+- Approving external communication, browser use, account actions, purchases, billing, deployments, release work, merges, or evidence promotion.
+- Resolving conflicts between specs, packets, guardrails, product boundaries, and operator instructions.
+
+## Operator-only actions
+
+The Self Operator MVP may prepare local drafts for operator review, but the operator must perform or explicitly authorize:
+
+- Any external action.
+- Any irreversible action.
+- Any cost-incurring action.
+- Any credential-affecting action.
+- Any provider-backed action.
+- Any production, deployment, merge, release, or publication action.
+- Any action that changes accepted evidence status.
+
+## Required stop behavior
+
+The Self Operator MVP must stop when:
+
+- Confirmation is missing, ambiguous, or stale.
+- The requested action is outside approved local artifact scope.
+- A credential, provider, billing, deployment, browser, merge, or external-action boundary is implicated.
+- Evidence labels or readiness claims would exceed accepted source evidence.
+- Traceability cannot be preserved without exposing secrets or unreviewed payloads.
+- Required checks fail or cannot be run.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-mvp-scope-matrix/out-of-scope-mvp.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-mvp-scope-matrix/out-of-scope-mvp.md
@@ -1,0 +1,22 @@
+# Out-of-Scope MVP
+
+Lane: `ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-MVP-SCOPE-MATRIX-PACKET-001`
+
+The following items are explicitly out of scope for the earliest safe Self Operator MVP:
+
+| Exclusion | Boundary |
+| --- | --- |
+| Browser takeover | No autonomous browser control, site navigation, form submission, scraping, account access, purchasing, posting, messaging, or external workflow execution. |
+| Provider calls | No local, hosted, third-party, fallback, benchmark, or quality-evaluation model calls. |
+| Provider routing | No provider registry activation, provider selection, implicit routing, hidden fallback, or provider-backed `/v1/solve` behavior. |
+| Billing and payments | No billing setup, metering, invoice reconciliation, purchase authorization, cost-incurring provider calls, or customer billing claims. |
+| Production readiness | No claim that Self Operator, providers, API routes, dashboards, deployments, billing, or operational support are production-ready. |
+| Autonomous merges | No autonomous branch merges, PR approvals, squash merges, release tagging, or evidence promotion. |
+| Autonomous deployments | No deployment to local, staging, hosted, production, customer, or public environments. |
+| Credential handling | No creation, collection, validation, storage, display, logging, dashboard rendering, evidence embedding, or use of credentials/secrets. |
+| External actions | No emails, chats, tickets, repository writes outside approved local scope, package publication, issue edits, cloud changes, account actions, or network-side effects. |
+| Runtime modification | No changes to runtime behavior, provider adapters, API routes, dashboard routes, orchestration logic, SAFE-OUT behavior, observability pipelines, or replay/determinism logic. |
+| Benchmarks and scoring | No benchmark runs, comparative scoring, model ranking, or provider quality claims. |
+| Unapproved fallback | No fallback behavior unless a later accepted lane defines an explicit, operator-visible, fail-closed fallback policy and implementation boundary. |
+
+If a requested MVP behavior touches any excluded area, the Self Operator MVP must stop and hand control back to the operator.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-mvp-scope-matrix/selected-next-action.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-mvp-scope-matrix/selected-next-action.md
@@ -1,0 +1,7 @@
+# Selected Next Action
+
+Selected next action:
+
+`NO_FURTHER_SELF_OPERATOR_MVP_SCOPE_MATRIX_LANES_SELECTED`
+
+This closes the Self Operator MVP scope matrix lane family for now. No follow-on Self Operator MVP scope matrix lane is selected, started, or authorized by this packet.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-mvp-scope-matrix/source-evidence-reviewed.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-mvp-scope-matrix/source-evidence-reviewed.md
@@ -1,0 +1,39 @@
+# Source Evidence Reviewed
+
+Lane: `ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-MVP-SCOPE-MATRIX-PACKET-001`
+
+## Preflight confirmations
+
+The following required source paths were present and reviewed before this packet was authored:
+
+- `docs/evals/runs/alpha-solver-post-level-3-level-7-provider-orchestration-design/`
+- `docs/evals/runs/alpha-solver-post-level-3-level-6-product-surface-design/`
+- `docs/evals/runs/alpha-solver-post-level-3-product-surface-operator-controls/`
+- `docs/evals/runs/alpha-solver-post-level-3-product-surface-observability-audit/`
+- `docs/evals/runs/alpha-solver-post-level-3-provider-credentials-secrets-boundary/`
+- `docs/evals/runs/alpha-solver-post-level-3-provider-routing-selection-policy/`
+- `docs/evals/runs/alpha-solver-post-level-3-provider-safety-claim-gates/`
+- `scripts/check_local_llm_evidence_boundaries.py`
+- `scripts/check_local_llm_doc_paths.py`
+- `scripts/check_local_llm_packet_consistency.py`
+- `Makefile`
+
+The accepted Level 7 provider orchestration design packet was present at `docs/evals/runs/alpha-solver-post-level-3-level-7-provider-orchestration-design/`.
+
+## Evidence reviewed and used
+
+- `docs/evals/runs/alpha-solver-post-level-3-level-7-provider-orchestration-design/README.md` states the provider orchestration packet is docs-only and does not implement provider routing, fallback, hosted calls, credentials, `/v1/solve`, dashboard, billing, benchmarking, or evidence promotion. This supports keeping the Self Operator MVP scope docs-only and non-runtime.
+- `docs/evals/runs/alpha-solver-post-level-3-level-7-provider-orchestration-design/fallback-and-fail-closed-requirements.md` requires future provider orchestration to fail closed when identity, credentials, capabilities, budget, quota, safety gates, timeout policy, retry policy, circuit-breaker state, provenance fields, or operator authorization are missing or invalid. This supports stop states and blocks unapproved fallback.
+- `docs/evals/runs/alpha-solver-post-level-3-level-7-provider-orchestration-design/stop-conditions.md` requires future work to stop rather than infer provider readiness, bypass operator approval, use incomplete provenance, or continue with ambiguous fallback. This supports the Self Operator MVP stop-state boundary.
+- `docs/evals/runs/alpha-solver-post-level-3-level-6-product-surface-design/README.md` and `docs/evals/runs/alpha-solver-post-level-3-level-6-product-surface-design/operator-controls.md` preserve product-surface design as non-implementation and require visible operator controls before product behavior is exposed.
+- `docs/evals/runs/alpha-solver-post-level-3-product-surface-operator-controls/confirmation-gates.md` requires explicit confirmation before irreversible, externally visible, provider-backed, credential-affecting, budget-affecting, or evidence-promoting actions. This supports MVP confirmation gates.
+- `docs/evals/runs/alpha-solver-post-level-3-product-surface-operator-controls/stop-conditions.md` requires stop behavior when enablement, role authority, confirmation, auditability, safe defaults, or rollback paths are unclear. This supports Self Operator halt states.
+- `docs/evals/runs/alpha-solver-post-level-3-product-surface-observability-audit/trace-fields.md` identifies trace fields needed for reviewability, including request identifiers, operator/session context, timestamps, decision paths, inputs/outputs references, and stop/failure reasons. This supports local artifact traceability.
+- `docs/evals/runs/alpha-solver-post-level-3-provider-credentials-secrets-boundary/secret-boundary-overview.md` says credentials and derived authorization artifacts must be treated as secrets and must not be committed, logged, rendered, embedded, echoed, or copied into evidence. This keeps credential handling out of MVP scope.
+- `docs/evals/runs/alpha-solver-post-level-3-provider-routing-selection-policy/disallowed-implicit-routing.md` blocks implicit routing and hidden fallback. This keeps provider calls, routing, and fallback out of the Self Operator MVP.
+- `docs/evals/runs/alpha-solver-post-level-3-provider-safety-claim-gates/blocked-provider-claims.md` blocks provider readiness, hosted readiness, fallback readiness, billing readiness, production readiness, MVP readiness, benchmark, API readiness, dashboard readiness, and evidence-promotion claims. This constrains claims made by this packet.
+- `scripts/check_local_llm_evidence_boundaries.py`, `scripts/check_local_llm_doc_paths.py`, `scripts/check_local_llm_packet_consistency.py`, and `Makefile` define the local orchestration guardrail checks used by this docs-only lane.
+
+## Pending dependency
+
+A separate provider fallback/fail-closed policy packet was not found under `docs/evals/runs/` as an independent support packet. The accepted Level 7 provider orchestration design packet includes `fallback-and-fail-closed-requirements.md`, so this packet proceeds while recording a standalone provider fallback/fail-closed policy packet as a pending dependency for later implementation lanes.


### PR DESCRIPTION
### Motivation

- Define a narrow, safe Self Operator MVP scope that is operator-supervised, local, reviewable, reversible, and explicitly non-autonomous. 
- Preserve evidence boundaries inherited from the accepted Level 7 provider orchestration design and block any runtime/provider/credential work until later lanes. 
- Provide a documented packet that operators and later lanes can reference for what is allowed, disallowed, operator-only, and blocked for later work.

### Description

- Added a docs-only packet at `docs/evals/runs/alpha-solver-post-level-7-self-operator-mvp-scope-matrix/` containing the required files: `README.md`, `source-evidence-reviewed.md`, `in-scope-mvp.md`, `out-of-scope-mvp.md`, `operator-only-boundary.md`, `blocked-until-later.md`, `dependency-notes.md`, `non-actions.md`, `selected-next-action.md`, `blocker-fallback-lane.md`, and `checks-run.md`.
- The packet defines the earliest safe MVP: operator-supervised task intake, plan drafting, explicit confirmation gates, local artifact generation, traceability, and named stop states; it excludes browser takeover, provider calls/routing, billing, production claims, autonomous merges/deploys, credential handling, and unapproved fallback.
- Records dependencies and evidence: cites `docs/evals/runs/alpha-solver-post-level-3-level-7-provider-orchestration-design/` as the accepted dependency and marks a standalone provider fallback/fail-closed policy as a pending dependency.
- Decision markers recorded: selected next action `NO_FURTHER_SELF_OPERATOR_MVP_SCOPE_MATRIX_LANES_SELECTED` and blocker fallback lane `ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-MVP-SCOPE-MATRIX-FIX-001`.

### Testing

- Ran `git status --short`, `git diff --name-only`, and `git diff --check` (no whitespace errors and all changes were initially untracked files under the new packet directory). 
- Executed `make check-local-llm-orchestration-guardrails` which ran `scripts/check_local_llm_evidence_boundaries.py`, `scripts/check_local_llm_doc_paths.py`, and the global `scripts/check_local_llm_packet_consistency.py`, and all passed.
- Ran the targeted validator `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-7-self-operator-mvp-scope-matrix` which passed after fixing an initial selected-next state formatting issue. 
- Confirmed changed files are only under `docs/evals/runs/alpha-solver-post-level-7-self-operator-mvp-scope-matrix/` and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26396dfb888329b98b1b72b4fd9b85)