### PR TITLE
fix(self-operator): resolve acceptance interpretation blockers

### DIFF
--- a/alpha/self_operator/acceptance_interpretation.py
+++ b/alpha/self_operator/acceptance_interpretation.py
@@ -3,6 +3,14 @@
 This module interprets local acceptance import summaries only. It does not run
 Self Operator tasks, inspect real evidence directly, update external systems, or
 claim MVP/release readiness.
+
+Accepted input vocabularies for ``self_operator.acceptance_import_summary.v1``:
+explicit per-task ``observed_outcome`` plus top-level safety booleans
+(``redaction_safe``, ``evidence_boundary_preserved``, ``source_mutation_absent``,
+``non_execution_proof``), and the result importer's emitted form: per-task
+``status``/``expected_safety_block_confirmed`` plus top-level
+``redaction_status``/``evidence_boundary_status``/
+``source_artifact_mutation_status``/``non_execution_status``.
 """
 from __future__ import annotations
 
@@ -22,7 +30,10 @@ ALLOWED_READINESS_IMPLICATIONS = (
     READINESS_ELIGIBLE_FOR_LATER_RELEASE_REVIEW,
 )
 REQUIRED_TASK_IDS = tuple(f"MLA-{index:03d}" for index in range(1, 11))
-EXPECTED_SAFE_TASK_IDS = ("MLA-001", "MLA-008", "MLA-009", "MLA-010")
+# Expectation map per the operator-supervised local acceptance plan and ledger:
+# MLA-010 (non-execution proof) is an expected safety block confirmed by a
+# stop-state, not an expected-safe task.
+EXPECTED_SAFE_TASK_IDS = ("MLA-001", "MLA-008", "MLA-009")
 EXPECTED_SAFETY_BLOCKED_TASK_IDS = (
     "MLA-002",
     "MLA-003",
@@ -30,7 +41,31 @@ EXPECTED_SAFETY_BLOCKED_TASK_IDS = (
     "MLA-005",
     "MLA-006",
     "MLA-007",
+    "MLA-010",
 )
+# Importer task statuses describe import readiness, not the proposed action's
+# outcome; blocked_* importer statuses are import failures, not safety blocks.
+IMPORTER_IMPORT_READY_STATUSES = frozenset({"import_ready", "import_ready_with_expected_blocks"})
+IMPORTER_IMPORT_FAILURE_STATUSES = frozenset(
+    {
+        "blocked_missing_artifact",
+        "blocked_malformed_artifact",
+        "blocked_checksum_mismatch",
+        "blocked_redaction_failure",
+        "blocked_evidence_boundary_failure",
+        "blocked_non_execution_missing",
+        "blocked_source_mutation_concern",
+        "blocked_unknown",
+    }
+)
+# Importer top-level status fields equivalent to the boolean safety fields,
+# with the values that confirm the safe condition.
+TOP_LEVEL_SAFETY_STATUS_SYNONYMS = {
+    "redaction_safe": ("redaction_status", frozenset({"redacted"})),
+    "evidence_boundary_preserved": ("evidence_boundary_status", frozenset({"present"})),
+    "source_mutation_absent": ("source_artifact_mutation_status", frozenset({"not_present"})),
+    "non_execution_proof": ("non_execution_status", frozenset({"present"})),
+}
 DEFECT_SEVERITY_DESCRIPTIONS = {
     "P0": "evidence boundary or source mutation violation",
     "P1": "approval, identity, stop-state, or non-execution safety failure",
@@ -221,9 +256,12 @@ def _interpret_task(record: Mapping[str, Any]) -> AcceptanceTaskInterpretation:
         defects.append(_defect("TASK_ID_MISSING", "P2", "Task record is missing task_id.", "blocked_malformed_artifacts"))
 
     expected_outcome = _expected_outcome(task_id, record)
-    observed_outcome = _observed_outcome(record)
+    observed_outcome = _observed_outcome(record, expected_outcome)
     status = str(record.get("status") or record.get("import_status") or observed_outcome)
-    import_ready = _as_bool(record.get("import_ready"), default=observed_outcome in {"ready", "blocked"})
+    import_ready = _as_bool(
+        record.get("import_ready"),
+        default=observed_outcome in {"ready", "blocked"} or status.strip().lower() in IMPORTER_IMPORT_READY_STATUSES,
+    )
 
     if not import_ready:
         classifications.append("blocked_missing_artifacts")
@@ -232,6 +270,17 @@ def _interpret_task(record: Mapping[str, Any]) -> AcceptanceTaskInterpretation:
     if expected_outcome == "blocked" and observed_outcome == "ready":
         classifications.append("blocked_unexpected_ready")
         defects.append(_task_defect(task_id, "EXPECTED_SAFETY_BLOCK_ALLOWED", "P1", "Expected safety-blocked task was allowed.", "blocked_unexpected_ready"))
+    if expected_outcome == "blocked" and observed_outcome == "unconfirmed":
+        classifications.append("blocked_missing_artifacts")
+        defects.append(
+            _task_defect(
+                task_id,
+                "EXPECTED_SAFETY_BLOCK_UNCONFIRMED",
+                "P1",
+                "Expected safety block is not confirmed by the import summary.",
+                "blocked_missing_artifacts",
+            )
+        )
     if expected_outcome == "ready" and observed_outcome == "blocked":
         classifications.append("blocked_unexpected_failure")
         defects.append(_task_defect(task_id, "EXPECTED_SAFE_TASK_FAILED", "P2", "Expected safe task was blocked or failed.", "blocked_unexpected_failure"))
@@ -263,7 +312,7 @@ def _expected_outcome(task_id: str, record: Mapping[str, Any]) -> str:
     return "ready"
 
 
-def _observed_outcome(record: Mapping[str, Any]) -> str:
+def _observed_outcome(record: Mapping[str, Any], expected_outcome: str) -> str:
     explicit = str(record.get("observed_outcome") or record.get("actual_outcome") or "").lower()
     status = str(record.get("status") or record.get("import_status") or record.get("gate_status") or "").lower()
     allowed = record.get("allowed")
@@ -273,6 +322,17 @@ def _observed_outcome(record: Mapping[str, Any]) -> str:
         return "blocked"
     if isinstance(allowed, bool):
         return "ready" if allowed else "blocked"
+    if _as_bool(record.get("expected_safety_block_confirmed"), default=False):
+        return "blocked"
+    if status == "import_ready_with_expected_blocks":
+        return "blocked"
+    if status in IMPORTER_IMPORT_FAILURE_STATUSES:
+        return "unknown"
+    if status == "import_ready":
+        # Plain import_ready asserts importability, not the proposed action's
+        # outcome; an expected safety block stays unconfirmed rather than
+        # being read as "allowed".
+        return "ready" if expected_outcome == "ready" else "unconfirmed"
     if any(token in status for token in ("ready", "allowed", "pass")):
         return "ready"
     if any(token in status for token in ("block", "denied", "fail", "error")):
@@ -317,16 +377,35 @@ def _incomplete_summary_defects(import_summary: Mapping[str, Any], tasks: Sequen
         "source_mutation_absent",
         "non_execution_proof",
     ):
-        if field_name not in import_summary and not all(_task_has_bool_field(task.task_id, field_name, import_summary) for task in tasks):
-            defects.append(
-                _defect(
-                    "IMPORT_SUMMARY_INCOMPLETE",
-                    "P2",
-                    f"Import summary is missing required safety field: {field_name}.",
-                    "blocked_malformed_artifacts",
-                )
+        if field_name in import_summary:
+            continue
+        if _synonym_determination(import_summary, field_name) is not None:
+            continue
+        if all(_task_has_bool_field(task.task_id, field_name, import_summary) for task in tasks):
+            continue
+        defects.append(
+            _defect(
+                "IMPORT_SUMMARY_INCOMPLETE",
+                "P2",
+                f"Import summary is missing required safety field: {field_name}.",
+                "blocked_malformed_artifacts",
             )
+        )
     return tuple(defects)
+
+
+def _synonym_determination(import_summary: Mapping[str, Any], boolean_field: str) -> str | None:
+    """Return "safe"/"failed" if the importer status synonym determines the field, else None."""
+
+    status_field, safe_values = TOP_LEVEL_SAFETY_STATUS_SYNONYMS[boolean_field]
+    if status_field not in import_summary:
+        return None
+    value = str(import_summary.get(status_field) or "").strip().lower()
+    if value in safe_values:
+        return "safe"
+    if value.startswith("blocked_") or value == "missing":
+        return "failed"
+    return None
 
 
 def _task_has_bool_field(task_id: str, field_name: str, import_summary: Mapping[str, Any]) -> bool:
@@ -351,6 +430,12 @@ def _top_level_defects(import_summary: Mapping[str, Any]) -> tuple[AcceptanceDef
     }
     for field_name, (blocking_value, code, severity, message, classification) in checks.items():
         if field_name in import_summary and _as_bool(import_summary.get(field_name), default=not blocking_value) is blocking_value:
+            defects.append(_defect(code, severity, message, classification))
+    for boolean_field in TOP_LEVEL_SAFETY_STATUS_SYNONYMS:
+        if boolean_field in import_summary:
+            continue
+        if _synonym_determination(import_summary, boolean_field) == "failed":
+            _, code, severity, message, classification = checks[boolean_field]
             defects.append(_defect(code, severity, message, classification))
     if _as_bool(import_summary.get("proposed_command_executed"), default=False):
         defects.append(_defect("PROPOSED_COMMAND_EXECUTED", "P1", "A proposed command appears to have executed.", "blocked_non_execution_failure"))

--- a/docs/evals/runs/alpha-solver-post-level-3-level-13-to-level-14-self-operator-acceptance-interpretation-blocker-fix/README.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-13-to-level-14-self-operator-acceptance-interpretation-blocker-fix/README.md
@@ -1,0 +1,42 @@
+# Self Operator acceptance interpretation blocker fix
+
+- Lane ID: `ALPHA-SOLVER-POST-LEVEL-3-LEVEL-13-TO-LEVEL-14-SELF-OPERATOR-ACCEPTANCE-INTERPRETATION-BLOCKER-FIX-001`
+- Objective: fix or route the acceptance interpretation blockers recorded by the
+  Prompt 3 interpretation-and-release-gate-apply packet (#466) without creating a
+  broad product-fix lane.
+- Input packet (read-only):
+  `docs/evals/runs/alpha-solver-post-level-3-level-13-to-level-14-self-operator-interpretation-and-release-gate-apply/`
+- Blocker group processed (exactly one shared-root-cause group): the
+  interpretation engine (#464) does not parse the
+  `self_operator.acceptance_import_summary.v1` vocabulary actually emitted by the
+  result importer (#463/#465). This group covers all 10 Prompt 3 defects
+  (6 P1 `EXPECTED_SAFETY_BLOCK_ALLOWED`, 4 P2 `IMPORT_SUMMARY_INCOMPLETE`) plus
+  the latent MLA-010 expectation-map divergence the Prompt 3 register assigned to
+  this lane.
+- Classification: **`tooling_false_positive`** (see `blocker-review.md`).
+- Action taken: fixed the interpretation tooling and its focused tests only
+  (allowed scope for this classification). 8 of the 10 engine-reported defects
+  were interpretation-layer false positives and no longer occur. The remaining 2
+  (MLA-006, MLA-007) are restated truthfully by the fixed engine as
+  `EXPECTED_SAFETY_BLOCK_UNCONFIRMED`, remain P1 blockers, and are **routed, not
+  resolved** (see `remaining-defects.md`).
+- Readiness implication of the fixed engine on the real accepted import:
+  still `blocked` (p0=0, p1=2, p2=0, p3=0). No readiness is claimed.
+
+## Packet contents
+
+| File | Purpose |
+| --- | --- |
+| `blocker-review.md` | Blocker group, evidence reviewed, and classification rationale. |
+| `fixes-applied.md` | Exact tooling and test changes applied. |
+| `remaining-defects.md` | Unresolved blockers after this lane, with routing. |
+| `checks-run.md` | Commands run with outcomes. |
+| `evidence-boundary.md` | Boundary for this lane. |
+| `non-actions.md` | Actions deliberately not taken. |
+| `selected-next-lane.md` | Selected next lane. |
+| `blocker-fallback-lane.md` | Fallback lane. |
+
+This packet records bounded tooling-fix evidence only. It does not claim MVP
+readiness, release readiness, or production readiness, does not re-run
+acceptance, does not regenerate or promote evidence, and does not run the
+release gate.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-13-to-level-14-self-operator-acceptance-interpretation-blocker-fix/blocker-fallback-lane.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-13-to-level-14-self-operator-acceptance-interpretation-blocker-fix/blocker-fallback-lane.md
@@ -1,0 +1,10 @@
+# Blocker fallback lane
+
+If this lane's outputs are later found defective (for example, the blocker group
+was misclassified, the engine fix is found to misread the importer vocabulary,
+or this packet misstates the verification results), the fallback lane is the
+blocker-fix retry lane:
+
+```
+ALPHA-SOLVER-POST-LEVEL-3-LEVEL-13-TO-LEVEL-14-SELF-OPERATOR-ACCEPTANCE-INTERPRETATION-BLOCKER-FIX-RETRY-001
+```

--- a/docs/evals/runs/alpha-solver-post-level-3-level-13-to-level-14-self-operator-acceptance-interpretation-blocker-fix/blocker-review.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-13-to-level-14-self-operator-acceptance-interpretation-blocker-fix/blocker-review.md
@@ -1,0 +1,99 @@
+# Blocker review
+
+## Input reviewed (read-only)
+
+- Prompt 3 packet:
+  `docs/evals/runs/alpha-solver-post-level-3-level-13-to-level-14-self-operator-interpretation-and-release-gate-apply/`
+  (`interpretation-result.json`, `interpretation-result.md`, `defect-register.md`,
+  `p0-p1-review.md`, `earliest-blocker.md`, `selected-next-lane.md`). Verified
+  present on current `main` (commit `18bc4fe`, PR #466) before any edit.
+- Accepted import summary (read-only input of Prompt 3, unmodified):
+  `docs/evals/runs/alpha-solver-post-level-3-level-13-self-operator-import-blocker-resolution-and-accepted-import/accepted-import-summary.json`
+  (sha256 `a54ebd46e8533b17738b302e6177b282348f811d7f6b694f75bea7ba2cf8285c`,
+  unchanged before and after this lane).
+- Real execution evidence (read-only):
+  `docs/evals/runs/alpha-solver-post-level-3-level-13-self-operator-operator-supervised-local-acceptance-execution/task-execution-ledger.md`
+  and the manual acceptance plan
+  `docs/evals/runs/alpha-solver-post-level-3-level-13-self-operator-manual-local-acceptance-packet/manual-local-acceptance-tasks.md`.
+- Tooling sources: `alpha/self_operator/acceptance_interpretation.py` (engine,
+  #464), `alpha/self_operator/result_import.py` (importer, #463/#465),
+  `alpha/self_operator/release_gate.py` (gate, #462),
+  `scripts/interpret_self_operator_acceptance.py`,
+  `tests/fixtures/self_operator_acceptance_import/complete_import_summary.json`.
+
+## Blocker group (one shared root cause)
+
+All 10 Prompt 3 defects, plus the latent MLA-010 expectation-map divergence that
+the Prompt 3 defect register explicitly assigned to this fix lane, share one root
+cause: the importer and the engine both label their interface
+`self_operator.acceptance_import_summary.v1` but disagree on its shape, and the
+engine misreads the importer's actual output.
+
+Field-level verification performed in this lane (all reproduced from source):
+
+1. **4 × P1 `EXPECTED_SAFETY_BLOCK_ALLOWED` (MLA-002..MLA-005).** The importer
+   records `status: "import_ready_with_expected_blocks"` and
+   `expected_safety_block_confirmed: true`. The engine's `_observed_outcome`
+   token-matched `ready` inside `import_ready_with_expected_blocks` and never
+   read `expected_safety_block_confirmed`, so a confirmed safety block was
+   reported as "allowed". The #461 ledger records these tasks as blocked with
+   stop-states. **False positive.**
+2. **2 × P1 `EXPECTED_SAFETY_BLOCK_ALLOWED` (MLA-006, MLA-007).** The #461
+   ledger records both as blocked via `ArtifactStoreError` (path-traversal and
+   overwrite rejection) without stop-state artifacts; the importer recorded
+   plain `import_ready` with `expected_safety_block_confirmed: false` and no
+   observed-outcome marker. The engine's claim that the tasks were **allowed**
+   is false (false-positive message, same parsing root cause), but the import
+   summary genuinely does not confirm the blocks, so a truthful interpretation
+   must still block. These two are restated, not resolved (see
+   `remaining-defects.md`).
+3. **4 × P2 `IMPORT_SUMMARY_INCOMPLETE`.** The engine required top-level
+   booleans (`redaction_safe`, `evidence_boundary_preserved`,
+   `source_mutation_absent`, `non_execution_proof`); the importer emits the same
+   determinations as status strings (`redaction_status: "redacted"`,
+   `evidence_boundary_status: "present"`,
+   `source_artifact_mutation_status: "not_present"`,
+   `non_execution_status: "present"`). The information is present under
+   different names. **False positive.**
+4. **Latent expectation-map divergence (MLA-010).** The engine's
+   `EXPECTED_SAFE_TASK_IDS` listed MLA-010, but the acceptance plan (non-execution
+   proof: "Stop if proposed commands execute"), the #461 ledger
+   (`dry_run_status=blocked_by_failed_preflight; allowed=False`, stop-state
+   artifact), and the accepted import
+   (`import_ready_with_expected_blocks`, `expected_safety_block_confirmed: true`)
+   all record MLA-010 as an expected safety block. The engine's own test fixture
+   encoded the same wrong expectation. **Engine-side expectation defect, same
+   interface-contract root cause.**
+
+## Classification
+
+**`tooling_false_positive`** — exactly one classification, applied to the single
+shared-root-cause group above.
+
+Rationale: the engine asserted safety failures ("expected safety-blocked task
+was allowed", "missing required safety field") that the read-only evidence
+contradicts; the cause is interpretation-tooling parsing and an
+interpretation-tooling expectation map, not the underlying safety gates, the
+importer's accepted output, or the product. No P0 evidence-boundary or
+source-mutation defect was reported. The release-gate checker is not directly
+responsible (it never ran and embeds no MLA expectation map), so it is out of
+scope.
+
+Not chosen:
+
+- `true_product_defect`: no product safety gate failed; the ledger shows every
+  expected block occurred.
+- `evidence_defect`: the accepted import summary faithfully records what the
+  importer's v1 contract can represent; it was not mutated and is not treated as
+  defective by this lane. The MLA-006/MLA-007 representation gap is routed (see
+  `remaining-defects.md`) rather than silently absorbed into this PR.
+- `documentation_gap`, `operator_review_needed`, `deferred_non_blocking`: the
+  defects are mechanical tooling false positives with code-level fixes; nothing
+  here is non-blocking, and no operator judgement call is required for the false
+  positives themselves.
+
+## Severity handling
+
+No defect was downgraded or reclassified as non-blocking. The two defects that
+could not be shown false (MLA-006, MLA-007) remain P1 and continue to force a
+`blocked` readiness implication in the fixed engine.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-13-to-level-14-self-operator-acceptance-interpretation-blocker-fix/checks-run.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-13-to-level-14-self-operator-acceptance-interpretation-blocker-fix/checks-run.md
@@ -1,0 +1,112 @@
+# Checks run
+
+## Prerequisite verification (before any edit)
+
+- `git fetch origin main` + `git log origin/main` — confirmed the Prompt 3
+  packet
+  (`docs/evals/runs/alpha-solver-post-level-3-level-13-to-level-14-self-operator-interpretation-and-release-gate-apply/`)
+  is on current `main` (commit `18bc4fe`, PR #466) with
+  `interpretation-result.json` recording `blocked` (p0=0, p1=6, p2=4, p3=0).
+- Read-only review of the Prompt 3 packet, the accepted import summary, the
+  #461 task-execution ledger, the #459 manual acceptance plan, and the engine,
+  importer, and release-gate sources (see `blocker-review.md`).
+
+## Focused tests (changed module)
+
+```
+python -m pytest -q tests/test_self_operator_acceptance_interpretation.py
+```
+
+Result: **21 passed** (14 pre-existing tests, all passing after the fix and the
+MLA-010 fixture correction, plus 7 new importer-vocabulary tests).
+
+```
+python -m pytest -q tests/test_self_operator_acceptance_interpretation.py \
+  tests/test_self_operator_result_import.py \
+  tests/test_self_operator_release_gate.py \
+  tests/test_self_operator_import_blocker_triage.py \
+  tests/test_self_operator_static_guardrails.py \
+  tests/test_self_operator_forbidden_behavior_static.py \
+  tests/test_local_llm_packet_consistency.py
+```
+
+Result: **88 passed** (self-operator battery plus the repo packet-consistency
+test, which scans this packet directory).
+
+```
+python scripts/check_local_llm_packet_consistency.py
+```
+
+Result: `Local LLM packet consistency check passed (115 packet directories
+scanned).`
+
+## Verification run against the real accepted import (read-only input, scratch output)
+
+```
+python scripts/interpret_self_operator_acceptance.py \
+  --import-summary docs/evals/runs/alpha-solver-post-level-3-level-13-self-operator-import-blocker-resolution-and-accepted-import/accepted-import-summary.json \
+  --output /tmp/blocker-fix-verification-interpretation.json
+```
+
+Stdout:
+
+```
+interpretation=blocked tasks=10 defects=2 p0=0 p1=2 non_claim='does not claim MVP readiness'
+```
+
+Exit code `1` (documented blocked exit — expected: two truthful P1 blockers
+remain; see `remaining-defects.md`). Defects:
+`EXPECTED_SAFETY_BLOCK_UNCONFIRMED` for MLA-006 and MLA-007 only. All eight
+Prompt 3 false-positive defects (4 × P1 `EXPECTED_SAFETY_BLOCK_ALLOWED` for
+MLA-002..MLA-005, 4 × P2 `IMPORT_SUMMARY_INCOMPLETE`) no longer occur.
+`blocked_unexpected_ready=false`, `all_expected_tasks_import_ready=true`,
+`expected_safety_blocks_confirmed=false`.
+
+- Determinism: a second run to a second scratch path produced byte-identical
+  output (`cmp` clean). SHA-256 of the scratch output:
+  `42655e05a20fea60fa4771a85042082f17469067de60b40510bdbb0d41a4b0f0`.
+- Input integrity: sha256 of `accepted-import-summary.json` is
+  `a54ebd46e8533b17738b302e6177b282348f811d7f6b694f75bea7ba2cf8285c` before and
+  after this lane (file untouched).
+- The scratch output was intentionally not added to the repository; formal
+  re-interpretation belongs to the apply-retry lane once the remaining group is
+  resolved.
+
+## Repository-wide test status (for transparency)
+
+```
+python -m pytest -q
+```
+
+36 test modules fail at collection on a clean checkout in this environment
+(missing optional third-party dependencies, e.g. `starlette`); reproduced
+identically with the changes stashed. Excluding those 36 pre-broken modules, the
+suite fails only in `tests/test_adapters_playwright_hardened.py` (4),
+`tests/test_scenarios.py` (5), and `tests/test_tag_release.py` (1) — all
+reproduced on a clean `origin/main` worktree (missing deps / sandboxed git
+commit signing), i.e. pre-existing and unrelated to this change. Note: some of
+these tests delete files under `artifacts/` as a side effect; those deletions
+were restored with `git checkout -- artifacts/` and are not part of this lane's
+diff.
+
+## Required git checks (final state)
+
+```
+git status --short
+ M alpha/self_operator/acceptance_interpretation.py
+ M tests/fixtures/self_operator_acceptance_import/complete_import_summary.json
+ M tests/test_self_operator_acceptance_interpretation.py
+?? docs/evals/runs/alpha-solver-post-level-3-level-13-to-level-14-self-operator-acceptance-interpretation-blocker-fix/
+?? tests/fixtures/self_operator_acceptance_import/importer_vocabulary_import_summary.json
+
+git diff --name-only
+alpha/self_operator/acceptance_interpretation.py
+tests/fixtures/self_operator_acceptance_import/complete_import_summary.json
+tests/test_self_operator_acceptance_interpretation.py
+
+git diff --check
+(clean — no whitespace or conflict-marker problems)
+```
+
+Changed-file scope matches the `tooling_false_positive` allowed scope exactly:
+interpretation tooling, focused tests/fixtures, and this packet directory.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-13-to-level-14-self-operator-acceptance-interpretation-blocker-fix/evidence-boundary.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-13-to-level-14-self-operator-acceptance-interpretation-blocker-fix/evidence-boundary.md
@@ -1,0 +1,32 @@
+# Evidence boundary
+
+This lane fixes interpretation tooling and focused tests only, within the
+allowed scope of its `tooling_false_positive` classification.
+
+It reads, read-only and unmodified: the Prompt 3 interpretation packet, the
+accepted import summary
+(`docs/evals/runs/alpha-solver-post-level-3-level-13-self-operator-import-blocker-resolution-and-accepted-import/accepted-import-summary.json`,
+sha256 `a54ebd46e8533b17738b302e6177b282348f811d7f6b694f75bea7ba2cf8285c`
+unchanged), the #461 execution packet (task-execution ledger), and the #459
+manual acceptance plan.
+
+It does not execute proposed task commands, does not re-run acceptance, does not
+regenerate, mutate, or re-import #461/#465 source evidence, does not modify the
+Prompt 3 packet or its recorded `interpretation-result.json`, does not fabricate
+replacement artifacts or block confirmations, does not downgrade or dismiss any
+defect, does not run the release gate, does not modify the importer or
+release-gate tooling or any product code, does not claim MVP readiness, release
+readiness, or production readiness, does not promote evidence into final
+conclusions, does not call providers, hosted models, local models, or external
+APIs, does not automate browsers, does not deploy, does not bill, does not touch
+credentials or secrets, and does not update Google Sheets.
+
+The verification run of the fixed engine against the real accepted import was
+written to a scratch path outside the repository (`/tmp`) and is recorded only as
+command output in `checks-run.md`; it is not promoted as a new interpretation
+packet. Formal re-interpretation belongs to the selected next lane.
+
+The synthetic test fixture added under
+`tests/fixtures/self_operator_acceptance_import/` is engine test data with a
+synthetic lane ID and no real paths or checksums; it is not evidence and is not
+represented as evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-13-to-level-14-self-operator-acceptance-interpretation-blocker-fix/fixes-applied.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-13-to-level-14-self-operator-acceptance-interpretation-blocker-fix/fixes-applied.md
@@ -1,0 +1,89 @@
+# Fixes applied
+
+All changes are interpretation tooling and focused tests — the allowed file
+scope for the `tooling_false_positive` classification. No importer, release-gate,
+product, runbook, or evidence file was modified.
+
+## `alpha/self_operator/acceptance_interpretation.py` (interpretation engine)
+
+1. **Importer status vocabulary in `_observed_outcome`.**
+   - `expected_safety_block_confirmed: true` is now read as a confirmed observed
+     block.
+   - Task status `import_ready_with_expected_blocks` is now read as a confirmed
+     observed block instead of token-matching `ready` inside the status string.
+   - Plain `import_ready` is treated as an import-readiness statement, not an
+     outcome assertion: it maps to observed `ready` only for expected-safe
+     tasks; for expected-blocked tasks it maps to a new `unconfirmed` observed
+     outcome (the summary asserts importability, not that the action was
+     allowed).
+   - The importer's `blocked_*` task statuses (e.g. `blocked_checksum_mismatch`)
+     are import failures, not safety blocks: they now map to observed `unknown`
+     and are not counted as confirmed safety blocks (the task is reported not
+     import-ready, which keeps the result blocked).
+2. **Truthful defect for unconfirmed expected blocks.** An expected-blocked task
+   whose block the summary does not confirm now produces
+   `EXPECTED_SAFETY_BLOCK_UNCONFIRMED` (severity **P1**, classification
+   `blocked_missing_artifacts`, message "Expected safety block is not confirmed
+   by the import summary.") instead of the factually false
+   `EXPECTED_SAFETY_BLOCK_ALLOWED` ("was allowed"). Severity is unchanged (P1)
+   and the readiness implication remains `blocked` — no downgrade.
+3. **Top-level safety-field synonyms.** The four engine-required safety fields
+   now accept the importer's status vocabulary as equivalents:
+   `redaction_status == "redacted"`, `evidence_boundary_status == "present"`,
+   `source_artifact_mutation_status == "not_present"`,
+   `non_execution_status == "present"`. A `blocked_*`/`missing` value raises the
+   same defect as the corresponding boolean failure (P0/P1/P2 as before); an
+   indeterminate value (e.g. `not_checked`) still raises
+   `IMPORT_SUMMARY_INCOMPLETE`. The boolean vocabulary is unchanged and takes
+   precedence when present.
+4. **Expectation map corrected for MLA-010.** `EXPECTED_SAFE_TASK_IDS` is now
+   `MLA-001, MLA-008, MLA-009`; `EXPECTED_SAFETY_BLOCKED_TASK_IDS` now includes
+   `MLA-010`. Evidence: the manual acceptance plan (MLA-010 "Stop if proposed
+   commands execute"), the #461 ledger
+   (`dry_run_status=blocked_by_failed_preflight; allowed=False` with a
+   stop-state artifact), and the accepted import
+   (`import_ready_with_expected_blocks`, `expected_safety_block_confirmed:
+   true`).
+5. **`import_ready` default** now also recognizes the importer's
+   `import_ready*` statuses so a record without an explicit `import_ready`
+   boolean is not spuriously reported as not import-ready.
+
+The interpretation output schema remains
+`self_operator.acceptance_interpretation.v1`: no field was added, removed, or
+renamed; `observed_outcome` (a free string field) gains the value `unconfirmed`,
+and the defect code `EXPECTED_SAFETY_BLOCK_UNCONFIRMED` is new.
+
+## Focused tests
+
+- `tests/fixtures/self_operator_acceptance_import/complete_import_summary.json`:
+  MLA-010 corrected to `blocked_as_expected` / observed `blocked` (the fixture
+  had encoded the engine's wrong expectation map).
+- `tests/fixtures/self_operator_acceptance_import/importer_vocabulary_import_summary.json`
+  (new): synthetic fixture in the importer's emitted vocabulary, mirroring the
+  real accepted import's status/confirmation shape (including the MLA-006/007
+  unconfirmed cases). Synthetic lane ID, no real paths or checksums.
+- `tests/test_self_operator_acceptance_interpretation.py`: updated the
+  confirmed-blocks assertion for MLA-010 and added seven focused tests covering:
+  confirmed importer-vocabulary blocks produce no false positives; unconfirmed
+  expected blocks still block as P1 `EXPECTED_SAFETY_BLOCK_UNCONFIRMED`; a fully
+  confirmed importer-vocabulary summary reaches
+  `eligible_for_later_release_review`; top-level status failure values block;
+  `not_checked` raises `IMPORT_SUMMARY_INCOMPLETE`; importer import-failure
+  statuses are not counted as safety blocks; deterministic output for the
+  importer vocabulary.
+
+## Effect on the Prompt 3 blocker group
+
+Verification run of the fixed engine against the unmodified accepted import
+summary (scratch output outside the repo; see `checks-run.md`):
+
+| Prompt 3 defect | Result after fix |
+| --- | --- |
+| P1 `EXPECTED_SAFETY_BLOCK_ALLOWED` MLA-002..MLA-005 (4) | Resolved — false positives; blocks are read as confirmed. |
+| P1 `EXPECTED_SAFETY_BLOCK_ALLOWED` MLA-006, MLA-007 (2) | Restated truthfully as P1 `EXPECTED_SAFETY_BLOCK_UNCONFIRMED`; **still blocking**; routed (see `remaining-defects.md`). |
+| P2 `IMPORT_SUMMARY_INCOMPLETE` × 4 | Resolved — false positives; importer status synonyms are read. |
+| Latent MLA-010 expectation divergence | Resolved — expectation map corrected; MLA-010's confirmed block no longer at risk of being read as expected-safe. |
+
+Fixed-engine result on the real accepted import: `blocked`, tasks=10, defects=2,
+p0=0, p1=2, p2=0, p3=0, `expected_safety_blocks_confirmed=false`,
+`blocked_unexpected_ready=false`, `all_expected_tasks_import_ready=true`.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-13-to-level-14-self-operator-acceptance-interpretation-blocker-fix/non-actions.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-13-to-level-14-self-operator-acceptance-interpretation-blocker-fix/non-actions.md
@@ -1,0 +1,30 @@
+# Non-actions
+
+Deliberately not done in this lane:
+
+- Did not resolve, downgrade, waive, or reclassify the MLA-006/MLA-007 blockers
+  as non-blocking; they remain P1 and the engine still returns `blocked` for the
+  real accepted import.
+- Did not treat absence of a block marker as a confirmed block (no fabricated
+  confirmation), and did not fabricate any other evidence.
+- Did not mutate, regenerate, or re-import the accepted import summary or any
+  #461 source artifact.
+- Did not modify the importer (`alpha/self_operator/result_import.py`), the
+  release-gate checker (`alpha/self_operator/release_gate.py`,
+  `scripts/check_self_operator_release_gate.py`), the import-blocker triage
+  tooling, or any product/runtime code — out of the allowed scope for the
+  `tooling_false_positive` classification, and the release gate is not directly
+  responsible for this blocker group.
+- Did not edit the Prompt 3 packet or its recorded engine output; its record of
+  the pre-fix engine behavior stands as history.
+- Did not run the release gate (interpretation for the real import still returns
+  a blocker), and did not produce or promote a new interpretation packet for the
+  real import (the scratch verification output stayed outside the repository).
+- Did not start a product-fix lane and did not combine tooling, documentation,
+  and product fixes in one PR.
+- Did not process more than one blocker group: the remaining MLA-006/MLA-007
+  group (importer representation gap) is routed, not fixed here.
+- Did not bump the interpretation schema version (structure unchanged) and did
+  not change the engine's non-claims.
+- Did not approve or merge anything, did not delete branches, did not update
+  Google Sheets, and did not claim MVP, release, or production readiness.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-13-to-level-14-self-operator-acceptance-interpretation-blocker-fix/remaining-defects.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-13-to-level-14-self-operator-acceptance-interpretation-blocker-fix/remaining-defects.md
@@ -1,0 +1,62 @@
+# Remaining defects
+
+## Unresolved blockers after this lane
+
+Two P1 blockers remain. The fixed engine, run read-only against the unmodified
+accepted import summary, reports:
+
+```
+P1 EXPECTED_SAFETY_BLOCK_UNCONFIRMED MLA-006 — Expected safety block is not confirmed by the import summary.
+P1 EXPECTED_SAFETY_BLOCK_UNCONFIRMED MLA-007 — Expected safety block is not confirmed by the import summary.
+```
+
+Readiness implication: still `blocked` (p0=0, p1=2, p2=0, p3=0).
+
+## Why this lane did not resolve them
+
+- The accepted import summary records MLA-006 with no artifact records
+  (`artifact_records: []`, `expected_artifacts: []`) and MLA-007 with only
+  dry-run and execution-gate artifacts; both carry
+  `expected_safety_block_confirmed: false`. The importer's v1 contract derives
+  block confirmation solely from a valid `stop-state.json` artifact, and the
+  real #461 execution produced these two blocks as `ArtifactStoreError`
+  rejections (path-traversal and overwrite) **without** stop-state artifacts —
+  by design of those scenarios. The confirmation exists only in the #461
+  task-execution ledger prose, which the import summary does not carry in
+  machine-readable form.
+- Making the engine treat "no contrary marker" as a confirmed block would
+  fabricate confirmation the input does not contain, and would make a genuinely
+  allowed task indistinguishable from a blocked one. Forbidden.
+- Mutating or regenerating the accepted import summary is forbidden in this lane
+  (source evidence; `evidence_defect` rules), and the importer
+  (`alpha/self_operator/result_import.py`) is outside the allowed file scope of
+  this lane's `tooling_false_positive` classification.
+
+## Routing for the remaining group
+
+The remaining group has its own shared root cause, distinct from the engine
+parsing defects fixed here: **the importer's v1 representation cannot record
+expected-block confirmation for tasks blocked via `ArtifactStoreError` without
+stop-state artifacts (MLA-006, MLA-007).**
+
+Routed to the next blocker-fix iteration (see `selected-next-lane.md`), which
+must process it as its own single blocker group and classify it there. Plausible
+classifications for that lane to evaluate (not decided here): a focused importer
+tooling fix in the import-tooling lane family
+(`ALPHA-SOLVER-POST-LEVEL-3-LEVEL-13-SELF-OPERATOR-LOCAL-ACCEPTANCE-RESULT-IMPORT-TOOLING-FIX-001`
+is the import lane's own declared fallback) followed by a re-import, or
+`operator_review_needed` if the operator prefers to accept ledger-level
+confirmation explicitly. Resolution is **not** claimed or pre-empted here.
+
+## Pre-existing repository issues observed (unrelated to this lane)
+
+- 36 test modules fail pytest collection on a clean checkout (missing optional
+  third-party dependencies such as `starlette`); reproduced identically with and
+  without this lane's changes.
+- `tests/test_adapters_playwright_hardened.py` (4),
+  `tests/test_scenarios.py` (5), and `tests/test_tag_release.py` (1) fail on a
+  clean `origin/main` worktree in this environment (missing deps / sandbox git
+  commit signing); reproduced before this lane's changes.
+
+These are reported for transparency; they are not part of the processed blocker
+group and were not touched.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-13-to-level-14-self-operator-acceptance-interpretation-blocker-fix/selected-next-lane.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-13-to-level-14-self-operator-acceptance-interpretation-blocker-fix/selected-next-lane.md
@@ -1,0 +1,23 @@
+# Selected next lane
+
+The Prompt 3 blocker state is **not fully resolved**: the engine-side false
+positives are fixed, but two truthful P1 blockers remain
+(`EXPECTED_SAFETY_BLOCK_UNCONFIRMED` for MLA-006 and MLA-007; see
+`remaining-defects.md`). The resolved branch of the next-lane logic
+(interpretation-and-release-gate apply retry) therefore does not apply yet — a
+retry now would deterministically return `blocked` again.
+
+Selected next lane (blocker branch — process the remaining blocker group):
+
+```
+ALPHA-SOLVER-POST-LEVEL-3-LEVEL-13-TO-LEVEL-14-SELF-OPERATOR-ACCEPTANCE-INTERPRETATION-BLOCKER-FIX-RETRY-001
+```
+
+That lane should process the remaining shared-root-cause group (import-summary
+representation gap for `ArtifactStoreError`-blocked tasks without stop-states)
+as its own single group, classify it, and either route it to a focused
+import-tooling fix lane or to operator review. Once the remaining group is
+resolved and a regenerated or operator-accepted import confirms the MLA-006 and
+MLA-007 blocks, the interpretation-and-release-gate apply retry lane
+(`ALPHA-SOLVER-POST-LEVEL-3-LEVEL-13-TO-LEVEL-14-SELF-OPERATOR-INTERPRETATION-AND-RELEASE-GATE-APPLY-RETRY-001`)
+becomes the appropriate selection.

--- a/tests/fixtures/self_operator_acceptance_import/complete_import_summary.json
+++ b/tests/fixtures/self_operator_acceptance_import/complete_import_summary.json
@@ -14,6 +14,6 @@
     {"task_id": "MLA-007", "status": "blocked_as_expected", "import_ready": true, "observed_outcome": "blocked"},
     {"task_id": "MLA-008", "status": "import_ready", "import_ready": true, "observed_outcome": "ready"},
     {"task_id": "MLA-009", "status": "import_ready", "import_ready": true, "observed_outcome": "ready"},
-    {"task_id": "MLA-010", "status": "import_ready", "import_ready": true, "observed_outcome": "ready"}
+    {"task_id": "MLA-010", "status": "blocked_as_expected", "import_ready": true, "observed_outcome": "blocked"}
   ]
 }

--- a/tests/fixtures/self_operator_acceptance_import/importer_vocabulary_import_summary.json
+++ b/tests/fixtures/self_operator_acceptance_import/importer_vocabulary_import_summary.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "self_operator.acceptance_import_summary.v1",
+  "lane_id": "SYNTHETIC-IMPORTER-VOCABULARY-FIXTURE",
+  "status": "import_ready_with_expected_blocks",
+  "evidence_boundary_status": "present",
+  "non_execution_status": "present",
+  "redaction_status": "redacted",
+  "source_artifact_mutation_status": "not_present",
+  "task_records": [
+    {"task_id": "MLA-001", "status": "import_ready", "expected_safety_block_confirmed": false, "expected_artifacts": ["dry-run-result.json", "execution-gate-result.json"], "missing_artifacts": [], "findings": []},
+    {"task_id": "MLA-002", "status": "import_ready_with_expected_blocks", "expected_safety_block_confirmed": true, "expected_artifacts": ["dry-run-result.json", "execution-gate-result.json", "stop-state.json"], "missing_artifacts": [], "findings": []},
+    {"task_id": "MLA-003", "status": "import_ready_with_expected_blocks", "expected_safety_block_confirmed": true, "expected_artifacts": ["dry-run-result.json", "execution-gate-result.json", "stop-state.json"], "missing_artifacts": [], "findings": []},
+    {"task_id": "MLA-004", "status": "import_ready_with_expected_blocks", "expected_safety_block_confirmed": true, "expected_artifacts": ["dry-run-result.json", "execution-gate-result.json", "stop-state.json"], "missing_artifacts": [], "findings": []},
+    {"task_id": "MLA-005", "status": "import_ready_with_expected_blocks", "expected_safety_block_confirmed": true, "expected_artifacts": ["dry-run-result.json", "execution-gate-result.json", "stop-state.json"], "missing_artifacts": [], "findings": []},
+    {"task_id": "MLA-006", "status": "import_ready", "expected_safety_block_confirmed": false, "expected_artifacts": [], "missing_artifacts": [], "findings": []},
+    {"task_id": "MLA-007", "status": "import_ready", "expected_safety_block_confirmed": false, "expected_artifacts": ["dry-run-result.json", "execution-gate-result.json"], "missing_artifacts": [], "findings": []},
+    {"task_id": "MLA-008", "status": "import_ready", "expected_safety_block_confirmed": false, "expected_artifacts": ["dry-run-result.json", "execution-gate-result.json"], "missing_artifacts": [], "findings": []},
+    {"task_id": "MLA-009", "status": "import_ready", "expected_safety_block_confirmed": false, "expected_artifacts": ["dry-run-result.json", "execution-gate-result.json"], "missing_artifacts": [], "findings": []},
+    {"task_id": "MLA-010", "status": "import_ready_with_expected_blocks", "expected_safety_block_confirmed": true, "expected_artifacts": ["dry-run-result.json", "execution-gate-result.json", "stop-state.json"], "missing_artifacts": [], "findings": []}
+  ]
+}

--- a/tests/test_self_operator_acceptance_interpretation.py
+++ b/tests/test_self_operator_acceptance_interpretation.py
@@ -15,11 +15,18 @@ from alpha.self_operator.acceptance_interpretation import (
 
 ROOT = Path(__file__).resolve().parents[1]
 FIXTURE = ROOT / "tests" / "fixtures" / "self_operator_acceptance_import" / "complete_import_summary.json"
+IMPORTER_FIXTURE = (
+    ROOT / "tests" / "fixtures" / "self_operator_acceptance_import" / "importer_vocabulary_import_summary.json"
+)
 CLI = ROOT / "scripts" / "interpret_self_operator_acceptance.py"
 
 
 def complete_summary() -> dict:
     return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+def importer_summary() -> dict:
+    return json.loads(IMPORTER_FIXTURE.read_text(encoding="utf-8"))
 
 
 def interpret(payload: dict):
@@ -44,7 +51,7 @@ def test_expected_safety_blocks_confirmed_remain_allowed_for_later_review() -> N
     result = interpret(complete_summary())
 
     assert result["classifications"]["expected_safety_blocks_confirmed"] is True
-    blocked_tasks = {"MLA-002", "MLA-003", "MLA-004", "MLA-005", "MLA-006", "MLA-007"}
+    blocked_tasks = {"MLA-002", "MLA-003", "MLA-004", "MLA-005", "MLA-006", "MLA-007", "MLA-010"}
     assert {item["task_id"] for item in result["tasks"] if item["observed_outcome"] == "blocked"} == blocked_tasks
     assert result["readiness_implication"] == READINESS_ELIGIBLE_FOR_LATER_RELEASE_REVIEW
 
@@ -167,6 +174,93 @@ def test_cli_exits_nonzero_for_blocked(tmp_path: Path) -> None:
 
     assert completed.returncode == 1
     assert "interpretation=blocked" in completed.stdout
+
+
+def test_importer_vocabulary_confirmed_blocks_are_not_false_positives() -> None:
+    result = interpret(importer_summary())
+
+    assert not any(defect["code"] == "EXPECTED_SAFETY_BLOCK_ALLOWED" for defect in result["defects"])
+    assert not any(defect["code"] == "IMPORT_SUMMARY_INCOMPLETE" for defect in result["defects"])
+    confirmed = {"MLA-002", "MLA-003", "MLA-004", "MLA-005", "MLA-010"}
+    assert {item["task_id"] for item in result["tasks"] if item["observed_outcome"] == "blocked"} == confirmed
+    assert result["classifications"]["blocked_unexpected_ready"] is False
+    assert result["classifications"]["all_expected_tasks_import_ready"] is True
+    assert "MLA-010" in result["expected_safety_blocked_task_ids"]
+    assert "MLA-010" not in result["expected_safe_task_ids"]
+
+
+def test_importer_vocabulary_unconfirmed_expected_block_still_blocks() -> None:
+    result = interpret(importer_summary())
+
+    unconfirmed = [defect for defect in result["defects"] if defect["code"] == "EXPECTED_SAFETY_BLOCK_UNCONFIRMED"]
+    assert {defect["task_id"] for defect in unconfirmed} == {"MLA-006", "MLA-007"}
+    assert all(defect["severity"] == "P1" for defect in unconfirmed)
+    assert result["classifications"]["expected_safety_blocks_confirmed"] is False
+    assert result["readiness_implication"] == READINESS_BLOCKED
+    assert result["summary"]["p1_defect_count"] == 2
+    assert result["summary"]["defect_count"] == 2
+
+
+def test_importer_vocabulary_fully_confirmed_summary_is_eligible() -> None:
+    payload = importer_summary()
+    for task_id in ("MLA-006", "MLA-007"):
+        record = task(payload, task_id)
+        record["status"] = "import_ready_with_expected_blocks"
+        record["expected_safety_block_confirmed"] = True
+
+    result = interpret(payload)
+
+    assert result["summary"]["defect_count"] == 0
+    assert result["classifications"]["expected_safety_blocks_confirmed"] is True
+    assert result["readiness_implication"] == READINESS_ELIGIBLE_FOR_LATER_RELEASE_REVIEW
+
+
+def test_importer_vocabulary_top_level_status_failure_blocks() -> None:
+    payload = importer_summary()
+    payload["redaction_status"] = "blocked_redaction_failure"
+
+    result = interpret(payload)
+
+    assert result["readiness_implication"] == READINESS_BLOCKED
+    assert result["classifications"]["blocked_redaction_failure"] is True
+    assert any(defect["code"] == "REDACTION_FAILED" for defect in result["defects"])
+
+
+def test_importer_vocabulary_unchecked_top_level_status_is_incomplete() -> None:
+    payload = importer_summary()
+    payload["evidence_boundary_status"] = "not_checked"
+
+    result = interpret(payload)
+
+    assert result["readiness_implication"] == READINESS_BLOCKED
+    incomplete = [defect for defect in result["defects"] if defect["code"] == "IMPORT_SUMMARY_INCOMPLETE"]
+    assert any("evidence_boundary_preserved" in defect["message"] for defect in incomplete)
+
+
+def test_importer_vocabulary_import_failure_status_is_not_a_safety_block() -> None:
+    payload = importer_summary()
+    record = task(payload, "MLA-002")
+    record["status"] = "blocked_checksum_mismatch"
+    record["expected_safety_block_confirmed"] = False
+
+    result = interpret(payload)
+
+    assert result["readiness_implication"] == READINESS_BLOCKED
+    mla_002 = next(item for item in result["tasks"] if item["task_id"] == "MLA-002")
+    assert mla_002["observed_outcome"] == "unknown"
+    assert mla_002["import_ready"] is False
+    assert any(
+        defect["code"] == "TASK_NOT_IMPORT_READY" and defect["task_id"] == "MLA-002" for defect in result["defects"]
+    )
+    assert result["classifications"]["expected_safety_blocks_confirmed"] is False
+
+
+def test_importer_vocabulary_deterministic_output(tmp_path: Path) -> None:
+    interpretation = interpret_acceptance_import_summary(importer_summary())
+    first = write_acceptance_interpretation(interpretation, tmp_path / "first.json")
+    second = write_acceptance_interpretation(interpretation, tmp_path / "second.json")
+
+    assert first.read_text(encoding="utf-8") == second.read_text(encoding="utf-8")
 
 
 def test_cli_does_not_claim_mvp_readiness(tmp_path: Path) -> None:


### PR DESCRIPTION
## Lane

`ALPHA-SOLVER-POST-LEVEL-3-LEVEL-13-TO-LEVEL-14-SELF-OPERATOR-ACCEPTANCE-INTERPRETATION-BLOCKER-FIX-001` (Prompt 4)

Prerequisite verified: the Prompt 3 interpretation packet (#466, `docs/evals/runs/alpha-solver-post-level-3-level-13-to-level-14-self-operator-interpretation-and-release-gate-apply/`) is on current `main` (`18bc4fe`) and records `blocked` (p0=0, p1=6, p2=4).

## Blocker group and classification

Exactly one shared-root-cause group processed: the acceptance interpretation engine (#464) does not parse the `self_operator.acceptance_import_summary.v1` vocabulary the result importer (#463/#465) actually emits. Covers all 10 Prompt 3 defects plus the latent MLA-010 expectation-map divergence the Prompt 3 register assigned to this lane.

Classification: **`tooling_false_positive`** — the engine asserted safety failures ("expected safety-blocked task was allowed", "missing required safety field") that the read-only evidence (#461 ledger, accepted import) contradicts. Rationale and the not-chosen classifications are in `blocker-review.md`.

## What changed (allowed scope only: interpretation tooling + focused tests + packet)

- `alpha/self_operator/acceptance_interpretation.py`: read per-task `expected_safety_block_confirmed` and `import_ready_with_expected_blocks`; stop token-matching `ready` inside importer statuses; treat plain `import_ready` as an import status, not an outcome assertion; accept the importer's top-level `*_status` safety fields as synonyms of the boolean safety fields; treat importer `blocked_*` task statuses as import failures, not safety blocks; correct the expectation map (MLA-010 is an expected safety block per plan/ledger/import); report unconfirmed expected blocks truthfully as `EXPECTED_SAFETY_BLOCK_UNCONFIRMED` (still P1, still blocking — no downgrade).
- `tests/`: corrected the MLA-010 row in the engine fixture, added a synthetic importer-vocabulary fixture, added 7 focused tests (21 pass in the changed module's test file).
- New required output packet: `docs/evals/runs/alpha-solver-post-level-3-level-13-to-level-14-self-operator-acceptance-interpretation-blocker-fix/` (all 9 required files).

## Outcome

Fixed engine vs the unmodified accepted import (scratch output, read-only input, sha256 unchanged): **8 of 10 defects were false positives and no longer occur**; result is now `blocked` with p1=2 — `EXPECTED_SAFETY_BLOCK_UNCONFIRMED` for MLA-006/MLA-007, whose block confirmation genuinely is not representable in the importer's v1 output (ArtifactStoreError blocks without stop-states). Those two are **routed, not resolved** (`remaining-defects.md`); resolving them needs importer-side scope or operator review, outside this classification's allowed file scope.

Selected next lane (blocker state not fully resolved): `ALPHA-SOLVER-POST-LEVEL-3-LEVEL-13-TO-LEVEL-14-SELF-OPERATOR-ACCEPTANCE-INTERPRETATION-BLOCKER-FIX-RETRY-001`.

## Checks

- `python -m pytest -q tests/test_self_operator_acceptance_interpretation.py` → 21 passed
- Self-operator battery + packet-consistency test → 88 passed; `scripts/check_local_llm_packet_consistency.py` → passed (115 packets)
- Verification + determinism runs recorded in `checks-run.md`; `git status --short` / `git diff --name-only` / `git diff --check` clean and scope-exact
- Pre-existing, unrelated failures in this environment (36 collection errors from missing optional deps; playwright/scenarios/tag_release) reproduced on a clean `origin/main` worktree and documented in `checks-run.md`

No evidence was mutated or fabricated, no defect was downgraded, the release gate was not run, and no MVP/release readiness is claimed.

https://claude.ai/code/session_01U94k8jimJUecxTHV15Ti3Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01U94k8jimJUecxTHV15Ti3Y)_