### PR TITLE
Add Self Operator local run harness design packet (docs-only, absolute no-provider-calls)

### DIFF
--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/README.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/README.md
@@ -1,0 +1,51 @@
+# Self Operator Local Run Harness Design Packet
+
+Lane: `ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-LOCAL-RUN-HARNESS-DESIGN-PACKET-001`
+
+## Status
+
+This packet is a docs-only, local-only harness design reference for future Self Operator work. It is a supporting reference only. It does not start Level 8, does not implement a runner, and does not authorize any execution beyond the local documentation and checker commands used to create and validate this packet.
+
+## Purpose
+
+This packet defines how a future local-only Self Operator harness should run preflights, execute bounded local tasks, capture local artifacts, handle stop states, and avoid external actions. The local harness may only perform bounded local preflights, local artifact capture, local docs/checker commands, and future local-only tasks explicitly authorized by a later implementation lane.
+
+## Absolute local-only boundary
+
+This design uses absolute no-provider-call language. The local harness design must not be read as authorizing provider calls. A future lane may separately design provider-aware behavior, but that future provider-aware design would be separate from this local run harness design.
+
+The local run harness defined here has no provider calls, no hosted model calls, no external API calls, no fallback, no credential use, no billing, no dashboard exposure, no `/v1/solve` exposure, no browser automation, no deployment, and no evidence promotion.
+
+## Relationship to accepted Self Operator prep packets
+
+This packet builds on the accepted Level 7 provider orchestration design and the existing Post-Level-7 Self Operator preparation packets. It narrows their future operator concepts into a local-only harness design reference without adding runtime behavior, provider behavior, API behavior, dashboard behavior, or evidence promotion.
+
+## Packet files
+
+- `source-evidence-reviewed.md` records source evidence reviewed before drafting.
+- `harness-overview.md` defines the local harness purpose, phases, and relationship to prior packets.
+- `preflight-requirements.md` defines required local preflights and stop-before-start gates.
+- `local-only-execution-boundary.md` defines the only work a future local harness may perform.
+- `artifact-capture-requirements.md` defines local artifact capture requirements.
+- `stop-state-handling.md` defines stop states and required handling.
+- `forbidden-external-actions.md` defines absolute forbidden external actions.
+- `non-actions.md` records actions not taken by this docs-only packet.
+- `selected-next-action.md` records the no-further-lanes decision.
+- `blocker-fallback-lane.md` records the fallback lane for packet correction.
+- `checks-run.md` records checks run for this packet.
+
+## Selected next action
+
+`NO_FURTHER_SELF_OPERATOR_LOCAL_RUN_HARNESS_DESIGN_LANES_SELECTED`
+
+No follow-on Self Operator local run harness design lane is selected by this packet.
+
+## Blocker fallback lane
+
+If this packet is incomplete, inconsistent, stale, unsafe, insufficiently local-only, unclear about stop states, or ambiguous about provider/external action prohibition, use blocker fallback lane:
+
+`ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-LOCAL-RUN-HARNESS-DESIGN-FIX-001`
+
+## Evidence boundary
+
+Docs-only local harness design. This does not create a runner, execute tasks, run models, call providers, modify runtime, expose dashboards, expose `/v1/solve`, deploy, control browsers, use credentials, incur billing, add fallback, or promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/artifact-capture-requirements.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/artifact-capture-requirements.md
@@ -1,0 +1,23 @@
+# Artifact Capture Requirements
+
+## Purpose
+
+A future local-only harness should capture enough local artifacts for human review of preflights, bounded local commands, stop states, and closeout without promoting those artifacts as validation evidence.
+
+## Required local artifacts
+
+A future run should capture local artifacts such as:
+
+- Run manifest with lane, task identifier, branch, commit, operator approval state, and declared local scope.
+- Preflight results with pass/fail state and stop-before-start reasons.
+- Command ledger containing only local command names, arguments, exit codes, start times, end times, and working directories.
+- Redacted stdout/stderr summaries where allowed by the future implementation lane.
+- File-change manifest for local files changed by the run.
+- Stop-state record when a stop condition is reached.
+- Closeout summary for operator review.
+
+## Artifact boundaries
+
+Artifact capture must remain local. It must not upload artifacts, expose dashboards, publish reports, call external APIs, call providers, call hosted models, use credentials, incur billing, deploy, automate browsers, expose `/v1/solve`, add fallback, or promote evidence.
+
+Artifacts produced by a future harness are local run records only unless a separate accepted evidence lane later reviews and promotes them. This packet itself does not promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/blocker-fallback-lane.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/blocker-fallback-lane.md
@@ -1,0 +1,7 @@
+# Blocker Fallback Lane
+
+If this packet is incomplete, inconsistent, stale, unsafe, insufficiently local-only, unclear about stop states, or ambiguous about provider/external action prohibition, use blocker fallback lane:
+
+`ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-LOCAL-RUN-HARNESS-DESIGN-FIX-001`
+
+This fallback lane is only for fixing this docs-only local harness design packet. It does not authorize runtime work, provider work, API work, dashboard work, deployment, browser automation, billing, fallback, credential use, model execution, or evidence promotion.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/checks-run.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/checks-run.md
@@ -1,0 +1,12 @@
+# Checks Run
+
+Checks for this packet:
+
+- `git status --short`
+- `git diff --name-only`
+- `git diff --check`
+- `make check-local-llm-orchestration-guardrails`
+- `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design`
+- `rg "no provider calls|no hosted model calls|no external API calls|no fallback|no credential use|no billing|no dashboard exposure|no /v1/solve exposure|NO_FURTHER_SELF_OPERATOR_LOCAL_RUN_HARNESS_DESIGN_LANES_SELECTED|ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-LOCAL-RUN-HARNESS-DESIGN-FIX-001" docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design`
+
+The final command outputs are recorded in the PR summary rather than embedded here to avoid treating command logs as authoritative packet decisions.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/forbidden-external-actions.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/forbidden-external-actions.md
@@ -1,0 +1,42 @@
+# Forbidden External Actions
+
+## Absolute prohibition
+
+The future local run harness described by this packet is strictly local-only. It must use absolute no-provider-call behavior. It must not include any exception, fallback, or interpretation that allows provider calls inside this local harness.
+
+Forbidden actions include:
+
+- no provider calls
+- no hosted model calls
+- no external API calls
+- no fallback
+- no credential use
+- no billing
+- no dashboard exposure
+- no /v1/solve exposure
+- no browser automation
+- no deployment
+- no evidence promotion
+
+## Additional forbidden actions
+
+The local harness must also not:
+
+- run local models;
+- run hosted models;
+- run Ollama;
+- configure credentials or secrets;
+- add provider routing;
+- add provider fallback;
+- add hosted fallback;
+- expose or call `/v1/solve`;
+- expose dashboards;
+- run benchmarks;
+- perform billing work;
+- deploy;
+- control browsers;
+- promote evidence.
+
+## Future provider-aware clarification
+
+A future lane may separately design provider-aware behavior, but this local run harness design must not be read as authorizing provider calls. The local harness may only perform bounded local preflights, local artifact capture, local docs/checker commands, and future local-only tasks explicitly authorized by a later implementation lane.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/harness-overview.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/harness-overview.md
@@ -1,0 +1,24 @@
+# Harness Overview
+
+## Purpose
+
+A future Self Operator local run harness would coordinate a narrow local-only workflow for an operator-approved task. The design goal is to make local preflight checks, bounded local execution, artifact capture, and stop handling explicit before any runner is implemented.
+
+## Future local-only phases
+
+A future local harness should be structured as four local-only phases:
+
+1. **Preflight phase** — validate repository state, packet evidence, operator intent, branch cleanliness, and local command allowlists before any task begins.
+2. **Bounded local task phase** — run only explicitly authorized local-only commands or local docs/checker tasks within a declared scope.
+3. **Artifact capture phase** — store local logs, command metadata, manifests, and stop-state records without promoting them as evidence.
+4. **Closeout phase** — summarize local results, stop states, and unresolved blockers for human review.
+
+## Relationship to accepted prep packets
+
+This packet is a supporting reference for the existing Self Operator prep packets. It relies on their accepted scope, lifecycle, approval, artifact, risk, and runbook concepts while adding a local-only harness design view.
+
+This packet does not supersede those prep packets. If this packet conflicts with a stricter accepted Self Operator prep packet boundary, the stricter boundary should govern future work.
+
+## Explicit non-authorization
+
+This packet does not implement a runner. This packet does not start Level 8. This packet does not authorize provider calls, hosted model calls, local model runs, external API calls, fallback, credential use, billing, dashboard exposure, `/v1/solve` exposure, browser automation, deployment, or evidence promotion.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/local-only-execution-boundary.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/local-only-execution-boundary.md
@@ -1,0 +1,29 @@
+# Local-Only Execution Boundary
+
+## Allowed future local work
+
+A future local run harness may only perform work that is explicitly authorized by a later local-only implementation lane and remains inside the local repository or local filesystem scope. Allowed categories are limited to:
+
+- Bounded local preflight checks.
+- Local artifact capture.
+- Local documentation commands.
+- Local checker commands.
+- Future local-only tasks explicitly authorized by a later lane.
+
+## Required execution controls
+
+A future local harness should require:
+
+- A declared task identifier.
+- A declared local working directory.
+- A declared command allowlist.
+- A declared artifact directory.
+- A declared stop-state policy.
+- Human-readable logs for each local command.
+- No automatic retry that changes scope or behavior.
+
+## External boundary
+
+The local harness must not cross the local-only boundary. It must not call providers, call hosted models, call external APIs, run local models, use credentials, incur billing, expose dashboard routes, expose or call `/v1/solve`, automate browsers, deploy, add fallback, or promote evidence.
+
+A future lane may separately design provider-aware behavior, but this local run harness design must not be read as authorizing provider calls.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/non-actions.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/non-actions.md
@@ -1,0 +1,35 @@
+# Non-Actions
+
+This docs-only packet does not take or authorize the following actions:
+
+- Does not create a runner.
+- Does not start Level 8.
+- Does not implement Self Operator.
+- Does not execute Self Operator tasks.
+- Does not run models.
+- Does not call providers.
+- Does not call hosted models.
+- Does not call external APIs.
+- Does not modify runtime code.
+- Does not modify provider code.
+- Does not modify API files.
+- Does not modify dashboard files.
+- Does not modify CLI files.
+- Does not modify checker scripts.
+- Does not modify tests.
+- Does not modify the Makefile.
+- Does not modify CI workflows.
+- Does not modify source-artifact files.
+- Does not configure credentials or secrets.
+- Does not add provider routing.
+- Does not add provider fallback.
+- Does not add hosted fallback.
+- Does not expose or call `/v1/solve`.
+- Does not expose dashboards.
+- Does not run benchmarks.
+- Does not perform billing work.
+- Does not deploy.
+- Does not control browsers.
+- Does not promote evidence.
+
+Evidence boundary: Docs-only local harness design. This does not create a runner, execute tasks, run models, call providers, modify runtime, expose dashboards, expose `/v1/solve`, deploy, control browsers, use credentials, incur billing, add fallback, or promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/preflight-requirements.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/preflight-requirements.md
@@ -1,0 +1,29 @@
+# Preflight Requirements
+
+## Required local preflights
+
+A future local-only harness should stop before execution unless all required local preflights pass:
+
+- Confirm the operator-selected task is local-only, bounded, and tied to an approved later lane.
+- Confirm the current branch and working tree are acceptable for the declared local task.
+- Confirm required source evidence packets and specs are present.
+- Confirm the local command allowlist contains only docs/checker commands or explicitly authorized local-only task commands.
+- Confirm no credential files, secret variables, provider configuration, billing configuration, dashboard exposure, or `/v1/solve` exposure are required.
+- Confirm artifact paths are local, deterministic, and scoped to the run.
+- Confirm stop-state handling is enabled before any local command starts.
+
+## Stop-before-start conditions
+
+The future harness must stop before start if any of these conditions are present:
+
+- Missing required source evidence.
+- Unclear operator intent or task boundary.
+- Dirty or unexpected repository state that would confuse artifact capture.
+- Any request for provider calls, hosted model calls, external API calls, local model runs, fallback, credentials, billing, deployment, browser automation, dashboard exposure, `/v1/solve` exposure, or evidence promotion.
+- Missing local artifact destination.
+- Missing human approval where a future lane requires approval.
+- A command that is outside the local-only allowlist.
+
+## Preflight outputs
+
+Preflight results should be captured as local artifacts only. They should record the check name, command if applicable, pass/fail state, timestamp, repository branch, and stop reason if the run stops.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/selected-next-action.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/selected-next-action.md
@@ -1,0 +1,5 @@
+# Selected Next Action
+
+`NO_FURTHER_SELF_OPERATOR_LOCAL_RUN_HARNESS_DESIGN_LANES_SELECTED`
+
+No further Self Operator local run harness design lanes are selected by this packet. This packet is a supporting reference only and does not start Level 8.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/source-evidence-reviewed.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/source-evidence-reviewed.md
@@ -1,0 +1,32 @@
+# Source Evidence Reviewed
+
+Lane: `ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-LOCAL-RUN-HARNESS-DESIGN-PACKET-001`
+
+## Required preflight evidence
+
+The following required paths were checked before drafting this packet:
+
+- `docs/evals/runs/alpha-solver-post-level-3-level-7-provider-orchestration-design/` — present.
+- `docs/evals/runs/alpha-solver-post-level-7-self-operator-mvp-scope-matrix/` — present.
+- `docs/evals/runs/alpha-solver-post-level-7-self-operator-lifecycle-state-machine/` — present.
+- `docs/evals/runs/alpha-solver-post-level-7-self-operator-human-approval-controls/` — present.
+- `docs/evals/runs/alpha-solver-post-level-7-self-operator-artifact-persistence-schema/` — present.
+- `docs/evals/runs/alpha-solver-post-level-7-self-operator-failure-mode-risk-register/` — present.
+- `scripts/check_local_llm_packet_consistency.py` — present.
+- `tests/test_local_llm_packet_consistency.py` — present.
+- `Makefile` — present.
+
+The accepted Level 7 provider orchestration design packet was present. The post-Level-7 packet discovery checker update was present because `scripts/check_local_llm_packet_consistency.py` includes the `alpha-solver-post-level-7-` packet marker and the associated tests reference Post-Level-7 packet discovery fixtures.
+
+## Additional Self Operator prep packet context
+
+This packet also reviewed the expected current-main Self Operator preparation packet set as context:
+
+- `docs/evals/runs/alpha-solver-post-level-7-self-operator-implementation-file-map/`
+- `docs/evals/runs/alpha-solver-post-level-7-self-operator-task-job-schema/`
+- `docs/evals/runs/alpha-solver-post-level-7-self-operator-acceptance-test-plan/`
+- `docs/evals/runs/alpha-solver-post-level-7-self-operator-operator-runbook-draft/`
+
+## Evidence boundary from review
+
+The evidence reviewed supports only a docs-only local harness design reference. It does not support a claim that a Self Operator runner exists, that Level 8 has started, that local tasks may be executed now, or that provider-aware behavior is authorized by this packet.

--- a/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/stop-state-handling.md
+++ b/docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/stop-state-handling.md
@@ -1,0 +1,30 @@
+# Stop-State Handling
+
+## Stop-state purpose
+
+A future local-only harness should stop predictably when a preflight, command, artifact, or boundary condition fails. Stop handling must favor safety, traceability, and human review over autonomous continuation.
+
+## Required stop states
+
+A future local harness should define at least these stop states:
+
+- `STOP_MISSING_EVIDENCE` — required source evidence or lane context is missing.
+- `STOP_UNCLEAR_TASK` — task scope, branch, or operator intent is unclear.
+- `STOP_UNAPPROVED_ACTION` — requested command or task is not approved by the applicable later lane.
+- `STOP_EXTERNAL_ACTION_REQUESTED` — requested action would cross the local-only boundary.
+- `STOP_CREDENTIAL_OR_BILLING_RISK` — requested action would use credentials, secrets, billing, or provider configuration.
+- `STOP_ARTIFACT_CAPTURE_FAILURE` — required local artifact capture cannot be completed.
+- `STOP_COMMAND_FAILURE` — an authorized local command fails and the stop policy requires halt.
+- `STOP_REPOSITORY_STATE_RISK` — repository state would make results ambiguous or unsafe.
+
+## Required handling
+
+When a stop state occurs, the future harness should:
+
+1. Halt additional task execution.
+2. Capture a local stop-state artifact.
+3. Record the reason, triggering preflight or command, and local repository state.
+4. Avoid retries that expand scope.
+5. Return control to the human operator.
+
+Stop-state handling must not invoke provider calls, hosted model calls, external API calls, fallback, credentials, billing, dashboards, `/v1/solve`, browser automation, deployment, or evidence promotion.


### PR DESCRIPTION
### Motivation

- Add a focused, docs-only local run harness design that defines how a future local-only Self Operator harness should run preflights, execute bounded local tasks, capture local artifacts, and handle stop states.  
- Ensure the design is strictly local-only with absolute no-provider-call wording so it cannot be read as authorizing any provider or external interactions.  
- Provide a clean replacement for the closed PR #427 as a new packet on a fresh branch for review and integration into the Post-Level-7 prep packets.

### Description

- Added a new docs-only packet under `docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/` containing `README.md`, `source-evidence-reviewed.md`, `harness-overview.md`, `preflight-requirements.md`, `local-only-execution-boundary.md`, `artifact-capture-requirements.md`, `stop-state-handling.md`, `forbidden-external-actions.md`, `non-actions.md`, `selected-next-action.md`, `blocker-fallback-lane.md`, and `checks-run.md`.  
- The packet defines purpose, required preflights, a strict local-only execution boundary, artifact capture requirements, explicit stop-state handling, and non-actions; it is explicitly a supporting reference only and does not implement a runner or start Level 8.  
- `forbidden-external-actions.md` uses absolute wording and includes the required exact concepts: `no provider calls`, `no hosted model calls`, `no external API calls`, `no fallback`, `no credential use`, `no billing`, `no dashboard exposure`, `no /v1/solve exposure`, `no browser automation`, `no deployment`, and `no evidence promotion`.  
- The packet documents its relationship to the accepted Post-Level-7 Self Operator prep packets and records the selected next action `NO_FURTHER_SELF_OPERATOR_LOCAL_RUN_HARNESS_DESIGN_LANES_SELECTED` and blocker fallback lane `ALPHA-SOLVER-POST-LEVEL-7-SELF-OPERATOR-LOCAL-RUN-HARNESS-DESIGN-FIX-001`.

### Testing

- Ran repository checks `git status --short`, `git diff --name-only`, and `git diff --check` to verify the change set and found only files under the new packet directory.  
- Ran guardrail checks via `make check-local-llm-orchestration-guardrails` which completed successfully.  
- Executed the packet-consistency checker with `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design` which passed.  
- Performed a grep validation `rg` for the required absolute no-provider-call phrases and lane tokens inside the new packet which found the required phrases and markers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26575669f8832991999910d8b84d1b)