### PR TITLE
Add Self Operator artifact persistence schema packet

### DIFF
--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-artifact-persistence-schema/README.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-artifact-persistence-schema/README.md
@@ -1,0 +1,53 @@
+# Self Operator Artifact Persistence Schema Packet
+
+## Lane
+
+`ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-ARTIFACT-PERSISTENCE-SCHEMA-PACKET-001`
+
+## Objective
+
+This docs-only packet defines the local artifact preservation schema for future Self Operator MVP operator-only runs.
+
+The schema requires future runs to preserve prompts, inputs, outputs, logs, confirmations, stop reasons, and reviewer notes while keeping raw artifacts separate from reviewer-authored summaries.
+
+## Scope
+
+This packet defines documentation and schema expectations only. It does not create actual run artifacts and does not change runtime behavior.
+
+## Required preservation principles
+
+- Preserve raw prompts exactly as submitted to the operator run.
+- Preserve source inputs and source evidence without mutation.
+- Preserve raw outputs exactly as emitted, including empty, partial, malformed, failed, or stopped outputs.
+- Preserve logs, confirmations, stop reasons, and review notes as separate artifact classes.
+- Use explicit redaction markers when sensitive values are removed.
+- Keep raw artifacts separate from reviewer summaries, interpretations, or acceptance notes.
+- Record enough run metadata for deterministic local review without claiming reproducibility of external systems.
+
+## Packet files
+
+- `README.md`
+- `source-evidence-reviewed.md`
+- `artifact-inventory.md`
+- `run-metadata-schema.md`
+- `prompt-preservation.md`
+- `output-preservation.md`
+- `confirmation-records.md`
+- `stop-reason-records.md`
+- `redaction-rules.md`
+- `non-actions.md`
+- `selected-next-action.md`
+- `blocker-fallback-lane.md`
+- `checks-run.md`
+
+## Selected next action
+
+`NO_FURTHER_SELF_OPERATOR_ARTIFACT_PERSISTENCE_SCHEMA_LANES_SELECTED`
+
+## Blocker fallback lane
+
+`ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-ARTIFACT-PERSISTENCE-SCHEMA-FIX-001`
+
+## Evidence boundary
+
+Docs-only artifact schema. This packet does not create actual run artifacts, run models, modify runtime, call providers, deploy, or promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-artifact-persistence-schema/artifact-inventory.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-artifact-persistence-schema/artifact-inventory.md
@@ -1,0 +1,40 @@
+# Artifact Inventory Schema
+
+## Purpose
+
+Future Self Operator MVP operator-only runs should include an artifact inventory that lists every preserved artifact and identifies whether it is raw evidence or reviewer-authored interpretation.
+
+## Required top-level artifact classes
+
+Each future run packet should preserve these classes when applicable:
+
+| Artifact class | Required path pattern | Raw or reviewer-authored | Preservation requirement |
+|---|---|---:|---|
+| Run metadata | `run_metadata.*` | Raw/run record | Preserve local run identity, timestamps, environment descriptors, and command context. |
+| Prompts | `raw/prompts/*` | Raw | Preserve exact prompt text, prompt files, prompt templates, prompt variables, and operator instructions. |
+| Inputs | `raw/inputs/*` | Raw | Preserve source inputs, source evidence, fixtures, config snippets, and operator-provided materials without mutation. |
+| Outputs | `raw/outputs/*` | Raw | Preserve stdout, stderr, response bodies, structured outputs, transcripts, and partial outputs exactly as emitted. |
+| Logs | `raw/logs/*` | Raw | Preserve terminal logs, application logs, trace snippets, and diagnostic logs exactly as captured. |
+| Confirmations | `records/confirmations.*` | Run record | Preserve human/operator confirmations, refusals, approvals, and explicit proceed/stop decisions. |
+| Stop reasons | `records/stop_reasons.*` | Run record | Preserve why a run ended, including completion, manual stop, timeout, guardrail stop, error, or ambiguity. |
+| Redaction ledger | `records/redactions.*` | Run record | Preserve every redaction marker, reason category, artifact path, and field location. |
+| Reviewer summaries | `review/*.md` | Reviewer-authored | Keep interpretations, acceptance notes, risks, caveats, and review notes separate from raw artifacts. |
+| Checks run | `checks-run.md` or `review/checks-run.md` | Reviewer-authored/run record | Preserve exact commands and outcomes used to review the packet. |
+
+## Inventory entry fields
+
+Each inventory entry should include:
+
+- `artifact_id`: stable local identifier unique within the run packet.
+- `path`: repo-relative or packet-relative path.
+- `artifact_class`: one of the required classes above or a documented extension.
+- `raw_or_reviewer_authored`: `raw`, `run_record`, or `reviewer_authored`.
+- `created_by`: `operator`, `runtime`, `reviewer`, `script`, or `unknown`.
+- `capture_time_utc`: ISO-8601 timestamp when available, otherwise `UNKNOWN_NOT_RECORDED`.
+- `source_mutated`: must be `false` for raw source evidence.
+- `redaction_status`: `none`, `redacted`, or `not_applicable`.
+- `notes`: short reviewer note that must not replace the raw artifact.
+
+## Raw versus reviewer separation
+
+Raw artifacts must remain in raw artifact locations. Reviewer summaries must not be stored in the same file as raw prompts, raw inputs, raw outputs, or raw logs.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-artifact-persistence-schema/blocker-fallback-lane.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-artifact-persistence-schema/blocker-fallback-lane.md
@@ -1,0 +1,13 @@
+# Blocker Fallback Lane
+
+## Fallback lane
+
+`ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-ARTIFACT-PERSISTENCE-SCHEMA-FIX-001`
+
+## Use condition
+
+Use this fallback lane only if this schema packet is found incomplete, internally inconsistent, missing required files, outside the allowed docs-only scope, or insufficiently clear about artifact preservation boundaries.
+
+## Non-use condition
+
+Do not use this fallback lane to create run artifacts, modify runtime, call providers, deploy, promote evidence, or begin Self Operator MVP implementation.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-artifact-persistence-schema/checks-run.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-artifact-persistence-schema/checks-run.md
@@ -1,0 +1,25 @@
+# Checks Run
+
+## Required checks
+
+- `git status --short`
+- `git diff --name-only`
+- `git diff --check`
+- `make check-local-llm-orchestration-guardrails`
+- `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-7-self-operator-artifact-persistence-schema`
+- Confirm changed files are only under `docs/evals/runs/alpha-solver-post-level-7-self-operator-artifact-persistence-schema/`.
+
+## Result log
+
+| Check | Result | Notes |
+|---|---|---|
+| `git status --short` | PASS | Only the new packet directory was listed as untracked before staging. |
+| `git diff --name-only` | PASS | Changed files were limited to the new packet directory. |
+| `git diff --check` | PASS | No whitespace errors were reported. |
+| `make check-local-llm-orchestration-guardrails` | PASS | Evidence-boundary, doc path/link, and packet consistency guardrails passed. |
+| `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-7-self-operator-artifact-persistence-schema` | PASS | Target packet consistency check passed for one packet directory. |
+| Changed-file boundary confirmation | PASS | `git diff --name-only` produced no paths outside the new packet directory. |
+
+## Non-actions confirmed during checks
+
+No local model inference, hosted provider call, runtime route call, dashboard route call, deployment, evidence promotion, or backlog workbook update was performed.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-artifact-persistence-schema/confirmation-records.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-artifact-persistence-schema/confirmation-records.md
@@ -1,0 +1,24 @@
+# Confirmation Records
+
+## Purpose
+
+Future operator-only runs should preserve explicit confirmations and non-confirmations so reviewers can see where an operator approved, refused, stopped, or declined to proceed.
+
+## Required confirmation fields
+
+A future confirmation record should include:
+
+- `confirmation_id`: stable local identifier.
+- `run_id`: associated run identifier.
+- `prompt_or_action_id`: related prompt, command, tool call, or decision.
+- `confirmation_type`: `approve`, `decline`, `stop`, `continue`, `manual_override`, `not_requested`, or `unknown`.
+- `confirmed_by`: operator identity category, not sensitive personal data.
+- `confirmation_text_raw_path`: path to the raw confirmation text when captured.
+- `captured_at_utc`: timestamp or `UNKNOWN_NOT_RECORDED`.
+- `scope_confirmed`: exact action or boundary confirmed.
+- `scope_excluded`: actions not approved by the confirmation.
+- `redaction_status`: `none`, `redacted`, or `not_applicable`.
+
+## Preservation rule
+
+Raw confirmation text must be preserved separately from reviewer interpretation. Reviewer comments about whether a confirmation was sufficient must be placed in a reviewer-authored notes file.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-artifact-persistence-schema/non-actions.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-artifact-persistence-schema/non-actions.md
@@ -1,0 +1,19 @@
+# Non-Actions
+
+This docs-only packet did not perform any of the following actions:
+
+- create actual Self Operator run artifacts;
+- run local models;
+- call hosted model providers;
+- call Alpha Solver runtime routes;
+- call `/v1/solve`;
+- exercise dashboard routes;
+- change runtime code;
+- change schemas used by application code;
+- change tests;
+- deploy services;
+- update backlog workbooks;
+- promote evidence;
+- claim production readiness, benchmark readiness, provider quality, local model quality, or Self Operator MVP readiness.
+
+This packet only defines a future artifact preservation schema for operator-only runs.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-artifact-persistence-schema/output-preservation.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-artifact-persistence-schema/output-preservation.md
@@ -1,0 +1,36 @@
+# Output Preservation
+
+## Purpose
+
+Future Self Operator run packets must preserve raw output exactly as emitted so reviewers can distinguish successful outputs from partial, failed, malformed, empty, interrupted, or stopped outputs.
+
+## Required output artifacts
+
+Preserve all applicable output materials under a raw output artifact location such as `raw/outputs/`:
+
+- stdout;
+- stderr;
+- structured response bodies;
+- streamed chunks;
+- final answer text;
+- tool output;
+- CLI output;
+- application output;
+- error messages;
+- empty-output markers;
+- partial-output markers.
+
+## Raw output preservation rule
+
+Raw output must not be cleaned, normalized, summarized, rewrapped, translated, corrected, or reclassified in place. If the output is malformed or incomplete, preserve the malformed or incomplete artifact and record reviewer interpretation separately.
+
+## Empty and missing outputs
+
+When an output channel is expected but empty, preserve an explicit raw marker file or structured field with one of these values:
+
+- `EMPTY_OUTPUT_CAPTURED`
+- `OUTPUT_CHANNEL_NOT_CREATED`
+- `OUTPUT_CAPTURE_FAILED`
+- `OUTPUT_NOT_APPLICABLE`
+
+Reviewer notes must explain the selected marker in a separate summary file.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-artifact-persistence-schema/prompt-preservation.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-artifact-persistence-schema/prompt-preservation.md
@@ -1,0 +1,28 @@
+# Prompt Preservation
+
+## Purpose
+
+Future Self Operator run packets must preserve prompts exactly enough for reviewer inspection of what was asked, what constraints were supplied, and what operator instructions governed the run.
+
+## Required prompt artifacts
+
+Preserve all applicable prompt materials under a raw prompt artifact location such as `raw/prompts/`:
+
+- initial user/operator prompt;
+- system or agent instructions available to the operator;
+- task packet instructions;
+- prompt templates;
+- prompt variables and substitutions;
+- follow-up prompts;
+- clarifying questions and answers;
+- explicit stop, continue, confirmation, or refusal prompts.
+
+## Exact preservation rule
+
+Prompt text must be preserved verbatim unless redaction is required. Formatting, ordering, whitespace, variable values, and delimiters should remain as captured.
+
+If redaction is required, replace only the sensitive span with an explicit marker documented in `redaction-rules.md`; do not paraphrase the surrounding prompt.
+
+## Separation rule
+
+Reviewer prompt analysis belongs in `review/` or a reviewer-authored notes file. It must not be mixed into raw prompt files.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-artifact-persistence-schema/redaction-rules.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-artifact-persistence-schema/redaction-rules.md
@@ -1,0 +1,41 @@
+# Redaction Rules
+
+## Purpose
+
+Future Self Operator artifacts should preserve raw evidence locally whenever safe. When sensitive values must be removed, redactions must be explicit, minimal, and auditable.
+
+## Required redaction markers
+
+Use bracketed markers that identify the redaction category without exposing the sensitive value:
+
+- `[REDACTED_SECRET]`
+- `[REDACTED_API_KEY]`
+- `[REDACTED_TOKEN]`
+- `[REDACTED_PASSWORD]`
+- `[REDACTED_PERSONAL_DATA]`
+- `[REDACTED_EMAIL]`
+- `[REDACTED_PHONE]`
+- `[REDACTED_LOCAL_PATH_SENSITIVE]`
+- `[REDACTED_ORG_PRIVATE_DATA]`
+- `[REDACTED_SECURITY_SENSITIVE]`
+
+## Redaction ledger fields
+
+Every redaction should be recorded with:
+
+- `redaction_id`;
+- `artifact_path`;
+- `field_or_line_reference`;
+- `redaction_marker`;
+- `reason_category`;
+- `redacted_by`;
+- `redacted_at_utc` or `UNKNOWN_NOT_RECORDED`;
+- `raw_value_preserved_elsewhere`: `false` unless a separately approved secure store exists.
+
+## Redaction constraints
+
+- Do not silently delete sensitive spans.
+- Do not replace sensitive values with vague prose such as "removed".
+- Do not redact more context than necessary.
+- Do not mutate source evidence except for the minimal marker substitution required for safety.
+- Do not claim unredacted evidence exists unless its location and access policy are documented in an approved secure evidence process.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-artifact-persistence-schema/run-metadata-schema.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-artifact-persistence-schema/run-metadata-schema.md
@@ -1,0 +1,45 @@
+# Run Metadata Schema
+
+## Purpose
+
+Future operator-only runs should preserve local run context without converting that context into a claim of runtime quality, deployment readiness, or external reproducibility.
+
+## Required fields
+
+A future `run_metadata.*` record should include:
+
+- `schema_name`: `self_operator_artifact_persistence_schema`.
+- `schema_packet_lane`: `ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-ARTIFACT-PERSISTENCE-SCHEMA-PACKET-001`.
+- `run_id`: stable local run identifier.
+- `packet_path`: path where the run packet is preserved.
+- `operator_role`: description of the human or agent operator role.
+- `run_intent`: brief operator-only objective.
+- `started_at_utc`: ISO-8601 timestamp or `UNKNOWN_NOT_RECORDED`.
+- `ended_at_utc`: ISO-8601 timestamp or `UNKNOWN_NOT_RECORDED`.
+- `timezone_context`: local timezone when relevant.
+- `repo_branch`: branch name at capture time when available.
+- `repo_commit`: commit SHA at capture time when available.
+- `dirty_worktree_before_run`: `true`, `false`, or `UNKNOWN_NOT_RECORDED`.
+- `dirty_worktree_after_run`: `true`, `false`, or `UNKNOWN_NOT_RECORDED`.
+- `commands_executed`: list of exact commands, if any.
+- `tools_used`: local tools used, if any.
+- `provider_calls_made`: must be explicit; use `none` when no provider was called.
+- `runtime_calls_made`: must be explicit; use `none` when runtime was not exercised.
+- `artifact_inventory_path`: path to the inventory record.
+- `redaction_ledger_path`: path to the redaction ledger, if any.
+- `stop_reason_record_path`: path to the stop reason record.
+- `confirmation_record_path`: path to the confirmation record, if any.
+
+## Prohibited metadata inflation
+
+Run metadata must not claim:
+
+- production readiness;
+- provider quality;
+- model quality;
+- benchmark success;
+- deployment status;
+- promoted eval evidence;
+- user-facing reliability.
+
+Those claims require separate approved evidence lanes.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-artifact-persistence-schema/selected-next-action.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-artifact-persistence-schema/selected-next-action.md
@@ -1,0 +1,11 @@
+# Selected Next Action
+
+## Selected action
+
+`NO_FURTHER_SELF_OPERATOR_ARTIFACT_PERSISTENCE_SCHEMA_LANES_SELECTED`
+
+## Meaning
+
+No additional Self Operator artifact persistence schema lane is selected by this packet.
+
+This selection does not block separately approved implementation, validation, runtime, or operator lanes. It only closes this docs-only schema packet without selecting another schema lane.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-artifact-persistence-schema/source-evidence-reviewed.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-artifact-persistence-schema/source-evidence-reviewed.md
@@ -1,0 +1,19 @@
+# Source Evidence Reviewed
+
+## Reviewed repo-local sources
+
+This packet was drafted from the user-approved lane instructions and existing repo-local eval packet conventions under `docs/evals/runs/`.
+
+Reviewed sources:
+
+- User-provided lane objective and required file list for `ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-ARTIFACT-PERSISTENCE-SCHEMA-PACKET-001`.
+- Repo-level agent instructions requiring docs-only, narrow, evidence-bound changes.
+- Existing eval packet patterns for source evidence, non-actions, selected next action, blocker fallback lane, and checks-run records.
+
+## Evidence handling rule
+
+Future Self Operator run packets that use this schema must preserve source evidence as immutable raw artifacts. Reviewer notes may reference, summarize, classify, or quote limited excerpts from source evidence, but reviewer notes must not overwrite, normalize, reformat, deduplicate, or otherwise mutate the source evidence artifact.
+
+## Boundary
+
+No external provider evidence, model output, runtime trace, deployment record, dashboard evidence, API evidence, billing evidence, or promoted eval result was reviewed or created by this packet.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-artifact-persistence-schema/stop-reason-records.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-artifact-persistence-schema/stop-reason-records.md
@@ -1,0 +1,36 @@
+# Stop Reason Records
+
+## Purpose
+
+Future operator-only runs should preserve why a run ended so reviewers can distinguish normal completion from operator stops, safety stops, timeouts, errors, and unresolved blockers.
+
+## Required stop reason fields
+
+A future stop reason record should include:
+
+- `stop_reason_id`: stable local identifier.
+- `run_id`: associated run identifier.
+- `ended_at_utc`: timestamp or `UNKNOWN_NOT_RECORDED`.
+- `stop_reason_code`: one of the allowed codes below.
+- `stop_reason_detail`: short factual detail.
+- `trigger_source`: `operator`, `agent`, `script`, `runtime`, `guardrail`, `environment`, or `unknown`.
+- `raw_evidence_path`: path to raw evidence supporting the stop reason, if captured.
+- `reviewer_summary_path`: path to reviewer-authored interpretation, if any.
+
+## Allowed stop reason codes
+
+- `COMPLETED_OPERATOR_ONLY_SCOPE`
+- `MANUAL_OPERATOR_STOP`
+- `CONFIRMATION_DECLINED`
+- `GUARDRAIL_STOP`
+- `TIMEOUT`
+- `RUNTIME_ERROR`
+- `ENVIRONMENT_LIMITATION`
+- `MISSING_REQUIRED_INPUT`
+- `AMBIGUITY_NOT_RESOLVED`
+- `ARTIFACT_CAPTURE_FAILURE`
+- `UNKNOWN_NOT_RECORDED`
+
+## Separation rule
+
+The stop reason record may classify why the run ended, but it must link to raw evidence rather than replacing raw logs or output.


### PR DESCRIPTION
### Motivation

- Define a docs-only local artifact preservation schema for the Self Operator MVP so future operator-only runs consistently preserve prompts, inputs, outputs, logs, confirmations, stop reasons, redactions, and reviewer notes.
- Provide a clear separation between immutable raw artifacts and reviewer-authored summaries and an auditable redaction ledger to avoid accidental mutation or silent deletions of evidence.

### Description

- Add a new docs packet at `docs/evals/runs/alpha-solver-post-level-7-self-operator-artifact-persistence-schema/` containing `README.md`, `source-evidence-reviewed.md`, `artifact-inventory.md`, `run-metadata-schema.md`, `prompt-preservation.md`, `output-preservation.md`, `confirmation-records.md`, `stop-reason-records.md`, `redaction-rules.md`, `non-actions.md`, `selected-next-action.md`, `blocker-fallback-lane.md`, and `checks-run.md` that together specify the schema and conventions for preserved artifacts.
- Define required artifact classes and inventory entry fields, a `run_metadata` schema that avoids inflating metadata claims, explicit preservation rules for prompts and outputs (verbatim unless redacted), confirmation and stop-reason record formats and allowed codes, and redaction markers plus a redaction ledger format.
- Record the packet-level decisions `NO_FURTHER_SELF_OPERATOR_ARTIFACT_PERSISTENCE_SCHEMA_LANES_SELECTED` as the selected next action and `ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-ARTIFACT-PERSISTENCE-SCHEMA-FIX-001` as the blocker fallback lane.
- Declare the evidence boundary and non-actions explicitly so the packet remains docs-only and does not create run artifacts, call providers, modify runtime, deploy, or promote evidence.

### Testing

- Ran the required checks: `git status --short`, `git diff --name-only`, `git diff --check`, `make check-local-llm-orchestration-guardrails`, and `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-7-self-operator-artifact-persistence-schema`, and all checks passed.
- Confirmed changed files are limited to the new packet directory, staged and committed on branch `work` as commit `2cc9e8a`, and a PR was created via the local `make_pr` helper (PR URL not available in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a263993df2c8329a2e037f682732796)