### PR TITLE
Add Level 8 MVP readiness review packet (operator-only Self Operator planning)

### DIFF
--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-mvp-readiness-review/README.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-mvp-readiness-review/README.md
@@ -1,0 +1,51 @@
+# Level 8 MVP Readiness Review Packet
+
+Lane: `ALPHA-SOLVER-POST-LEVEL-3-LEVEL-8-MVP-READINESS-REVIEW-PACKET-001`
+
+## Objective
+
+This docs-only Level 8 packet decides whether Alpha Solver is ready to start a narrow operator-only Self Operator MVP implementation plan.
+
+## Decision
+
+`READY_FOR_NARROW_OPERATOR_ONLY_MVP_IMPLEMENTATION_PLAN`
+
+MVP implementation planning may begin only as the selected follow-on planning packet. This readiness decision does not start implementation, does not modify runtime behavior, and does not authorize Self Operator execution.
+
+## Selected next lane
+
+Exactly one next lane is selected:
+
+`ALPHA-SOLVER-POST-LEVEL-3-LEVEL-9-SELF-OPERATOR-MVP-IMPLEMENTATION-PLAN-PACKET-001`
+
+Selecting this lane authorizes a docs/spec planning packet only. It does not authorize code changes, runtime work, provider calls, browser control, deployment, billing, autonomous merge, evidence promotion, or public product-surface exposure.
+
+## Earliest allowed MVP scope
+
+The earliest allowed MVP scope is a local-only, operator-supervised, no-provider-call Self Operator implementation plan that may define narrow future code-change gates for a local run harness, local task/job records, local artifacts, local approval stops, and local acceptance tests. Any future implementation remains blocked until explicit implementation gates are satisfied and an accepted implementation lane authorizes code changes.
+
+## Required defaults
+
+Future planning and any later implementation must default to local-only, operator-supervised, no provider calls, no browser control, no deployment, no billing, and no autonomous merge.
+
+## Packet files
+
+- `source-evidence-reviewed.md` records source evidence reviewed and preflight confirmations.
+- `current-state-summary.md` summarizes the accepted prior state carried into this review.
+- `readiness-question.md` states the controlling readiness question.
+- `readiness-findings.md` records readiness findings.
+- `mvp-allowed-scope.md` defines the narrow earliest allowed MVP planning scope.
+- `mvp-blocked-scope.md` defines blocked work.
+- `implementation-readiness-gates.md` defines gates required before code changes.
+- `evidence-requirements.md` defines evidence requirements before readiness or implementation claims.
+- `safety-gates.md` defines safety gates for future planning and implementation lanes.
+- `release-blockers.md` records release blockers and non-release status.
+- `decision.md` records the readiness decision.
+- `selected-next-lane.md` records the one selected next lane.
+- `blocker-fallback-lane.md` records the fallback lane if this packet is blocked.
+- `non-actions.md` records actions not taken by this docs-only packet.
+- `checks-run.md` records validation checks run for this packet.
+
+## Evidence boundary
+
+Docs-only Level 8 MVP readiness review. This does not implement Self Operator, run Self Operator, modify runtime, call providers, expose `/v1/solve`, expose dashboards, configure credentials, run models, run benchmarks, deploy, perform billing work, autonomously merge, control browsers, or promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-mvp-readiness-review/blocker-fallback-lane.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-mvp-readiness-review/blocker-fallback-lane.md
@@ -1,0 +1,7 @@
+# Blocker Fallback Lane
+
+If this packet is incomplete, inconsistent, stale, unsafe by default, contradictory with accepted prior packets, missing required evidence, ambiguous about blocked work, or unable to preserve local-only operator-supervised defaults, use blocker fallback lane:
+
+`ALPHA-SOLVER-POST-LEVEL-3-LEVEL-8-MVP-READINESS-REVIEW-FIX-001`
+
+This fallback lane is only for fixing this docs-only readiness review packet. It does not authorize implementation, runtime work, provider calls, browser control, deployment, billing, autonomous merge, or evidence promotion.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-mvp-readiness-review/checks-run.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-mvp-readiness-review/checks-run.md
@@ -1,0 +1,15 @@
+# Checks Run
+
+The required checks for this packet are recorded here after execution:
+
+- `git status --short`
+- `git diff --name-only`
+- `git diff --check`
+- `make check-local-llm-orchestration-guardrails`
+- `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-level-8-mvp-readiness-review`
+- Required readiness, lane, fallback, and boundary phrase scan was run with `rg` against this packet directory.
+- Changed-file confirmation: only files under `docs/evals/runs/alpha-solver-post-level-3-level-8-mvp-readiness-review/` were changed.
+
+## Evidence boundary
+
+These checks are local documentation and static guardrail checks only. They do not implement Self Operator, call providers, run models, expose routes, deploy, bill, control browsers, autonomously merge, or promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-mvp-readiness-review/current-state-summary.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-mvp-readiness-review/current-state-summary.md
@@ -1,0 +1,23 @@
+# Current State Summary
+
+## Accepted prior state
+
+The current accepted prior state carried into this Level 8 review is:
+
+- Level 7 provider orchestration design is accepted.
+- Level 7 provider support packets are accepted.
+- Post-Level-7 Self Operator prep packets are accepted.
+- Post-Level-7 packet discovery checker fix is accepted.
+- Self Operator local run harness design with absolute no-provider-call wording is accepted.
+
+## Current implementation state
+
+This packet treats the current state as design-ready for a planning lane only. Runtime Self Operator behavior remains unimplemented by this packet, and this packet does not implement Self Operator.
+
+## Discovery path
+
+This packet uses the default-discovered packet family path:
+
+`docs/evals/runs/alpha-solver-post-level-3-level-8-mvp-readiness-review/`
+
+It intentionally does not use an `alpha-solver-post-level-8-*` packet path because current default packet discovery covers `alpha-solver-post-level-3-*` packet directories.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-mvp-readiness-review/decision.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-mvp-readiness-review/decision.md
@@ -1,0 +1,15 @@
+# Decision
+
+## Readiness decision
+
+`READY_FOR_NARROW_OPERATOR_ONLY_MVP_IMPLEMENTATION_PLAN`
+
+Alpha Solver is ready to start a narrow operator-only Self Operator MVP implementation planning packet.
+
+## Scope of this decision
+
+This decision allows planning to begin. It does not start implementation, does not implement Self Operator, does not run Self Operator, does not modify runtime, does not call providers, does not expose routes, does not run agents, does not run models, does not deploy, does not bill, does not autonomously merge, does not control browsers, and does not promote evidence.
+
+## Reason
+
+The required prior Level 7 provider orchestration design, provider support evidence, and Post-Level-7 Self Operator preparation packets are present and sufficient to support a narrow planning lane, provided all local-only and operator-supervised safety defaults remain binding.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-mvp-readiness-review/evidence-requirements.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-mvp-readiness-review/evidence-requirements.md
@@ -1,0 +1,13 @@
+# Evidence Requirements
+
+## Evidence required before planning claims
+
+The Level 9 planning lane must preserve this packet's source-evidence review and explicitly restate which prior packets it relies on.
+
+## Evidence required before MVP readiness claims
+
+Before any later lane claims Self Operator MVP readiness, it must provide accepted acceptance-test evidence for the authorized scope. Acceptance tests must cover local-only execution, operator approvals, stop conditions, artifact persistence, blocked actions, and claim boundaries.
+
+## Evidence not established here
+
+This packet does not establish runtime evidence, model evidence, provider evidence, `/v1/solve` evidence, dashboard evidence, benchmark evidence, deployment evidence, billing evidence, browser-control evidence, autonomous-merge evidence, or production readiness evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-mvp-readiness-review/implementation-readiness-gates.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-mvp-readiness-review/implementation-readiness-gates.md
@@ -1,0 +1,20 @@
+# Implementation Readiness Gates
+
+Before any Self Operator code changes may begin, a later accepted lane must explicitly satisfy all gates below.
+
+## Required gates before code changes
+
+1. An accepted implementation plan must name the exact future implementation lane.
+2. The implementation plan must cite the approved files or modules that may change.
+3. The implementation plan must define local-only behavior and stop conditions.
+4. The implementation plan must preserve operator-supervised approval controls.
+5. The implementation plan must preserve no provider calls, no browser control, no deployment, no billing, and no autonomous merge defaults.
+6. The implementation plan must define acceptance tests before claiming MVP readiness.
+7. The implementation plan must define evidence boundaries and blocked claims.
+8. The implementation plan must define rollback or stop-state handling for failed local checks.
+9. Reviewers must confirm that implementation scope is narrower than or equal to the allowed MVP scope.
+10. Any runtime file changes must be blocked until the accepted implementation lane names them.
+
+## Gate failure handling
+
+If any gate cannot be satisfied, the project must use the blocker fallback lane instead of beginning implementation planning or code changes.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-mvp-readiness-review/mvp-allowed-scope.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-mvp-readiness-review/mvp-allowed-scope.md
@@ -1,0 +1,34 @@
+# MVP Allowed Scope
+
+## Earliest allowed planning scope
+
+If the selected Level 9 planning lane is accepted, it may plan only a narrow operator-only Self Operator MVP with these defaults:
+
+- Local-only execution.
+- Operator-supervised starts, stops, approvals, and reviews.
+- No provider calls.
+- No hosted model calls.
+- No external API calls.
+- No browser control.
+- No deployment.
+- No billing or cost-incurring behavior.
+- No autonomous merge.
+- No evidence promotion.
+
+## Planning topics allowed
+
+The selected planning lane may define future implementation requirements for:
+
+- local task/job records;
+- local lifecycle state transitions;
+- local artifact persistence;
+- explicit human approval checkpoints;
+- stop-before-start preflights;
+- deterministic local checks;
+- acceptance tests required before MVP readiness can be claimed;
+- operator runbook handoffs;
+- future code-change gates.
+
+## Not yet authorized
+
+Even inside the selected planning lane, the project may not implement Self Operator, run Self Operator, call providers, run models, expose `/v1/solve`, expose dashboards, deploy, bill, autonomously merge, control browsers, or promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-mvp-readiness-review/mvp-blocked-scope.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-mvp-readiness-review/mvp-blocked-scope.md
@@ -1,0 +1,20 @@
+# MVP Blocked Scope
+
+The following work is blocked by this Level 8 readiness review and remains blocked unless a later accepted lane explicitly authorizes it:
+
+- Implementing Self Operator runtime behavior.
+- Running Self Operator.
+- Running agents or autonomous task loops.
+- Calling hosted providers or local providers.
+- Calling hosted models or local models.
+- Adding provider routing, provider fallback, or hosted fallback.
+- Configuring credentials, secrets, tokens, accounts, quotas, or billing.
+- Exposing or calling `/v1/solve`.
+- Exposing dashboards or product surfaces.
+- Running benchmarks or scoring outputs.
+- Deploying services or infrastructure.
+- Performing billing work or cost-incurring work.
+- Autonomously merging, pushing releases, or changing branch protection.
+- Controlling browsers, browser automation, or external websites.
+- Promoting evidence beyond docs-only readiness review status.
+- Modifying runtime, API, dashboard, provider, CLI, CI, checker, or test files in this packet.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-mvp-readiness-review/non-actions.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-mvp-readiness-review/non-actions.md
@@ -1,0 +1,35 @@
+# Non-Actions
+
+This docs-only Level 8 readiness review does not take or authorize the following actions:
+
+- Does not implement Self Operator.
+- Does not start Self Operator runtime work.
+- Does not run Self Operator.
+- Does not run agents.
+- Does not run models.
+- Does not call providers.
+- Does not make provider calls.
+- Does not call hosted models.
+- Does not call external APIs.
+- Does not configure credentials, tokens, accounts, quotas, secrets, or billing.
+- Does not modify runtime code.
+- Does not modify provider code.
+- Does not modify API files.
+- Does not expose or call `/v1/solve`.
+- Does not expose dashboards.
+- Does not modify dashboard files.
+- Does not modify CLI files.
+- Does not modify checker scripts.
+- Does not modify tests.
+- Does not modify the Makefile.
+- Does not modify CI workflows.
+- Does not run benchmarks.
+- Does not score outputs.
+- Does not deploy.
+- Does not perform billing work.
+- Does not autonomously merge.
+- Does not control browsers.
+- Does not perform browser control.
+- Does not promote evidence.
+
+Evidence boundary: Docs-only Level 8 MVP readiness review. This does not implement Self Operator, run Self Operator, modify runtime, call providers, expose `/v1/solve`, expose dashboards, configure credentials, run models, run benchmarks, deploy, perform billing work, autonomously merge, control browsers, or promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-mvp-readiness-review/readiness-findings.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-mvp-readiness-review/readiness-findings.md
@@ -1,0 +1,21 @@
+# Readiness Findings
+
+## Finding 1: sufficient prior planning exists
+
+The accepted provider orchestration design and provider fail-closed support evidence provide enough boundary language for a follow-on implementation planning packet.
+
+## Finding 2: Self Operator prep coverage is sufficient for planning
+
+The accepted Self Operator prep packets cover scope, implementation file mapping, lifecycle states, task/job records, human approvals, artifact persistence, local harness behavior, acceptance testing, risk handling, and operator runbook expectations.
+
+## Finding 3: implementation itself remains blocked
+
+The evidence is sufficient for planning, not implementation. Any code changes must wait for explicit implementation gates in an accepted follow-on implementation plan and a later implementation lane.
+
+## Finding 4: safety defaults are non-negotiable
+
+The future MVP must remain local-only, operator-supervised, no provider calls, no browser control, no deployment, no billing, and no autonomous merge by default.
+
+## Finding 5: evidence claims must remain narrow
+
+This packet does not provide runtime evidence, provider evidence, model evidence, browser evidence, deployment evidence, benchmark evidence, billing evidence, or production readiness evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-mvp-readiness-review/readiness-question.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-mvp-readiness-review/readiness-question.md
@@ -1,0 +1,13 @@
+# Readiness Question
+
+## Controlling question
+
+Is Alpha Solver ready to start a narrow operator-only Self Operator MVP implementation plan?
+
+## Answer boundary
+
+The answer may only decide whether implementation planning may begin. It must not start implementation, change runtime files, call providers, expose routes, run agents, run models, deploy, bill, autonomously merge, control browsers, or promote evidence.
+
+## Required decision options
+
+This packet must choose one readiness result and either one next lane or one fallback lane. The selected decision is recorded in `decision.md`.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-mvp-readiness-review/release-blockers.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-mvp-readiness-review/release-blockers.md
@@ -1,0 +1,16 @@
+# Release Blockers
+
+## Release status
+
+This packet does not create a releasable Self Operator MVP. It only decides that a narrow operator-only implementation planning packet may begin.
+
+## Blockers to release or runtime use
+
+The following remain blockers to any MVP release, runtime claim, or operator use claim:
+
+- No accepted implementation plan exists yet.
+- No accepted implementation lane exists yet.
+- No Self Operator code has been implemented by this packet.
+- No acceptance tests have been implemented or passed for MVP runtime behavior.
+- No local run evidence has been produced by this packet.
+- No provider, model, API, dashboard, deployment, billing, browser, or autonomous-merge evidence exists from this packet.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-mvp-readiness-review/safety-gates.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-mvp-readiness-review/safety-gates.md
@@ -1,0 +1,19 @@
+# Safety Gates
+
+Future planning and implementation lanes must preserve these safety gates:
+
+- Default local-only execution.
+- Default operator supervision.
+- Stop-before-start preflights.
+- Explicit human approval controls.
+- No provider calls.
+- No hosted model calls.
+- No browser control.
+- No deployment.
+- No billing or cost-incurring behavior.
+- No autonomous merge.
+- No credential or secret configuration.
+- No public API or dashboard exposure.
+- No evidence promotion without accepted evidence.
+
+A later lane must stop if any safety gate becomes ambiguous, stale, contradicted, or unenforceable.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-mvp-readiness-review/selected-next-lane.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-mvp-readiness-review/selected-next-lane.md
@@ -1,0 +1,9 @@
+# Selected Next Lane
+
+Lane: `ALPHA-SOLVER-POST-LEVEL-3-LEVEL-8-MVP-READINESS-REVIEW-PACKET-001`
+
+Exactly one next lane is selected:
+
+`ALPHA-SOLVER-POST-LEVEL-3-LEVEL-9-SELF-OPERATOR-MVP-IMPLEMENTATION-PLAN-PACKET-001`
+
+The selected next lane is a planning packet only. It does not implement Self Operator, run Self Operator, call providers, expose `/v1/solve`, expose dashboards, configure credentials, run models, run benchmarks, deploy, perform billing work, autonomously merge, control browsers, or promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-mvp-readiness-review/source-evidence-reviewed.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-mvp-readiness-review/source-evidence-reviewed.md
@@ -1,0 +1,31 @@
+# Source Evidence Reviewed
+
+## Required preflight status
+
+The required preflight artifacts were present before drafting this packet:
+
+- `docs/evals/runs/alpha-solver-post-level-3-level-7-provider-orchestration-design/`
+- `docs/evals/runs/alpha-solver-post-level-3-provider-fallback-fail-closed-policy/`
+- `docs/evals/runs/alpha-solver-post-level-7-self-operator-mvp-scope-matrix/`
+- `docs/evals/runs/alpha-solver-post-level-7-self-operator-implementation-file-map/`
+- `docs/evals/runs/alpha-solver-post-level-7-self-operator-lifecycle-state-machine/`
+- `docs/evals/runs/alpha-solver-post-level-7-self-operator-task-job-schema/`
+- `docs/evals/runs/alpha-solver-post-level-7-self-operator-human-approval-controls/`
+- `docs/evals/runs/alpha-solver-post-level-7-self-operator-artifact-persistence-schema/`
+- `docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/`
+- `docs/evals/runs/alpha-solver-post-level-7-self-operator-acceptance-test-plan/`
+- `docs/evals/runs/alpha-solver-post-level-7-self-operator-failure-mode-risk-register/`
+- `docs/evals/runs/alpha-solver-post-level-7-self-operator-operator-runbook-draft/`
+- `scripts/check_local_llm_packet_consistency.py`
+- `tests/test_local_llm_packet_consistency.py`
+- `Makefile`
+
+The accepted Level 7 provider orchestration design packet and the accepted local run harness design packet were present, so this review did not stop at preflight.
+
+## Evidence reviewed
+
+This packet reviewed the prior provider orchestration design, provider fail-closed policy, Self Operator scope matrix, implementation file map, lifecycle state machine, task/job schema, human approval controls, artifact persistence schema, local run harness design, acceptance test plan, failure mode/risk register, and operator runbook draft.
+
+## Evidence interpretation
+
+The reviewed evidence supports starting a narrow implementation planning packet. It does not prove that Self Operator is implemented, usable, safe to run, provider-ready, browser-ready, deployable, billable, or ready for autonomous operation.


### PR DESCRIPTION
### Motivation

- Provide a docs-only Level 8 readiness review that decides whether Alpha Solver may begin a narrow operator-only Self Operator MVP implementation planning lane. 
- Preserve an explicit docs-only evidence boundary so no runtime, provider, deployment, billing, browser-control, or autonomous actions are started by this packet. 
- Ensure the readiness decision is grounded on accepted Level 7 provider and Self Operator prep packets discovered during preflight. 

### Description

- Add a new packet at `docs/evals/runs/alpha-solver-post-level-3-level-8-mvp-readiness-review/` containing focused docs: `README.md`, `decision.md`, `selected-next-lane.md`, `blocker-fallback-lane.md`, `non-actions.md`, `checks-run.md`, `source-evidence-reviewed.md`, `current-state-summary.md`, `readiness-question.md`, `readiness-findings.md`, `mvp-allowed-scope.md`, `mvp-blocked-scope.md`, `implementation-readiness-gates.md`, `evidence-requirements.md`, `safety-gates.md`, and `release-blockers.md`. 
- Record the readiness decision `READY_FOR_NARROW_OPERATOR_ONLY_MVP_IMPLEMENTATION_PLAN` and select exactly one next lane `ALPHA-SOLVER-POST-LEVEL-3-LEVEL-9-SELF-OPERATOR-MVP-IMPLEMENTATION-PLAN-PACKET-001`. 
- Define the earliest allowed planning scope as local-only and operator-supervised with strict defaults of no provider calls, no browser control, no deployment, no billing, and no autonomous merge. 
- Add explicit implementation-readiness gates, evidence requirements, safety gates, blocked-scope enumeration, and a blocker fallback lane `ALPHA-SOLVER-POST-LEVEL-3-LEVEL-8-MVP-READINESS-REVIEW-FIX-001` to require further fixes if needed. 

### Testing

- Ran the required local checks: `git status --short`, `git diff --name-only`, and `git diff --check`, all observed as part of preflight and packet validation. 
- Executed `make check-local-llm-orchestration-guardrails` which ran the repo static doc/evidence guardrail checks and passed. 
- Ran `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-level-8-mvp-readiness-review` which passed and reported the new packet as consistent. 
- Performed phrase scans with `rg` against the new packet and verified that changed files are confined to `docs/evals/runs/alpha-solver-post-level-3-level-8-mvp-readiness-review/`; all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a265bc559448329a6b1df6a3bb2792f)