### PR TITLE
docs(level-9): add operator-confirmation hard stop to Level 10 prompt pack

### DIFF
--- a/docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-level-10-code-prompt-pack/checks-run.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-level-10-code-prompt-pack/checks-run.md
@@ -1,12 +1,65 @@
 # Checks run
 
-Requested checks for this docs-only packet:
+Lane: `ALPHA-SOLVER-POST-LEVEL-3-LEVEL-9-SELF-OPERATOR-HARD-STOP-CONSISTENCY-FIX-001`
 
-- `git status --short`
-- `git diff --name-only`
-- `git diff --check`
-- `make check-local-llm-orchestration-guardrails`
-- `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-level-10-code-prompt-pack`
-- Confirm changed files are only under `docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-level-10-code-prompt-pack/`.
+These checks were run for this docs-only prompt-pack hard-stop consistency fix. They validate documentation packet consistency only and do not start Level 10 implementation, run models, call providers, expose routes, deploy, bill, touch credentials, update Google Sheets, or promote evidence.
 
-Results are recorded in the PR summary/final response after execution. These checks validate documentation packet consistency only and do not start implementation.
+## Results
+
+### `git status --short`
+
+Result: passed.
+
+Concise output summary before final commit: only files under `docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-level-10-code-prompt-pack/` were modified or added.
+
+### `git diff --name-only`
+
+Result: passed.
+
+Concise output summary before final commit: tracked-file diffs were limited to the allowed prompt-pack directory. The new coverage artifact appeared as untracked in `git status --short` until staging.
+
+### `git diff --check`
+
+Result: passed with no whitespace errors.
+
+### Operator-confirmation text check
+
+Command:
+
+```bash
+rg -n "operator confirmation|confirmation is missing|SELF_OPERATOR_OPERATOR_CONFIRMATION_MISSING|explicit operator confirmation" docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-level-10-code-prompt-pack
+```
+
+Result: passed. The check found the operator-confirmation hard stop in `universal-hard-stops.md`, all eight `prompt-*.md` future prompt files, `codex-usage-guidance.md`, `prompt-pack-overview.md`, and `operator-confirmation-hard-stop-coverage.md`.
+
+### Universal hard-stop text check
+
+Command:
+
+```bash
+rg -n "Universal hard stops|hard stop|stop if|stop on|stop unless" docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-level-10-code-prompt-pack
+```
+
+Result: passed. The check found the authoritative universal hard-stop list and each copied prompt hard-stop list, including `stop if explicit operator confirmation is missing;`.
+
+### `make check-local-llm-orchestration-guardrails`
+
+Result: passed.
+
+Concise output summary:
+
+- `Local LLM evidence-boundary static check passed (450 files scanned).`
+- `Local LLM doc path/link check passed (49 files scanned).`
+- `Local LLM packet consistency check passed (88 packet directories scanned).`
+
+### `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-level-10-code-prompt-pack`
+
+Result: passed.
+
+Concise output summary:
+
+- `Local LLM packet consistency check passed (1 packet directories scanned).`
+
+## Scope proof
+
+All changed files are under `docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-level-10-code-prompt-pack/`.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-level-10-code-prompt-pack/codex-usage-guidance.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-level-10-code-prompt-pack/codex-usage-guidance.md
@@ -3,3 +3,5 @@
 Use these prompts only after the Level 9 implementation plan is accepted, merged, and GS done. Before running a prompt, paste the controlling packet path, selected Level 10 lane identifier, allowed files, forbidden files, and required checks into the Codex context.
 
 Do not run more than one prompt unless the current lane explicitly authorizes that batch. Stop if any prompt would exceed the selected lane's allowed scope.
+
+Every future prompt run must preserve `universal-hard-stops.md` as authoritative. Stop if explicit operator confirmation is missing.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-level-10-code-prompt-pack/operator-confirmation-hard-stop-coverage.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-level-10-code-prompt-pack/operator-confirmation-hard-stop-coverage.md
@@ -1,0 +1,50 @@
+# Operator-confirmation hard-stop coverage
+
+Lane: `ALPHA-SOLVER-POST-LEVEL-3-LEVEL-9-SELF-OPERATOR-HARD-STOP-CONSISTENCY-FIX-001`
+
+## Required hard-stop phrase
+
+The prompt pack now preserves the exact required phrase:
+
+- `stop if explicit operator confirmation is missing`
+
+## Source directories reviewed
+
+All required source directories existed and were inspected before editing:
+
+- `docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-mvp-implementation-plan/`
+- `docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-first-code-scope-contract/`
+- `docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-level-10-code-prompt-pack/`
+- `docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-approval-stopstate-spec/`
+- `docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-static-test-scaffold-spec/`
+- `docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-first-code-lane-stop-conditions/`
+- `docs/evals/runs/alpha-solver-post-level-3-level-8-self-operator-implementation-authorization-criteria/`
+
+## Prompt-pack files inspected
+
+| File | Coverage outcome |
+| --- | --- |
+| `README.md` | Inspected; does not repeat or operationalize the universal hard-stop list, so no edit was required. |
+| `blocker-fallback-lane.md` | Inspected; does not repeat or operationalize the universal hard-stop list, so no edit was required. |
+| `checks-run.md` | Updated with the actual checks run for this hard-stop consistency fix. |
+| `codex-usage-guidance.md` | Updated to preserve `universal-hard-stops.md` as authoritative and to require stopping if explicit operator confirmation is missing. |
+| `non-actions.md` | Inspected; does not repeat or operationalize the universal hard-stop list, so no edit was required. |
+| `operator-confirmation-hard-stop-coverage.md` | Added as this coverage artifact. |
+| `prompt-01-static-test-scaffold.md` | Added `stop if explicit operator confirmation is missing;` to the copied hard-stop list. |
+| `prompt-02-inert-fixtures.md` | Added `stop if explicit operator confirmation is missing;` to the copied hard-stop list. |
+| `prompt-03-finding-schema.md` | Added `stop if explicit operator confirmation is missing;` to the copied hard-stop list. |
+| `prompt-04-artifact-schema-code-scaffold.md` | Added `stop if explicit operator confirmation is missing;` to the copied hard-stop list. |
+| `prompt-05-local-preflight-code-scaffold.md` | Added `stop if explicit operator confirmation is missing;` to the copied hard-stop list. |
+| `prompt-06-approval-record-code-scaffold.md` | Added `stop if explicit operator confirmation is missing;` to the copied hard-stop list. |
+| `prompt-07-stop-state-code-scaffold.md` | Added `stop if explicit operator confirmation is missing;` to the copied hard-stop list. |
+| `prompt-08-local-harness-dry-run-wrapper.md` | Added `stop if explicit operator confirmation is missing;` to the copied hard-stop list. |
+| `prompt-pack-overview.md` | Updated to identify `universal-hard-stops.md` as authoritative and to name the operator-confirmation hard stop. |
+| `selected-next-action.md` | Inspected; does not repeat or operationalize the universal hard-stop list, so no edit was required. |
+| `source-evidence-reviewed.md` | Inspected; does not repeat or operationalize the universal hard-stop list, so no edit was required. |
+| `universal-hard-stops.md` | Added `stop if explicit operator confirmation is missing;` to the authoritative universal hard-stop list. |
+
+## Evidence boundary and non-actions
+
+This is a docs-only prompt-pack consistency fix. No runtime, tests, source code, scripts, CI, provider, API, dashboard, credential, deployment, billing, Google Sheets, source-artifact, or evidence-promotion changes were made.
+
+This packet does not implement Self Operator, does not start Level 10 implementation, does not validate runtime behavior, does not call providers, does not run hosted or local models, does not expose APIs or dashboards, does not deploy, does not bill, does not touch credentials, does not update Google Sheets, and does not promote evidence beyond the prompt-pack hard-stop consistency boundary.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-level-10-code-prompt-pack/prompt-01-static-test-scaffold.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-level-10-code-prompt-pack/prompt-01-static-test-scaffold.md
@@ -6,6 +6,7 @@ Use this prompt only after the Level 9 implementation plan is accepted and GS do
 
 - stop unless Level 9 implementation plan is accepted and GS done;
 - stop unless the selected Level 10 lane matches the prompt;
+- stop if explicit operator confirmation is missing;
 - stop if current branch is not current-main-based;
 - stop if changed files exceed allowed scope;
 - stop on provider call risk;

--- a/docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-level-10-code-prompt-pack/prompt-02-inert-fixtures.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-level-10-code-prompt-pack/prompt-02-inert-fixtures.md
@@ -6,6 +6,7 @@ Use this prompt only after the Level 9 implementation plan is accepted and GS do
 
 - stop unless Level 9 implementation plan is accepted and GS done;
 - stop unless the selected Level 10 lane matches the prompt;
+- stop if explicit operator confirmation is missing;
 - stop if current branch is not current-main-based;
 - stop if changed files exceed allowed scope;
 - stop on provider call risk;

--- a/docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-level-10-code-prompt-pack/prompt-03-finding-schema.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-level-10-code-prompt-pack/prompt-03-finding-schema.md
@@ -6,6 +6,7 @@ Use this prompt only after the Level 9 implementation plan is accepted and GS do
 
 - stop unless Level 9 implementation plan is accepted and GS done;
 - stop unless the selected Level 10 lane matches the prompt;
+- stop if explicit operator confirmation is missing;
 - stop if current branch is not current-main-based;
 - stop if changed files exceed allowed scope;
 - stop on provider call risk;

--- a/docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-level-10-code-prompt-pack/prompt-04-artifact-schema-code-scaffold.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-level-10-code-prompt-pack/prompt-04-artifact-schema-code-scaffold.md
@@ -6,6 +6,7 @@ Use this prompt only after the Level 9 implementation plan is accepted and GS do
 
 - stop unless Level 9 implementation plan is accepted and GS done;
 - stop unless the selected Level 10 lane matches the prompt;
+- stop if explicit operator confirmation is missing;
 - stop if current branch is not current-main-based;
 - stop if changed files exceed allowed scope;
 - stop on provider call risk;

--- a/docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-level-10-code-prompt-pack/prompt-05-local-preflight-code-scaffold.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-level-10-code-prompt-pack/prompt-05-local-preflight-code-scaffold.md
@@ -6,6 +6,7 @@ Use this prompt only after the Level 9 implementation plan is accepted and GS do
 
 - stop unless Level 9 implementation plan is accepted and GS done;
 - stop unless the selected Level 10 lane matches the prompt;
+- stop if explicit operator confirmation is missing;
 - stop if current branch is not current-main-based;
 - stop if changed files exceed allowed scope;
 - stop on provider call risk;

--- a/docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-level-10-code-prompt-pack/prompt-06-approval-record-code-scaffold.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-level-10-code-prompt-pack/prompt-06-approval-record-code-scaffold.md
@@ -6,6 +6,7 @@ Use this prompt only after the Level 9 implementation plan is accepted and GS do
 
 - stop unless Level 9 implementation plan is accepted and GS done;
 - stop unless the selected Level 10 lane matches the prompt;
+- stop if explicit operator confirmation is missing;
 - stop if current branch is not current-main-based;
 - stop if changed files exceed allowed scope;
 - stop on provider call risk;

--- a/docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-level-10-code-prompt-pack/prompt-07-stop-state-code-scaffold.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-level-10-code-prompt-pack/prompt-07-stop-state-code-scaffold.md
@@ -6,6 +6,7 @@ Use this prompt only after the Level 9 implementation plan is accepted and GS do
 
 - stop unless Level 9 implementation plan is accepted and GS done;
 - stop unless the selected Level 10 lane matches the prompt;
+- stop if explicit operator confirmation is missing;
 - stop if current branch is not current-main-based;
 - stop if changed files exceed allowed scope;
 - stop on provider call risk;

--- a/docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-level-10-code-prompt-pack/prompt-08-local-harness-dry-run-wrapper.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-level-10-code-prompt-pack/prompt-08-local-harness-dry-run-wrapper.md
@@ -6,6 +6,7 @@ Use this prompt only after the Level 9 implementation plan is accepted and GS do
 
 - stop unless Level 9 implementation plan is accepted and GS done;
 - stop unless the selected Level 10 lane matches the prompt;
+- stop if explicit operator confirmation is missing;
 - stop if current branch is not current-main-based;
 - stop if changed files exceed allowed scope;
 - stop on provider call risk;

--- a/docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-level-10-code-prompt-pack/prompt-pack-overview.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-level-10-code-prompt-pack/prompt-pack-overview.md
@@ -2,4 +2,4 @@
 
 This packet drafts future Codex prompts for the first code batch. The prompts are inactive until the controlling Level 9 implementation plan is accepted, merged, and gate sync is complete.
 
-The prompts preserve static-test-first sequencing and do not authorize runtime Self Operator behavior by themselves.
+The prompts preserve static-test-first sequencing and do not authorize runtime Self Operator behavior by themselves. The authoritative universal hard-stop list is `universal-hard-stops.md`, including `stop if explicit operator confirmation is missing`.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-level-10-code-prompt-pack/universal-hard-stops.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-level-10-code-prompt-pack/universal-hard-stops.md
@@ -4,6 +4,7 @@ Every future Codex prompt in this pack must include these hard stops:
 
 - stop unless Level 9 implementation plan is accepted and GS done;
 - stop unless the selected Level 10 lane matches the prompt;
+- stop if explicit operator confirmation is missing;
 - stop if current branch is not current-main-based;
 - stop if changed files exceed allowed scope;
 - stop on provider call risk;


### PR DESCRIPTION
### Motivation

- Lane ID: `ALPHA-SOLVER-POST-LEVEL-3-LEVEL-9-SELF-OPERATOR-HARD-STOP-CONSISTENCY-FIX-001` and intent: ensure the Level 10 prompt pack explicitly blocks proceeding when an explicit operator confirmation is missing. 
- Remove a known Level 10 blocker by making the universal hard-stop authoritative and ensuring every prompt that copies or summarizes hard stops includes the operator-confirmation-missing stop.

### Description

- Added the exact hard-stop phrase to the authoritative list in `universal-hard-stops.md` as: `stop if explicit operator confirmation is missing`.
- Inserted the same operator-confirmation hard stop into every `prompt-*.md` file in the Level 10 prompt-pack that contained a copied hard-stop list, and updated prompt guidance to reference the authoritative list rather than diverging copies.
- Updated `codex-usage-guidance.md` and `prompt-pack-overview.md` to preserve `universal-hard-stops.md` as authoritative and to name the operator-confirmation hard stop; added `operator-confirmation-hard-stop-coverage.md` to document files inspected and coverage outcomes.
- Updated `checks-run.md` to record the actual checks executed and concise results for this docs-only consistency fix.

### Testing

- Ran repository and diff checks: `git status --short`, `git diff --name-only`, and `git diff --check`, all passed and showed only allowed prompt-pack files changed.
- Verified text coverage with ripgrep using the `operator confirmation`/`explicit operator confirmation` and universal hard-stop patterns, which found the new phrase in `universal-hard-stops.md`, all edited `prompt-*.md` files, `codex-usage-guidance.md`, `prompt-pack-overview.md`, and the new coverage artifact, and the checks passed.
- Ran packet/guardrail checks: `make check-local-llm-orchestration-guardrails` and `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-level-10-code-prompt-pack`, both passed.
- Confirmed scope: all changed/added files are under `docs/evals/runs/alpha-solver-post-level-3-level-9-self-operator-level-10-code-prompt-pack/` and no runtime, source, test, CI, provider, credentials, deployment, billing, Google Sheets, or evidence artifacts were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27395b4c20832995ebc6b42e6daa39)