### PR TITLE
Include post-Level-7 Self Operator packets in packet consistency discovery

### DIFF
--- a/docs/local_llm_solver_orchestration_guardrails/checker-inventory.md
+++ b/docs/local_llm_solver_orchestration_guardrails/checker-inventory.md
@@ -70,7 +70,7 @@ python scripts/check_local_llm_packet_consistency.py
 
 What it protects:
 
-- Discovers local LLM solver orchestration packet directories under `docs/evals/runs/`, including post-Level-3 release-readiness packets named `alpha-solver-post-level-3-*`.
+- Discovers local LLM solver orchestration packet directories under `docs/evals/runs/`, including post-Level-3 release-readiness packets named `alpha-solver-post-level-3-*` and post-Level-7 Self Operator packets named `alpha-solver-post-level-7-*`.
 - Requires selected-next state or an explicit closed/no-further state where applicable.
 - Requires blocker fallback lane files when packet patterns indicate they are needed.
 - Requires evidence-boundary, blocked-claims, non-actions, or equivalent boundary files when packet patterns indicate they are needed.

--- a/scripts/check_local_llm_packet_consistency.py
+++ b/scripts/check_local_llm_packet_consistency.py
@@ -34,6 +34,7 @@ PACKET_DIR_MARKERS = (
     "local-llm-solver-orchestration",
     "20260607-local-llm-controlled-usage-operator-run-001",
     "alpha-solver-post-level-3-",
+    "alpha-solver-post-level-7-",
 )
 SOURCE_ARTIFACT_MARKERS = (
     "/source-artifact/",

--- a/tests/test_local_llm_packet_consistency.py
+++ b/tests/test_local_llm_packet_consistency.py
@@ -112,26 +112,76 @@ def test_default_discovery_includes_future_post_level_3_level_4_packet(tmp_path)
     assert iter_packet_dirs(tmp_path) == [packet_dir]
 
 
-def test_default_discovery_excludes_post_level_3_source_artifact_payloads(tmp_path):
-    packet_dir = Path("docs/evals/runs/alpha-solver-post-level-3-fixture")
-    nested_source_artifact_dir = packet_dir / "source-artifact"
+def test_default_discovery_includes_future_post_level_7_self_operator_packet(tmp_path):
+    packet_dir = Path(
+        "docs/evals/runs/"
+        "alpha-solver-post-level-7-self-operator-static-checker-hardening"
+    )
+    _write_packet(
+        tmp_path,
+        packet_dir,
+        selected_text=(
+            "`ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-"
+            "STATIC-CHECKER-HARDENING-NEXT-001`\n"
+        ),
+    )
+
+    assert iter_packet_dirs(tmp_path) == [packet_dir]
+
+
+def test_future_post_level_7_packet_with_full_boundary_files_validates(tmp_path):
+    packet_dir = Path(
+        "docs/evals/runs/"
+        "alpha-solver-post-level-7-self-operator-validation-fixture"
+    )
+    _write_packet(
+        tmp_path,
+        packet_dir,
+        selected_text=(
+            "`ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-"
+            "VALIDATION-FOLLOWUP-001`\n"
+        ),
+        boundary_name="non-actions.md",
+    )
+    (tmp_path / packet_dir / "evidence-boundary.md").write_text(
+        "# Evidence boundary\n\nStatic checker fixture only.\n",
+        encoding="utf-8",
+    )
+
+    assert iter_packet_dirs(tmp_path) == [packet_dir]
+    assert check_packet_dir(packet_dir, tmp_path) == []
+
+
+def test_default_discovery_excludes_source_artifact_payloads_for_packet_families(tmp_path):
+    post_level_3_packet_dir = Path("docs/evals/runs/alpha-solver-post-level-3-fixture")
+    post_level_7_packet_dir = Path(
+        "docs/evals/runs/alpha-solver-post-level-7-self-operator-fixture"
+    )
+    nested_source_artifact_dir = post_level_7_packet_dir / "source-artifact"
     named_source_artifact_dir = Path(
-        "docs/evals/runs/alpha-solver-post-level-3-source-artifact-fixture"
+        "docs/evals/runs/alpha-solver-post-level-7-source-artifact-fixture"
     )
     suffix_source_artifact_dir = Path(
-        "docs/evals/runs/alpha-solver-post-level-3-level-4-source-artifact"
+        "docs/evals/runs/alpha-solver-post-level-7-self-operator-source-artifact"
     )
-    _write_packet(tmp_path, packet_dir)
+    existing_marker_source_artifact_dir = Path(
+        "docs/evals/runs/alpha-solver-post-level-7-self-operator-source-artifact-fixture"
+    )
+    _write_packet(tmp_path, post_level_3_packet_dir)
+    _write_packet(tmp_path, post_level_7_packet_dir)
     _write_packet(tmp_path, nested_source_artifact_dir)
     _write_packet(tmp_path, named_source_artifact_dir)
     _write_packet(tmp_path, suffix_source_artifact_dir)
+    _write_packet(tmp_path, existing_marker_source_artifact_dir)
 
     packet_dirs = iter_packet_dirs(tmp_path)
 
-    assert packet_dir in packet_dirs
+    assert post_level_3_packet_dir in packet_dirs
+    assert post_level_7_packet_dir in packet_dirs
     assert nested_source_artifact_dir not in packet_dirs
     assert named_source_artifact_dir not in packet_dirs
     assert suffix_source_artifact_dir not in packet_dirs
+    assert existing_marker_source_artifact_dir not in packet_dirs
     assert not any(
         part == "source-artifact" or part.endswith("-source-artifact")
         for path in packet_dirs


### PR DESCRIPTION
### Motivation
- Lane: `ALPHA-SOLVER-POST-LEVEL-7-PACKET-DISCOVERY-CHECKER-FIX-001` to harden packet-discovery so default static checks include post-Level-7 Self Operator packets; the previous default discovered `alpha-solver-post-level-3-*` but missed `alpha-solver-post-level-7-*` unless passed explicitly. 
- The change is a narrow static checker hardening to broaden discovery only and must not modify any Self Operator packet content or runtime behavior.

### Description
- Added the new marker `"alpha-solver-post-level-7-"` to `PACKET_DIR_MARKERS` so `iter_packet_dirs()` will include `docs/evals/runs/alpha-solver-post-level-7-*` by default, while preserving `alpha-solver-post-level-3-*` discovery (`scripts/check_local_llm_packet_consistency.py`).
- Added tests that prove default discovery includes `alpha-solver-post-level-7-self-operator-*`, continues to include `alpha-solver-post-level-3-*`, continues to exclude source-artifact payload directories, and validates a future post-Level-7 fixture with README, selected-next, blocker fallback, non-actions, and evidence-boundary files (`tests/test_local_llm_packet_consistency.py`).
- Updated docs inventory wording to document that the packet consistency checker now covers both `alpha-solver-post-level-3-*` and `alpha-solver-post-level-7-*` families (`docs/local_llm_solver_orchestration_guardrails/checker-inventory.md`).
- The change scope is limited to discovery and tests; no packet content, runtime code, provider code, API, dashboard, CLI, Makefile, CI workflows, or source-artifact payload content was modified.

### Testing
- Ran `python -m py_compile scripts/check_local_llm_packet_consistency.py` and it succeeded with no syntax errors.
- Ran `python -m pytest -q tests/test_local_llm_packet_consistency.py` and the test suite passed (new and existing tests succeeded).
- Ran the checker directly with `python scripts/check_local_llm_packet_consistency.py` and it reported a passing check (`Local LLM packet consistency check passed`).
- Ran the aggregate guardrail target `make check-local-llm-orchestration-guardrails` and it passed including evidence-boundary, doc-path/link, and packet-consistency checks.


Required items (summary):
- Lane name: `ALPHA-SOLVER-POST-LEVEL-7-PACKET-DISCOVERY-CHECKER-FIX-001`.
- Discovery gap fixed: default discovery now includes `docs/evals/runs/alpha-solver-post-level-7-*` packets in addition to `alpha-solver-post-level-3-*`.
- Files changed: `scripts/check_local_llm_packet_consistency.py`, `tests/test_local_llm_packet_consistency.py`, `docs/local_llm_solver_orchestration_guardrails/checker-inventory.md`.
- Tests added/updated: tests proving inclusion of post-Level-7 packets, preservation of post-Level-3 discovery, continued exclusion of source-artifact directories, and a validated post-Level-7 fixture with required boundary files.
- Evidence boundary: this is static checker hardening only and does not change or run any Self Operator packet content or runtime evidence.
- Explicit non-actions: no Self Operator packet content changed, and no runtime/provider/API/dashboard/CLI/source-artifact/Makefile/CI workflow files were modified or executed as part of this change.
- Final scope confirmation: scope is limited to packet discovery/checker hardening, focused tests, and documentation inventory update only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a264995f92083299505368df0f72c2d)