### PR TITLE
Add Self Operator Level 8 release closeout criteria packet (docs-only)

### DIFF
--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-release-closeout-criteria/README.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-release-closeout-criteria/README.md
@@ -1,0 +1,31 @@
+# Self Operator Release Closeout Criteria Packet
+
+Lane: `ALPHA-SOLVER-POST-LEVEL-3-LEVEL-8-SELF-OPERATOR-RELEASE-CLOSEOUT-CRITERIA-PACKET-001`
+
+## Objective
+
+Create a docs-only release closeout criteria packet for the earliest Self Operator MVP. This packet defines what must be true before an operator-only MVP can be called released. It does not release Alpha Solver, ship product behavior, execute tests, call providers, run browser automation, deploy services, or authorize autonomous operation.
+
+## Packet contents
+
+- `source-evidence-reviewed.md` records the repository evidence reviewed while drafting this criteria packet.
+- `closeout-criteria.md` defines mandatory release closeout gates for the operator-only MVP.
+- `required-tests.md` defines the planned test evidence that must pass before release can be claimed.
+- `required-artifacts.md` defines raw artifact preservation requirements.
+- `required-docs.md` defines required runbook, approval, and release-documentation updates.
+- `blocked-release-claims.md` records claims that remain blocked by this packet and by the earliest operator-only MVP boundary.
+- `release-notes-requirements.md` defines release notes content requirements for any future release claim.
+- `non-actions.md` defines the docs-only evidence boundary and prohibited actions for this packet.
+- `selected-next-action.md` records the selected next action decision.
+- `blocker-fallback-lane.md` records the blocker fallback lane.
+- `checks-run.md` records required local checks for this docs-only packet.
+
+## Release boundary
+
+An earliest Self Operator MVP release claim is blocked unless all planned tests pass, raw artifacts are preserved, the runbook is updated, operator approvals are documented, and release notes accurately state the operator-only constraints. The MVP boundary also requires no provider calls, no browser automation, no deployment, no production claim, and no autonomous operation claim.
+
+## Required decision markers
+
+Selected next action: `NO_FURTHER_LEVEL_8_SELF_OPERATOR_RELEASE_CLOSEOUT_CRITERIA_LANES_SELECTED`
+
+Blocker fallback lane: `ALPHA-SOLVER-POST-LEVEL-3-LEVEL-8-SELF-OPERATOR-RELEASE-CLOSEOUT-CRITERIA-FIX-001`

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-release-closeout-criteria/blocked-release-claims.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-release-closeout-criteria/blocked-release-claims.md
@@ -1,0 +1,22 @@
+# Blocked Release Claims
+
+This packet does not authorize any release claim. It defines criteria that must be satisfied before a future operator-only MVP can be called released.
+
+## Claims blocked by this packet
+
+- Production readiness.
+- General availability.
+- Deployment readiness.
+- Live service availability.
+- Hosted-provider safety or provider-routing readiness.
+- Browser-automation readiness.
+- Autonomous operation.
+- Unsupervised operation.
+- Automatic deployment, publishing, tunneling, or remote mutation.
+- Dashboard readiness.
+- `/v1/solve` readiness.
+- Evidence promotion beyond a docs-only criteria packet.
+
+## Claims blocked for the earliest operator-only MVP unless separately approved
+
+Even after a future operator-only MVP passes closeout, it must not claim provider calls, browser automation, deployment, production readiness, or autonomous operation unless a later approved lane explicitly expands the release boundary and supplies passing evidence for that expanded scope.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-release-closeout-criteria/blocker-fallback-lane.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-release-closeout-criteria/blocker-fallback-lane.md
@@ -1,0 +1,5 @@
+# Blocker Fallback Lane
+
+`ALPHA-SOLVER-POST-LEVEL-3-LEVEL-8-SELF-OPERATOR-RELEASE-CLOSEOUT-CRITERIA-FIX-001`
+
+Use this fallback lane only if this docs-only packet is blocked by missing required files, incomplete closeout criteria, incomplete required tests, incomplete required artifacts, incomplete required docs, inconsistent selected-next state, missing evidence boundary language, or failed docs-only consistency checks.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-release-closeout-criteria/checks-run.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-release-closeout-criteria/checks-run.md
@@ -1,0 +1,16 @@
+# Checks Run
+
+This file records the required docs-only validation commands for this packet.
+
+## Results
+
+- `git status --short` — passed; only the new packet directory was untracked before staging.
+- `git diff --name-only` — passed; no tracked-file diff outside the packet was present before staging.
+- `git diff --check` — passed; no whitespace errors reported.
+- `make check-local-llm-orchestration-guardrails` — passed.
+- `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-release-closeout-criteria` — passed.
+- Changed-file scope confirmation — passed; all changed files are under `docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-release-closeout-criteria/`.
+
+## Evidence boundary confirmation
+
+These checks validate repository-local docs and guardrails only. They do not release the product, execute release tests, run models, call providers, read credentials, run browser automation, expose dashboard routes, expose `/v1/solve`, deploy, claim production readiness, claim autonomous operation, or promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-release-closeout-criteria/closeout-criteria.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-release-closeout-criteria/closeout-criteria.md
@@ -1,0 +1,19 @@
+# Closeout Criteria
+
+The earliest Self Operator MVP may be called released only when every required criterion below is satisfied and documented in the release packet.
+
+## Mandatory release gates
+
+1. **All planned tests pass.** Every planned static, local smoke, blocked-action, approval-gate, artifact-preservation, stop-condition, and release-notes check required for the MVP must pass with no unresolved release-blocking failures.
+2. **Raw artifacts are preserved.** Raw inputs, outputs, logs, transcripts, operator decisions, approval records, checks, and generated evidence required by the release packet must be preserved in the approved artifact location without destructive rewriting.
+3. **Runbook is updated.** The operator runbook must describe the exact operator-only workflow, required setup, required approvals, stop conditions, artifact-retention steps, and non-goals for the release.
+4. **Operator approvals are documented.** Human operator approvals must be recorded before release closeout, including who approved, what was approved, when it was approved, and the evidence reviewed.
+5. **No provider calls occurred.** Release validation must not call hosted providers, billable model APIs, remote inference endpoints, or any provider fallback path.
+6. **No browser automation occurred.** Release validation must not drive a browser, headless browser, remote browser session, crawler, or UI automation tool.
+7. **No deployment occurred.** Release validation must not deploy, publish, expose, tunnel, mutate, or promote any service or remote environment.
+8. **No production claim is made.** The release can be described only as an operator-only MVP if supported by evidence; it must not be described as production-ready, generally available, or suitable for unattended production use.
+9. **No autonomous operation claim is made.** The release must not claim autonomous operation, unsupervised operation, automatic provider use, automatic browser use, or automatic deployment.
+
+## Closeout decision rule
+
+If any mandatory release gate is incomplete, ambiguous, contradicted by evidence, or missing an artifact, the Self Operator MVP is not released. The packet must use the fallback lane instead of making or implying a release claim.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-release-closeout-criteria/non-actions.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-release-closeout-criteria/non-actions.md
@@ -1,0 +1,28 @@
+# Non-Actions and Evidence Boundary
+
+This is a docs-only release closeout criteria packet.
+
+## Non-actions
+
+This packet does not:
+
+- Release Alpha Solver or the Self Operator MVP.
+- Implement runtime behavior.
+- Modify runtime behavior.
+- Implement tests.
+- Execute release tests.
+- Run local models.
+- Call hosted providers.
+- Exercise provider routing or fallback behavior.
+- Read, validate, print, copy, write, or require credentials.
+- Start, expose, probe, tunnel, or advertise a dashboard route.
+- Start, expose, probe, tunnel, or advertise `/v1/solve`.
+- Run browser automation, headless browser automation, crawlers, or UI-driving tools.
+- Deploy, publish, promote, or mutate remote services or environments.
+- Promote evidence.
+- Claim production readiness.
+- Claim autonomous operation.
+
+## Evidence boundary
+
+The boundary is: docs-only release criteria. This packet defines what must be true before a future operator-only MVP can be called released. It does not itself release the product.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-release-closeout-criteria/release-notes-requirements.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-release-closeout-criteria/release-notes-requirements.md
@@ -1,0 +1,20 @@
+# Release Notes Requirements
+
+Any future release notes for the earliest Self Operator MVP must be accurate, non-promotional, and limited to the operator-only evidence boundary.
+
+## Required release notes content
+
+- Identify the release as an operator-only MVP, not a production release.
+- State that all planned release-closeout tests passed, with a link or reference to the preserved raw artifacts.
+- State that raw artifacts were preserved and where reviewers can find the artifact manifest.
+- State that the operator runbook was updated and identify the runbook version or location.
+- State that operator approvals were documented and identify the approval record location.
+- State explicitly that validation used no provider calls.
+- State explicitly that validation used no browser automation.
+- State explicitly that validation performed no deployment.
+- State explicitly that the release does not claim production readiness.
+- State explicitly that the release does not claim autonomous operation.
+
+## Required omissions
+
+Release notes must not imply hosted-provider access, browser automation, deployment, production readiness, general availability, autonomous operation, unattended execution, or downstream evidence promotion.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-release-closeout-criteria/required-artifacts.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-release-closeout-criteria/required-artifacts.md
@@ -1,0 +1,19 @@
+# Required Artifacts
+
+A future operator-only MVP release claim requires preservation of raw release evidence before closeout.
+
+## Required raw artifacts
+
+- Planned-test inventory and final pass/fail summary.
+- Raw command outputs for every required check.
+- Raw local smoke inputs, outputs, logs, and transcripts.
+- Raw blocked-action check results showing no provider calls, no browser automation, and no deployment.
+- Operator approval records, including reviewer identity or role, timestamp, scope approved, and evidence reviewed.
+- Runbook update diff or final runbook reference.
+- Release notes draft or final release notes reference.
+- Artifact manifest mapping every required artifact to its preserved location.
+- Known limitations and blocked-claims record.
+
+## Preservation criteria
+
+Raw artifacts must be kept in their original form when practical. Summaries may be added, but they must not replace raw evidence. If a raw artifact is unavailable, the release is blocked until the missing artifact is recovered or the fallback lane resolves the gap.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-release-closeout-criteria/required-docs.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-release-closeout-criteria/required-docs.md
@@ -1,0 +1,15 @@
+# Required Docs
+
+A future operator-only MVP release claim requires documentation that makes the release boundary clear to operators and reviewers.
+
+## Required documentation updates
+
+- Operator runbook updated with the exact MVP workflow, prerequisites, commands, approvals, artifacts, stop conditions, and escalation path.
+- Release closeout packet updated with final test results, artifact manifest, and operator approval references.
+- Release notes prepared with operator-only scope, limitations, and blocked claims.
+- Blocked-claims documentation confirming no provider calls, no browser automation, no deployment, no production claim, and no autonomous operation claim.
+- Known limitations documentation explaining what the MVP does not do and what remains unreleased.
+
+## Documentation pass condition
+
+Docs pass only when they are specific enough for an operator to repeat the release validation locally and for a reviewer to verify that no blocked release claim is implied.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-release-closeout-criteria/required-tests.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-release-closeout-criteria/required-tests.md
@@ -1,0 +1,17 @@
+# Required Tests
+
+A future operator-only MVP release claim requires recorded passing results for all planned tests in this file.
+
+## Required passing test categories
+
+- Static documentation and configuration checks proving that the release packet, runbook, approvals, artifact locations, and blocked claims are internally consistent.
+- Local-only smoke checks proving that the operator workflow can be exercised without provider calls, browser automation, deployment, production exposure, or autonomous execution.
+- Blocked-action checks proving that provider calls, browser automation, deployments, production claims, and autonomous-operation claims remain prohibited by the release boundary.
+- Approval-gate checks proving that human operator approval is required and recorded before any closeout claim is made.
+- Artifact-preservation checks proving that raw artifacts are retained, named, and linked without destructive transformation.
+- Stop-condition checks proving that release closeout stops when a planned test fails, an artifact is missing, an approval is missing, or a blocked action is requested.
+- Release-notes checks proving that the notes state operator-only scope and do not claim production, deployment, browser automation, provider access, or autonomous operation.
+
+## Pass condition
+
+Every planned test must pass. A partial pass, skipped release-blocking test, missing test record, missing command output, missing approval check, or unresolved failure blocks release closeout.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-release-closeout-criteria/selected-next-action.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-release-closeout-criteria/selected-next-action.md
@@ -1,0 +1,5 @@
+# Selected Next Action
+
+`NO_FURTHER_LEVEL_8_SELF_OPERATOR_RELEASE_CLOSEOUT_CRITERIA_LANES_SELECTED`
+
+No follow-on Level 8 Self Operator release closeout criteria lane is selected by this packet. Any future implementation, test execution, release claim, evidence promotion, provider access, browser automation, deployment, production claim, or autonomous-operation claim requires a separately approved lane.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-release-closeout-criteria/source-evidence-reviewed.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-release-closeout-criteria/source-evidence-reviewed.md
@@ -1,0 +1,19 @@
+# Source Evidence Reviewed
+
+This packet was drafted from repository-local instructions and existing Self Operator planning context only. No provider, model, browser, deployment, dashboard, production, or `/v1/solve` evidence was collected.
+
+## Reviewed sources
+
+- `AGENTS.md`: repo-level workflow, safety, validation, and docs-only expectations.
+- `docs/OPERATING_GUIDE.md`: operator workflow context; reviewed only as workflow context and not as an override of `AGENTS.md`.
+- `docs/evals/runs/alpha-solver-post-level-7-self-operator-acceptance-test-plan/`: existing Self Operator acceptance-test planning structure and boundary language.
+- `docs/evals/runs/alpha-solver-post-level-7-self-operator-artifact-persistence-schema/`: existing Self Operator artifact-preservation planning context.
+- `docs/evals/runs/alpha-solver-post-level-7-self-operator-local-run-harness-design/`: existing local-only run-harness planning context.
+- `docs/evals/runs/alpha-solver-post-level-7-self-operator-lifecycle-state-machine/`: existing lifecycle and operator-gate planning context.
+- `docs/evals/runs/alpha-solver-post-level-7-self-operator-failure-mode-risk-register/`: existing risk and blocked-action planning context.
+- `scripts/check_local_llm_packet_consistency.py`: packet continuity expectations for selected-next state, blocker fallback files, and boundary files.
+- `Makefile`: required local guardrail check target names.
+
+## Evidence boundary
+
+The reviewed evidence is sufficient only to define release closeout criteria for a future operator-only MVP. It is not sufficient to claim release completion, production readiness, deployment readiness, provider safety, browser-automation safety, dashboard safety, `/v1/solve` safety, or autonomous operation readiness.


### PR DESCRIPTION
### Motivation

- Define a docs-only release closeout criteria packet that specifies what must be true before the earliest operator-only Self Operator MVP can be called released. 
- Capture explicit evidence boundaries and prohibited actions to prevent premature production, deployment, provider, browser-automation, or autonomous-operation claims. 

### Description

- Create a new packet directory `docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-release-closeout-criteria/` containing 12 docs files that define the release gates and required artifacts, tests, and docs. 
- Added the required files `README.md`, `source-evidence-reviewed.md`, `closeout-criteria.md`, `required-tests.md`, `required-artifacts.md`, `required-docs.md`, `blocked-release-claims.md`, `release-notes-requirements.md`, `non-actions.md`, `selected-next-action.md`, `blocker-fallback-lane.md`, and `checks-run.md`. 
- Closeout gates require that all planned tests pass, raw artifacts are preserved, the runbook is updated, operator approvals are documented, and explicitly prohibit provider calls, browser automation, deployments, production claims, and autonomous-operation claims. 
- Record decision markers: Selected next action `NO_FURTHER_LEVEL_8_SELF_OPERATOR_RELEASE_CLOSEOUT_CRITERIA_LANES_SELECTED` and fallback lane `ALPHA-SOLVER-POST-LEVEL-3-LEVEL-8-SELF-OPERATOR-RELEASE-CLOSEOUT-CRITERIA-FIX-001`. 

### Testing

- Ran the repository-local guardrail checks: `git status --short`, `git diff --name-only`, and `git diff --check` which showed only the new packet as untracked and no whitespace issues. 
- Executed `make check-local-llm-orchestration-guardrails` which ran the evidence-boundary and doc path checks and passed. 
- Ran `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-release-closeout-criteria` which passed and validated packet consistency. 
- Confirmed changed-file scope such that all added/modified files are contained under `docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-release-closeout-criteria/` and no out-of-scope files were changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a265c4eef4c83299e0f6fc574a8c294)