### PR TITLE
Add Self Operator operator UX acceptance packet

### DIFF
--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-operator-ux-acceptance/README.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-operator-ux-acceptance/README.md
@@ -1,0 +1,33 @@
+# Alpha Solver Post-Level-3 Level-8 Self Operator Operator UX Acceptance Packet
+
+Lane: `ALPHA-SOLVER-POST-LEVEL-3-LEVEL-8-SELF-OPERATOR-OPERATOR-UX-ACCEPTANCE-PACKET-001`
+
+## Objective
+
+Create a docs-only operator UX acceptance packet for the earliest Self Operator MVP. The packet defines the text and review requirements for what the operator sees, approves, monitors, stops, and reviews before any runtime, UI, CLI, dashboard, or Self Operator implementation is accepted.
+
+## Evidence boundary
+
+This packet is documentation-only UX acceptance evidence. It does not implement UI, CLI, dashboard, runtime orchestration, provider routing, hosted model access, local model execution, artifact persistence, or Self Operator behavior.
+
+## Required operator-visible moments
+
+The earliest MVP UX must provide clear copy for these operator moments:
+
+1. **Task intake** — the operator sees the submitted task, its scope, requested outputs, allowed evidence sources, and explicit no-provider-call boundary before approval.
+2. **Preflight result** — the operator sees whether local prerequisites passed, warned, or blocked, including the reason and required next step.
+3. **Approval request** — the operator sees a human approval prompt that names the action, boundaries, artifacts to be created, and stop option.
+4. **Running status** — the operator sees live status that distinguishes queued, preflight, approved, running, stopping, stopped, blocked, completed, and failed states.
+5. **Stop state** — the operator sees confirmation that a stop was requested, whether work halted cleanly, and where partial artifacts or logs are located.
+6. **Blocked action** — the operator sees a plain-language block reason, the boundary that prevented continuation, and the fallback lane for unresolved blocker handling.
+7. **Completed state** — the operator sees completion status, generated artifacts, unresolved warnings, and whether review is required before using outputs.
+8. **Artifact location** — the operator sees exact artifact paths or stable identifiers for every reviewable output.
+9. **No-provider-call boundary** — the operator sees that this MVP UX acceptance lane makes no provider calls and that the eventual MVP must not silently call providers outside an explicit approved provider lane.
+
+## Acceptance summary
+
+The packet accepts only the operator-facing text requirements and unacceptable UX boundaries for the earliest Self Operator MVP. A future implementation may use this packet as acceptance input, but this packet does not authorize implementation or runtime behavior.
+
+Selected next action: `NO_FURTHER_LEVEL_8_SELF_OPERATOR_OPERATOR_UX_ACCEPTANCE_LANES_SELECTED`
+
+Blocker fallback lane: `ALPHA-SOLVER-POST-LEVEL-3-LEVEL-8-SELF-OPERATOR-OPERATOR-UX-ACCEPTANCE-FIX-001`

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-operator-ux-acceptance/approval-copy.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-operator-ux-acceptance/approval-copy.md
@@ -1,0 +1,34 @@
+# Approval Copy
+
+## Required approval request text
+
+The approval request must include copy equivalent to:
+
+> Review this Self Operator task before it runs. Approve only if the task, scope, evidence boundary, artifacts, and stop option match your intent.
+
+## Required fields
+
+- Task name or identifier.
+- Requested action.
+- Scope summary.
+- Evidence sources to use.
+- Files, directories, or artifacts expected to be read or created.
+- Whether the action is inspect-only or change-producing.
+- Stop instruction.
+- Provider boundary statement.
+
+## No-provider-call boundary copy
+
+The approval request must include copy equivalent to:
+
+> This approval does not authorize hosted provider calls, billing, credential use, or external model fallback. If provider access is required, stop and route to an explicitly approved provider lane.
+
+## Approval buttons or commands
+
+The operator must have distinct choices equivalent to:
+
+- `Approve this action`
+- `Reject / do not run`
+- `Stop and mark blocked`
+
+The UX must not use ambiguous approval copy such as `continue` when the next action could make changes, create artifacts, consume credentials, or call providers.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-operator-ux-acceptance/artifact-review-copy.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-operator-ux-acceptance/artifact-review-copy.md
@@ -1,0 +1,28 @@
+# Artifact Review Copy
+
+## Required artifact location copy
+
+The completed or stopped state must include copy equivalent to:
+
+> Artifacts are available at the listed path or stable identifier. Review them before using the output as evidence.
+
+## Required artifact fields
+
+- Artifact path or stable identifier.
+- Artifact type.
+- Creation state: `created`, `partial`, `not created`, or `superseded`.
+- Review requirement.
+- Evidence boundary.
+- Known warnings or omissions.
+
+## Review prompt
+
+Required copy:
+
+> Review the artifact list for completeness, boundary compliance, and unresolved warnings. Do not treat logs, partial outputs, or scratch notes as final acceptance evidence unless explicitly marked final.
+
+## No artifact case
+
+If no artifacts were created, required copy is:
+
+> No reviewable artifacts were created. Use the blocked or failed state details to decide whether to retry, revise scope, or route to the fallback lane.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-operator-ux-acceptance/blocked-state-copy.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-operator-ux-acceptance/blocked-state-copy.md
@@ -1,0 +1,28 @@
+# Blocked State Copy
+
+## Required blocked action text
+
+A blocked action must use copy equivalent to:
+
+> Blocked: the Self Operator cannot continue because the requested action crosses an approval, evidence, safety, provider, credential, or path boundary.
+
+## Required blocked state fields
+
+- Blocked state label.
+- Plain-language reason.
+- Boundary or rule that prevented continuation.
+- Whether any artifacts were created before the block.
+- Artifact or log location, if available.
+- Required operator decision or fallback lane.
+
+## Required fallback copy
+
+For unresolved acceptance packet issues, the UX packet records this fallback lane:
+
+`ALPHA-SOLVER-POST-LEVEL-3-LEVEL-8-SELF-OPERATOR-OPERATOR-UX-ACCEPTANCE-FIX-001`
+
+## Provider boundary block
+
+If a task would require a provider call not explicitly approved, the required blocked copy is:
+
+> Blocked: this action would require a provider call or credential use that is outside the approved boundary. No provider call was made. Route to an approved provider lane before retrying.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-operator-ux-acceptance/blocker-fallback-lane.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-operator-ux-acceptance/blocker-fallback-lane.md
@@ -1,0 +1,7 @@
+# Blocker Fallback Lane
+
+If this docs-only operator UX acceptance packet is incomplete, contradictory, or fails packet consistency checks, route the blocker to:
+
+`ALPHA-SOLVER-POST-LEVEL-3-LEVEL-8-SELF-OPERATOR-OPERATOR-UX-ACCEPTANCE-FIX-001`
+
+The fallback lane is only for fixing this acceptance packet. It does not authorize implementation of UI, CLI, dashboard, runtime behavior, provider access, or Self Operator execution.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-operator-ux-acceptance/checks-run.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-operator-ux-acceptance/checks-run.md
@@ -1,0 +1,12 @@
+# Checks Run
+
+Required checks for this packet:
+
+- `git status --short`
+- `git diff --name-only`
+- `git diff --check`
+- `make check-local-llm-orchestration-guardrails`
+- `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-operator-ux-acceptance`
+- Confirm changed files are only under `docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-operator-ux-acceptance/`.
+
+This file records the expected check set; the final PR response records the observed results from the working tree.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-operator-ux-acceptance/non-actions.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-operator-ux-acceptance/non-actions.md
@@ -1,0 +1,15 @@
+# Non-Actions
+
+This docs-only UX acceptance packet does not perform or authorize any of the following:
+
+- Implementing Self Operator runtime behavior.
+- Building or changing UI, CLI, dashboard, API, or route surfaces.
+- Calling hosted providers, local model providers, external APIs, or fallback models.
+- Using credentials, secrets, billing accounts, or provider registry entries.
+- Running tasks, jobs, agents, schedulers, or background workers.
+- Creating runtime artifacts outside this packet directory.
+- Changing SAFE-OUT, MCP, routing, budget guard, determinism, observability, replay, or SolverEnvelope behavior.
+- Promoting this packet to runtime validation evidence.
+- Selecting any further Level 8 Self Operator operator UX acceptance lane.
+
+No provider call was made or authorized by this packet.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-operator-ux-acceptance/operator-flow.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-operator-ux-acceptance/operator-flow.md
@@ -1,0 +1,50 @@
+# Operator Flow
+
+## Required MVP flow
+
+The earliest Self Operator MVP must make the operator flow explicit and reviewable.
+
+1. **Task intake**
+   - Show the task title or identifier.
+   - Show the requested outcome and any known constraints.
+   - Show whether the task is inspect-only or requests changes.
+   - Show the evidence boundary and the no-provider-call boundary before any approval.
+
+2. **Preflight result**
+   - Show prerequisite checks and status: `pass`, `warning`, or `blocked`.
+   - Show any missing inputs, unsafe ambiguity, path issues, or policy boundary conflicts.
+   - Do not advance to approval when preflight is blocked.
+
+3. **Approval request**
+   - Ask the operator to approve the specific next action, not a vague session.
+   - Include the planned artifacts and stop mechanism.
+   - State that approval does not authorize provider calls unless the provider boundary is explicitly included.
+
+4. **Running status**
+   - Show current lifecycle state and last operator-visible event.
+   - Show whether the run is still within approved scope.
+   - Show artifact paths as soon as they are reserved or created.
+
+5. **Stop state**
+   - Offer a visible stop control or stop instruction throughout running state.
+   - Show `stop requested`, then either `stopped` or `stop failed` with reason.
+   - Preserve partial artifacts where possible and identify incomplete outputs.
+
+6. **Blocked action**
+   - Stop progression when an approval, safety, evidence, credential, provider, path, or policy boundary blocks the action.
+   - Show the block reason in operator-readable language.
+   - Point unresolved blocker handling to the fallback lane.
+
+7. **Completed state**
+   - Show a concise completion message.
+   - List created artifacts and review steps.
+   - Identify any warnings, non-actions, and outputs that must not be treated as implementation evidence.
+
+8. **Artifact review**
+   - Provide stable artifact locations.
+   - Identify the minimum files the operator must review.
+   - Distinguish final artifacts from logs, partial outputs, and scratch evidence.
+
+## State labels
+
+The UX must use stable state labels or equivalents: `intake`, `preflight`, `awaiting_approval`, `approved`, `running`, `stopping`, `stopped`, `blocked`, `completed`, and `failed`.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-operator-ux-acceptance/run-status-copy.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-operator-ux-acceptance/run-status-copy.md
@@ -1,0 +1,56 @@
+# Run Status Copy
+
+## Task intake status
+
+Required copy:
+
+> Intake received. Review task scope, requested outputs, evidence boundary, artifact destination, and provider-call boundary before approval.
+
+## Preflight result status
+
+Pass copy:
+
+> Preflight passed. The task can be presented for operator approval within the documented boundary.
+
+Warning copy:
+
+> Preflight warning. Review the warning before approval; the task may continue only if the warning is acceptable within scope.
+
+Blocked copy:
+
+> Preflight blocked. The task cannot proceed until the listed blocker is resolved.
+
+## Running status
+
+Required copy:
+
+> Running within approved scope. Monitor current step, stop option, and artifact location.
+
+The status view must show:
+
+- Current state.
+- Current step or phase.
+- Last update time or event sequence.
+- Stop option.
+- Artifact path or pending artifact reservation.
+- Warning count, if any.
+
+## Stop state status
+
+Stop requested copy:
+
+> Stop requested. The Self Operator is attempting to halt within the approved boundary.
+
+Stopped copy:
+
+> Stopped. Review partial artifacts and logs before re-running or closing the task.
+
+Stop failed copy:
+
+> Stop failed or incomplete. Treat the run as blocked and review logs before taking further action.
+
+## Completed status
+
+Required copy:
+
+> Completed. Review generated artifacts, warnings, non-actions, and evidence boundaries before relying on the output.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-operator-ux-acceptance/selected-next-action.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-operator-ux-acceptance/selected-next-action.md
@@ -1,0 +1,5 @@
+# Selected Next Action
+
+`NO_FURTHER_LEVEL_8_SELF_OPERATOR_OPERATOR_UX_ACCEPTANCE_LANES_SELECTED`
+
+This packet closes the docs-only operator UX acceptance lane. No follow-on Level 8 Self Operator operator UX acceptance lane is selected by this packet.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-operator-ux-acceptance/source-evidence-reviewed.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-operator-ux-acceptance/source-evidence-reviewed.md
@@ -1,0 +1,20 @@
+# Source Evidence Reviewed
+
+## Reviewed repo evidence
+
+This packet was drafted against existing Self Operator planning and acceptance documents in this repository, including:
+
+- Level 7 Self Operator operator runbook draft.
+- Level 7 Self Operator human approval controls.
+- Level 7 Self Operator lifecycle state machine.
+- Level 7 Self Operator artifact persistence schema.
+- Level 7 Self Operator acceptance test plan.
+- Local LLM packet consistency checker expectations for selected-next action, blocker fallback, and non-action boundary files.
+
+## Evidence use
+
+The reviewed evidence was used only to define operator UX acceptance copy and review criteria. It was not used to change product behavior, runtime code, provider configuration, routing, storage, dashboard surfaces, or CLI behavior.
+
+## Evidence boundary
+
+This packet is not runtime evidence. It does not prove that a Self Operator can run tasks, call models, stop jobs, persist artifacts, or display status in a user interface. It only records the operator copy requirements that a future MVP implementation must satisfy.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-operator-ux-acceptance/unacceptable-ux.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-operator-ux-acceptance/unacceptable-ux.md
@@ -1,0 +1,15 @@
+# Unacceptable UX
+
+The earliest Self Operator MVP is not acceptable if any of the following UX patterns are present:
+
+- Starts running without an explicit operator approval moment.
+- Uses vague approval copy such as `continue` without naming the action and boundary.
+- Hides or omits the no-provider-call boundary.
+- Silently calls hosted providers, uses credentials, bills, or falls back to external models.
+- Shows running status without a visible stop option or stop instruction.
+- Fails to distinguish blocked, failed, stopped, and completed states.
+- Omits artifact locations after completion, stop, or block when artifacts exist.
+- Treats partial artifacts as final without review copy.
+- Continues after a blocked preflight result.
+- Uses implementation-success language for this docs-only packet.
+- Implies dashboard, CLI, runtime, or Self Operator behavior has been implemented by this packet.


### PR DESCRIPTION
### Motivation

- Provide a docs-only UX acceptance packet that specifies what an operator must see, approve, monitor, stop, and review for the earliest Self Operator MVP.
- Make the no-provider-call boundary and non-action constraints explicit so this packet remains documentation-only and does not authorize runtime or provider behavior.
- Produce a concise acceptance artifact that future implementations can use as input without implying any UI, CLI, dashboard, runtime, or Self Operator implementation.

### Description

- Add a new packet under `docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-operator-ux-acceptance/` containing the required files: `README.md`, `source-evidence-reviewed.md`, `operator-flow.md`, `approval-copy.md`, `blocked-state-copy.md`, `run-status-copy.md`, `artifact-review-copy.md`, `unacceptable-ux.md`, `non-actions.md`, `selected-next-action.md`, `blocker-fallback-lane.md`, and `checks-run.md`.
- Define operator-flow and stable state labels, required approval and blocked-state copy, run status and stop-state copy, artifact review wording, unacceptable UX patterns, and explicit non-actions for the packet.
- Record the evidence boundary and note the reviewed Level 7 planning artifacts and packet-consistency expectations used to draft the UX copy.
- Set the selected next action to `NO_FURTHER_LEVEL_8_SELF_OPERATOR_OPERATOR_UX_ACCEPTANCE_LANES_SELECTED` and the blocker fallback lane to `ALPHA-SOLVER-POST-LEVEL-3-LEVEL-8-SELF-OPERATOR-OPERATOR-UX-ACCEPTANCE-FIX-001`.

### Testing

- Ran `make check-local-llm-orchestration-guardrails`, which executed the evidence boundary, doc-path, and packet-consistency checks and completed successfully.
- Ran `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-operator-ux-acceptance` which passed for 1 packet directory.
- Verified local repository checks `git status --short`, `git diff --name-only`, and `git diff --check` and confirmed the changed files are limited to the new packet directory `docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-operator-ux-acceptance/` (12 files added).
- Working branch is `work` and the PR URL is not available from the local environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a265c35297c8329b4d5b059b86043fe)