### PR TITLE
Add Self Operator local run harness design packet (docs-only)

### DIFF
--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/README.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/README.md
@@ -12,14 +12,20 @@ This packet is a design artifact only. It does not create a runner, execute task
 
 The future harness design requires:
 
-- No provider calls.
-- No dashboard exposure.
+- no provider calls.
+- no hosted model calls.
+- no local model execution unless a later explicit local-only implementation lane authorizes it.
+- no external API calls.
+- no fallback.
+- no credential use.
+- no billing.
+- no dashboard exposure.
+- no `/v1/solve` exposure.
 - No deployment.
 - No browser control.
-- No credential use.
-- No billing.
 - No evidence promotion.
 - Local-only filesystem artifact capture.
+- The harness may only perform bounded local preflights, local artifact capture, and local docs/checker commands that are explicitly allowed by a future implementation lane.
 - Explicit stop-state handling before, during, and after task execution.
 
 ## Packet files

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/README.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/README.md
@@ -1,0 +1,43 @@
+# Self Operator Local Run Harness Design Packet
+
+Lane: `ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-LOCAL-RUN-HARNESS-DESIGN-PACKET-001`
+
+## Purpose
+
+This packet defines a docs-only design for a future local-only Self Operator MVP run harness. It describes how that future harness should run local preflights, execute bounded tasks, capture artifacts, handle stop states, and avoid external actions.
+
+## Required boundary
+
+This packet is a design artifact only. It does not create a runner, execute tasks, run models, call providers, modify runtime behavior, expose dashboards, deploy services, control browsers, use credentials, create billing activity, or promote evidence.
+
+The future harness design requires:
+
+- No provider calls.
+- No dashboard exposure.
+- No deployment.
+- No browser control.
+- No credential use.
+- No billing.
+- No evidence promotion.
+- Local-only filesystem artifact capture.
+- Explicit stop-state handling before, during, and after task execution.
+
+## Packet files
+
+- `source-evidence-reviewed.md` records the local source evidence reviewed for this docs-only design.
+- `harness-overview.md` summarizes the proposed future harness shape.
+- `preflight-requirements.md` defines preflight checks the future harness should perform.
+- `local-only-execution-boundary.md` defines the execution sandbox and no-external-actions boundary.
+- `artifact-capture-requirements.md` defines required local artifact capture.
+- `stop-state-handling.md` defines stop states and expected harness responses.
+- `forbidden-external-actions.md` enumerates actions the future harness must not perform.
+- `non-actions.md` records work intentionally not done by this packet.
+- `selected-next-action.md` records the required selected next action.
+- `blocker-fallback-lane.md` records the required fallback lane.
+- `checks-run.md` records validation checks for this docs-only packet.
+
+## Decision state
+
+Selected next action: `NO_FURTHER_SELF_OPERATOR_LOCAL_RUN_HARNESS_DESIGN_LANES_SELECTED`
+
+Blocker fallback lane: `ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-LOCAL-RUN-HARNESS-DESIGN-FIX-001`

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/artifact-capture-requirements.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/artifact-capture-requirements.md
@@ -1,0 +1,28 @@
+# Artifact Capture Requirements
+
+A future local-only harness should capture enough information for local operator review without turning the run into promoted evidence.
+
+## Required local artifacts
+
+- `run-manifest.json` or equivalent local manifest containing run id, timestamp, branch, task id, command, timeout, and artifact directory.
+- `preflight-results.md` or equivalent preflight summary.
+- `command-provenance.txt` containing the exact local command executed.
+- `stdout.txt` and `stderr.txt` for raw local command streams.
+- `exit-status.txt` containing numeric exit status or stop-state marker.
+- `elapsed-time.txt` containing local elapsed runtime.
+- `artifact-inventory.md` listing every file written by the harness.
+- `redaction-summary.md` confirming whether any secret-like strings were found and how they were handled.
+- `stop-state.md` documenting pass, fail, blocked, or stopped state.
+- `evidence-boundary.md` confirming the run is local, non-promotional, and not provider-backed.
+
+## Capture rules
+
+- Artifacts must be written only under the approved local artifact directory.
+- Raw outputs must not be edited in place.
+- Redacted summaries must be separate from raw captures.
+- The harness must record when no task execution occurred because a preflight or stop state blocked the run.
+- Artifact manifests must not claim production readiness, benchmark status, model quality, provider integration, dashboard availability, or deployment readiness.
+
+## Retention boundary
+
+Artifacts captured by the future harness remain local run artifacts. They are not promoted evidence unless a separate authorized evidence-promotion lane explicitly reviews and accepts them.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/blocker-fallback-lane.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/blocker-fallback-lane.md
@@ -1,0 +1,5 @@
+# Blocker Fallback Lane
+
+`ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-LOCAL-RUN-HARNESS-DESIGN-FIX-001`
+
+Use this fallback lane only if this docs-only design packet is found incomplete, inconsistent, or insufficiently bounded. The fallback remains docs-only unless separately authorized.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/checks-run.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/checks-run.md
@@ -1,6 +1,6 @@
 # Checks Run
 
-## Validation results
+## Validation results for original packet
 
 - `git status --short` — passed; output showed only files under `docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/` before staging.
 - `git diff --name-only` — passed; no tracked-file diff was present before staging because the packet files were newly created and untracked.
@@ -9,6 +9,15 @@
 - `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design` — passed.
 - Changed-file scope confirmation — passed; all created files are under `docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/`.
 
+## Validation results for provider-call exception review fix
+
+- `git status --short` — passed; output showed only modified files under `docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/`.
+- `git diff --name-only` — passed; output showed only files under `docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/`.
+- `git diff --check` — passed; no whitespace errors reported.
+- `make check-local-llm-orchestration-guardrails` — passed.
+- `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design` — passed.
+- `rg "no provider calls|no hosted model calls|no external API calls|no fallback|no credential use|no billing|NO_FURTHER_SELF_OPERATOR_LOCAL_RUN_HARNESS_DESIGN_LANES_SELECTED|ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-LOCAL-RUN-HARNESS-DESIGN-FIX-001" docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design` — passed; required wording and decision markers are present.
+
 ## Evidence boundary
 
-These checks validate this docs-only packet. They did not create a runner, execute Self Operator tasks, run models, call providers, expose dashboards, deploy services, control browsers, use credentials, trigger billing, or promote evidence.
+These checks validate this docs-only packet. They did not create a runner, execute Self Operator tasks, run models, call providers, expose dashboards, expose `/v1/solve`, deploy services, control browsers, use credentials, trigger billing, add fallback, or promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/checks-run.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/checks-run.md
@@ -1,0 +1,14 @@
+# Checks Run
+
+## Validation results
+
+- `git status --short` — passed; output showed only files under `docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/` before staging.
+- `git diff --name-only` — passed; no tracked-file diff was present before staging because the packet files were newly created and untracked.
+- `git diff --check` — passed; no whitespace errors reported.
+- `make check-local-llm-orchestration-guardrails` — passed.
+- `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design` — passed.
+- Changed-file scope confirmation — passed; all created files are under `docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/`.
+
+## Evidence boundary
+
+These checks validate this docs-only packet. They did not create a runner, execute Self Operator tasks, run models, call providers, expose dashboards, deploy services, control browsers, use credentials, trigger billing, or promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/forbidden-external-actions.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/forbidden-external-actions.md
@@ -1,19 +1,39 @@
 # Forbidden External Actions
 
-A future Self Operator local run harness must not perform, trigger, or require any of the following actions.
+A future Self Operator local run harness must remain local-only and must not leave any provider-call path inside the harness.
 
 ## Forbidden actions
 
-- Provider calls to hosted or local-provider APIs that are not explicitly authorized by a future implementation lane.
-- Model execution, model download, or model warmup.
-- Dashboard exposure, dashboard publishing, or dashboard screenshot capture.
+The local run harness design requires:
+
+- no provider calls.
+- no hosted model calls.
+- no local model execution unless a later explicit local-only implementation lane authorizes it.
+- no external API calls.
+- no fallback.
+- no credential use.
+- no billing.
+- no dashboard exposure.
+- no `/v1/solve` exposure.
+
+The harness must not perform, trigger, or require any of the following actions:
+
+- Provider API calls, hosted model API calls, local-provider API calls, or any other external API calls.
+- Hosted model calls, model download, model warmup, or model execution by default.
+- Local model execution unless a later explicit local-only implementation lane authorizes it.
+- Fallback execution, fallback provider routing, fallback model routing, or fallback remediation.
+- Dashboard exposure, dashboard publishing, dashboard screenshot capture, or `/v1/solve` exposure.
 - Deployment to cloud, container registry, preview environment, production, staging, or any remote host.
 - Browser control, browser automation, profile loading, cookie access, or web navigation.
 - Credential use, credential discovery, secret loading, API-key validation, OAuth flow, token refresh, or cloud identity lookup.
 - Billing, metering, quota mutation, cost-incurring call, or account-level usage check.
 - Evidence promotion, registry promotion, score promotion, benchmark claim, or production-readiness claim.
 - External issue creation, pull request creation by the harness, ticket mutation, notification sending, or chat posting.
-- Network-based remediation, package installation, remote fetch, or dependency update.
+- Network-based remediation, package installation, remote fetch, dependency update, or any other external action.
+
+## Allowed local-only scope
+
+The harness may only perform bounded local preflights, local artifact capture, and local docs/checker commands that are explicitly allowed by a future implementation lane.
 
 ## Required response to forbidden actions
 
@@ -23,5 +43,5 @@ If a forbidden action is requested, the future harness must:
 2. Emit `FORBIDDEN_EXTERNAL_ACTION_REQUESTED`.
 3. Capture a local stop-state artifact.
 4. Avoid partial execution of the forbidden action.
-5. Avoid substituting another external action.
+5. Avoid substituting another external action or fallback path.
 6. Preserve the evidence boundary as local and non-promotional.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/forbidden-external-actions.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/forbidden-external-actions.md
@@ -8,7 +8,7 @@ The local run harness design requires:
 
 - no provider calls.
 - no hosted model calls.
-- no local model execution unless a later explicit local-only implementation lane authorizes it.
+- no local model execution unless a later explicit local-only implementation lane authorizes local model execution outside this harness boundary.
 - no external API calls.
 - no fallback.
 - no credential use.
@@ -18,9 +18,11 @@ The local run harness design requires:
 
 The harness must not perform, trigger, or require any of the following actions:
 
-- Provider API calls, hosted model API calls, local-provider API calls, or any other external API calls.
-- Hosted model calls, model download, model warmup, or model execution by default.
-- Local model execution unless a later explicit local-only implementation lane authorizes it.
+- Provider calls to hosted or local-provider APIs.
+- Hosted model calls.
+- Local model execution unless a later explicit local-only implementation lane authorizes local model execution outside this harness boundary.
+- External API calls.
+- Model download, model warmup, or model execution by default.
 - Fallback execution, fallback provider routing, fallback model routing, or fallback remediation.
 - Dashboard exposure, dashboard publishing, dashboard screenshot capture, or `/v1/solve` exposure.
 - Deployment to cloud, container registry, preview environment, production, staging, or any remote host.
@@ -30,6 +32,10 @@ The harness must not perform, trigger, or require any of the following actions:
 - Evidence promotion, registry promotion, score promotion, benchmark claim, or production-readiness claim.
 - External issue creation, pull request creation by the harness, ticket mutation, notification sending, or chat posting.
 - Network-based remediation, package installation, remote fetch, dependency update, or any other external action.
+
+## Provider-boundary clarification
+
+A future lane may create a separate provider-aware implementation design, but this local run harness design must not be read as authorizing provider calls. Provider calls, hosted model calls, local-provider API calls, external API calls, fallback routing, credential use, billing, dashboard exposure, and `/v1/solve` exposure remain outside this local harness boundary.
 
 ## Allowed local-only scope
 

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/forbidden-external-actions.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/forbidden-external-actions.md
@@ -1,0 +1,27 @@
+# Forbidden External Actions
+
+A future Self Operator local run harness must not perform, trigger, or require any of the following actions.
+
+## Forbidden actions
+
+- Provider calls to hosted or local-provider APIs that are not explicitly authorized by a future implementation lane.
+- Model execution, model download, or model warmup.
+- Dashboard exposure, dashboard publishing, or dashboard screenshot capture.
+- Deployment to cloud, container registry, preview environment, production, staging, or any remote host.
+- Browser control, browser automation, profile loading, cookie access, or web navigation.
+- Credential use, credential discovery, secret loading, API-key validation, OAuth flow, token refresh, or cloud identity lookup.
+- Billing, metering, quota mutation, cost-incurring call, or account-level usage check.
+- Evidence promotion, registry promotion, score promotion, benchmark claim, or production-readiness claim.
+- External issue creation, pull request creation by the harness, ticket mutation, notification sending, or chat posting.
+- Network-based remediation, package installation, remote fetch, or dependency update.
+
+## Required response to forbidden actions
+
+If a forbidden action is requested, the future harness must:
+
+1. Refuse the action.
+2. Emit `FORBIDDEN_EXTERNAL_ACTION_REQUESTED`.
+3. Capture a local stop-state artifact.
+4. Avoid partial execution of the forbidden action.
+5. Avoid substituting another external action.
+6. Preserve the evidence boundary as local and non-promotional.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/forbidden-external-actions.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/forbidden-external-actions.md
@@ -8,7 +8,7 @@ The local run harness design requires:
 
 - no provider calls.
 - no hosted model calls.
-- no local model execution unless a later explicit local-only implementation lane authorizes local model execution outside this harness boundary.
+- no local model execution unless a later explicit local-only implementation lane authorizes local model execution outside this local harness boundary.
 - no external API calls.
 - no fallback.
 - no credential use.
@@ -20,9 +20,8 @@ The harness must not perform, trigger, or require any of the following actions:
 
 - Provider calls to hosted or local-provider APIs.
 - Hosted model calls.
-- Local model execution unless a later explicit local-only implementation lane authorizes local model execution outside this harness boundary.
 - External API calls.
-- Model download, model warmup, or model execution by default.
+- Model execution, model download, or model warmup, unless a later explicit local-only implementation lane authorizes local model execution outside this local harness boundary.
 - Fallback execution, fallback provider routing, fallback model routing, or fallback remediation.
 - Dashboard exposure, dashboard publishing, dashboard screenshot capture, or `/v1/solve` exposure.
 - Deployment to cloud, container registry, preview environment, production, staging, or any remote host.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/harness-overview.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/harness-overview.md
@@ -1,0 +1,39 @@
+# Harness Overview
+
+## Design goal
+
+A future Self Operator MVP local run harness should provide a deterministic, operator-readable wrapper around bounded local tasks. The harness should make it easy to confirm preconditions, run an explicitly scoped local task, preserve artifacts, and stop safely when the requested action leaves the approved local-only boundary.
+
+## Future harness phases
+
+1. **Prepare local run directory**
+   - Create a timestamped local artifact directory under a repo-approved evidence path.
+   - Record command provenance, branch name, git status, and packet/run identifier.
+   - Refuse to overwrite prior artifacts unless the operator explicitly chooses a new local output path.
+
+2. **Run preflights**
+   - Validate that required local tools are present.
+   - Validate no required credentials are requested or loaded.
+   - Validate that the task manifest is local, bounded, and does not request external effects.
+   - Validate that the repository is in an expected state for the operator's intended task.
+
+3. **Execute bounded local task**
+   - Run only an allowlisted local command or script.
+   - Apply fixed timeout, output-size, and artifact-size limits.
+   - Record stdout, stderr, exit status, and elapsed time.
+   - Stop immediately if the task requests provider calls, browser control, deployment, dashboard exposure, credential access, billing activity, or evidence promotion.
+
+4. **Capture artifacts**
+   - Preserve raw local outputs.
+   - Preserve redacted operator-facing summaries where needed.
+   - Preserve stop-state and preflight outcomes.
+   - Preserve a manifest proving artifacts stayed local.
+
+5. **Close run state**
+   - Mark the run as passed, failed, blocked, or stopped.
+   - Avoid interpreting local artifacts as promoted evidence.
+   - Require a separate authorized lane before any implementation, runtime change, evidence promotion, or external integration.
+
+## Non-goal
+
+This packet does not implement the harness. It only describes the design requirements for a possible future local-only harness.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/harness-overview.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/harness-overview.md
@@ -18,10 +18,10 @@ A future Self Operator MVP local run harness should provide a deterministic, ope
    - Validate that the repository is in an expected state for the operator's intended task.
 
 3. **Execute bounded local task**
-   - Run only an allowlisted local command or script.
+   - Run only bounded local preflights, local artifact capture, and local docs/checker commands explicitly allowed by a future implementation lane.
    - Apply fixed timeout, output-size, and artifact-size limits.
    - Record stdout, stderr, exit status, and elapsed time.
-   - Stop immediately if the task requests provider calls, browser control, deployment, dashboard exposure, credential access, billing activity, or evidence promotion.
+   - Stop immediately if the task requests provider calls, hosted model calls, local model execution without later explicit local-only implementation authorization, external API calls, fallback, browser control, deployment, dashboard exposure, `/v1/solve` exposure, credential access, billing activity, or evidence promotion.
 
 4. **Capture artifacts**
    - Preserve raw local outputs.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/local-only-execution-boundary.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/local-only-execution-boundary.md
@@ -1,0 +1,31 @@
+# Local-Only Execution Boundary
+
+## Boundary statement
+
+A future Self Operator local run harness must be local-only by default and must fail closed when a task requests external action. Local-only means the harness may read repository files, run approved local commands, and write artifacts to an approved local directory. It must not interact with external providers, dashboards, deployment targets, browsers, credentials, billing systems, or evidence promotion systems.
+
+## Allowed future harness actions
+
+- Read local repository files needed for the approved task.
+- Run allowlisted local commands with explicit timeouts.
+- Capture stdout, stderr, exit code, elapsed time, and local manifests.
+- Write artifacts under the approved local run artifact directory.
+- Produce a local operator summary that clearly labels the run as non-promotional.
+- Stop safely when the requested task exceeds the local-only boundary.
+
+## Required controls
+
+- Default-deny command policy.
+- Explicit allowlist for local commands.
+- No implicit shell expansion into external tools.
+- No credential discovery.
+- No browser automation hooks.
+- No service deployment hooks.
+- No dashboard publish hooks.
+- No provider SDK initialization.
+- No billing or metering calls.
+- No evidence-promotion writes.
+
+## Boundary confirmation
+
+The design in this packet is docs-only. It does not create a runner, execute bounded tasks, run models, call providers, modify runtime, or promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/local-only-execution-boundary.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/local-only-execution-boundary.md
@@ -2,12 +2,14 @@
 
 ## Boundary statement
 
-A future Self Operator local run harness must be local-only by default and must fail closed when a task requests external action. Local-only means the harness may read repository files, run approved local commands, and write artifacts to an approved local directory. It must not interact with external providers, dashboards, deployment targets, browsers, credentials, billing systems, or evidence promotion systems.
+A future Self Operator local run harness must be local-only by default and must fail closed when a task requests external action. Local-only means the harness may read repository files, run approved local commands, and write artifacts to an approved local directory. It must not interact with external providers, hosted models, external APIs, dashboards, deployment targets, browsers, credentials, billing systems, `/v1/solve` exposure paths, fallback paths, or evidence promotion systems.
 
 ## Allowed future harness actions
 
+The harness may only perform bounded local preflights, local artifact capture, and local docs/checker commands that are explicitly allowed by a future implementation lane.
+
 - Read local repository files needed for the approved task.
-- Run allowlisted local commands with explicit timeouts.
+- Run allowlisted local docs/checker commands with explicit timeouts.
 - Capture stdout, stderr, exit code, elapsed time, and local manifests.
 - Write artifacts under the approved local run artifact directory.
 - Produce a local operator summary that clearly labels the run as non-promotional.
@@ -23,6 +25,15 @@ A future Self Operator local run harness must be local-only by default and must 
 - No service deployment hooks.
 - No dashboard publish hooks.
 - No provider SDK initialization.
+- no provider calls.
+- no hosted model calls.
+- no local model execution unless a later explicit local-only implementation lane authorizes it.
+- no external API calls.
+- no fallback.
+- no credential use.
+- no billing.
+- no dashboard exposure.
+- no `/v1/solve` exposure.
 - No billing or metering calls.
 - No evidence-promotion writes.
 

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/non-actions.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/non-actions.md
@@ -1,0 +1,19 @@
+# Non-Actions
+
+This packet intentionally does not perform or authorize the following work:
+
+- No runner is created.
+- No task is executed by a new harness.
+- No model is run.
+- No provider is called.
+- No dashboard is exposed.
+- No deployment is performed.
+- No browser is controlled.
+- No credentials are used or inspected.
+- No billing activity is triggered.
+- No evidence is promoted.
+- No runtime code is modified.
+- No CLI, API, service, MCP, routing, SAFE-OUT, budget guard, determinism, observability, replay, or SolverEnvelope behavior is changed.
+- No backlog workbook is modified.
+
+Evidence boundary: docs-only harness design. This does not create a runner, execute tasks, run models, call providers, modify runtime, or promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/non-actions.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/non-actions.md
@@ -5,7 +5,15 @@ This packet intentionally does not perform or authorize the following work:
 - No runner is created.
 - No task is executed by a new harness.
 - No model is run.
-- No provider is called.
+- no provider calls.
+- no hosted model calls.
+- no local model execution unless a later explicit local-only implementation lane authorizes it.
+- no external API calls.
+- no fallback.
+- no credential use.
+- no billing.
+- no dashboard exposure.
+- no `/v1/solve` exposure.
 - No dashboard is exposed.
 - No deployment is performed.
 - No browser is controlled.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/preflight-requirements.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/preflight-requirements.md
@@ -1,0 +1,28 @@
+# Preflight Requirements
+
+A future local-only Self Operator harness should fail closed unless all required preflights pass.
+
+## Required preflights
+
+- **Repository location:** confirm the harness is running from the intended repository root.
+- **Branch and status capture:** record branch name and `git status --short` before executing a task.
+- **Task manifest presence:** require a local manifest or operator-supplied task description that declares allowed command, timeout, artifact path, and expected stop states.
+- **Local-only assertion:** require the task manifest to state that no provider calls, deployment, dashboard exposure, browser control, credential use, billing, or evidence promotion are allowed.
+- **Network boundary check:** require the command plan to avoid network-dependent operations unless a future authorized lane explicitly permits a local-only network-free substitute. The default should be no outbound network use.
+- **Credential boundary check:** confirm no environment variable, secret file, token, API key, browser profile, or cloud credential is required.
+- **Command allowlist check:** run only commands approved for local evidence capture, such as local static checks, local scripts, or local test commands.
+- **Timeout check:** require a bounded runtime limit before execution starts.
+- **Artifact path check:** require artifacts to be written only inside the approved local run artifact directory.
+- **Overwrite check:** refuse to overwrite existing artifacts from prior runs.
+- **Redaction plan check:** require stdout, stderr, and manifests to be reviewed for secrets before any human-facing summary is generated.
+
+## Preflight stop behavior
+
+If a preflight fails, the future harness should:
+
+1. Stop before task execution.
+2. Record a `PREFLIGHT_FAILED` stop state.
+3. Capture which preflight failed.
+4. Avoid fallback execution.
+5. Avoid external remediation.
+6. Avoid evidence promotion.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/preflight-requirements.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/preflight-requirements.md
@@ -7,10 +7,10 @@ A future local-only Self Operator harness should fail closed unless all required
 - **Repository location:** confirm the harness is running from the intended repository root.
 - **Branch and status capture:** record branch name and `git status --short` before executing a task.
 - **Task manifest presence:** require a local manifest or operator-supplied task description that declares allowed command, timeout, artifact path, and expected stop states.
-- **Local-only assertion:** require the task manifest to state that no provider calls, deployment, dashboard exposure, browser control, credential use, billing, or evidence promotion are allowed.
+- **Local-only assertion:** require the task manifest to state: no provider calls, no hosted model calls, no local model execution unless a later explicit local-only implementation lane authorizes it, no external API calls, no fallback, no credential use, no billing, no dashboard exposure, no `/v1/solve` exposure, and no evidence promotion.
 - **Network boundary check:** require the command plan to avoid network-dependent operations unless a future authorized lane explicitly permits a local-only network-free substitute. The default should be no outbound network use.
 - **Credential boundary check:** confirm no environment variable, secret file, token, API key, browser profile, or cloud credential is required.
-- **Command allowlist check:** run only commands approved for local evidence capture, such as local static checks, local scripts, or local test commands.
+- **Command allowlist check:** run only bounded local preflights, local artifact capture, and local docs/checker commands explicitly allowed by a future implementation lane.
 - **Timeout check:** require a bounded runtime limit before execution starts.
 - **Artifact path check:** require artifacts to be written only inside the approved local run artifact directory.
 - **Overwrite check:** refuse to overwrite existing artifacts from prior runs.
@@ -23,6 +23,6 @@ If a preflight fails, the future harness should:
 1. Stop before task execution.
 2. Record a `PREFLIGHT_FAILED` stop state.
 3. Capture which preflight failed.
-4. Avoid fallback execution.
+4. Enforce no fallback execution.
 5. Avoid external remediation.
 6. Avoid evidence promotion.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/selected-next-action.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/selected-next-action.md
@@ -1,0 +1,5 @@
+# Selected Next Action
+
+`NO_FURTHER_SELF_OPERATOR_LOCAL_RUN_HARNESS_DESIGN_LANES_SELECTED`
+
+No further Self Operator local run harness design lanes are selected by this packet. Any future implementation, runtime integration, evidence promotion, provider integration, dashboard exposure, deployment, browser control, credential use, or billing-related work requires a separately authorized lane.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/source-evidence-reviewed.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/source-evidence-reviewed.md
@@ -1,0 +1,19 @@
+# Source Evidence Reviewed
+
+## Scope
+
+The review was limited to repository-local documentation and guardrail files needed to design a future local-only Self Operator MVP harness packet. No runtime execution evidence was promoted and no provider, dashboard, deployment, browser, credential, or billing system was contacted.
+
+## Reviewed local sources
+
+- `AGENTS.md` for repository workflow, safety, docs-only lane expectations, and validation guidance.
+- `docs/OPERATING_GUIDE.md` for operator workflow context and inspect-only versus implementation boundaries.
+- `docs/local_llm_solver_orchestration_guardrails/README.md` for local orchestration guardrail intent.
+- `docs/local_llm_solver_orchestration_operator_guide/evidence-boundary-quick-reference.md` for local evidence boundary framing.
+- `docs/local_llm_solver_orchestration_operator_guide/failure-modes-and-stop-conditions.md` for stop-condition terminology and operator-facing failure handling patterns.
+- `docs/local_llm_solver_orchestration_operator_guide/artifact-preservation-guidance.md` for local artifact retention expectations.
+- `scripts/check_local_llm_packet_consistency.py` for packet consistency expectations around selected-next state, blocker fallbacks, and boundary files.
+
+## Evidence boundary
+
+This file is not evidence of a harness run. It is only evidence that repository-local docs and checks were reviewed to draft a future harness design. The packet does not create or run a harness, execute model calls, invoke providers, modify runtime code, or promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/stop-state-handling.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/stop-state-handling.md
@@ -6,7 +6,7 @@ A future local-only harness must treat stop states as first-class outcomes rathe
 
 - `PREFLIGHT_FAILED`: a required local preflight did not pass.
 - `TASK_OUT_OF_SCOPE`: the requested task is not bounded or not local-only.
-- `FORBIDDEN_EXTERNAL_ACTION_REQUESTED`: the task requested provider calls, dashboard exposure, deployment, browser control, credential use, billing, or evidence promotion.
+- `FORBIDDEN_EXTERNAL_ACTION_REQUESTED`: the task requested provider calls, hosted model calls, local model execution without later explicit local-only implementation authorization, external API calls, fallback, dashboard exposure, `/v1/solve` exposure, deployment, browser control, credential use, billing, or evidence promotion.
 - `COMMAND_NOT_ALLOWLISTED`: the requested command is not approved for local execution.
 - `TIMEOUT_EXCEEDED`: the local task exceeded the configured timeout.
 - `OUTPUT_LIMIT_EXCEEDED`: stdout, stderr, or generated artifacts exceeded configured limits.
@@ -23,7 +23,7 @@ For every stop state, the future harness should:
 2. Capture the stop state in the local artifact directory.
 3. Record which requirement triggered the state.
 4. Avoid automatic retries that could expand scope.
-5. Avoid provider calls, deployments, dashboard exposure, browser control, credential access, billing, and evidence promotion.
+5. Avoid provider calls, hosted model calls, local model execution without later explicit local-only implementation authorization, external API calls, fallback, deployments, dashboard exposure, `/v1/solve` exposure, browser control, credential access, billing, and evidence promotion.
 6. Tell the operator which separate authorized lane would be needed for remediation if remediation is outside the local-only boundary.
 
 ## Fail-closed requirement

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/stop-state-handling.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/stop-state-handling.md
@@ -1,0 +1,31 @@
+# Stop-State Handling
+
+A future local-only harness must treat stop states as first-class outcomes rather than exceptions to bypass.
+
+## Required stop states
+
+- `PREFLIGHT_FAILED`: a required local preflight did not pass.
+- `TASK_OUT_OF_SCOPE`: the requested task is not bounded or not local-only.
+- `FORBIDDEN_EXTERNAL_ACTION_REQUESTED`: the task requested provider calls, dashboard exposure, deployment, browser control, credential use, billing, or evidence promotion.
+- `COMMAND_NOT_ALLOWLISTED`: the requested command is not approved for local execution.
+- `TIMEOUT_EXCEEDED`: the local task exceeded the configured timeout.
+- `OUTPUT_LIMIT_EXCEEDED`: stdout, stderr, or generated artifacts exceeded configured limits.
+- `ARTIFACT_CAPTURE_FAILED`: the harness could not write required local artifacts.
+- `REDACTION_REQUIRED`: secret-like material appeared in an output and requires local operator review before sharing.
+- `TASK_FAILED`: the local command completed with a non-zero exit status.
+- `TASK_PASSED`: the local command completed successfully within the approved boundary.
+
+## Stop-state behavior
+
+For every stop state, the future harness should:
+
+1. Stop additional execution unless the state is `TASK_PASSED` and no post-run boundary issue exists.
+2. Capture the stop state in the local artifact directory.
+3. Record which requirement triggered the state.
+4. Avoid automatic retries that could expand scope.
+5. Avoid provider calls, deployments, dashboard exposure, browser control, credential access, billing, and evidence promotion.
+6. Tell the operator which separate authorized lane would be needed for remediation if remediation is outside the local-only boundary.
+
+## Fail-closed requirement
+
+Ambiguous states must resolve to stop, not continue. If the harness cannot determine whether an action is local-only and bounded, it must emit `TASK_OUT_OF_SCOPE` or `FORBIDDEN_EXTERNAL_ACTION_REQUESTED` and stop.


### PR DESCRIPTION
### Motivation

- Provide a docs-only design packet for a future Self Operator MVP local run harness that specifies how preflights, bounded local execution, artifact capture, and stop-state handling should work.
- Constrain the design to be local-only and fail-closed, explicitly forbidding provider calls, dashboard exposure, deployments, browser control, credential use, billing, and evidence promotion.

### Description

- Added a new docs-only packet at `docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/` containing the required files: `README.md`, `source-evidence-reviewed.md`, `harness-overview.md`, `preflight-requirements.md`, `local-only-execution-boundary.md`, `artifact-capture-requirements.md`, `stop-state-handling.md`, `forbidden-external-actions.md`, `non-actions.md`, `selected-next-action.md`, `blocker-fallback-lane.md`, and `checks-run.md`.
- The packet documents the future harness phases (prepare run dir, run preflights, execute allowlisted local task under time/output limits, capture local artifacts, close run state) and enumerates required preflights, artifact manifests, stop states, and forbidden external actions.
- Records decision state and lanes: selected next action `NO_FURTHER_SELF_OPERATOR_LOCAL_RUN_HARNESS_DESIGN_LANES_SELECTED` and blocker fallback lane `ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-LOCAL-RUN-HARNESS-DESIGN-FIX-001`.
- Confirms evidence boundary: this PR is docs-only and does not create a runner, run models, call providers, modify runtime, expose dashboards, deploy, control browsers, use credentials, incur billing, or promote evidence.

### Testing

- Ran `git status --short`, `git diff --name-only`, and `git diff --check`; results show the new files are untracked then staged and contain no whitespace errors.
- Ran `make check-local-llm-orchestration-guardrails` and its subchecks; `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design` passed and the doc path / evidence-boundary static checks passed.
- Confirmed changed files are only under `docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/` and recorded validation results in `checks-run.md`.
- All automated checks listed above passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26399b75a88329a13891a500d256fc)