### PR TITLE
Add Self Operator human approval controls docs packet

### DIFF
--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-human-approval-controls/README.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-human-approval-controls/README.md
@@ -1,0 +1,43 @@
+# Alpha Solver Post-Level-7 Self Operator Human Approval Controls
+
+## Lane
+
+`ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-HUMAN-APPROVAL-CONTROLS-PACKET-001`
+
+## Objective
+
+Create a docs-only human approval controls packet for the Self Operator MVP.
+
+This packet defines what requires operator approval, what is forbidden without approval, approval records, confirmation wording, stop conditions, non-actions, selected next action, blocker fallback lane, and validation checks for approval-control documentation.
+
+## Status
+
+This packet is an approval-control design artifact only. It does not implement approval controls, execute actions, call external providers, modify runtime behavior, deploy, merge, or promote evidence.
+
+Self Operator must default to stop when approval state is missing, stale, contradictory, incomplete, or ambiguous.
+
+## Files in this packet
+
+- `source-evidence-reviewed.md` records the local source evidence reviewed for the docs-only approval-control design.
+- `approval-principles.md` defines approval-control principles for Self Operator MVP.
+- `actions-requiring-approval.md` lists actions that require explicit operator approval.
+- `forbidden-without-approval.md` lists actions forbidden unless approval is present and valid.
+- `approval-record-schema.md` defines the approval record fields required before gated actions.
+- `confirmation-wording.md` defines confirmation wording and denial wording.
+- `stop-conditions.md` defines stop conditions, including missing or ambiguous approval state.
+- `non-actions.md` records explicit actions not taken.
+- `selected-next-action.md` records the selected next action.
+- `blocker-fallback-lane.md` records the blocker fallback lane.
+- `checks-run.md` records validation commands and interpretation limits.
+
+## Selected next action
+
+`NO_FURTHER_SELF_OPERATOR_HUMAN_APPROVAL_CONTROLS_LANES_SELECTED`
+
+## Blocker fallback lane
+
+`ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-HUMAN-APPROVAL-CONTROLS-FIX-001`
+
+## Evidence boundary
+
+Docs-only approval-control design. This does not implement controls, execute actions, call providers, modify runtime, deploy, merge, or promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-human-approval-controls/actions-requiring-approval.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-human-approval-controls/actions-requiring-approval.md
@@ -1,0 +1,21 @@
+# Actions Requiring Approval
+
+Self Operator must obtain explicit operator approval before performing any action in this file.
+
+## Required approval categories
+
+Approval is required for:
+
+- PR creation, including opening a pull request, updating a pull request description with final claims, or requesting review.
+- Merge instructions, including instructing a human or automation to merge, squash merge, rebase merge, fast-forward merge, close-and-reopen, or otherwise complete integration.
+- External provider calls, including hosted model calls, hosted embedding calls, hosted search calls, hosted browser APIs, payment APIs, deployment APIs, observability APIs, issue-tracker APIs, or any third-party service that receives task data.
+- File deletion, including deleting source files, docs, tests, artifacts, generated outputs, placeholders, legacy files, reference files, or evidence packets.
+- Deployment, including production deployment, staging deployment, preview deployment, release publication, package publication, container publication, or infra mutation.
+- Billing, including creating charges, changing subscription state, touching payment providers, changing metering, changing quotas, issuing credits, or modifying invoice-related records.
+- Credential use, including reading, exporting, exchanging, rotating, validating, or submitting secrets, API keys, tokens, cookies, SSH keys, service account files, or browser session credentials.
+- Browser automation, including logging into websites, clicking buttons, submitting forms, scraping authenticated pages, changing account settings, sending messages, purchasing, posting, or using a browser session to act outside local docs review.
+- Evidence promotion, including upgrading local evidence to release evidence, benchmark evidence, production-readiness evidence, MVP-readiness evidence, public claims, marketing claims, provider-readiness claims, or release notes.
+
+## Scope requirement
+
+Approval must name the exact action category, target, intended result, constraints, and allowed time window. If any of these fields are missing or unclear, Self Operator must stop.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-human-approval-controls/approval-principles.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-human-approval-controls/approval-principles.md
@@ -1,0 +1,25 @@
+# Approval Principles
+
+## Default-to-stop rule
+
+Self Operator must default to stop when approval state is missing or ambiguous.
+
+This includes cases where approval is absent, stale, contradictory, partial, inherited from a different task, recorded for a different action, recorded for a different target, or recorded without enough detail to verify scope.
+
+## Explicit approval only
+
+Approval must be explicit, action-specific, target-specific, time-bounded, and recorded before a gated action is performed.
+
+An operator's general intent, broad project goal, previous approval, issue description, backlog row, lane name, PR comment, or implied urgency is not enough by itself to authorize a gated action.
+
+## Narrowest safe action
+
+When approval is valid, Self Operator must execute only the narrowest approved action. If the next step would exceed the approved scope, Self Operator must stop and request a new approval record before proceeding.
+
+## No approval by silence
+
+Silence, lack of objection, timeout, ambiguous wording, or unavailable operator response must be treated as no approval.
+
+## Auditability
+
+Every gated action must be traceable to an approval record that identifies the operator, requested action, target, scope, constraints, timestamp, confirmation wording, and stop conditions.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-human-approval-controls/approval-record-schema.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-human-approval-controls/approval-record-schema.md
@@ -1,0 +1,26 @@
+# Approval Record Schema
+
+A valid approval record must exist before Self Operator performs any gated action.
+
+## Required fields
+
+Each approval record must include:
+
+- `approval_id`: Stable identifier for the approval record.
+- `operator_identity`: Human operator identity or accountable approval source.
+- `approval_timestamp_utc`: UTC timestamp when approval was granted.
+- `requested_action_category`: One of the gated categories, such as PR creation, merge instructions, external provider calls, file deletion, deployment, billing, credential use, browser automation, or evidence promotion.
+- `requested_action_details`: Specific action to perform.
+- `target`: Exact repository, branch, PR, file path, environment, provider, account, credential, browser target, billing target, deployment target, or evidence artifact affected.
+- `scope_limits`: Boundaries on what may and may not be done.
+- `time_window`: Validity window for the approval.
+- `confirmation_wording`: Exact wording that the operator confirmed.
+- `stop_conditions_acknowledged`: Stop conditions acknowledged by the operator.
+- `evidence_boundary`: Statement that approval does not expand evidence claims beyond the approved action.
+- `record_location`: Where the approval record is stored.
+
+## Invalid records
+
+An approval record is invalid if it is missing required fields, uses ambiguous language, conflicts with another instruction, references a different action, references a different target, exceeds the time window, or cannot be audited.
+
+When the approval record is invalid, Self Operator must stop.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-human-approval-controls/blocker-fallback-lane.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-human-approval-controls/blocker-fallback-lane.md
@@ -1,0 +1,7 @@
+# Blocker Fallback Lane
+
+`ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-HUMAN-APPROVAL-CONTROLS-FIX-001`
+
+Use this blocker fallback lane only if this docs-only approval-control packet needs correction for missing required wording, incorrect evidence boundaries, missing selected-next state, missing blocker fallback state, unsafe approval wording, incomplete stop conditions, or static consistency failure.
+
+The blocker fallback lane is not selected as a next implementation lane and does not authorize runtime work, provider work, browser automation, credential use, deployment, billing, PR creation, merge instructions, file deletion, or evidence promotion.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-human-approval-controls/checks-run.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-human-approval-controls/checks-run.md
@@ -1,0 +1,25 @@
+# Checks Run
+
+This packet is docs-only. Checks confirm static documentation consistency and guardrail compatibility only.
+
+## Required checks
+
+- `git status --short`
+- `git diff --name-only`
+- `git diff --check`
+- `make check-local-llm-orchestration-guardrails`
+- `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-7-self-operator-human-approval-controls`
+- Confirm changed files are only under `docs/evals/runs/alpha-solver-post-level-7-self-operator-human-approval-controls/`.
+
+## Interpretation boundary
+
+Passing checks does not establish that approval controls are implemented, enforced, tested in runtime, deployed, merged, connected to providers, connected to billing systems, connected to browser automation, or able to promote evidence.
+
+## Results recorded for this packet
+
+- PASS: `git status --short` showed only the new docs-only packet directory before staging.
+- PASS: `git diff --name-only` produced no tracked-file output before staging because the packet files were new and untracked.
+- PASS: `git diff --check` reported no whitespace errors.
+- PASS: `make check-local-llm-orchestration-guardrails` passed.
+- PASS: `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-7-self-operator-human-approval-controls` passed and reported `1 packet directories scanned`.
+- PASS: Changed-file review confirmed all changed files are under `docs/evals/runs/alpha-solver-post-level-7-self-operator-human-approval-controls/`.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-human-approval-controls/confirmation-wording.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-human-approval-controls/confirmation-wording.md
@@ -1,0 +1,29 @@
+# Confirmation Wording
+
+## Required confirmation pattern
+
+For gated actions, Self Operator should require confirmation that follows this pattern:
+
+```text
+I approve Self Operator to perform [ACTION CATEGORY] on [EXACT TARGET] for [SPECIFIC PURPOSE] within [TIME WINDOW], limited to [SCOPE LIMITS]. I understand Self Operator must stop if approval state becomes missing, ambiguous, stale, contradictory, or out of scope.
+```
+
+## Category examples
+
+- PR creation: `I approve Self Operator to create a PR for branch [BRANCH] targeting [BASE] for [PACKET OR CHANGE SUMMARY] within [TIME WINDOW], limited to [SCOPE LIMITS].`
+- Merge instructions: `I approve Self Operator to provide merge instructions for PR [PR IDENTIFIER] within [TIME WINDOW], limited to [SCOPE LIMITS].`
+- External provider calls: `I approve Self Operator to call [PROVIDER] for [PURPOSE] using [DATA BOUNDARY] within [TIME WINDOW], limited to [SCOPE LIMITS].`
+- File deletion: `I approve Self Operator to delete [EXACT FILE PATHS] for [PURPOSE] within [TIME WINDOW], limited to [SCOPE LIMITS].`
+- Deployment: `I approve Self Operator to deploy [ARTIFACT OR SERVICE] to [ENVIRONMENT] for [PURPOSE] within [TIME WINDOW], limited to [SCOPE LIMITS].`
+- Billing: `I approve Self Operator to perform [BILLING ACTION] on [BILLING TARGET] for [PURPOSE] within [TIME WINDOW], limited to [SCOPE LIMITS].`
+- Credential use: `I approve Self Operator to use [CREDENTIAL NAME OR SOURCE] for [PURPOSE] within [TIME WINDOW], limited to [SCOPE LIMITS].`
+- Browser automation: `I approve Self Operator to automate browser actions on [EXACT SITE OR SESSION TARGET] for [PURPOSE] within [TIME WINDOW], limited to [SCOPE LIMITS].`
+- Evidence promotion: `I approve Self Operator to promote [EVIDENCE ARTIFACT] to [CLAIM OR RELEASE STATUS] for [PURPOSE] within [TIME WINDOW], limited to [SCOPE LIMITS].`
+
+## Denial and stop wording
+
+When approval is absent or unclear, Self Operator should use wording equivalent to:
+
+```text
+Approval is missing or ambiguous for this gated action. Self Operator will stop and will not proceed unless a valid approval record is provided.
+```

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-human-approval-controls/forbidden-without-approval.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-human-approval-controls/forbidden-without-approval.md
@@ -1,0 +1,25 @@
+# Forbidden Without Approval
+
+Self Operator must not perform the actions below unless a valid approval record exists before the action begins.
+
+## Forbidden actions
+
+Without explicit approval, Self Operator must not:
+
+- Create, submit, update for final review, or request review on a PR.
+- Give merge instructions or imply that a merge should occur.
+- Call external providers or send task data to third-party services.
+- Delete files or remove preserved artifacts, placeholders, legacy files, or reference files.
+- Deploy, publish, release, mutate infrastructure, or modify runtime hosting state.
+- Perform billing operations or modify billing-related state.
+- Use, reveal, validate, rotate, exchange, or transmit credentials.
+- Run browser automation that acts on websites, accounts, forms, sessions, or authenticated pages.
+- Promote evidence from local, non-promotional, draft, design-only, or bounded packet status into stronger claims.
+
+## Ambiguity handling
+
+If Self Operator cannot determine whether an action falls into a forbidden-without-approval category, Self Operator must treat the action as forbidden and stop.
+
+## No workaround rule
+
+Self Operator must not split, rename, sequence, or indirectly perform a forbidden action to avoid approval. An indirect equivalent of a gated action remains gated.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-human-approval-controls/non-actions.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-human-approval-controls/non-actions.md
@@ -1,0 +1,27 @@
+# Non-Actions
+
+This packet did not:
+
+- Implement approval controls.
+- Modify runtime code.
+- Modify provider code.
+- Modify CLI behavior.
+- Modify checker scripts.
+- Modify tests.
+- Modify the Makefile.
+- Modify CI.
+- Execute Self Operator actions.
+- Create, update, or request review on a PR as part of the packet content.
+- Provide merge instructions.
+- Call external providers.
+- Delete files.
+- Deploy or publish anything.
+- Perform billing work.
+- Use credentials.
+- Run browser automation.
+- Promote evidence.
+- Claim that approval controls are enforced in runtime.
+
+## Boundary restatement
+
+Docs-only approval-control design. This does not implement controls, execute actions, call providers, modify runtime, deploy, merge, or promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-human-approval-controls/selected-next-action.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-human-approval-controls/selected-next-action.md
@@ -1,0 +1,7 @@
+# Selected Next Action
+
+`NO_FURTHER_SELF_OPERATOR_HUMAN_APPROVAL_CONTROLS_LANES_SELECTED`
+
+No follow-on Self Operator human approval controls lane is selected by this packet.
+
+This closed selected-next state does not authorize implementation, runtime changes, PR creation, merge instructions, external provider calls, file deletion, deployment, billing, credential use, browser automation, or evidence promotion.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-human-approval-controls/source-evidence-reviewed.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-human-approval-controls/source-evidence-reviewed.md
@@ -1,0 +1,24 @@
+# Source Evidence Reviewed
+
+## Reviewed areas
+
+This docs-only approval-control packet was authored by reviewing local repository instructions and existing packet conventions rather than executing Self Operator runtime behavior:
+
+- `AGENTS.md`
+- `docs/OPERATING_GUIDE.md`
+- `.specs/`
+- `docs/evals/runs/local-llm-solver-orchestration-index/`
+- `docs/evals/runs/alpha-solver-post-level-3-release-readiness-ladder/`
+- `docs/local_llm_solver_orchestration_guardrails/`
+- `scripts/check_local_llm_packet_consistency.py`
+- `Makefile`
+
+## Evidence interpretation
+
+The reviewed material supports only a docs-only approval-control design for future Self Operator MVP work.
+
+It does not provide proof that approval controls are implemented, enforced, tested in runtime, deployed, merged, connected to providers, connected to billing systems, connected to browser automation, or connected to evidence-promotion workflows.
+
+## Evidence boundary
+
+Docs-only approval-control design. This does not implement controls, execute actions, call providers, modify runtime, deploy, merge, or promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-human-approval-controls/stop-conditions.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-human-approval-controls/stop-conditions.md
@@ -1,0 +1,34 @@
+# Stop Conditions
+
+Self Operator must stop before taking a gated action when any condition in this file is present.
+
+## Approval-state stop conditions
+
+Self Operator must stop when approval state is:
+
+- Missing.
+- Ambiguous.
+- Contradictory.
+- Stale or outside the approved time window.
+- Partial or missing required approval-record fields.
+- Attached to a different action, target, branch, provider, environment, credential, browser target, billing target, deployment target, or evidence artifact.
+- Broader than allowed by repo instructions, specs, safety rules, or the current lane.
+- Not auditable.
+
+## Action-boundary stop conditions
+
+Self Operator must stop when the next action may involve:
+
+- PR creation without approval.
+- Merge instructions without approval.
+- External provider calls without approval.
+- File deletion without approval.
+- Deployment without approval.
+- Billing without approval.
+- Credential use without approval.
+- Browser automation without approval.
+- Evidence promotion without approval.
+
+## Evidence-boundary stop condition
+
+Self Operator must stop if a proposed action would imply that docs-only approval-control design has implemented controls, executed actions, called providers, modified runtime, deployed, merged, or promoted evidence.


### PR DESCRIPTION
### Motivation

- Define a docs-only human approval controls packet for the Self Operator MVP to establish what actions require operator approval and to document safe stop behavior.  
- Provide a consistent, auditable approval-record schema, confirmation wording, and explicit stop conditions so gated actions cannot proceed without clear, scoped approval.  
- Preserve an evidence boundary clarifying this is a design artifact and does not implement runtime controls, provider calls, deployments, merges, or evidence promotion.

### Description

- Add a new docs-only packet at `docs/evals/runs/alpha-solver-post-level-7-self-operator-human-approval-controls/` containing `README.md`, `source-evidence-reviewed.md`, `approval-principles.md`, `actions-requiring-approval.md`, `forbidden-without-approval.md`, `approval-record-schema.md`, `confirmation-wording.md`, `stop-conditions.md`, `non-actions.md`, `selected-next-action.md`, `blocker-fallback-lane.md`, and `checks-run.md` (12 files).  
- Specify gated categories that require explicit operator approval: PR creation, merge instructions, external provider calls, file deletion, deployment, billing, credential use, browser automation, and evidence promotion.  
- Define an approval-record schema with required fields (`approval_id`, `operator_identity`, `approval_timestamp_utc`, `requested_action_category`, `requested_action_details`, `target`, `scope_limits`, `time_window`, `confirmation_wording`, `stop_conditions_acknowledged`, `evidence_boundary`, `record_location`) plus rules for invalid records, confirmation wording templates, and a strict default-to-stop rule whenever approval state is missing or ambiguous.  
- Record the decision tokens: selected next action `NO_FURTHER_SELF_OPERATOR_HUMAN_APPROVAL_CONTROLS_LANES_SELECTED` and blocker fallback lane `ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-HUMAN-APPROVAL-CONTROLS-FIX-001`.

### Testing

- Branch: `work`, PR URL: not returned by the environment tooling in this run.  
- Run required static checks: `git status --short`, `git diff --name-only`, `git diff --check`, `make check-local-llm-orchestration-guardrails`, and `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-7-self-operator-human-approval-controls`, and confirmed changed files are only under the new packet directory.  
- All required checks passed in this environment and `python scripts/check_local_llm_packet_consistency.py` reported the packet was scanned successfully.  
- Evidence boundary confirmation: this packet is docs-only and does not implement controls, execute actions, call providers, modify runtime, deploy, merge, or promote evidence.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26398bb0a48329ba1d7305410ae764)