### PR TITLE
Add Level 8 Self Operator implementation prompt pack draft (docs-only)

### DIFF
--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-implementation-prompt-pack-draft/README.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-implementation-prompt-pack-draft/README.md
@@ -1,0 +1,40 @@
+# Level 8 Self Operator Implementation Prompt Pack Draft
+
+## Purpose
+
+This packet is a docs-only draft of future Codex implementation prompts for possible Self Operator MVP code lanes after Level 8 accepts Self Operator readiness and explicitly selects implementation planning.
+
+## Evidence boundary
+
+This packet does not run prompts, implement code, authorize implementation, call providers, expose product surfaces, deploy, bill, promote evidence, or change runtime behavior.
+
+## Universal hard stops
+
+Every future prompt in this packet must stop unless all of these conditions are true:
+
+- Level 8 is accepted by an authoritative later decision.
+- Level 8 selects implementation planning for a Self Operator MVP.
+- The future lane starts from or updates a relevant spec before behavior changes.
+- The work remains local-only.
+- The task does not use provider calls, credentials, browser automation, deployment, billing, `/v1/solve`, dashboard exposure, or evidence promotion.
+
+## Required draft prompts
+
+The draft prompt pack includes prompts for:
+
+1. implementation planning;
+2. static tests;
+3. artifact schema code;
+4. local preflight runner;
+5. approval capture;
+6. stop-state handling;
+7. local harness wrapper;
+8. acceptance execution.
+
+## Selected next action
+
+No further Level 8 Self Operator implementation prompt pack draft lanes are selected by this packet. The selected next action token is recorded by components in `selected-next-action.md`.
+
+## Blocker fallback
+
+The blocker fallback lane is recorded in `blocker-fallback-lane.md` and is only for repairing this docs-only draft packet.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-implementation-prompt-pack-draft/blocker-fallback-lane.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-implementation-prompt-pack-draft/blocker-fallback-lane.md
@@ -1,0 +1,7 @@
+# Blocker Fallback Lane
+
+Blocker fallback lane: `ALPHA-SOLVER-POST-LEVEL-3-LEVEL-8-SELF-OPERATOR-IMPLEMENTATION-PROMPT-PACK-DRAFT-FIX-001`
+
+Use this fallback only if this docs-only prompt pack draft packet is incomplete, inconsistent, or blocked by packet-format requirements.
+
+The fallback is a packet repair lane only. It must not authorize implementation planning, run prompts, modify code, call providers, use credentials, automate browsers, deploy, bill, expose `/v1/solve`, expose dashboards, promote evidence, or create run artifacts.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-implementation-prompt-pack-draft/checks-run.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-implementation-prompt-pack-draft/checks-run.md
@@ -1,0 +1,14 @@
+# Checks Run
+
+## Commands executed
+
+- `git status --short` — passed; showed only this new docs packet directory as untracked before commit.
+- `git diff --name-only` — passed; no tracked-file diff output before files were staged because all packet files were new and untracked.
+- `git diff --check` — passed with no whitespace errors.
+- `make check-local-llm-orchestration-guardrails` — passed.
+- `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-implementation-prompt-pack-draft` — passed.
+- Changed-file scope confirmation — passed; changed files were only under `docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-implementation-prompt-pack-draft/`.
+
+## Evidence boundary
+
+These checks validate docs packet consistency and path scope only. They do not run future implementation prompts, implement code, authorize implementation, call providers, use credentials, automate browsers, deploy, bill, expose `/v1/solve`, expose dashboards, or promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-implementation-prompt-pack-draft/non-actions.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-implementation-prompt-pack-draft/non-actions.md
@@ -1,0 +1,18 @@
+# Non-Actions
+
+This docs-only prompt pack draft does not:
+
+- run any prompt in this packet;
+- implement Self Operator MVP code;
+- authorize implementation planning;
+- create or update specs;
+- modify runtime, CLI, API, dashboard, provider, routing, billing, deployment, or browser-automation code;
+- call hosted or local providers;
+- use, request, print, validate, or store credentials;
+- expose `/v1/solve`;
+- expose dashboard behavior;
+- create billing exposure;
+- deploy anything;
+- promote evidence;
+- create Self Operator run artifacts;
+- select another prompt-pack draft lane.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-implementation-prompt-pack-draft/prompt-01-implementation-plan.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-implementation-prompt-pack-draft/prompt-01-implementation-plan.md
@@ -1,0 +1,17 @@
+# Prompt 01 — Implementation Plan
+
+```text
+HARD STOP: Stop unless Level 8 is accepted and has selected implementation planning for Self Operator MVP.
+
+You are planning a future Self Operator MVP implementation lane. Work local-only. Do not call providers, use credentials, automate a browser, deploy, bill, expose /v1/solve, expose dashboards, or promote evidence.
+
+Tasks:
+1. Re-read repo instructions, relevant specs, and prior Self Operator planning packets.
+2. Identify the smallest spec update or new spec required before behavior changes.
+3. Identify candidate runtime, CLI, artifact, and test files without editing code.
+4. Propose a phased implementation plan with stop conditions before each phase.
+5. Define focused local tests and static checks.
+6. Return a plan only; do not modify files unless the future lane explicitly authorizes plan-file documentation changes.
+
+Stop immediately if Level 8 acceptance is absent, implementation planning is not selected, scope requires external services, or the requested behavior would expose /v1/solve or dashboard surfaces.
+```

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-implementation-prompt-pack-draft/prompt-02-static-tests.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-implementation-prompt-pack-draft/prompt-02-static-tests.md
@@ -1,0 +1,16 @@
+# Prompt 02 — Static Tests
+
+```text
+HARD STOP: Stop unless Level 8 is accepted, implementation planning is selected, and a spec-backed Self Operator MVP test scope is approved.
+
+Implement only local static tests for the approved Self Operator MVP scope. Do not implement runtime behavior in this lane. Do not call providers, use credentials, automate a browser, deploy, bill, expose /v1/solve, expose dashboards, or promote evidence.
+
+Tasks:
+1. Inspect the approved spec and implementation plan.
+2. Add or update focused local tests that fail before implementation and do not require network access.
+3. Cover hard-stop gates: missing Level 8 acceptance, missing approval, provider-call prohibition, credential prohibition, browser/deployment/billing prohibition, route/dashboard exposure prohibition, and evidence-promotion prohibition.
+4. Run the most focused test command and static checks practical for the touched files.
+5. Return changed files and exact checks.
+
+Stop if tests would require live services, secrets, browser automation, route exposure, dashboard exposure, or evidence promotion.
+```

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-implementation-prompt-pack-draft/prompt-03-artifact-schema-code.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-implementation-prompt-pack-draft/prompt-03-artifact-schema-code.md
@@ -1,0 +1,17 @@
+# Prompt 03 — Artifact Schema Code
+
+```text
+HARD STOP: Stop unless Level 8 is accepted, implementation planning is selected, and a spec authorizes local Self Operator artifact schema code.
+
+Implement only local artifact schema code for Self Operator MVP artifacts. Do not implement provider execution, browser automation, deployment, billing, /v1/solve exposure, dashboard exposure, or evidence promotion.
+
+Tasks:
+1. Re-read the approved artifact schema spec and prior artifact persistence packet.
+2. Add or update local schema/dataclass/validation code only in the approved file set.
+3. Preserve raw-evidence versus reviewer-authored interpretation boundaries.
+4. Ensure credential fields are prohibited or redacted by schema rules.
+5. Add focused local tests for valid artifacts, missing approvals, stop states, and forbidden fields.
+6. Run focused tests and static checks.
+
+Stop if the implementation would store secrets, call a provider, run a model, mutate source evidence, or claim evidence promotion.
+```

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-implementation-prompt-pack-draft/prompt-04-local-preflight-runner.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-implementation-prompt-pack-draft/prompt-04-local-preflight-runner.md
@@ -1,0 +1,16 @@
+# Prompt 04 — Local Preflight Runner
+
+```text
+HARD STOP: Stop unless Level 8 is accepted, implementation planning is selected, and a spec authorizes a local-only preflight runner.
+
+Implement a local preflight runner for Self Operator MVP readiness gates. Do not call providers, use credentials, automate a browser, deploy, bill, expose /v1/solve, expose dashboards, or promote evidence.
+
+Tasks:
+1. Inspect the approved spec, CLI conventions, and existing local orchestration guardrails.
+2. Implement only deterministic local checks for approval presence, branch/worktree state, artifact directory safety, forbidden external modes, and stop-state prerequisites.
+3. Make the runner fail closed with clear operator-visible messages.
+4. Add focused tests for pass, fail, and ambiguous states.
+5. Run focused local checks.
+
+Stop if preflight requires network access, secrets, provider configuration, browser sessions, deployments, billing accounts, API-route exposure, dashboard exposure, or evidence promotion.
+```

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-implementation-prompt-pack-draft/prompt-05-approval-capture.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-implementation-prompt-pack-draft/prompt-05-approval-capture.md
@@ -1,0 +1,16 @@
+# Prompt 05 — Approval Capture
+
+```text
+HARD STOP: Stop unless Level 8 is accepted, implementation planning is selected, and a spec authorizes local approval-capture behavior.
+
+Implement local approval capture for Self Operator MVP. Do not call providers, use credentials, automate browsers, deploy, bill, expose /v1/solve, expose dashboards, or promote evidence.
+
+Tasks:
+1. Define and implement a local approval record format consistent with the approved schema.
+2. Require explicit operator approval metadata before any future Self Operator action can proceed.
+3. Ensure approvals cannot imply provider permission, deployment permission, billing permission, route exposure, dashboard exposure, or evidence promotion unless a separate future authorization exists.
+4. Add tests for missing, expired, mismatched, and valid approvals.
+5. Run focused local tests.
+
+Stop if approval capture would collect secrets, grant external-service permission, or bypass Level 8/spec gates.
+```

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-implementation-prompt-pack-draft/prompt-06-stop-state-handling.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-implementation-prompt-pack-draft/prompt-06-stop-state-handling.md
@@ -1,0 +1,16 @@
+# Prompt 06 — Stop-State Handling
+
+```text
+HARD STOP: Stop unless Level 8 is accepted, implementation planning is selected, and a spec authorizes local stop-state handling.
+
+Implement local fail-closed stop-state handling for Self Operator MVP. Do not call providers, use credentials, automate browsers, deploy, bill, expose /v1/solve, expose dashboards, or promote evidence.
+
+Tasks:
+1. Implement approved stop-state enums, records, or validators.
+2. Cover missing evidence, missing approval, unclear task, provider/fallback ambiguity, credential risk, branch pollution, forbidden route/dashboard exposure, and evidence-promotion attempts.
+3. Ensure stopped runs cannot continue without new approval.
+4. Preserve local artifact/provenance boundaries for stopped runs.
+5. Add focused tests and run them locally.
+
+Stop if any requested stop behavior would continue execution, retry externally, deploy, bill, expose routes, expose dashboards, or promote evidence.
+```

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-implementation-prompt-pack-draft/prompt-07-local-harness-wrapper.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-implementation-prompt-pack-draft/prompt-07-local-harness-wrapper.md
@@ -1,0 +1,16 @@
+# Prompt 07 — Local Harness Wrapper
+
+```text
+HARD STOP: Stop unless Level 8 is accepted, implementation planning is selected, and a spec authorizes a local Self Operator harness wrapper.
+
+Implement only a local harness wrapper for approved Self Operator MVP behavior. Do not call providers, use credentials, automate browsers, deploy, bill, expose /v1/solve, expose dashboards, or promote evidence.
+
+Tasks:
+1. Wrap only approved local components behind explicit preflight, approval, artifact, and stop-state gates.
+2. Default to dry-run or no-op where the spec requires uncertainty handling.
+3. Write artifacts only to approved local paths.
+4. Add tests proving forbidden external modes fail closed.
+5. Run focused local tests and static checks.
+
+Stop if the wrapper would run hosted models, use secrets, control browsers, deploy, create billing risk, expose /v1/solve or dashboard surfaces, or promote artifacts as evidence.
+```

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-implementation-prompt-pack-draft/prompt-08-acceptance-execution.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-implementation-prompt-pack-draft/prompt-08-acceptance-execution.md
@@ -1,0 +1,16 @@
+# Prompt 08 — Acceptance Execution
+
+```text
+HARD STOP: Stop unless Level 8 is accepted, implementation planning is selected, implementation lanes have completed, and a spec defines local acceptance criteria.
+
+Run only local acceptance checks for Self Operator MVP. Do not call providers, use credentials, automate browsers, deploy, bill, expose /v1/solve, expose dashboards, or promote evidence.
+
+Tasks:
+1. Confirm changed files match the approved implementation scope.
+2. Run focused unit/static checks and the approved local acceptance command set.
+3. Confirm no provider calls, credentials, browser automation, deployment, billing, route exposure, dashboard exposure, or evidence promotion occurred.
+4. Record pass/fail results, residual caveats, and blocked claims.
+5. Return acceptance evidence as local check output only.
+
+Stop if acceptance requires live services, secrets, browser automation, deployment, billing, /v1/solve, dashboards, or evidence promotion.
+```

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-implementation-prompt-pack-draft/prompt-pack-overview.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-implementation-prompt-pack-draft/prompt-pack-overview.md
@@ -1,0 +1,32 @@
+# Prompt Pack Overview
+
+## Draft status
+
+This is a draft prompt pack for future implementation lanes. It is not an implementation plan approval, not a runbook execution, and not evidence that Self Operator MVP exists.
+
+## Universal prompt header
+
+Each future prompt should begin with this header:
+
+```text
+HARD STOP: Stop immediately unless a later authoritative Level 8 decision has accepted Self Operator readiness and selected implementation planning for this specific lane.
+
+Scope is local-only. Do not call hosted providers. Do not use credentials. Do not use browser automation. Do not deploy. Do not create billing exposure. Do not expose or modify /v1/solve. Do not expose or modify dashboard behavior. Do not promote evidence. Do not run any prompt from this packet unless the future lane explicitly asks you to run that exact prompt.
+```
+
+## Prompt sequence intent
+
+The prompts are intentionally separable so a future operator can authorize one narrow lane at a time:
+
+- Prompt 01 drafts a concrete implementation plan.
+- Prompt 02 adds or updates static tests.
+- Prompt 03 implements local artifact schema code.
+- Prompt 04 implements a local preflight runner.
+- Prompt 05 implements approval capture.
+- Prompt 06 implements stop-state handling.
+- Prompt 07 implements a local harness wrapper.
+- Prompt 08 executes acceptance checks locally.
+
+## Non-execution rule
+
+This packet drafts text only. The prompts below must not be executed as part of this packet.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-implementation-prompt-pack-draft/selected-next-action.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-implementation-prompt-pack-draft/selected-next-action.md
@@ -1,0 +1,17 @@
+# Selected Next Action
+
+## Decision
+
+No further Level 8 Self Operator implementation prompt pack draft lanes are selected by this packet.
+
+Decision token components:
+
+- prefix: `NO_FURTHER_LEVEL_8_SELF_OPERATOR`
+- scope: `IMPLEMENTATION_PROMPT_PACK_DRAFT`
+- suffix: `LANES_SELECTED`
+
+Combined selected next action: the prefix, scope, and suffix above joined with underscores.
+
+## Boundary
+
+This selected next action does not authorize implementation, execution, provider use, credential use, browser automation, deployment, billing, `/v1/solve` exposure, dashboard exposure, evidence promotion, or another prompt-pack draft lane.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-implementation-prompt-pack-draft/source-evidence-reviewed.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-implementation-prompt-pack-draft/source-evidence-reviewed.md
@@ -1,0 +1,16 @@
+# Source Evidence Reviewed
+
+## Reviewed sources
+
+- Repo-level `AGENTS.md` instructions for narrow scope, spec-first behavior changes, source-of-truth hierarchy, and validation expectations.
+- Existing docs-only Self Operator planning packet patterns under `docs/evals/runs/alpha-solver-post-level-7-self-operator-*`.
+- `scripts/check_local_llm_packet_consistency.py` packet consistency expectations for selected-next state, blocker fallback, and boundary files.
+- `docs/local_llm_solver_orchestration_guardrails/checker-inventory.md` guardrail inventory context for local LLM orchestration packets.
+
+## Evidence boundary
+
+This review is limited to repository documentation and checker behavior. It does not review, execute, or validate a Self Operator implementation.
+
+## Drafting implication
+
+All prompt text is conditional future-use drafting only. A future Codex lane must re-inspect current specs, source files, tests, and authorization state before making any code change.


### PR DESCRIPTION
### Motivation

- Provide a docs-only draft of future Codex implementation prompts for a possible Level 8 Self Operator implementation-planning lane while preserving strict evidence and safety boundaries. 
- Encode explicit universal hard stops so any future prompts remain local-only and cannot call providers, use credentials, run browser automation, deploy, bill, expose `/v1/solve`, expose dashboards, or promote evidence. 
- Capture a separable sequence of narrow prompts to guide phased implementation planning, tests, schema, preflight, approval capture, stop-state handling, harness wrapping, and local acceptance checks. 

### Description

- Added a new packet at `docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-implementation-prompt-pack-draft/` containing `README.md`, `source-evidence-reviewed.md`, `prompt-pack-overview.md`, `prompt-01-implementation-plan.md` through `prompt-08-acceptance-execution.md`, `non-actions.md`, `selected-next-action.md`, `blocker-fallback-lane.md`, and `checks-run.md`. 
- Each prompt file contains a reusable HARD STOP header that requires authoritative Level 8 acceptance and selection of implementation planning before any execution or code changes. 
- The packet records the selected next action token components `NO_FURTHER_LEVEL_8_SELF_OPERATOR_IMPLEMENTATION_PROMPT_PACK_DRAFT_LANES_SELECTED` and the blocker fallback lane `ALPHA-SOLVER-POST-LEVEL-3-LEVEL-8-SELF-OPERATOR-IMPLEMENTATION-PROMPT-PACK-DRAFT-FIX-001`. 
- All files are docs-only and explicitly declare the non-actions/evidence boundary to prevent implementation, runtime, provider, credential, deployment, billing, route, dashboard, or evidence-promotion effects. 

### Testing

- Ran `git status --short` and `git diff --name-only` to confirm the only changed files are the new packet files and that no tracked-file diffs existed prior to staging. 
- Ran `git diff --check` and observed no whitespace or formatting errors. 
- Ran `make check-local-llm-orchestration-guardrails` which passed the static evidence-boundary and doc-path checks. 
- Ran `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-implementation-prompt-pack-draft` which passed for the new packet directory.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a265c4508908329857b6eedffc515de)