### PR TITLE
fix(self-operator): require approval identity match

### DIFF
--- a/alpha/self_operator/execution_gate.py
+++ b/alpha/self_operator/execution_gate.py
@@ -83,11 +83,12 @@ def evaluate_execution_gate(
     preflight = _preflight_from_input(preflight_result) if preflight_result is not None else run_local_preflight(proposed)
     approval = approval_from_mapping(approval_record)
     approval_validation = _validate_approval(approval)
-    findings = list(approval_validation.findings) + list(preflight.findings)
+    identity_validation = _validate_approval_identity(proposed, approval)
+    findings = list(approval_validation.findings) + list(identity_validation.findings) + list(preflight.findings)
 
-    gate_status, reason_code = _gate_status(preflight, approval, approval_validation)
+    gate_status, reason_code = _gate_status(preflight, approval, approval_validation, identity_validation)
     stable_findings = tuple(sorted(set(findings)))
-    approval_summary = _approval_summary(approval, approval_validation)
+    approval_summary = _approval_summary(approval, approval_validation, identity_validation)
     preflight_summary = _preflight_summary(preflight)
     evidence_boundary = approval.evidence_boundary if approval and approval.evidence_boundary.strip() else preflight.evidence_boundary
     artifact_paths = tuple(preflight.artifact_paths)
@@ -164,6 +165,7 @@ def _gate_status(
     preflight: PreflightResult,
     approval: ApprovalRecord | None,
     approval_validation: ValidationResult,
+    identity_validation: ValidationResult,
 ) -> tuple[str, str]:
     if approval is None:
         return "blocked_by_missing_approval", "missing_approval"
@@ -174,6 +176,8 @@ def _gate_status(
         if "missing_evidence_boundary" in reason_codes:
             return "blocked_by_evidence_boundary_issue", "evidence_boundary_issue"
         return "blocked_by_missing_approval", "approval_invalid"
+    if not identity_validation.valid:
+        return "blocked_by_approval_identity_mismatch", "approval_identity_mismatch"
     if not preflight.allowed:
         reason_codes = {finding.reason_code for finding in preflight.findings}
         if "artifact_path_outside_output_root" in reason_codes:
@@ -216,17 +220,66 @@ def _build_stop_state(
     )
 
 
-def _approval_summary(approval: ApprovalRecord | None, validation: ValidationResult) -> dict[str, Any]:
+def _approval_summary(
+    approval: ApprovalRecord | None,
+    validation: ValidationResult,
+    identity_validation: ValidationResult,
+) -> dict[str, Any]:
     if approval is None:
-        return {"present": False, "valid": False, "finding_ids": [item.id for item in validation.findings]}
+        return {
+            "identity_match": False,
+            "identity_finding_ids": [item.id for item in identity_validation.findings],
+            "present": False,
+            "valid": False,
+            "finding_ids": [item.id for item in validation.findings],
+        }
     return {
         "approved": approval.approved,
         "finding_ids": [item.id for item in validation.findings],
+        "identity_finding_ids": [item.id for item in identity_validation.findings],
+        "identity_match": identity_validation.valid,
         "lane_id": approval.lane_id,
         "present": True,
         "run_id": approval.run_id,
         "valid": validation.valid,
     }
+
+
+def _validate_approval_identity(proposed: ProposedTask, approval: ApprovalRecord | None) -> ValidationResult:
+    """Fail closed when an approval record does not match the proposed task identity."""
+
+    if approval is None:
+        return ValidationResult(valid=True)
+
+    mismatches: list[str] = []
+    if approval.lane_id.strip() and proposed.lane_id.strip() and approval.lane_id != proposed.lane_id:
+        mismatches.append("lane_id")
+
+    approval_run_id = approval.run_id.strip()
+    proposed_run_id = _proposed_run_id(proposed).strip()
+    if approval_run_id and proposed_run_id and approval_run_id != proposed_run_id:
+        mismatches.append("run_id")
+
+    approval_scope_identity = _approval_scope_identity(approval)
+    proposed_scope_identity = _proposed_scope_identity(proposed)
+    if approval_scope_identity and proposed_scope_identity and approval_scope_identity != proposed_scope_identity:
+        mismatches.append("scope_identity")
+
+    if not mismatches:
+        return ValidationResult(valid=True)
+
+    mismatch_text = ", ".join(sorted(mismatches))
+    return ValidationResult(
+        valid=False,
+        findings=(
+            ArtifactFinding(
+                id="SELF_OPERATOR_APPROVAL_IDENTITY_MISMATCH",
+                reason_code="approval_identity_mismatch",
+                message=f"approval record does not match proposed task identity: {mismatch_text}",
+                surface="approval_identity",
+            ),
+        ),
+    )
 
 
 def _preflight_summary(preflight: PreflightResult) -> dict[str, Any]:
@@ -274,10 +327,39 @@ def _items(value: Any) -> list[Any]:
     return value if isinstance(value, list) else list(value) if isinstance(value, tuple) else []
 
 
+def _approval_scope_identity(approval: ApprovalRecord) -> str:
+    metadata = approval.metadata if isinstance(approval.metadata, Mapping) else {}
+    for key in ("task_identity", "scope_identity", "scope_summary", "requested_action"):
+        value = metadata.get(key)
+        if value is not None and str(value).strip():
+            return _normalize_identity(value)
+    return _normalize_identity(approval.scope_summary)
+
+
+def _proposed_scope_identity(proposed: ProposedTask) -> str:
+    metadata = proposed.metadata if isinstance(proposed.metadata, Mapping) else {}
+    for key in ("task_identity", "scope_identity", "scope_summary"):
+        value = metadata.get(key)
+        if value is not None and str(value).strip():
+            return _normalize_identity(value)
+    return ""
+
+
+def _normalize_identity(value: Any) -> str:
+    return " ".join(str(value).split())
+
+
+def _proposed_run_id(proposed: ProposedTask) -> str:
+    metadata_run_id = proposed.metadata.get("run_id") if isinstance(proposed.metadata, Mapping) else None
+    return str(metadata_run_id or "")
+
+
 def _run_id(proposed: ProposedTask, approval_record: ApprovalRecord | Mapping[str, Any] | None) -> str:
+    proposed_run_id = _proposed_run_id(proposed).strip()
+    if proposed_run_id:
+        return proposed_run_id
     if isinstance(approval_record, ApprovalRecord) and approval_record.run_id.strip():
         return approval_record.run_id
     if isinstance(approval_record, Mapping) and str(approval_record.get("run_id", "")).strip():
         return str(approval_record["run_id"])
-    metadata_run_id = proposed.metadata.get("run_id") if isinstance(proposed.metadata, Mapping) else None
-    return str(metadata_run_id or "missing-approval-run")
+    return "missing-approval-run"

--- a/docs/evals/runs/alpha-solver-post-level-3-level-11-self-operator-approval-stopstate-gate-foundation/approval-identity-mismatch-followup.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-11-self-operator-approval-stopstate-gate-foundation/approval-identity-mismatch-followup.md
@@ -1,0 +1,29 @@
+# PR #456 approval identity/correlation follow-up
+
+Lane: `ALPHA-SOLVER-POST-LEVEL-3-LEVEL-11-SELF-OPERATOR-APPROVAL-IDENTITY-MISMATCH-FIX-001`
+
+PR #456 was merged with a blocking approval identity/correlation follow-up: a valid approval record for one lane could be evaluated with a proposed task for another lane because the execution gate validated approval completeness separately from proposed-task identity.
+
+This follow-up fixes the issue by failing closed before any `allowed_for_local_dry_run_wrapper` readiness result when available approval and proposed-task identity fields mismatch. The added gate check compares lane identity, run identity when both sides expose it, and comparable scope/task identity when present.
+
+Focused tests were added in `tests/test_self_operator_execution_gate.py` for lane mismatch, run mismatch, scope mismatch, deterministic blocked reason/finding output, stop-state creation, continued matching approval readiness, non-execution of proposed commands, deterministic JSON serialization, and temporary-output-root bounded artifact writes.
+
+Checks run for this follow-up are recorded in this PR and include focused ruff, focused approval/stop-state/execution-gate tests, #454 foundation tests, static guardrail tests, packet consistency, and a full-suite attempt where practical.
+
+Evidence boundary is unchanged: this is a local approval-boundary safety fix only. It does not run Self Operator, execute proposed commands, call providers, run hosted or local models, expose APIs or dashboards, change product CLI behavior, automate browsers, deploy, bill, touch credentials, update Google Sheets, mutate source artifacts, promote evidence, run acceptance, or claim MVP readiness.
+
+The dry-run harness lane remains blocked until this fix is merged and GS done:
+
+`ALPHA-SOLVER-POST-LEVEL-3-LEVEL-12-SELF-OPERATOR-LOCAL-HARNESS-DRY-RUN-WRAPPER-001`
+
+## Checks run for this follow-up
+
+- `git status --short` — passed; showed only the scoped execution-gate, focused test, and packet follow-up changes.
+- `git diff --name-only` — passed; changed paths remained limited to `alpha/self_operator/execution_gate.py`, `tests/test_self_operator_execution_gate.py`, and this packet follow-up file.
+- `git diff --check` — passed; no whitespace errors reported.
+- `python -m ruff check alpha/self_operator tests/test_self_operator_approval.py tests/test_self_operator_stop_state.py tests/test_self_operator_execution_gate.py` — passed.
+- `python -m pytest -q tests/test_self_operator_approval.py tests/test_self_operator_stop_state.py tests/test_self_operator_execution_gate.py` — passed, 32 tests.
+- `python -m pytest -q tests/test_self_operator_artifact_schema.py tests/test_self_operator_artifact_store.py tests/test_self_operator_preflight.py tests/test_self_operator_command_classification.py` — passed, 38 tests.
+- `python -m pytest -q tests/test_self_operator_static_guardrails.py tests/test_self_operator_approval_stopstate_static.py tests/test_self_operator_artifact_schema_static.py tests/test_self_operator_forbidden_behavior_static.py` — passed, 16 tests.
+- `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-level-11-self-operator-approval-stopstate-gate-foundation` — passed.
+- `python -m pytest -q` — failed on pre-existing unrelated product tests: `tests/test_api_endpoints.py::test_solve_openai_provider_errors_return_safe_responses[timeout-504]`, `tests/test_api_endpoints.py::test_solve_openai_provider_errors_return_safe_responses[rate_limit-429]`, `tests/test_api_endpoints.py::test_solve_openai_provider_errors_return_safe_responses[network-503]`, `tests/test_cost_tracking.py::test_cost_tracking`, and `tests/test_security.py::test_a3_1_prompt_subset_passes_solve_input_validation`.

--- a/tests/test_self_operator_execution_gate.py
+++ b/tests/test_self_operator_execution_gate.py
@@ -11,6 +11,7 @@ from alpha.self_operator.execution_gate import evaluate_execution_gate, write_ex
 LANE_ID = "ALPHA-SOLVER-POST-LEVEL-3-LEVEL-11-SELF-OPERATOR-APPROVAL-STOPSTATE-GATE-FOUNDATION-001"
 RUN_ID = "unit-run-gate-001"
 EVIDENCE_BOUNDARY = "local-only; no execution; no source-artifact mutation; no evidence promotion"
+SCOPE_SUMMARY = "Approval, stop-state, and execution-gate foundation only."
 
 
 def task(tmp_path: Path, **overrides):
@@ -26,7 +27,7 @@ def task(tmp_path: Path, **overrides):
         "output_root": str(tmp_path),
         "evidence_boundary": EVIDENCE_BOUNDARY,
         "artifact_paths": ("gate-result.json",),
-        "metadata": {"run_id": RUN_ID},
+        "metadata": {"run_id": RUN_ID, "scope_summary": SCOPE_SUMMARY},
     }
     payload.update(overrides)
     return payload
@@ -42,13 +43,22 @@ def approval(**overrides) -> ApprovalRecord:
         "approval_text": "Approved for local gate foundation tests only.",
         "approved_by": "unit-operator",
         "approved_at": "2026-06-09T00:00:00Z",
-        "scope_summary": "Approval, stop-state, and execution-gate foundation only.",
+        "scope_summary": SCOPE_SUMMARY,
         "evidence_boundary": EVIDENCE_BOUNDARY,
         "redaction_status": "redacted",
         "metadata": {"test": "execution_gate"},
     }
     payload.update(overrides)
     return ApprovalRecord(**payload)
+
+
+def assert_identity_mismatch_blocked(result) -> None:  # noqa: ANN001
+    assert result.allowed_for_local_dry_run is False
+    assert result.gate_status == "blocked_by_approval_identity_mismatch"
+    assert result.reason_code == "approval_identity_mismatch"
+    assert result.stop_state_record is not None
+    assert result.stop_state_record.reason_code == "approval_identity_mismatch"
+    assert "SELF_OPERATOR_APPROVAL_IDENTITY_MISMATCH" in {finding.id for finding in result.findings}
 
 
 def test_missing_approval_returns_blocked_result_and_stop_state_record(tmp_path: Path) -> None:
@@ -79,6 +89,65 @@ def test_valid_approval_plus_unsafe_command_remains_blocked(tmp_path: Path) -> N
     assert result.allowed_for_local_dry_run is False
     assert result.gate_status == "blocked_by_failed_preflight"
     assert "SELF_OPERATOR_EXTERNAL_API_BLOCKED" in {finding.id for finding in result.findings}
+
+
+def test_approval_lane_mismatch_blocks_with_stop_state_record(tmp_path: Path) -> None:
+    result = evaluate_execution_gate(
+        task(tmp_path, lane_id="ALPHA-SOLVER-POST-LEVEL-3-LEVEL-11-DIFFERENT-LANE-001"),
+        approval(),
+        timestamp_provider=lambda: "2026-06-09T00:00:00Z",
+    )
+    assert_identity_mismatch_blocked(result)
+    rendered = dumps_artifact_json(result.to_dict())
+    assert rendered == dumps_artifact_json(
+        evaluate_execution_gate(
+            task(tmp_path, lane_id="ALPHA-SOLVER-POST-LEVEL-3-LEVEL-11-DIFFERENT-LANE-001"),
+            approval(),
+            timestamp_provider=lambda: "2026-06-09T00:00:00Z",
+        ).to_dict()
+    )
+    assert json.loads(rendered)["stop_state_record"]["reason_code"] == "approval_identity_mismatch"
+
+
+def test_approval_run_mismatch_blocks_when_run_identity_is_available(tmp_path: Path) -> None:
+    result = evaluate_execution_gate(task(tmp_path), approval(run_id="unit-run-gate-other"))
+    assert_identity_mismatch_blocked(result)
+    assert result.run_id == RUN_ID
+
+
+def test_approval_scope_mismatch_blocks_when_scope_identity_is_available(tmp_path: Path) -> None:
+    result = evaluate_execution_gate(
+        task(tmp_path, metadata={"run_id": RUN_ID, "scope_summary": "Different task scope."}),
+        approval(),
+    )
+    assert_identity_mismatch_blocked(result)
+
+
+def test_identity_mismatch_does_not_execute_proposed_task_commands(tmp_path: Path) -> None:
+    sentinel = tmp_path / "identity-mismatch-command-executed"
+    result = evaluate_execution_gate(
+        task(
+            tmp_path,
+            lane_id="ALPHA-SOLVER-POST-LEVEL-3-LEVEL-11-DIFFERENT-LANE-001",
+            proposed_commands=(f"touch {sentinel}",),
+        ),
+        approval(),
+    )
+    assert_identity_mismatch_blocked(result)
+    assert not sentinel.exists()
+
+
+def test_identity_mismatch_artifact_write_stays_under_temporary_output_root(tmp_path: Path) -> None:
+    result = evaluate_execution_gate(task(tmp_path), approval(run_id="unit-run-gate-other"))
+    assert_identity_mismatch_blocked(result)
+    path = write_execution_gate_result_json(
+        result,
+        output_root=tmp_path,
+        relative_path="records/identity-mismatch-gate-result.json",
+    )
+    assert path.is_relative_to(tmp_path)
+    persisted = read_artifact_json(output_root=tmp_path, relative_path="records/identity-mismatch-gate-result.json")
+    assert persisted["reason_code"] == "approval_identity_mismatch"
 
 
 def test_valid_approval_plus_safe_local_preflight_returns_allowed_for_local_dry_run_result(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation

- Fix a P1 approval-boundary bug introduced by the merged PR #456 where a valid approval for lane A could improperly authorize a proposed task for lane B by validating approval completeness in isolation.
- Ensure the execution gate fails closed when approval and proposed-task identity fields do not correlate, preserving explicit per-lane approval boundaries (Lane: `ALPHA-SOLVER-POST-LEVEL-3-LEVEL-11-SELF-OPERATOR-APPROVAL-IDENTITY-MISMATCH-FIX-001`).

### Description

- Added a deterministic identity/correlation validation (`_validate_approval_identity`) in `alpha/self_operator/execution_gate.py` that compares `lane_id`, `run_id` when both sides expose it, and comparable scope/task identity when available, and emits a stable finding `SELF_OPERATOR_APPROVAL_IDENTITY_MISMATCH` with reason code `approval_identity_mismatch` on mismatch.
- Integrated identity validation into the gate flow so identity mismatches return a blocked gate result (`blocked_by_approval_identity_mismatch`) and produce a local-only `StopStateRecord`; preserved JSON-serializable, deterministic result shapes and summary fields (including identity summary keys in the approval summary).
- Prefer proposed-task run identity for the gate `run_id` when present so a stale approval run does not overwrite the proposed-task identity in results.
- Added focused tests in `tests/test_self_operator_execution_gate.py` and a concise follow-up doc at `docs/evals/runs/alpha-solver-post-level-3-level-11-self-operator-approval-stopstate-gate-foundation/approval-identity-mismatch-followup.md` to document the remediation and checks run.
- Files changed: `alpha/self_operator/execution_gate.py`, `tests/test_self_operator_execution_gate.py`, and the docs follow-up file; no provider adapters, models, external APIs, credentials, deployment, billing, Google Sheets, or source-artifact mutations were altered.
- Selected next lane: `ALPHA-SOLVER-POST-LEVEL-3-LEVEL-12-SELF-OPERATOR-LOCAL-HARNESS-DRY-RUN-WRAPPER-001`; blocker fallback lane: `ALPHA-SOLVER-POST-LEVEL-3-LEVEL-11-SELF-OPERATOR-APPROVAL-IDENTITY-MISMATCH-FIX-FOLLOWUP-001`.

### Testing

- Ran focused lint: `python -m ruff check alpha/self_operator tests/test_self_operator_approval.py tests/test_self_operator_stop_state.py tests/test_self_operator_execution_gate.py` — passed.
- Ran focused unit tests: `python -m pytest -q tests/test_self_operator_approval.py tests/test_self_operator_stop_state.py tests/test_self_operator_execution_gate.py` — passed (32 tests); additional self-operator foundation tests (`tests/test_self_operator_artifact_schema.py`, `tests/test_self_operator_artifact_store.py`, `tests/test_self_operator_preflight.py`, `tests/test_self_operator_command_classification.py`) passed (38 tests); static guardrail tests passed (16 tests); packet consistency check passed.
- Verified focused execution-gate tests exercised: approval lane mismatch, run mismatch, scope mismatch, deterministic mismatch finding/reason, stop-state creation, allowed readiness on matching approval + safe preflight, non-execution of proposed commands, deterministic JSON serialization, and temporary-output-root bounded artifact writes — all passed.
- Full-suite run: `python -m pytest -q` was attempted for visibility and failed on pre-existing unrelated product tests (listed exactly): `tests/test_api_endpoints.py::test_solve_openai_provider_errors_return_safe_responses[timeout-504]`, `tests/test_api_endpoints.py::test_solve_openai_provider_errors_return_safe_responses[rate_limit-429]`, `tests/test_api_endpoints.py::test_solve_openai_provider_errors_return_safe_responses[network-503]`, `tests/test_cost_tracking.py::test_cost_tracking`, and `tests/test_security.py::test_a3_1_prompt_subset_passes_solve_input_validation` (these failures are unrelated to this approval-boundary fix).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2778fb3d988329b5fb70cdf62013b7)