### PR TITLE
Add Self Operator implementation file-map packet (docs-only)

### DIFF
--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-implementation-file-map/README.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-implementation-file-map/README.md
@@ -1,0 +1,27 @@
+# Self Operator MVP implementation file map packet
+
+## Objective
+
+This docs-only packet maps likely repository areas for future Self Operator MVP work. It is an implementation file map only: it identifies files, modules, tests, docs, scripts, artifacts, and CI paths that a future authorized lane may need to inspect or modify, without modifying those files now.
+
+## Evidence boundary
+
+This packet is documentation only. It does not modify runtime, tests, scripts, CI, API routes, provider code, dashboard routes, credentials, generated artifacts, source artifacts, or solver behavior.
+
+## Packet files
+
+- `source-evidence-reviewed.md` records local source evidence reviewed while creating the map.
+- `likely-runtime-files.md` separates runtime files a future lane may inspect from runtime files it may modify later only with authorization.
+- `likely-test-files.md` maps focused candidate tests and test areas.
+- `likely-doc-files.md` maps candidate docs, specs, and operator guides.
+- `forbidden-files.md` lists files and surfaces that must not change without explicit authorization.
+- `implementation-scope-rules.md` defines narrow scope rules for any later implementation lane.
+- `open-questions.md` captures questions a future lane must resolve before changing behavior.
+- `non-actions.md` records what this packet deliberately did not do.
+- `selected-next-action.md` records the selected next action decision.
+- `blocker-fallback-lane.md` records the fallback lane if this packet is blocked or needs repair.
+- `checks-run.md` records the requested checks.
+
+## File-map summary
+
+A future Self Operator MVP lane will likely begin by inspecting the local LLM operator CLI and orchestration modules, entrypoint documentation, local orchestration specs, local LLM guardrail scripts, packet consistency checks, CI guardrails, and focused local LLM tests. Modification authority is not granted by this packet; future modifications must be tied to a separate approved spec or lane.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-implementation-file-map/blocker-fallback-lane.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-implementation-file-map/blocker-fallback-lane.md
@@ -1,0 +1,5 @@
+# Blocker fallback lane
+
+Blocker fallback lane: `ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-IMPLEMENTATION-FILE-MAP-FIX-001`
+
+Use this fallback only if this docs-only file map is found incomplete, inconsistent, or blocked by packet-format requirements. The fallback is a packet repair lane only; it does not authorize runtime, tests, scripts, CI, API, provider, dashboard, credentials, or source artifact changes.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-implementation-file-map/checks-run.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-implementation-file-map/checks-run.md
@@ -1,0 +1,12 @@
+# Checks run
+
+Requested checks for this packet:
+
+- `git status --short`
+- `git diff --name-only`
+- `git diff --check`
+- `make check-local-llm-orchestration-guardrails`
+- `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-7-self-operator-implementation-file-map`
+- Confirm changed files are only under `docs/evals/runs/alpha-solver-post-level-7-self-operator-implementation-file-map/`.
+
+Results are recorded in the PR summary/final response after execution.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-implementation-file-map/forbidden-files.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-implementation-file-map/forbidden-files.md
@@ -1,0 +1,33 @@
+# Forbidden files and surfaces without explicit authorization
+
+The following files and surfaces must not change in a future Self Operator MVP lane unless the user or a new approved spec explicitly authorizes that exact surface.
+
+## Canonical and sensitive entrypoints
+
+- `alpha_solver_portable.py`
+- `alpha-solver-v91-python.py`
+- `alpha_solver_entry.py`
+- `alpha_solver_cli.py`
+- `cli/alpha_solver_cli.py`
+- `docs/ENTRYPOINTS.md`, unless the authorized change is documentation-only entrypoint alignment.
+
+## Runtime behavior surfaces
+
+- `/v1/solve` or any API route behavior in `service/app.py`, `alpha/api/*`, or `alpha/webapp/routes/*`.
+- Dashboard preview, dashboard auth, web templates, or dashboard JSON configuration.
+- Hosted provider adapters, provider fallback, provider credential handling, provider telemetry, or live provider tests.
+- SAFE-OUT, routing, MCP, budget guard, determinism, replay, observability, and SolverEnvelope behavior.
+- Authentication, OAuth, API key, JWT, secret store, tenancy, and credential configuration paths.
+
+## Planning, provenance, and generated artifacts
+
+- Backlog workbooks or external planning ledgers.
+- `data/alpha_solver_master_table_v0_7_0.*` registry export/provenance artifacts.
+- Historical evidence packet source artifacts under `docs/evals/runs/**/source-artifact*/`.
+- Runtime output folders such as `artifacts/`, `telemetry/`, and `logs/`, except for explicitly authorized new run artifacts.
+
+## Deletion and rename restrictions
+
+- Do not delete, rename, merge, or consolidate legacy/reference files merely because they appear redundant.
+- Do not move existing specs or historical packet files casually.
+- Do not treat placeholder files as deletable until their status is resolved by an approved spec or explicit user authorization.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-implementation-file-map/implementation-scope-rules.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-implementation-file-map/implementation-scope-rules.md
@@ -1,0 +1,27 @@
+# Implementation scope rules for future lanes
+
+## Required before behavior changes
+
+1. Start from an approved Self Operator MVP spec or update an existing relevant spec before changing behavior.
+2. Define whether the lane is inspect-only, docs-only, test-only, guardrail-only, or runtime implementation.
+3. State the exact entrypoint and runtime surfaces in scope.
+4. State which sensitive surfaces are explicitly out of scope.
+5. Add or update focused tests before broad regression claims.
+6. Preserve default-off, local-only, no-silent-hosted-fallback, fail-closed, and non-evidence boundaries unless a later approved spec explicitly changes them.
+
+## May inspect vs. may modify later
+
+- `may inspect` means a future lane can read the file to understand contracts, dependencies, and risks.
+- `may modify later` means modification is possible only after a separate approved implementation scope names that file or surface.
+- This packet grants no current permission to modify runtime, tests, scripts, CI, API, provider, dashboard, credentials, source artifacts, or generated artifacts.
+
+## Narrow implementation preference
+
+- Prefer local LLM operator CLI and local orchestration surfaces first if future Self Operator MVP behavior is local/operator-only.
+- Prefer focused tests for the exact changed behavior.
+- Avoid broad refactors, opportunistic cleanup, or cross-surface consolidation.
+- Keep historical evidence packets immutable unless the future lane is an explicitly authorized packet repair lane.
+
+## Required future validation pattern
+
+A future implementation lane should run the most focused relevant tests first, then the local LLM guardrail suite, then broader `python -m pytest -q` when practical. Any skipped live, hosted-provider, local-model, dashboard, or deployment check must be reported with the reason.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-implementation-file-map/likely-doc-files.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-implementation-file-map/likely-doc-files.md
@@ -1,0 +1,43 @@
+# Likely docs, specs, scripts, artifacts, and CI files
+
+## May inspect
+
+### Specs and repo operating contracts
+
+- `AGENTS.md` — repo operating instructions and sensitive file rules.
+- `.specs/INDEX.md` — spec index to keep synchronized when future specs are added.
+- `.specs/LOCAL-LLM-SOLVER-ORCHESTRATION-001.md` — local solver orchestration contract.
+- `.specs/LOCAL-LLM-RUNTIME-INTEGRATION-001.md` — local runtime integration contract.
+- `.specs/PROVIDER-*.md`, `.specs/MCP-*.md`, `.specs/FINOPS-BUDGET-001.md`, and `.specs/PROVIDER-BUDGET-001.md` — adjacent provider, MCP, and budget contracts for boundary checks.
+
+### Operator and entrypoint docs
+
+- `docs/ENTRYPOINTS.md` — entrypoint roles and caution rules.
+- `docs/local_llm_solver_orchestration_operator_guide/*.md` — operator guide, command reference, evidence boundary, safe-use, local environment, examples, and selected-next state.
+- `docs/OPERATING_GUIDE.md` — operator workflow background, subordinate to `AGENTS.md`.
+- `docs/API_REFERENCE.md`, `docs/api.md`, `docs/CLI.md`, `docs/RUN_GUIDE.md`, `docs/RUNTIME_READINESS.md`, and `docs/MVP_READINESS_CHECKPOINT.md` — user-facing operational docs that may need future alignment.
+- `docs/BUDGETING.md`, `docs/FINOPS.md`, `docs/DETERMINISM.md`, `docs/REPLAY_GUIDE.md`, `docs/OBSERVABILITY.md`, `docs/TELEMETRY_SCHEMA.md`, `docs/POLICY.md`, and `docs/SECRETS_REDACTION.md` — adjacent safety and operations docs.
+
+### Evidence packets and artifact folders
+
+- `docs/evals/runs/local-llm-solver-orchestration-index/*` — local orchestration evidence index and decision ledger.
+- `docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-001/*` — Level 3 validation packet and closeout state.
+- `docs/evals/runs/20260607-local-llm-controlled-usage-operator-run-001/*` — controlled usage operator run packet and closeout state.
+- `docs/evals/runs/20260604-*local-llm*`, `docs/evals/runs/20260605-*local-llm*`, and `docs/evals/runs/20260606-*local-llm*` — earlier local LLM evidence packets.
+- `artifacts/`, `telemetry/`, `logs/`, and any packet-local source artifact folders — output/artifact locations to understand, not to rewrite in this packet.
+
+### Guardrail scripts and CI
+
+- `Makefile` — local guardrail target definitions.
+- `scripts/check_local_llm_evidence_boundaries.py` — static evidence-boundary guardrail.
+- `scripts/check_local_llm_doc_paths.py` — static doc path/link guardrail.
+- `scripts/check_local_llm_packet_consistency.py` — packet consistency guardrail.
+- `scripts/check_env.py`, `scripts/preflight.py`, `scripts/replay.py`, `scripts/env_snapshot.py`, and `scripts/bundle_artifacts.py` — adjacent operator/runtime utility scripts.
+- `.github/workflows/ci.yml`, `.github/workflows/tests.yml`, `.github/workflows/gates.yml`, `.github/workflows/nightly.yml`, and `.github/pull_request_template.md` — CI and PR validation surfaces.
+
+## May modify later only with a separate approved implementation scope
+
+- A future lane may add a Self Operator spec under `.specs/` and synchronize `.specs/INDEX.md` if behavior work is authorized.
+- A future lane may update operator guide docs only if it preserves evidence boundaries and selected-next consistency.
+- A future lane may update guardrail scripts or CI only if the spec explicitly requires new static checks and includes focused tests for the script changes.
+- A future lane must not rewrite historical evidence packets, source artifacts, exported registries, backlog workbooks, or generated runtime artifacts unless explicitly authorized.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-implementation-file-map/likely-runtime-files.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-implementation-file-map/likely-runtime-files.md
@@ -1,0 +1,49 @@
+# Likely runtime files
+
+## May inspect for future Self Operator MVP planning
+
+### Entrypoints and CLI surfaces
+
+- `docs/ENTRYPOINTS.md` — entrypoint role contract and sensitivity guide.
+- `alpha_solver_portable.py` — portable standalone behavior contract; inspect only unless explicitly authorized.
+- `alpha-solver-v91-python.py` — modular/reference compatibility entrypoint; inspect for compatibility impacts.
+- `alpha_solver_entry.py` — import bridge used by import-based callers.
+- `alpha_solver_cli.py` — root CLI wrapper over the compatibility entry path.
+- `cli/alpha_solver_cli.py` — command-oriented CLI for repo workflows.
+- `alpha/cli/__main__.py` and `alpha/cli/main.py` — package CLI entry surfaces.
+- `alpha/local_llm/operator_cli.py` — local-only operator wrapper and likely first Self Operator CLI inspection point.
+
+### Local orchestration modules
+
+- `alpha/local_llm/orchestration_runner.py` — local orchestration flow and status normalization.
+- `alpha/local_llm/provider_adapter.py` — local runtime config, endpoint validation, transport, parser, fail-closed behavior, and provenance.
+- `alpha/local_llm/portable_contract.py` — local LLM proof/contract helper.
+- `alpha/local_llm/__init__.py` — package exports and import boundary.
+
+### Solver, routing, and policy surfaces to inspect cautiously
+
+- `alpha/core/orchestrator.py`, `alpha/core/runner.py`, `alpha/core/router.py`, and `alpha/core/plan.py` — core orchestration, runner, router, and plan surfaces.
+- `alpha/routing/router_v12.py`, `alpha/router/agents_v12.py`, and `alpha/router/progressive.py` — routing surfaces that may intersect with operator behavior.
+- `alpha/policy/safe_out.py`, `alpha/policy/safe_out_sm.py`, `alpha/policy/engine.py`, and `alpha/policy/governance.py` — SAFE-OUT and governance behavior.
+- `alpha/core/budgets.py`, `alpha/finops/budget.py`, `service/budget/guard.py`, and `service/budget/simulator.py` — budget and spend guard paths.
+- `alpha/core/determinism.py`, `alpha/core/replay.py`, `service/determinism/harness.py`, and `service/replay/*` — determinism and replay paths.
+- `alpha/core/observability.py`, `alpha/core/telemetry.py`, `alpha/solver/observability.py`, `service/observability/*`, and `service/metrics/exporter.py` — observability and metrics paths.
+
+### API and dashboard surfaces to inspect only when explicitly in scope
+
+- `service/app.py`, `alpha/api/health.py`, and `service/health.py` — API app and health surfaces.
+- `alpha/webapp/routes/*.py` and `alpha/webapp/templates/*.html` — dashboard/web app surfaces.
+- `alpha/dashboard/*.json`, `dashboards/*.json`, and `docs/DASHBOARDS.md` — dashboard configuration and documentation.
+
+### Providers and credentials surfaces to inspect only when explicitly in scope
+
+- `alpha/providers/*.py`, `alpha/adapters/*.py`, and `service/adapters/*.py` — hosted/local provider and adapter paths.
+- `.env.example`, `scripts/check_env.py`, `service/config/secrets.example.yaml`, and `service/config/*` — environment and credential expectation paths.
+
+## May modify later only with a separate approved implementation scope
+
+- `alpha/local_llm/operator_cli.py` may be a candidate future modification point for a narrow Self Operator command surface, but only if a future spec authorizes behavior changes.
+- `alpha/local_llm/orchestration_runner.py` may be a candidate future modification point for local-only Self Operator orchestration behavior, but only with focused tests and preserved evidence boundaries.
+- `alpha/local_llm/provider_adapter.py` may be modified later only if endpoint, timeout, local runtime, or provenance behavior is explicitly in scope.
+- CLI entrypoints may be modified later only after an entrypoint-specific impact statement explains portable, modular, bridge, and command CLI implications.
+- API, dashboard, hosted-provider, credential, budget, SAFE-OUT, routing, determinism, replay, observability, MCP, and SolverEnvelope behavior must not be modified unless a future spec explicitly authorizes that surface.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-implementation-file-map/likely-test-files.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-implementation-file-map/likely-test-files.md
@@ -1,0 +1,36 @@
+# Likely test files
+
+## May inspect
+
+### Focused local LLM and operator tests
+
+- `tests/test_local_llm_operator_cli.py` — operator CLI argument, opt-in, prompt, and output behavior.
+- `tests/test_local_llm_solver_orchestration_runner.py` — local orchestration runner behavior.
+- `tests/test_local_llm_provider_adapter.py` — provider adapter validation and fail-closed behavior.
+- `tests/test_local_llm_runtime_integration.py` — runtime config, endpoint, timeout, and local runtime integration behavior.
+- `tests/test_local_llm_contract_consumption_proof.py` — local LLM contract proof helper behavior.
+
+### Docs and packet guardrail tests
+
+- `tests/test_local_llm_doc_paths.py` — local LLM doc path consistency.
+- `tests/test_local_llm_evidence_boundaries.py` — evidence-boundary checker behavior.
+- `tests/test_local_llm_packet_consistency.py` — packet continuity and selected-next consistency.
+
+### Adjacent behavior tests to inspect cautiously
+
+- `tests/cli/test_alpha_solver_cli.py`, `tests/test_console_entry.py`, `tests/test_cli_run.py`, `tests/test_cli_gates.py`, and `tests/test_cli_replay.py` — CLI behavior and workflow coverage.
+- `tests/test_alpha_minimal_behavior_contract.py` and `tests/fixtures/alpha_minimal_behavior_cases.json` — minimal behavior contracts.
+- `tests/policy/test_safe_out.py`, `tests/policy/test_safe_out_sm.py`, `tests/policy/test_safe_out_v12.py`, and `tests/test_governance.py` — SAFE-OUT and governance behavior.
+- `tests/test_budget_gate.py`, `tests/test_budget_guard.py`, `tests/finops/test_budget.py`, and `tests/test_budget_cli_guard.py` — budget guard behavior.
+- `tests/test_determinism.py`, `tests/test_determinism_cli.py`, `tests/test_determinism_harness.py`, and `tests/test_tot_determinism.py` — determinism expectations.
+- `tests/observability/*`, `tests/test_observability.py`, and `tests/test_metrics_smoke.py` — observability and metric expectations.
+- `tests/test_api_endpoints.py`, `tests/test_api_auth_ratelimit.py`, and `tests/api/test_health.py` — API boundary tests.
+- `tests/dashboard/*` — dashboard configuration tests.
+- `tests/providers/*` — provider contract, accounting, telemetry, and live-smoke boundaries.
+- `tests/test_mcp_*.py` and `tests/test_mcp_adapter.py` — MCP behavior and guardrail tests.
+
+## May modify later only with a separate approved implementation scope
+
+- Future Self Operator MVP implementation should add or update focused local LLM/operator tests before broad regression work.
+- Tests for API, dashboard, hosted-provider fallback, credentials, budget, routing, SAFE-OUT, determinism, replay, observability, MCP, or SolverEnvelope behavior may be modified only when the future implementation spec explicitly includes those behavior surfaces.
+- Live provider tests must not be broadened or enabled as part of Self Operator MVP work unless a separate live-service authorization is granted.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-implementation-file-map/non-actions.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-implementation-file-map/non-actions.md
@@ -1,0 +1,19 @@
+# Non-actions
+
+This packet did not:
+
+- modify runtime code;
+- modify tests;
+- modify scripts;
+- modify CI;
+- modify API routes or `/v1/solve` behavior;
+- modify dashboard routes, templates, or dashboard JSON;
+- modify provider adapters, hosted-provider fallback, or credential paths;
+- modify SAFE-OUT, routing, MCP, budget guard, determinism, replay, observability, or SolverEnvelope behavior;
+- run a local model or call Ollama;
+- call hosted providers or use provider credentials;
+- deploy, benchmark, or run live services;
+- create or rewrite runtime artifacts, telemetry, logs, source artifacts, registry exports, or backlog workbooks;
+- select another Self Operator implementation file-map lane.
+
+Evidence boundary: docs-only file map. This does not modify runtime, tests, scripts, CI, API, provider, dashboard, credentials, or source artifacts.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-implementation-file-map/open-questions.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-implementation-file-map/open-questions.md
@@ -1,0 +1,12 @@
+# Open questions for future Self Operator MVP work
+
+1. What exact Self Operator MVP behavior is authorized: command generation, local orchestration execution, packet creation assistance, guardrail running, artifact preservation, or another operator workflow?
+2. Should the future surface be a new CLI, an extension of `alpha/local_llm/operator_cli.py`, an extension of existing repo CLI commands, or documentation-only operator workflow guidance?
+3. Is Self Operator constrained to local-only non-production execution, or does any future lane require explicit hosted-provider integration?
+4. What evidence model applies to Self Operator outputs, and must `behavior_evidence=false` remain mandatory?
+5. Which artifact/output directories may Self Operator create, and what naming, redaction, and retention rules apply?
+6. What stop conditions are required for credentials, remote endpoints, live provider calls, dashboard/API routes, and deployment surfaces?
+7. Should the existing local LLM guardrail scripts be extended for Self Operator packets, or should a separate Self Operator guardrail script be created?
+8. What minimal tests prove safe operator behavior without claiming model quality, production readiness, MVP readiness, or Alpha superiority?
+9. Does CI need a new static guardrail target, or should future work reuse `check-local-llm-orchestration-guardrails`?
+10. Are there any external backlog ledgers that must be updated outside the repo after implementation, and who owns those updates?

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-implementation-file-map/selected-next-action.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-implementation-file-map/selected-next-action.md
@@ -1,0 +1,11 @@
+# Selected next action
+
+Selected next action: no further Self Operator implementation file-map lanes selected.
+
+Decision token components for the selected action are:
+
+- prefix: `NO_FURTHER_SELF_OPERATOR`
+- scope: `IMPLEMENTATION_FILE_MAP`
+- suffix: `LANES_SELECTED`
+
+No additional Self Operator implementation file-map lane is selected by this packet. Any future Self Operator MVP implementation must be authorized separately and must start from or update a relevant spec before changing behavior.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-implementation-file-map/source-evidence-reviewed.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-implementation-file-map/source-evidence-reviewed.md
@@ -1,0 +1,27 @@
+# Source evidence reviewed
+
+## Commands used for source review
+
+- `git status --short`
+- `git branch --show-current`
+- `find alpha service cli scripts tests docs/local_llm_solver_orchestration_operator_guide .github/workflows -maxdepth 3 -type f | sort`
+- `sed -n '1,220p' docs/ENTRYPOINTS.md`
+- `rg -n "check-local|local-llm|orchestration|guardrail|pytest|ci|lint|eval" Makefile scripts docs .github tests pyproject.toml`
+- `sed -n '1,220p' alpha/local_llm/operator_cli.py`
+- `sed -n '1,220p' alpha/local_llm/orchestration_runner.py`
+- `sed -n '1,180p' .specs/LOCAL-LLM-SOLVER-ORCHESTRATION-001.md`
+- `sed -n '1,160p' .specs/LOCAL-LLM-RUNTIME-INTEGRATION-001.md`
+
+## Evidence reviewed
+
+- Entrypoint role documentation identifies the portable behavior contract, modular/reference compatibility entrypoint, import bridge, root CLI wrapper, and command-oriented CLI as distinct surfaces that must not be casually merged or renamed.
+- `alpha/local_llm/operator_cli.py` is an operator-only, default-off, local-only CLI wrapper that delegates to the local orchestration runner and states that it does not expose production solver, dashboard, hosted fallback, or provider fallback paths.
+- `alpha/local_llm/orchestration_runner.py` is a non-production local solver orchestration runner that reuses the approved local LLM runtime config/backend path and preserves the non-evidence local runtime boundary.
+- `.specs/LOCAL-LLM-SOLVER-ORCHESTRATION-001.md` and `.specs/LOCAL-LLM-RUNTIME-INTEGRATION-001.md` define important default-off, local-only, fail-closed, non-evidence, and no-silent-hosted-fallback constraints.
+- `Makefile` exposes `check-local-llm-orchestration-guardrails`, which runs local LLM evidence-boundary, doc-path, and packet-consistency checks.
+- `.github/workflows/ci.yml` runs the local LLM orchestration guardrail suite before the broader test suite.
+- Focused tests already exist for local LLM operator CLI, runner, provider adapter, runtime integration, doc paths, evidence boundaries, and packet consistency.
+
+## Review limits
+
+This review was static and local. It did not run a local model, call Ollama, call hosted providers, exercise `/v1/solve`, exercise dashboard routes, deploy, benchmark, generate artifacts, or inspect credentials.


### PR DESCRIPTION
### Motivation

- Provide a focused docs-only implementation file map to identify candidate repo files, modules, tests, docs, scripts, artifact folders, and CI surfaces a future Self Operator MVP lane may need to inspect or modify. 
- Preserve strict evidence and safety boundaries by documenting `may inspect` vs `may modify later` and naming files/surfaces that must not change without explicit authorization. 
- Capture open questions, non-actions, and a blocker fallback lane to make future implementation lanes narrow, auditable, and repeatable. 

### Description

- Add a new docs-only packet at `docs/evals/runs/alpha-solver-post-level-7-self-operator-implementation-file-map/` containing `README.md`, `source-evidence-reviewed.md`, `likely-runtime-files.md`, `likely-test-files.md`, `likely-doc-files.md`, `forbidden-files.md`, `implementation-scope-rules.md`, `open-questions.md`, `non-actions.md`, `selected-next-action.md`, `blocker-fallback-lane.md`, and `checks-run.md`. 
- Map candidate runtime surfaces (CLI entrypoints, `alpha/local_llm/*`, routing/policy, observability, budget, determinism, replay, API/dashboard), focused tests, docs/specs, guardrail scripts, artifact folders, and CI targets while clearly separating `may inspect` from `may modify later`. 
- Define forbidden/sensitive files and surfaces (including `alpha_solver_portable.py`, `alpha-solver-v91-python.py`, `/v1/solve`, dashboard routes, hosted-provider credential paths, SAFE-OUT/MCP/routing/determinism/observability/ SolverEnvelope behavior, and historical packet source artifacts) and provide implementation scope rules that require an approved spec before behavior changes. 
- Record the selected next action token `NO_FURTHER_SELF_OPERATOR_IMPLEMENTATION_FILE_MAP_LANES_SELECTED` and the blocker fallback lane `ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-IMPLEMENTATION-FILE-MAP-FIX-001`. 
- Changed files: `docs/evals/runs/alpha-solver-post-level-7-self-operator-implementation-file-map/README.md`, `source-evidence-reviewed.md`, `likely-runtime-files.md`, `likely-test-files.md`, `likely-doc-files.md`, `forbidden-files.md`, `implementation-scope-rules.md`, `open-questions.md`, `non-actions.md`, `selected-next-action.md`, `blocker-fallback-lane.md`, and `checks-run.md`. 

### Testing

- Ran the requested automated guardrails and static checks: `git status --short`, `git diff --name-only`, `git diff --check`, `git diff --cached --check`, `make check-local-llm-orchestration-guardrails`, and `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-7-self-operator-implementation-file-map`; all checks passed. 
- Confirmed the packet is in the intended docs-only path and that no runtime, tests, scripts, CI, API, provider, dashboard, credentials, source artifacts, or generated artifacts were modified by this change. 
- Verified packet-level consistency with the repo guardrail scripts and that focused guardrail tests for local-LLM doc paths and evidence boundaries completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26397474dc8329ba02a7099315d496)