### PR TITLE
Add docs-only Self Operator lifecycle/state-machine packet

### DIFF
--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-lifecycle-state-machine/README.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-lifecycle-state-machine/README.md
@@ -1,0 +1,52 @@
+# Self Operator Lifecycle State-Machine Packet
+
+## Lane
+
+`ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-LIFECYCLE-STATE-MACHINE-PACKET-001`
+
+## Objective
+
+Create a docs-only Self Operator lifecycle and state-machine packet for future implementation planning. The packet defines lifecycle states, safe transitions, stop states, approval gates, failure states, and audit requirements.
+
+## Evidence boundary
+
+This packet is a docs-only state-machine design. It does not implement state handling, run jobs, modify runtime, call providers, deploy, or promote evidence.
+
+## Required lifecycle states
+
+- `created`
+- `preflight`
+- `awaiting_operator_confirmation`
+- `running_local_only`
+- `blocked`
+- `stopped`
+- `completed`
+- `failed`
+- `archived`
+
+## Safety posture
+
+The future Self Operator must fail closed when permission, evidence, scope, credentials boundaries, fallback boundaries, or claim safety are missing or unclear. The operator must approve all externally visible actions before they occur.
+
+## Selected next action
+
+`NO_FURTHER_SELF_OPERATOR_LIFECYCLE_STATE_MACHINE_LANES_SELECTED`
+
+## Blocker fallback lane
+
+`ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-LIFECYCLE-STATE-MACHINE-FIX-001`
+
+## Packet files
+
+- `README.md`
+- `source-evidence-reviewed.md`
+- `lifecycle-overview.md`
+- `state-list.md`
+- `transition-rules.md`
+- `approval-gates.md`
+- `stop-and-blocked-states.md`
+- `audit-requirements.md`
+- `non-actions.md`
+- `selected-next-action.md`
+- `blocker-fallback-lane.md`
+- `checks-run.md`

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-lifecycle-state-machine/approval-gates.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-lifecycle-state-machine/approval-gates.md
@@ -1,0 +1,36 @@
+# Approval Gates
+
+## Required operator approval
+
+The operator must approve all externally visible actions before they occur. Externally visible actions include, but are not limited to:
+
+- Calling hosted providers or external APIs.
+- Deploying, releasing, or promoting artifacts.
+- Updating dashboards, public documentation, tickets, spreadsheets, or customer-visible records.
+- Sending notifications, comments, pull requests, issues, or messages outside the local evidence packet.
+- Using credentials beyond an explicitly documented local boundary.
+- Promoting docs-only evidence into runtime, benchmark, production, or readiness claims.
+
+## Gate before `running_local_only`
+
+Transition from `awaiting_operator_confirmation` to `running_local_only` requires an approval record that names:
+
+- The requested action.
+- The approved scope.
+- The local-only boundary.
+- The evidence being used.
+- The credentials boundary.
+- The fallback boundary.
+- The non-claims and prohibited external actions.
+
+## Re-approval triggers
+
+A future implementation must return to `awaiting_operator_confirmation` or fail closed if any of these change:
+
+- Scope.
+- Evidence source.
+- Credentials use.
+- External visibility.
+- Fallback path.
+- Runtime target.
+- Claims about readiness, quality, benchmark status, provider support, or deployment.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-lifecycle-state-machine/audit-requirements.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-lifecycle-state-machine/audit-requirements.md
@@ -1,0 +1,31 @@
+# Audit Requirements
+
+## Minimum audit fields
+
+A future Self Operator implementation should record:
+
+- Lifecycle run identifier.
+- Current state and prior state.
+- Transition timestamp.
+- Actor or system component requesting the transition.
+- Operator approval identifier when applicable.
+- Scope statement.
+- Evidence references.
+- Credentials boundary.
+- Fallback boundary.
+- External visibility classification.
+- Non-actions and blocked claims.
+- Failure or blocked reason.
+- Checks run and check results.
+
+## Approval audit
+
+Every approval-gated transition must preserve the exact approval context. A future implementation must be able to answer who approved, what was approved, when it was approved, which evidence was reviewed, and which actions remained prohibited.
+
+## Failure audit
+
+For `blocked` and `failed`, the audit record must identify the fail-closed trigger, the last safe state, and the required fallback path. Missing audit data is itself a fail-closed condition.
+
+## Immutability expectation
+
+Archived lifecycle records should be append-only or immutable. Corrections should be separate, timestamped, and clearly identified as metadata corrections rather than edits to historical facts.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-lifecycle-state-machine/blocker-fallback-lane.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-lifecycle-state-machine/blocker-fallback-lane.md
@@ -1,0 +1,5 @@
+# Blocker Fallback Lane
+
+`ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-LIFECYCLE-STATE-MACHINE-FIX-001`
+
+If this packet is blocked, incomplete, or found inconsistent, use this fallback lane to repair the docs-only state-machine packet before any future implementation work is considered.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-lifecycle-state-machine/checks-run.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-lifecycle-state-machine/checks-run.md
@@ -1,0 +1,23 @@
+# Checks Run
+
+This file records the required checks for the docs-only Self Operator lifecycle state-machine packet.
+
+## Required checks
+
+- `git status --short`
+- `git diff --name-only`
+- `git diff --check`
+- `make check-local-llm-orchestration-guardrails`
+- `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-7-self-operator-lifecycle-state-machine`
+- Confirm changed files are only under the new packet directory.
+
+## Checks executed for this PR
+
+Recorded after final local verification.
+
+- PASS: `git status --short` showed only the new docs-only packet directory before staging.
+- PASS: `git diff --name-only` produced no tracked-file modifications before staging because all changes were new untracked docs files.
+- PASS: `git diff --check` reported no whitespace errors for tracked unstaged changes.
+- PASS: `make check-local-llm-orchestration-guardrails` passed.
+- PASS: `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-7-self-operator-lifecycle-state-machine` passed.
+- PASS: changed-file confirmation listed only files under `docs/evals/runs/alpha-solver-post-level-7-self-operator-lifecycle-state-machine/`.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-lifecycle-state-machine/lifecycle-overview.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-lifecycle-state-machine/lifecycle-overview.md
@@ -1,0 +1,21 @@
+# Lifecycle Overview
+
+## Purpose
+
+The Self Operator lifecycle is a future control plane model for bounded, auditable operator-assisted automation. It is designed to keep the system local-only unless and until an operator explicitly approves an externally visible action.
+
+## Lifecycle shape
+
+1. `created`: a proposed operator run exists as a record or plan.
+2. `preflight`: local-only checks validate scope, permissions, evidence, credential boundaries, fallback boundaries, and claim safety.
+3. `awaiting_operator_confirmation`: the run is ready to proceed but requires explicit operator approval.
+4. `running_local_only`: approved local-only activity is in progress inside the documented boundary.
+5. Terminal or stop states: `blocked`, `stopped`, `completed`, `failed`, and `archived`.
+
+## Fail-closed rule
+
+The lifecycle must fail closed into `blocked` or `failed` when any required safety condition is missing, stale, or ambiguous. Missing permission, missing evidence, unclear scope, missing credentials boundary, missing fallback boundary, or unsafe claims must never be treated as implicit approval.
+
+## External visibility rule
+
+The operator must approve all externally visible actions. A future implementation must not post, deploy, call hosted providers, update external systems, change public artifacts, send notifications, or promote evidence without explicit operator approval recorded before the action.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-lifecycle-state-machine/non-actions.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-lifecycle-state-machine/non-actions.md
@@ -1,0 +1,20 @@
+# Non-Actions
+
+This packet does not perform implementation or operational work.
+
+## Explicit non-actions
+
+- Does not implement Self Operator state handling.
+- Does not create runtime state-machine code.
+- Does not run jobs.
+- Does not modify runtime behavior.
+- Does not call hosted providers or external APIs.
+- Does not use or validate live credentials.
+- Does not deploy or release anything.
+- Does not promote evidence.
+- Does not update dashboards, spreadsheets, issues, tickets, or external systems.
+- Does not claim production readiness, benchmark readiness, provider readiness, autonomous operation readiness, or MVP readiness.
+
+## Evidence boundary confirmation
+
+This is a docs-only state-machine design packet. It preserves the boundary that future implementation requires separate approval and separate code changes.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-lifecycle-state-machine/selected-next-action.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-lifecycle-state-machine/selected-next-action.md
@@ -1,0 +1,5 @@
+# Selected Next Action
+
+`NO_FURTHER_SELF_OPERATOR_LIFECYCLE_STATE_MACHINE_LANES_SELECTED`
+
+No additional Self Operator lifecycle state-machine lane is selected by this packet.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-lifecycle-state-machine/source-evidence-reviewed.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-lifecycle-state-machine/source-evidence-reviewed.md
@@ -1,0 +1,19 @@
+# Source Evidence Reviewed
+
+## Evidence class
+
+This packet reviews repository instructions and lane requirements only. It is a docs-only state-machine design packet for future Self Operator implementation planning.
+
+## Reviewed inputs
+
+- Repo-level agent instructions requiring narrow, spec-linked, docs-only work for approved scope.
+- The lane objective: define Self Operator lifecycle states, transitions, stop states, approval gates, failure states, and audit requirements.
+- The lane evidence boundary: no implementation, runtime modification, provider call, deployment, or evidence promotion.
+
+## Evidence boundary
+
+The reviewed evidence is limited to documentation requirements. This packet does not claim that any Self Operator runtime state machine exists.
+
+## Non-reviewed evidence
+
+This packet did not review live credentials, hosted provider configuration, deployment state, production telemetry, customer data, or external service status.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-lifecycle-state-machine/state-list.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-lifecycle-state-machine/state-list.md
@@ -1,0 +1,37 @@
+# State List
+
+## `created`
+
+A run request or lifecycle record has been created. No work is authorized beyond local preflight evaluation.
+
+## `preflight`
+
+The system performs local-only checks for authorization, scope, evidence, credentials boundary, fallback boundary, and unsafe claims. Preflight must not call providers, deploy, or perform externally visible actions.
+
+## `awaiting_operator_confirmation`
+
+Preflight passed and the system is waiting for explicit operator confirmation. No externally visible action is authorized in this state.
+
+## `running_local_only`
+
+The approved activity is running only inside the local documented boundary. Any new external action, scope expansion, credential use, fallback change, or claim promotion returns control to `awaiting_operator_confirmation` or fails closed.
+
+## `blocked`
+
+A recoverable blocking condition prevents safe progress. Typical reasons include missing permission, missing evidence, unclear scope, missing credentials boundary, missing fallback boundary, unsafe claims, unavailable prerequisites, or required operator approval not yet granted.
+
+## `stopped`
+
+The operator or system intentionally stopped the run before completion. A stopped run must not resume automatically without a new approval path.
+
+## `completed`
+
+The approved local-only work completed inside the evidence boundary. Completion does not imply deployment, production readiness, provider readiness, benchmark success, or evidence promotion.
+
+## `failed`
+
+The run reached a non-recoverable failure or safety violation. Failure requires audit capture and cannot transition back to active execution automatically.
+
+## `archived`
+
+The run record is preserved for audit and historical review. Archived records are immutable except for clearly marked archival metadata corrections.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-lifecycle-state-machine/stop-and-blocked-states.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-lifecycle-state-machine/stop-and-blocked-states.md
@@ -1,0 +1,34 @@
+# Stop and Blocked States
+
+## Stop states
+
+The lifecycle stop states are `blocked`, `stopped`, `completed`, `failed`, and `archived`.
+
+## `blocked`
+
+`blocked` is the default recoverable fail-closed state. The lifecycle must enter `blocked` for:
+
+- Missing permission.
+- Missing evidence.
+- Unclear scope.
+- Missing credentials boundary.
+- Missing fallback boundary.
+- Unsafe claims.
+- Stale or ambiguous operator approval.
+- Any requested action that exceeds the approved local-only boundary.
+
+## `stopped`
+
+`stopped` records intentional cancellation or halt. It prevents automatic resumption and requires either archival or a separate future approved lane to restart safely.
+
+## `completed`
+
+`completed` records in-bound local-only completion. It is not an approval to deploy, publish, call providers, or promote evidence.
+
+## `failed`
+
+`failed` records non-recoverable execution or safety failure. It requires audit evidence, error classification, and prevention of automatic retry.
+
+## `archived`
+
+`archived` is the final preservation state. Archived records are retained for audit and must not be mutated into active lifecycle records.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-lifecycle-state-machine/transition-rules.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-lifecycle-state-machine/transition-rules.md
@@ -1,0 +1,35 @@
+# Transition Rules
+
+## Allowed transitions
+
+| From | To | Condition |
+| --- | --- | --- |
+| `created` | `preflight` | A lifecycle record exists and local-only preflight is allowed. |
+| `created` | `blocked` | Required initial scope, permission, or evidence is missing or unclear. |
+| `preflight` | `awaiting_operator_confirmation` | All local preflight checks pass and an operator decision is required before execution. |
+| `preflight` | `blocked` | Permission, evidence, scope, credentials boundary, fallback boundary, or claim safety is missing or ambiguous. |
+| `preflight` | `failed` | A non-recoverable safety violation or corrupted lifecycle record is detected. |
+| `awaiting_operator_confirmation` | `running_local_only` | Explicit operator approval is recorded for the precise local-only action. |
+| `awaiting_operator_confirmation` | `stopped` | The operator declines, cancels, or stops the run. |
+| `awaiting_operator_confirmation` | `blocked` | Approval is absent, stale, ambiguous, or narrower than the requested action. |
+| `running_local_only` | `completed` | Approved local-only activity completes inside scope. |
+| `running_local_only` | `blocked` | New permission, evidence, scope, credentials, fallback, or claim question appears. |
+| `running_local_only` | `stopped` | Operator or system stop is requested. |
+| `running_local_only` | `failed` | Non-recoverable execution error or safety violation occurs. |
+| `blocked` | `preflight` | A future approved fix lane supplies missing documentation or local preflight input. |
+| `blocked` | `stopped` | Operator chooses not to continue. |
+| `stopped` | `archived` | Audit record is complete and no resumption is authorized. |
+| `completed` | `archived` | Completion evidence is recorded and preserved. |
+| `failed` | `archived` | Failure audit record is complete and preserved. |
+
+## Disallowed transitions
+
+- `created` directly to `running_local_only`.
+- `preflight` directly to externally visible action.
+- `awaiting_operator_confirmation` to `running_local_only` without explicit operator approval.
+- `blocked`, `stopped`, `completed`, `failed`, or `archived` directly back to `running_local_only`.
+- `archived` to any active state.
+
+## Fail-closed transition rule
+
+If a future implementation cannot determine the safe next transition, it must transition to `blocked` when recoverable or `failed` when non-recoverable. It must not infer permission from silence, missing files, incomplete evidence, defaults, or prior unrelated approvals.


### PR DESCRIPTION
### Motivation

- Provide a canonical, docs-only design for a Self Operator lifecycle and state machine to guide future implementation and reviews.
- Define required states, safe transitions, stop/failure states, approval gates, and audit requirements so implementations must follow a fail-closed safety posture.
- Preserve an evidence boundary that prevents this packet from performing runtime actions, provider calls, deployments, or evidence promotion.

### Description

- Add a new packet directory `docs/evals/runs/alpha-solver-post-level-7-self-operator-lifecycle-state-machine/` containing `README.md`, `source-evidence-reviewed.md`, `lifecycle-overview.md`, `state-list.md`, `transition-rules.md`, `approval-gates.md`, `stop-and-blocked-states.md`, `audit-requirements.md`, `non-actions.md`, `selected-next-action.md`, `blocker-fallback-lane.md`, and `checks-run.md` that together specify the state machine and guardrails.
- Document the required states (`created`, `preflight`, `awaiting_operator_confirmation`, `running_local_only`, `blocked`, `stopped`, `completed`, `failed`, `archived`) and enumerate allowed and disallowed transitions with a fail-closed rule for ambiguous or unsafe conditions.
- Require explicit operator approval for all externally visible actions and define re-approval triggers, audit fields, immutability expectations, and a blocker fallback lane `ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-LIFECYCLE-STATE-MACHINE-FIX-001`.
- Record the selected next action as `NO_FURTHER_SELF_OPERATOR_LIFECYCLE_STATE_MACHINE_LANES_SELECTED` and include a `checks-run.md` that lists the required repository validation commands for this docs-only packet.

### Testing

- Ran repository checks: `git status --short`, `git diff --name-only`, and `git diff --check`, all of which passed for the new untracked docs files. (PASS)
- Ran guardrail checks via `make check-local-llm-orchestration-guardrails` which calls `python scripts/check_local_llm_evidence_boundaries.py` and `python scripts/check_local_llm_doc_paths.py`, and they passed. (PASS)
- Ran packet consistency check `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-7-self-operator-lifecycle-state-machine` and it passed. (PASS)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26397ade38832982fb65186444b576)