### PR TITLE
fix(self-operator): apply release gate checker

### DIFF
--- a/alpha/self_operator/release_gate.py
+++ b/alpha/self_operator/release_gate.py
@@ -110,6 +110,9 @@ _DEFECT_RE = re.compile(
     re.IGNORECASE,
 )
 _RESOLVED_RE = re.compile(r"\b(no|none|absent|resolved|closed)\b[^\n]{0,80}\b(P0|P1)\b", re.IGNORECASE)
+# Backtick-quoted tokens such as `P0` are severity-vocabulary references
+# (taxonomy/contract definitions), not unresolved defect markers.
+_INLINE_CODE_RE = re.compile(r"`[^`]*`")
 
 
 @dataclass(frozen=True)
@@ -225,7 +228,8 @@ def _p0_p1_gate(root: Path) -> SelfOperatorReleaseGate:
     for path in scanned_paths:
         text = path.read_text(encoding="utf-8", errors="replace")
         for line_no, line in enumerate(text.splitlines(), start=1):
-            if _DEFECT_RE.search(line) and not _RESOLVED_RE.search(line):
+            scannable = _INLINE_CODE_RE.sub(" ", line)
+            if _DEFECT_RE.search(scannable) and not _RESOLVED_RE.search(scannable):
                 rel = _repo_relative(path, root)
                 defect_hits.append(f"{rel.as_posix()}:{line_no}")
     if defect_hits:

--- a/alpha/self_operator/release_gate.py
+++ b/alpha/self_operator/release_gate.py
@@ -111,8 +111,29 @@ _DEFECT_RE = re.compile(
 )
 _RESOLVED_RE = re.compile(r"\b(no|none|absent|resolved|closed)\b[^\n]{0,80}\b(P0|P1)\b", re.IGNORECASE)
 # Backtick-quoted tokens such as `P0` are severity-vocabulary references
-# (taxonomy/contract definitions), not unresolved defect markers.
+# (taxonomy/contract definitions) unless the line is an actual defect-register
+# entry: a table row pairing the severity with a defect word, or an explicit
+# unresolved/open marker near the severity token.
 _INLINE_CODE_RE = re.compile(r"`[^`]*`")
+_QUOTED_SEVERITY_RE = re.compile(r"`(P0|P1)`", re.IGNORECASE)
+_UNRESOLVED_NEAR_SEVERITY_RE = re.compile(
+    r"\b(P0|P1)\b[^\n]{0,80}\b(unresolved|open)\b"
+    r"|\b(unresolved|open)\b[^\n]{0,80}\b(P0|P1)\b",
+    re.IGNORECASE,
+)
+
+
+def _line_has_unresolved_defect_marker(line: str) -> bool:
+    bare = _INLINE_CODE_RE.sub(" ", line)
+    if _DEFECT_RE.search(bare) and not _RESOLVED_RE.search(bare):
+        return True
+    if not _QUOTED_SEVERITY_RE.search(line):
+        return False
+    if _RESOLVED_RE.search(line):
+        return False
+    if line.lstrip().startswith("|") and _DEFECT_RE.search(line):
+        return True
+    return bool(_UNRESOLVED_NEAR_SEVERITY_RE.search(line))
 
 
 @dataclass(frozen=True)
@@ -228,8 +249,7 @@ def _p0_p1_gate(root: Path) -> SelfOperatorReleaseGate:
     for path in scanned_paths:
         text = path.read_text(encoding="utf-8", errors="replace")
         for line_no, line in enumerate(text.splitlines(), start=1):
-            scannable = _INLINE_CODE_RE.sub(" ", line)
-            if _DEFECT_RE.search(scannable) and not _RESOLVED_RE.search(scannable):
+            if _line_has_unresolved_defect_marker(line):
                 rel = _repo_relative(path, root)
                 defect_hits.append(f"{rel.as_posix()}:{line_no}")
     if defect_hits:

--- a/docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-gate-apply/README.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-gate-apply/README.md
@@ -1,0 +1,43 @@
+# Self Operator release-gate apply
+
+- Lane ID: `ALPHA-SOLVER-POST-LEVEL-3-LEVEL-14-SELF-OPERATOR-RELEASE-GATE-APPLY-001`
+- Objective: apply the Self Operator MVP release-gate checker (#462 tooling) to the
+  current repo state and the accepted evidence chain after #470, and record the
+  checker's deterministic result without making any readiness claim.
+- Base repo state: `main` at `40f3e654dc97f8ba56a97a3f22d70b406d08c48a`
+  (#470 merged; #470 interpretation result records p0=0, p1=0, p2=0, p3=0 with
+  `readiness_implication = eligible_for_later_release_review`).
+- Release-gate result (post tooling fix): `blocked_missing_runbook_finalization`,
+  earliest missing gate `mvp_runbook_finalized_or_updated`, 8/11 gates pass,
+  `ready: false`, CLI exit code 1 (see `release-gate-report.md` and
+  `release-gate-report.json`).
+- Tooling bug found and fixed in this lane: the first checker run blocked the
+  `p0_p1_defects_absent` gate on three false-positive matches against
+  backtick-quoted severity-vocabulary definition lines, contradicting the
+  authoritative defect registers (which record zero defects). A narrow fix was
+  applied to `alpha/self_operator/release_gate.py` with a regression test
+  (see `changed-file-scope-proof.md` and `checks-run.md`).
+- Selected next lane:
+  `ALPHA-SOLVER-POST-LEVEL-3-LEVEL-14-SELF-OPERATOR-RUNBOOK-FINALIZATION-AND-BOUNDARY-REVIEW-001`
+  (see `selected-next-lane.md`).
+
+## Packet contents
+
+| File | Purpose |
+| --- | --- |
+| `source-evidence-reviewed.md` | Evidence chain reviewed read-only before any edit. |
+| `changed-file-scope-proof.md` | Proof that all changes stay inside the allowed scope. |
+| `release-gate-input.md` | Exact repo state and evidence inputs the gate consumed. |
+| `release-gate-report.md` | Human-readable record of both checker runs. |
+| `release-gate-report.json` | Deterministic checker JSON output (post-fix run). |
+| `earliest-blocker.md` | Earliest missing release gate and its meaning. |
+| `checks-run.md` | Exact commands run with outcomes. |
+| `evidence-boundary.md` | Boundary for this lane. |
+| `non-actions.md` | Actions deliberately not taken. |
+| `selected-next-lane.md` | Selected next lane per the lane logic. |
+| `blocker-fallback-lane.md` | Fallback lane if this lane's outputs are later found defective. |
+
+This packet records bounded release-gate evidence only. The checker's only
+success vocabulary is `eligible_for_release_closeout_review`, which was not
+reached. This packet does not claim MVP readiness, does not claim release
+readiness, and does not promote evidence.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-gate-apply/blocker-fallback-lane.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-gate-apply/blocker-fallback-lane.md
@@ -1,0 +1,13 @@
+# Blocker fallback lane
+
+If this lane's outputs are later found defective — for example, the checker
+fix is shown to mask a genuine defect marker, the recorded gate result is
+shown to be non-deterministic, or a scope violation is found — the fallback
+lane is:
+
+```text
+ALPHA-SOLVER-POST-LEVEL-3-LEVEL-14-SELF-OPERATOR-RELEASE-GATE-APPLY-FIX-001
+```
+
+That lane would re-run the release gate after correcting the defect, without
+mutating this packet in place.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-gate-apply/changed-file-scope-proof.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-gate-apply/changed-file-scope-proof.md
@@ -1,0 +1,45 @@
+# Changed-file scope proof
+
+## Allowed scope for this lane
+
+- Packet directory:
+  `docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-gate-apply/`
+- Code files, only because a release-gate tooling bug was proven:
+  - `alpha/self_operator/release_gate.py`
+  - `scripts/check_self_operator_release_gate.py`
+  - `tests/test_self_operator_release_gate.py`
+
+## Proven tooling bug
+
+The `p0_p1_defects_absent` defect scan matched backtick-quoted
+severity-vocabulary references (taxonomy and contract definition lines such as
+"- `P0`: evidence boundary or source mutation violation") as if they were
+unresolved defect markers. The authoritative defect registers record zero
+defects, so the gate's first-run block contradicted the evidence it scans.
+This masked the true earliest missing gate and prevented this lane from
+producing a correct result.
+
+## Fix applied
+
+- `alpha/self_operator/release_gate.py`: the defect scan now strips markdown
+  inline-code spans from each line before matching, so backtick-quoted
+  severity vocabulary is treated as a reference, not a defect marker. Bare
+  defect markers (e.g. "P0 defect: open source mutation violation") still
+  block, as the existing tests assert.
+- `tests/test_self_operator_release_gate.py`: added
+  `test_backticked_severity_vocabulary_does_not_block` reproducing the exact
+  false-positive lines and asserting the gate passes.
+- `scripts/check_self_operator_release_gate.py`: unchanged.
+
+## Changed files in this PR (complete list)
+
+```
+alpha/self_operator/release_gate.py
+tests/test_self_operator_release_gate.py
+docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-gate-apply/ (new packet, 12 files)
+```
+
+`git status --short`, `git diff --name-only`, and `git diff --check` outputs
+are recorded in `checks-run.md`. Every changed file is inside the allowed
+scope; no existing evidence packet, source artifact, or out-of-scope file was
+modified.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-gate-apply/changed-file-scope-proof.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-gate-apply/changed-file-scope-proof.md
@@ -21,14 +21,24 @@ producing a correct result.
 
 ## Fix applied
 
-- `alpha/self_operator/release_gate.py`: the defect scan now strips markdown
-  inline-code spans from each line before matching, so backtick-quoted
-  severity vocabulary is treated as a reference, not a defect marker. Bare
-  defect markers (e.g. "P0 defect: open source mutation violation") still
-  block, as the existing tests assert.
-- `tests/test_self_operator_release_gate.py`: added
-  `test_backticked_severity_vocabulary_does_not_block` reproducing the exact
-  false-positive lines and asserting the gate passes.
+- `alpha/self_operator/release_gate.py`: the defect scan distinguishes
+  severity-vocabulary references from actual defect markers per line. Bare
+  (non-backticked) P0/P1 markers keep the original scan behavior. A
+  backtick-quoted severity token (`P0`/`P1`) is treated as a vocabulary
+  reference unless the line is an actual defect-register entry: a markdown
+  table row pairing the severity with a defect word, or a line with an
+  explicit unresolved/open marker near the severity token. Inline code spans
+  are not stripped globally, so real backticked defect markers (for example
+  "- `P1`: unresolved approval failure" or "| `P0` | source mutation
+  violation |") still block, while taxonomy-only definition lines do not.
+  Resolved references (e.g. "No `P0` or `P1` defects remain open") stay
+  allowed only when clearly marked resolved.
+- `tests/test_self_operator_release_gate.py`: added focused regression tests:
+  `test_backticked_severity_vocabulary_does_not_block`,
+  `test_backticked_unresolved_p0_marker_blocks`,
+  `test_backticked_unresolved_p1_marker_blocks`,
+  `test_table_form_backticked_defect_rows_block`, and
+  `test_resolved_backticked_references_allowed_only_when_marked_resolved`.
 - `scripts/check_self_operator_release_gate.py`: unchanged.
 
 ## Changed files in this PR (complete list)

--- a/docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-gate-apply/checks-run.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-gate-apply/checks-run.md
@@ -1,0 +1,64 @@
+# Checks run
+
+## Release-gate checker
+
+```bash
+python scripts/check_self_operator_release_gate.py \
+  --repo-root . \
+  --output docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-gate-apply/release-gate-report.json
+```
+
+- First run (pre-fix): exit 1, `final_status: blocked_release_closeout_not_reviewed`,
+  `earliest_missing_gate: p0_p1_defects_absent` — false positive, see
+  `release-gate-report.md`.
+- Final run (post-fix): exit 1, `final_status: blocked_missing_runbook_finalization`,
+  `earliest_missing_gate: mvp_runbook_finalized_or_updated`.
+- Determinism: run twice post-fix; byte-identical JSON output
+  (sha256 `69674953f6c4ac776b6ec85431c64644adad3a535b27b0f56e040c3179e85242`).
+- The non-zero exit is the checker's contract for any `blocked_*` final
+  status and is the expected outcome of this lane, not a tooling failure.
+
+## Focused tests (code changed)
+
+```bash
+python -m pytest -q tests/test_self_operator_release_gate.py
+```
+
+Result: 13 passed (12 pre-existing + 1 new regression test
+`test_backticked_severity_vocabulary_does_not_block`).
+
+## Required git checks
+
+```bash
+git status --short
+```
+
+```
+ M alpha/self_operator/release_gate.py
+ M tests/test_self_operator_release_gate.py
+?? docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-gate-apply/
+```
+
+```bash
+git diff --name-only
+```
+
+```
+alpha/self_operator/release_gate.py
+tests/test_self_operator_release_gate.py
+```
+
+```bash
+git diff --check
+```
+
+Result: clean (exit 0, no whitespace errors).
+
+## Packet consistency
+
+```bash
+python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-gate-apply
+```
+
+Result: `Local LLM packet consistency check passed (1 packet directories scanned).`
+(exit 0).

--- a/docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-gate-apply/checks-run.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-gate-apply/checks-run.md
@@ -24,8 +24,10 @@ python scripts/check_self_operator_release_gate.py \
 python -m pytest -q tests/test_self_operator_release_gate.py
 ```
 
-Result: 13 passed (12 pre-existing + 1 new regression test
-`test_backticked_severity_vocabulary_does_not_block`).
+Result: 17 passed (12 pre-existing + 5 focused regression tests covering
+taxonomy-only backticked severity definitions, unresolved backticked `P0`
+and `P1` markers, table-form defect rows, and resolved-only references; see
+`changed-file-scope-proof.md`).
 
 ## Required git checks
 

--- a/docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-gate-apply/earliest-blocker.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-gate-apply/earliest-blocker.md
@@ -1,0 +1,39 @@
+# Earliest blocker
+
+## Earliest missing release gate
+
+The checker's earliest missing gate, in its deterministic order, is:
+
+```
+mvp_runbook_finalized_or_updated
+```
+
+Required evidence packet directory absent:
+
+```
+docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-mvp-runbook-finalization
+```
+
+Checker-required next action: "Finalize or update the Self Operator MVP
+runbook packet."
+
+## Downstream gates also missing (not the earliest blocker)
+
+- `evidence_boundary_review_complete`
+  (`docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-evidence-boundary-review` absent)
+- `release_closeout_review_complete`
+  (`docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-closeout` absent)
+
+## What is not blocking
+
+Execution, import, interpretation, and the P0/P1 defect gate all pass. The
+accepted import evidence (#465) and the accepted applied interpretation
+evidence (#470, p0=0/p1=0/p2=0/p3=0) are consumed and clean; no P0, P1, or
+unresolved P2 interpretation defects remain.
+
+## Tooling blocker resolved within this lane
+
+The first run's apparent `p0_p1_defects_absent` block was a checker false
+positive on severity-vocabulary definition text, not an evidence defect. It
+was fixed narrowly in `alpha/self_operator/release_gate.py` with a regression
+test; see `release-gate-report.md` and `changed-file-scope-proof.md`.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-gate-apply/evidence-boundary.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-gate-apply/evidence-boundary.md
@@ -1,0 +1,19 @@
+# Evidence boundary
+
+This lane is a static, local, deterministic release-gate application.
+
+- All evidence-chain inputs (#461, #465, #466, #467, #468, #469, #470 packets)
+  were consumed read-only. None were mutated, rewritten in place, moved, or
+  deleted.
+- The only new evidence is this packet directory plus the narrow checker fix
+  recorded in `changed-file-scope-proof.md`.
+- The release-gate result is bounded vocabulary from the checker contract:
+  `blocked_missing_runbook_finalization` with earliest missing gate
+  `mvp_runbook_finalized_or_updated`. It is not a readiness status.
+- The checker's success vocabulary (`eligible_for_release_closeout_review`)
+  was not returned; even if it had been, it explicitly carries "no readiness
+  claim" per the checker contract and summary text.
+- No evidence is promoted by this lane. Downstream lanes must re-read the
+  source packets; this packet's summaries are not a substitute for them.
+- This packet does not claim MVP readiness, release readiness, or production
+  readiness.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-gate-apply/non-actions.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-gate-apply/non-actions.md
@@ -1,0 +1,20 @@
+# Non-actions
+
+Deliberately not done in this lane:
+
+- Did not mutate, rewrite, move, or delete any #461 source artifact.
+- Did not overwrite the #465 accepted import output.
+- Did not mutate or rewrite the #466, #467, #468, #469, or #470 packets in place.
+- Did not fabricate, reconstruct, or recreate any earlier evidence.
+- Did not run providers, hosted models, local models, external APIs, browser
+  automation, dashboard routes, deployment, billing, credentials, secrets, or
+  runtime solve behavior.
+- Did not update Google Sheets or any external ledger.
+- Did not approve or merge any PR, and did not delete any branch.
+- Did not claim MVP readiness.
+- Did not claim release readiness; the checker did not return its success
+  vocabulary, and that vocabulary would itself not be a readiness claim.
+- Did not run runbook finalization, evidence-boundary review, or release
+  closeout work; those belong to the selected next lane.
+- Did not widen the checker fix beyond the proven false positive; the checker
+  CLI interface and gate order are unchanged.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-gate-apply/release-gate-input.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-gate-apply/release-gate-input.md
@@ -1,0 +1,49 @@
+# Release-gate input
+
+## Repo state
+
+- Base: `main` at `40f3e654dc97f8ba56a97a3f22d70b406d08c48a` (#470 merged).
+- Working branch: `claude/release-gate-checker-apply-p0uf7x`, containing only
+  this packet plus the narrow checker fix recorded in
+  `changed-file-scope-proof.md`.
+
+## Exact command
+
+```bash
+python scripts/check_self_operator_release_gate.py \
+  --repo-root . \
+  --output docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-gate-apply/release-gate-report.json
+```
+
+The CLI interface documented in the lane (`--repo-root`, `--output`) is the
+checker's actual interface; no alternative invocation was needed.
+
+## Evidence the checker consumes (directory-presence gates, deterministic order)
+
+1. `implementation_foundation_complete` — `docs/evals/runs/alpha-solver-post-level-3-level-10-self-operator-static-test-scaffold-implementation`
+2. `approval_identity_fix_complete` — `docs/evals/runs/alpha-solver-post-level-3-level-11-self-operator-approval-stopstate-gate-foundation`
+3. `dry_run_wrapper_complete` — `docs/evals/runs/alpha-solver-post-level-3-level-12-self-operator-local-harness-dry-run-wrapper`
+4. `manual_acceptance_packet_complete` — `docs/evals/runs/alpha-solver-post-level-3-level-13-self-operator-manual-local-acceptance-packet`
+5. `operator_supervised_acceptance_executed` — `docs/evals/runs/alpha-solver-post-level-3-level-13-self-operator-operator-supervised-local-acceptance-execution`
+6. `result_import_complete` — `docs/evals/runs/alpha-solver-post-level-3-level-13-self-operator-local-acceptance-result-import-tooling`
+7. `acceptance_interpretation_complete` — `docs/evals/runs/alpha-solver-post-level-3-to-level-14-self-operator-acceptance-interpretation-engine`
+8. `p0_p1_defects_absent` — defect-marker scan over the checker's six scanned packets.
+9. `mvp_runbook_finalized_or_updated` — `docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-mvp-runbook-finalization`
+10. `evidence_boundary_review_complete` — `docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-evidence-boundary-review`
+11. `release_closeout_review_complete` — `docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-closeout`
+
+## Accepted evidence reviewed alongside the checker (read-only)
+
+- Accepted import evidence (#465):
+  `docs/evals/runs/alpha-solver-post-level-3-level-13-self-operator-import-blocker-resolution-and-accepted-import/accepted-import-summary.json`
+  — all ten MLA task artifact sets present, checksums matched, import-ready.
+- Accepted interpretation evidence (#470):
+  `docs/evals/runs/alpha-solver-post-level-3-level-13-to-level-14-self-operator-operator-decision-interpretation-apply/interpretation-result.json`
+  — p0=0, p1=0, p2=0, p3=0;
+  `readiness_implication = eligible_for_later_release_review`; the #469
+  operator ledger-level acceptance consumed for MLA-006/MLA-007 only.
+
+The checker's own interpretation gate keys on the engine packet directory
+(item 7); the #470 applied-interpretation result above is the accepted defect
+register this lane uses to validate that no P0, P1, or unresolved P2
+interpretation defects remain.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-gate-apply/release-gate-report.json
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-gate-apply/release-gate-report.json
@@ -1,0 +1,92 @@
+{
+  "earliest_missing_gate": "mvp_runbook_finalized_or_updated",
+  "final_status": "blocked_missing_runbook_finalization",
+  "gates": [
+    {
+      "evidence_path": "docs/evals/runs/alpha-solver-post-level-3-level-10-self-operator-static-test-scaffold-implementation",
+      "gate_id": "implementation_foundation_complete",
+      "reason": "Required evidence packet directory is present.",
+      "required_next_action": "No action for this gate; preserve evidence boundary.",
+      "status": "pass"
+    },
+    {
+      "evidence_path": "docs/evals/runs/alpha-solver-post-level-3-level-11-self-operator-approval-stopstate-gate-foundation",
+      "gate_id": "approval_identity_fix_complete",
+      "reason": "Required evidence packet directory is present.",
+      "required_next_action": "No action for this gate; preserve evidence boundary.",
+      "status": "pass"
+    },
+    {
+      "evidence_path": "docs/evals/runs/alpha-solver-post-level-3-level-12-self-operator-local-harness-dry-run-wrapper",
+      "gate_id": "dry_run_wrapper_complete",
+      "reason": "Required evidence packet directory is present.",
+      "required_next_action": "No action for this gate; preserve evidence boundary.",
+      "status": "pass"
+    },
+    {
+      "evidence_path": "docs/evals/runs/alpha-solver-post-level-3-level-13-self-operator-manual-local-acceptance-packet",
+      "gate_id": "manual_acceptance_packet_complete",
+      "reason": "Required evidence packet directory is present.",
+      "required_next_action": "No action for this gate; preserve evidence boundary.",
+      "status": "pass"
+    },
+    {
+      "evidence_path": "docs/evals/runs/alpha-solver-post-level-3-level-13-self-operator-operator-supervised-local-acceptance-execution",
+      "gate_id": "operator_supervised_acceptance_executed",
+      "reason": "Required evidence packet directory is present.",
+      "required_next_action": "No action for this gate; preserve evidence boundary.",
+      "status": "pass"
+    },
+    {
+      "evidence_path": "docs/evals/runs/alpha-solver-post-level-3-level-13-self-operator-local-acceptance-result-import-tooling",
+      "gate_id": "result_import_complete",
+      "reason": "Required evidence packet directory is present.",
+      "required_next_action": "No action for this gate; preserve evidence boundary.",
+      "status": "pass"
+    },
+    {
+      "evidence_path": "docs/evals/runs/alpha-solver-post-level-3-to-level-14-self-operator-acceptance-interpretation-engine",
+      "gate_id": "acceptance_interpretation_complete",
+      "reason": "Required evidence packet directory is present.",
+      "required_next_action": "No action for this gate; preserve evidence boundary.",
+      "status": "pass"
+    },
+    {
+      "evidence_path": "docs/evals/runs/self-operator-release-gate-packets",
+      "gate_id": "p0_p1_defects_absent",
+      "reason": "No unresolved P0/P1 defect markers found in scanned release-gate evidence.",
+      "required_next_action": "No action for this gate; continue to preserve defect evidence boundaries.",
+      "status": "pass"
+    },
+    {
+      "evidence_path": "docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-mvp-runbook-finalization",
+      "gate_id": "mvp_runbook_finalized_or_updated",
+      "reason": "Required evidence packet directory is absent.",
+      "required_next_action": "Finalize or update the Self Operator MVP runbook packet.",
+      "status": "missing"
+    },
+    {
+      "evidence_path": "docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-evidence-boundary-review",
+      "gate_id": "evidence_boundary_review_complete",
+      "reason": "Required evidence packet directory is absent.",
+      "required_next_action": "Complete the evidence-boundary review packet.",
+      "status": "missing"
+    },
+    {
+      "evidence_path": "docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-closeout",
+      "gate_id": "release_closeout_review_complete",
+      "reason": "Required evidence packet directory is absent.",
+      "required_next_action": "Complete release closeout review only after all preceding gates pass.",
+      "status": "missing"
+    }
+  ],
+  "non_actions": [
+    "does not claim MVP readiness",
+    "does not update Google Sheets",
+    "does not mutate source artifacts",
+    "does not run providers, hosted models, local models, external APIs, browser automation, deployment, or billing"
+  ],
+  "ready": false,
+  "schema_version": "self_operator.release_gate_report.v1",
+  "summary": "8/11 gates pass; final status is blocked_missing_runbook_finalization. This is not a readiness claim."
+}

--- a/docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-gate-apply/release-gate-report.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-gate-apply/release-gate-report.md
@@ -1,0 +1,77 @@
+# Release-gate report (human-readable)
+
+## First run (pre-fix, defective tooling output)
+
+The first checker run returned:
+
+```
+final_status: blocked_release_closeout_not_reviewed
+earliest_missing_gate: p0_p1_defects_absent
+exit code: 1
+```
+
+The `p0_p1_defects_absent` gate reported three hits:
+
+```
+docs/evals/runs/alpha-solver-post-level-3-to-level-14-self-operator-acceptance-interpretation-engine/defect-taxonomy.md:4
+docs/evals/runs/alpha-solver-post-level-3-to-level-14-self-operator-acceptance-interpretation-engine/defect-taxonomy.md:5
+docs/evals/runs/alpha-solver-post-level-3-to-level-14-self-operator-acceptance-interpretation-engine/readiness-implication-contract.md:8
+```
+
+All three lines are backtick-quoted severity-vocabulary definitions
+(e.g. "- `P0`: evidence boundary or source mutation violation"), not
+unresolved defect markers. The authoritative defect registers — the #470
+applied interpretation result and the engine packet's own outputs — record
+zero defects at every severity. This was a release-gate tooling false
+positive, fixed narrowly (see `changed-file-scope-proof.md`). The defective
+first-run JSON was not preserved as evidence; it was superseded by the
+post-fix deterministic output below.
+
+## Final run (post-fix)
+
+Command:
+
+```bash
+python scripts/check_self_operator_release_gate.py \
+  --repo-root . \
+  --output docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-gate-apply/release-gate-report.json
+```
+
+Output:
+
+```
+final_status: blocked_missing_runbook_finalization
+ready: false (does not claim MVP readiness)
+earliest_missing_gate: mvp_runbook_finalized_or_updated
+exit code: 1
+```
+
+Gate-by-gate (deterministic order):
+
+| # | Gate | Status |
+| --- | --- | --- |
+| 1 | `implementation_foundation_complete` | pass |
+| 2 | `approval_identity_fix_complete` | pass |
+| 3 | `dry_run_wrapper_complete` | pass |
+| 4 | `manual_acceptance_packet_complete` | pass |
+| 5 | `operator_supervised_acceptance_executed` | pass |
+| 6 | `result_import_complete` | pass |
+| 7 | `acceptance_interpretation_complete` | pass |
+| 8 | `p0_p1_defects_absent` | pass |
+| 9 | `mvp_runbook_finalized_or_updated` | missing |
+| 10 | `evidence_boundary_review_complete` | missing |
+| 11 | `release_closeout_review_complete` | missing |
+
+Summary line from the report: "8/11 gates pass; final status is
+blocked_missing_runbook_finalization. This is not a readiness claim."
+
+Determinism: the checker was run twice with identical output;
+`release-gate-report.json` sha256 =
+`69674953f6c4ac776b6ec85431c64644adad3a535b27b0f56e040c3179e85242`.
+
+## Claim boundary
+
+The checker's only success vocabulary is
+`eligible_for_release_closeout_review`, which was not returned. No release
+readiness is claimed, and `eligible_for_release_closeout_review` itself would
+not be a readiness claim. No MVP readiness is claimed.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-gate-apply/selected-next-lane.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-gate-apply/selected-next-lane.md
@@ -1,0 +1,17 @@
+# Selected next lane
+
+The release gate's earliest missing gate is `mvp_runbook_finalized_or_updated`
+— runbook finalization — with evidence-boundary review also missing
+immediately behind it. Per this lane's next-lane logic (earliest missing gate
+is runbook finalization or runbook/boundary work), the selected next lane is:
+
+```text
+ALPHA-SOLVER-POST-LEVEL-3-LEVEL-14-SELF-OPERATOR-RUNBOOK-FINALIZATION-AND-BOUNDARY-REVIEW-001
+```
+
+That lane — not this one — may produce the MVP runbook finalization packet and
+the evidence-boundary review packet the checker requires. This selection is
+not a readiness claim: the recorded gate status is
+`blocked_missing_runbook_finalization`, and release closeout remains gated
+behind runbook finalization and evidence-boundary review in the checker's
+deterministic order.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-gate-apply/source-evidence-reviewed.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-gate-apply/source-evidence-reviewed.md
@@ -1,0 +1,42 @@
+# Source evidence reviewed (read-only)
+
+All inputs below were reviewed read-only before any edit. None were mutated,
+moved, renamed, or rewritten in place.
+
+## Prerequisite verification
+
+- `AGENTS.md` — repo agent operating instructions.
+- `main` fetched and confirmed up to date; local `main`, `origin/main`, and the
+  working base all resolve to `40f3e654dc97f8ba56a97a3f22d70b406d08c48a`.
+- PR #470 merge commit `40f3e65` ("fix(self-operator): consume operator
+  safety-block decision (#470)") is the head of current `main`.
+- #470 packet exists:
+  `docs/evals/runs/alpha-solver-post-level-3-level-13-to-level-14-self-operator-operator-decision-interpretation-apply/`
+- #470 interpretation result exists and records the required values:
+  `interpretation-result.json` with `summary.p0_defect_count=0`,
+  `p1_defect_count=0`, `p2_defect_count=0`, `p3_defect_count=0`, and
+  `readiness_implication = "eligible_for_later_release_review"`.
+- #470 `selected-next-lane.md` selects this lane:
+  `ALPHA-SOLVER-POST-LEVEL-3-LEVEL-14-SELF-OPERATOR-RELEASE-GATE-APPLY-001`.
+
+## Required evidence chain reviewed
+
+- `docs/evals/runs/alpha-solver-post-level-3-level-13-self-operator-operator-supervised-local-acceptance-execution/`
+  (#461 supervised execution packet; raw artifacts untouched).
+- `docs/evals/runs/alpha-solver-post-level-3-level-13-self-operator-import-blocker-resolution-and-accepted-import/accepted-import-summary.json`
+  (#465 accepted import summary; all artifacts `checksum_status: matched`,
+  `status: import_ready`).
+- `docs/evals/runs/alpha-solver-post-level-3-level-13-to-level-14-self-operator-interpretation-and-release-gate-apply/`
+  (#466; confirms the release gate was intentionally not run there).
+- `docs/evals/runs/alpha-solver-post-level-3-level-13-to-level-14-self-operator-acceptance-interpretation-blocker-fix/` (#467).
+- `docs/evals/runs/alpha-solver-post-level-3-level-13-to-level-14-self-operator-acceptance-interpretation-blocker-fix-retry/` (#468).
+- `docs/evals/runs/alpha-solver-post-level-3-level-13-to-level-14-self-operator-expected-safety-block-operator-review/` (#469).
+- `docs/evals/runs/alpha-solver-post-level-3-level-13-to-level-14-self-operator-operator-decision-interpretation-apply/` (#470).
+
+## Tooling reviewed
+
+- `alpha/self_operator/release_gate.py` — deterministic release-gate evaluator.
+- `scripts/check_self_operator_release_gate.py` — CLI wrapper.
+- `tests/test_self_operator_release_gate.py` — checker contract tests.
+- `docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-mvp-release-gate-checker/`
+  (#462 checker packet, read-only).

--- a/tests/test_self_operator_release_gate.py
+++ b/tests/test_self_operator_release_gate.py
@@ -158,6 +158,69 @@ def test_backticked_severity_vocabulary_does_not_block(tmp_path: Path) -> None:
     assert report.final_status == "eligible_for_release_closeout_review"
 
 
+def test_backticked_unresolved_p0_marker_blocks(tmp_path: Path) -> None:
+    _write_all_packets(tmp_path)
+    register = tmp_path / INTERPRETATION_PACKET / "defect-register.md"
+    register.write_text(
+        "# Defect register\n\n- `P0`: unresolved source mutation violation\n",
+        encoding="utf-8",
+    )
+
+    report = evaluate_self_operator_release_gates(tmp_path)
+
+    assert _gate_statuses(tmp_path)["p0_p1_defects_absent"] == "blocked"
+    assert report.ready is False
+
+
+def test_backticked_unresolved_p1_marker_blocks(tmp_path: Path) -> None:
+    _write_all_packets(tmp_path)
+    register = tmp_path / INTERPRETATION_PACKET / "defect-register.md"
+    register.write_text(
+        "# Defect register\n\n- `P1`: unresolved approval failure\n",
+        encoding="utf-8",
+    )
+
+    report = evaluate_self_operator_release_gates(tmp_path)
+
+    assert _gate_statuses(tmp_path)["p0_p1_defects_absent"] == "blocked"
+    assert report.ready is False
+
+
+def test_table_form_backticked_defect_rows_block(tmp_path: Path) -> None:
+    _write_all_packets(tmp_path)
+    register = tmp_path / INTERPRETATION_PACKET / "defect-register.md"
+    register.write_text(
+        "# Defect register\n\n"
+        "| Severity | Defect |\n"
+        "| --- | --- |\n"
+        "| `P0` | source mutation violation |\n"
+        "| `P1` | approval failure |\n",
+        encoding="utf-8",
+    )
+
+    report = evaluate_self_operator_release_gates(tmp_path)
+
+    assert _gate_statuses(tmp_path)["p0_p1_defects_absent"] == "blocked"
+    assert report.ready is False
+
+
+def test_resolved_backticked_references_allowed_only_when_marked_resolved(tmp_path: Path) -> None:
+    _write_all_packets(tmp_path)
+    register = tmp_path / INTERPRETATION_PACKET / "defect-register.md"
+
+    register.write_text(
+        "# Defect register\n\nNo `P0` or `P1` defects remain open; all are resolved.\n",
+        encoding="utf-8",
+    )
+    assert _gate_statuses(tmp_path)["p0_p1_defects_absent"] == "pass"
+
+    register.write_text(
+        "# Defect register\n\n`P1` defect remains open.\n",
+        encoding="utf-8",
+    )
+    assert _gate_statuses(tmp_path)["p0_p1_defects_absent"] == "blocked"
+
+
 def test_deterministic_json_output(tmp_path: Path) -> None:
     _write_all_packets(tmp_path, except_packets={IMPORT_PACKET})
     report = evaluate_self_operator_release_gates(tmp_path)

--- a/tests/test_self_operator_release_gate.py
+++ b/tests/test_self_operator_release_gate.py
@@ -141,6 +141,23 @@ def test_p1_defect_blocks(tmp_path: Path) -> None:
     assert _gate_statuses(tmp_path)["p0_p1_defects_absent"] == "blocked"
 
 
+def test_backticked_severity_vocabulary_does_not_block(tmp_path: Path) -> None:
+    _write_all_packets(tmp_path)
+    taxonomy = tmp_path / INTERPRETATION_PACKET / "defect-taxonomy.md"
+    taxonomy.write_text(
+        "# Defect Taxonomy\n\n"
+        "- `P0`: evidence boundary or source mutation violation\n"
+        "- `P1`: approval, identity, stop-state, or non-execution safety failure\n"
+        "\n`blocked` is emitted for any `P0` or `P1` defect.\n",
+        encoding="utf-8",
+    )
+
+    report = evaluate_self_operator_release_gates(tmp_path)
+
+    assert _gate_statuses(tmp_path)["p0_p1_defects_absent"] == "pass"
+    assert report.final_status == "eligible_for_release_closeout_review"
+
+
 def test_deterministic_json_output(tmp_path: Path) -> None:
     _write_all_packets(tmp_path, except_packets={IMPORT_PACKET})
     report = evaluate_self_operator_release_gates(tmp_path)


### PR DESCRIPTION
## Lane

`ALPHA-SOLVER-POST-LEVEL-3-LEVEL-14-SELF-OPERATOR-RELEASE-GATE-APPLY-001`

Applies the Self Operator MVP release-gate checker to current `main` (`40f3e65`, #470 merged) and the accepted evidence chain after #470, recording the result in a new evidence packet. Read-only consumption of the #461/#465/#466/#467/#468/#469/#470 packets; none were mutated or rewritten in place.

## Prerequisites verified

- `main` up to date; #470 merge commit is head of `main`.
- #470 packet and `interpretation-result.json` present, recording p0=0, p1=0, p2=0, p3=0 and `readiness_implication = eligible_for_later_release_review`.
- #470 `selected-next-lane.md` selects this lane.

## Release-gate result

```
final_status: blocked_missing_runbook_finalization
earliest_missing_gate: mvp_runbook_finalized_or_updated
gates: 8/11 pass; ready: false; exit code 1
```

Execution, import, interpretation, and the P0/P1 defect gate all pass. Missing gates, in deterministic order: `mvp_runbook_finalized_or_updated`, `evidence_boundary_review_complete`, `release_closeout_review_complete`.

## Focused tooling fix (why `fix:` not `docs:`)

The first checker run blocked `p0_p1_defects_absent` on three matches in the interpretation-engine packet that are backtick-quoted severity-vocabulary definitions (e.g. ``- `P0`: evidence boundary or source mutation violation``), contradicting the authoritative defect registers (zero defects at every severity). The defect scan in `alpha/self_operator/release_gate.py` now strips markdown inline-code spans before matching; bare defect markers still block (existing tests unchanged, plus a new regression test reproducing the exact false-positive lines).

## New packet

`docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-gate-apply/` with all 12 required files, including deterministic `release-gate-report.json` (sha256 `69674953f6c4ac776b6ec85431c64644adad3a535b27b0f56e040c3179e85242`, byte-identical across repeated runs).

## Checks run

- `python scripts/check_self_operator_release_gate.py --repo-root . --output docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-gate-apply/release-gate-report.json` (exit 1, expected `blocked_*` contract)
- `python -m pytest -q tests/test_self_operator_release_gate.py` — 13 passed
- `python -m pytest -q` on release-gate + self-operator static guardrail tests — 26 passed
- `git status --short`, `git diff --name-only`, `git diff --check` — clean, all changes in allowed scope
- `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-gate-apply` — passed

## Selected next lane

`ALPHA-SOLVER-POST-LEVEL-3-LEVEL-14-SELF-OPERATOR-RUNBOOK-FINALIZATION-AND-BOUNDARY-REVIEW-001` (earliest missing gate is runbook finalization, with boundary review missing immediately behind it). Fallback: `ALPHA-SOLVER-POST-LEVEL-3-LEVEL-14-SELF-OPERATOR-RELEASE-GATE-APPLY-FIX-001`.

## Claim boundary

No MVP readiness claimed. No release readiness claimed — the checker did not return its success vocabulary (`eligible_for_release_closeout_review`), and that vocabulary itself carries no readiness claim. No Google Sheets updates. No source evidence mutated.

https://claude.ai/code/session_01VoYYFzkCyDEUrBZmANBwXY

---
_Generated by [Claude Code](https://claude.ai/code/session_01VoYYFzkCyDEUrBZmANBwXY)_