### PR TITLE
Add Level 8 self-operator first-code-lane stop conditions packet (docs-only)

### DIFF
--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-first-code-lane-stop-conditions/README.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-first-code-lane-stop-conditions/README.md
@@ -1,0 +1,39 @@
+# Level 8 self-operator first-code-lane stop conditions packet
+
+Lane: `ALPHA-SOLVER-POST-LEVEL-3-LEVEL-8-SELF-OPERATOR-FIRST-CODE-LANE-STOP-CONDITIONS-PACKET-001`
+
+## Objective
+
+This packet defines docs-only stop conditions for any future first code lane after the Level 8 self-operator readiness decision point. It tells a future code-lane operator when to stop before editing, before committing, or before opening a PR.
+
+## Accepted prerequisite state required for future code work
+
+A future first code lane must not begin unless Level 8 has been accepted and an implementation lane has been explicitly selected by the controlling operator decision record.
+
+## Required hard stops
+
+A future first code lane must stop without making changes or opening a PR if any of these conditions appear:
+
+- Level 8 is not accepted.
+- An implementation lane is not selected.
+- The branch is not current-main-based.
+- Changed files exceed the allowed scope.
+- Provider call risk appears.
+- Credential risk appears.
+- Browser automation appears.
+- Deployment appears.
+- Billing appears.
+- External API appears.
+- `/v1/solve` or dashboard exposure appears.
+- Evidence promotion appears.
+- Source artifacts would be modified.
+
+## Packet role
+
+This packet is limited to stop-condition documentation. It does not authorize implementation, does not implement code, and does not select any further Level 8 self-operator first-code-lane stop-condition lane.
+
+## Decision
+
+Selected next action: `NO_FURTHER_LEVEL_8_SELF_OPERATOR_FIRST_CODE_LANE_STOP_CONDITIONS_LANES_SELECTED`
+
+Blocker fallback lane: `ALPHA-SOLVER-POST-LEVEL-3-LEVEL-8-SELF-OPERATOR-FIRST-CODE-LANE-STOP-CONDITIONS-FIX-001`

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-first-code-lane-stop-conditions/blocker-fallback-lane.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-first-code-lane-stop-conditions/blocker-fallback-lane.md
@@ -1,0 +1,5 @@
+# Blocker fallback lane
+
+Blocker fallback lane: `ALPHA-SOLVER-POST-LEVEL-3-LEVEL-8-SELF-OPERATOR-FIRST-CODE-LANE-STOP-CONDITIONS-FIX-001`
+
+Use this fallback only if this docs-only stop-condition packet needs a corrective follow-up. The fallback does not authorize implementation work, provider calls, credentials, browser automation, deployment, billing, external APIs, `/v1/solve` exposure, dashboard exposure, evidence promotion, or source artifact modification.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-first-code-lane-stop-conditions/checks-run.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-first-code-lane-stop-conditions/checks-run.md
@@ -1,0 +1,12 @@
+# Checks run
+
+The following checks were run for this docs-only packet:
+
+| Check | Result |
+| --- | --- |
+| `git status --short` | Passed; only the new packet directory was untracked before staging. |
+| `git diff --name-only` | Passed; no tracked file diff was present before staging. |
+| `git diff --check` | Passed. |
+| `make check-local-llm-orchestration-guardrails` | Passed. |
+| `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-first-code-lane-stop-conditions` | Passed. |
+| Changed-file scope confirmation | Passed; changed files are only under `docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-first-code-lane-stop-conditions/`. |

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-first-code-lane-stop-conditions/evidence-boundary-stop.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-first-code-lane-stop-conditions/evidence-boundary-stop.md
@@ -1,0 +1,7 @@
+# Evidence boundary stop
+
+Evidence boundary: docs-only stop conditions. This does not implement code.
+
+A future first code lane must stop if the lane would promote evidence, reinterpret source artifacts as implementation approval, or modify source artifacts. Evidence may be cited to explain a stop condition, but it must not be promoted into a stronger product, validation, deployment, `/v1/solve`, dashboard, billing, provider, or external API claim.
+
+If evidence is insufficient to prove Level 8 acceptance and implementation-lane selection, the operator must stop before editing.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-first-code-lane-stop-conditions/forbidden-scope-stop.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-first-code-lane-stop-conditions/forbidden-scope-stop.md
@@ -1,0 +1,18 @@
+# Forbidden scope stop
+
+A future first code lane must stop when the requested work or observed diff enters forbidden scope.
+
+## Forbidden scope for this stop packet
+
+- Provider calls or provider-routing behavior.
+- Credentials, secrets, tokens, or authentication material.
+- Browser automation.
+- Deployment, release, hosting, or infrastructure changes.
+- Billing, metering, or payment changes.
+- External API integration or invocation.
+- `/v1/solve` exposure or dashboard exposure.
+- Evidence promotion or claims beyond the accepted evidence boundary.
+- Source artifact modification.
+- Any file outside the future selected lane's allowed scope.
+
+The operator must stop rather than partially implement forbidden scope.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-first-code-lane-stop-conditions/non-actions.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-first-code-lane-stop-conditions/non-actions.md
@@ -1,0 +1,16 @@
+# Non-actions
+
+This packet does not perform or authorize any of the following actions:
+
+- No code implementation.
+- No provider calls.
+- No credential handling.
+- No browser automation.
+- No deployment.
+- No billing work.
+- No external API work.
+- No `/v1/solve` exposure.
+- No dashboard exposure.
+- No evidence promotion.
+- No source artifact modification.
+- No future implementation lane selection.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-first-code-lane-stop-conditions/polluted-branch-stop.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-first-code-lane-stop-conditions/polluted-branch-stop.md
@@ -1,0 +1,14 @@
+# Polluted branch stop
+
+A future first code lane must stop if the branch is polluted or not current-main-based.
+
+## Polluted branch indicators
+
+- The branch contains unrelated local modifications before the lane starts.
+- The branch is behind or unrelated to current `main`.
+- The branch contains files outside the selected lane's allowed scope.
+- The branch contains generated, source artifact, credential, deployment, billing, browser automation, external API, `/v1/solve`, or dashboard changes that are not explicitly authorized by the selected lane.
+
+## Required response
+
+Do not edit, commit, or open a PR from a polluted branch. Report the branch state and restart from a clean current-main-based branch before any future implementation work proceeds.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-first-code-lane-stop-conditions/selected-next-action.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-first-code-lane-stop-conditions/selected-next-action.md
@@ -1,0 +1,5 @@
+# Selected next action
+
+Selected next action: `NO_FURTHER_LEVEL_8_SELF_OPERATOR_FIRST_CODE_LANE_STOP_CONDITIONS_LANES_SELECTED`
+
+No follow-on Level 8 self-operator first-code-lane stop-condition lane is selected by this packet.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-first-code-lane-stop-conditions/source-evidence-reviewed.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-first-code-lane-stop-conditions/source-evidence-reviewed.md
@@ -1,0 +1,13 @@
+# Source evidence reviewed
+
+This packet reviewed only repo-local guidance and packet requirements supplied for this lane.
+
+## Reviewed sources
+
+- Repo agent instructions for docs-only scope, source-of-truth, validation, and narrow PR expectations.
+- The lane request for `ALPHA-SOLVER-POST-LEVEL-3-LEVEL-8-SELF-OPERATOR-FIRST-CODE-LANE-STOP-CONDITIONS-PACKET-001`.
+- Existing packet consistency rules enforced by `scripts/check_local_llm_packet_consistency.py`.
+
+## Evidence boundary from reviewed sources
+
+The reviewed evidence supports only a docs-only stop-conditions packet. It does not support changing implementation files, promoting source artifacts, executing provider calls, exposing product routes, or performing deployment, billing, browser automation, credential, or external API work.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-first-code-lane-stop-conditions/stop-before-commit.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-first-code-lane-stop-conditions/stop-before-commit.md
@@ -1,0 +1,11 @@
+# Stop before commit
+
+A future first code lane must stop before committing if review of the working tree shows any of these conditions:
+
+- Level 8 acceptance is absent or ambiguous.
+- The selected lane is not an implementation lane.
+- The branch is not current-main-based.
+- Changed files exceed the allowed scope for the selected lane.
+- Any diff indicates provider call risk, credential risk, browser automation, deployment, billing, external API behavior, `/v1/solve` exposure, dashboard exposure, evidence promotion, or source artifact modification.
+
+If any condition is found after edits have already occurred, the future operator must not commit and must report the condition. The operator must not use a commit to normalize or hide an out-of-scope diff.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-first-code-lane-stop-conditions/stop-before-editing.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-first-code-lane-stop-conditions/stop-before-editing.md
@@ -1,0 +1,19 @@
+# Stop before editing
+
+A future first code lane must stop before editing any file if one or more of these conditions is true:
+
+1. Level 8 has not been accepted in the controlling decision record.
+2. A concrete implementation lane has not been selected by the controlling decision record.
+3. The working branch is not current-main-based.
+4. The requested edit would exceed the allowed scope of the selected code lane.
+5. The requested edit introduces or requires provider call risk.
+6. The requested edit introduces or requires credential risk.
+7. The requested edit introduces or requires browser automation.
+8. The requested edit introduces or requires deployment.
+9. The requested edit introduces or requires billing work.
+10. The requested edit introduces or requires an external API.
+11. The requested edit exposes or changes `/v1/solve` or dashboard behavior.
+12. The requested edit promotes evidence beyond its accepted boundary.
+13. The requested edit modifies source artifacts.
+
+When any stop condition applies, the future operator must leave the working tree unchanged and report the blocker instead of editing.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-first-code-lane-stop-conditions/stop-before-pr.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-first-code-lane-stop-conditions/stop-before-pr.md
@@ -1,0 +1,19 @@
+# Stop before PR
+
+A future first code lane must stop before opening a PR if any of these checks fails:
+
+- Level 8 is accepted.
+- A concrete implementation lane is selected.
+- The branch is current-main-based.
+- The committed files are within the selected lane's allowed scope.
+- The committed files do not introduce provider call risk.
+- The committed files do not introduce credential risk.
+- The committed files do not introduce browser automation.
+- The committed files do not introduce deployment.
+- The committed files do not introduce billing.
+- The committed files do not introduce external API behavior.
+- The committed files do not expose or modify `/v1/solve` or dashboard behavior.
+- The committed files do not promote evidence.
+- The committed files do not modify source artifacts.
+
+If any check fails, the future operator must not open a PR and must use the blocker fallback lane if a corrective docs-only stop-condition fix is needed.


### PR DESCRIPTION
### Motivation
- Define explicit docs-only stop conditions that require a future first-code lane to halt before editing, committing, or opening a PR unless Level 8 acceptance and an implementation lane selection are in place.
- Prevent premature implementation work that could introduce provider, credential, browser automation, deployment, billing, external-API, `/v1/solve` or evidence-promotion risks.

### Description
- Add a new packet directory at `docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-first-code-lane-stop-conditions/` containing stop-condition guidance and supporting files.
- Create the following docs-only files: `README.md`, `source-evidence-reviewed.md`, `stop-before-editing.md`, `stop-before-commit.md`, `stop-before-pr.md`, `polluted-branch-stop.md`, `forbidden-scope-stop.md`, `evidence-boundary-stop.md`, `non-actions.md`, `selected-next-action.md`, `blocker-fallback-lane.md`, and `checks-run.md`.
- Enumerate required hard stops that force a halt when Level 8 is not accepted, an implementation lane is not selected, the branch is not current-main-based, changed files exceed scope, provider/credential/browser/deployment/billing/external-API or `/v1/solve`/dashboard risks appear, evidence promotion would occur, or source artifacts would be modified.
- Record the decision state `NO_FURTHER_LEVEL_8_SELF_OPERATOR_FIRST_CODE_LANE_STOP_CONDITIONS_LANES_SELECTED` and the blocker fallback lane `ALPHA-SOLVER-POST-LEVEL-3-LEVEL-8-SELF-OPERATOR-FIRST-CODE-LANE-STOP-CONDITIONS-FIX-001`.

### Testing
- Ran `git status --short`, `git diff --name-only`, and `git diff --check`, and confirmed no tracked-file diffs outside the new packet directory; these checks passed.
- Ran `make check-local-llm-orchestration-guardrails` and the packet/static doc checks which all passed.
- Ran `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-first-code-lane-stop-conditions` and received a successful packet-consistency result.
- Confirmed changed files are only under `docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-first-code-lane-stop-conditions/` and that the packet is docs-only (no implementation changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a265c5c79348329850a7191ff87777e)