### PR TITLE
docs: align self-operator evidence artifact commands

### DIFF
--- a/docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-execution-evidence-001/artifacts-index.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-execution-evidence-001/artifacts-index.md
@@ -6,51 +6,117 @@ and PR #496's predecessor packet is likewise markdown-only.
 
 ## Artifact 1 — Self Operator suite result (JUnit XML, summarized)
 
-- Producer: `python -m pytest tests/test_self_operator_*.py --junit-xml=…`
+- Producer: `python -m pytest tests/test_self_operator_*.py -q --junit-xml=<artifacts/self-operator-pytest-junit.xml>`
 - Summary: `collected=213 passed=213 failed=0 errors=0 skipped=0 time=1.429s`
 - Storage boundary: only aggregate counts and failing-test identifiers are recorded; no environment dump,
   no secrets, no provider payloads.
 
 ## Artifact 2 — Full-suite validation result (JUnit XML, summarized)
 
-- Producer: `env -u MODEL_PROVIDER -u MODEL_SET -u OPENAI_API_KEY -u OPENAI_BASE_URL python -m pytest --junit-xml=…`
+- Producer: `env -u MODEL_PROVIDER -u MODEL_SET -u OPENAI_API_KEY -u OPENAI_BASE_URL python -m pytest -q --junit-xml=<artifacts/provider-env-unset-full-suite-junit.xml>`
 - Summary: `collected=1216 passed=1211 failed=2 errors=0 skipped=3 time=37.751s`
 - Failing tests: `tests/test_smoke_quickstart.py::test_release_script`, `tests/test_tag_release.py::test_tag_release`
   (see `failure-analysis.md`).
 
 ## Artifact 3 — Release-gate JSON report (embedded verbatim)
 
-- Producer: `python scripts/check_self_operator_release_gate.py --repo-root . --output <artifacts/…>`
+- Producer: `python scripts/check_self_operator_release_gate.py --repo-root . --output <artifacts/self-operator-release-gate-report.json>`
 - Schema: `self_operator.release_gate_report.v1`; size 4549 bytes; exit code `0`.
 - Storage boundary: the report contains only in-repo evidence-directory paths and gate statuses; no
   secrets, credentials, provider payloads, or private data.
 
 ```json
 {
-    "earliest_missing_gate": null,
-    "final_status": "eligible_for_release_closeout_review",
-    "gates": [
-        {"gate_id": "implementation_foundation_complete", "status": "pass", "reason": "Required evidence packet directory is present.", "evidence_path": "docs/evals/runs/alpha-solver-post-level-3-level-10-self-operator-static-test-scaffold-implementation"},
-        {"gate_id": "approval_identity_fix_complete", "status": "pass", "reason": "Required evidence packet directory is present.", "evidence_path": "docs/evals/runs/alpha-solver-post-level-3-level-11-self-operator-approval-stopstate-gate-foundation"},
-        {"gate_id": "dry_run_wrapper_complete", "status": "pass", "reason": "Required evidence packet directory is present.", "evidence_path": "docs/evals/runs/alpha-solver-post-level-3-level-12-self-operator-local-harness-dry-run-wrapper"},
-        {"gate_id": "manual_acceptance_packet_complete", "status": "pass", "reason": "Required evidence packet directory is present.", "evidence_path": "docs/evals/runs/alpha-solver-post-level-3-level-13-self-operator-manual-local-acceptance-packet"},
-        {"gate_id": "operator_supervised_acceptance_executed", "status": "pass", "reason": "Required evidence packet directory is present.", "evidence_path": "docs/evals/runs/alpha-solver-post-level-3-level-13-self-operator-operator-supervised-local-acceptance-execution"},
-        {"gate_id": "result_import_complete", "status": "pass", "reason": "Required evidence packet directory is present.", "evidence_path": "docs/evals/runs/alpha-solver-post-level-3-level-13-self-operator-local-acceptance-result-import-tooling"},
-        {"gate_id": "acceptance_interpretation_complete", "status": "pass", "reason": "Required evidence packet directory is present.", "evidence_path": "docs/evals/runs/alpha-solver-post-level-3-to-level-14-self-operator-acceptance-interpretation-engine"},
-        {"gate_id": "p0_p1_defects_absent", "status": "pass", "reason": "No unresolved P0/P1 defect markers found in scanned release-gate evidence.", "evidence_path": "docs/evals/runs/self-operator-release-gate-packets"},
-        {"gate_id": "mvp_runbook_finalized_or_updated", "status": "pass", "reason": "Required evidence packet directory is present.", "evidence_path": "docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-mvp-runbook-finalization"},
-        {"gate_id": "evidence_boundary_review_complete", "status": "pass", "reason": "Required evidence packet directory is present.", "evidence_path": "docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-evidence-boundary-review"},
-        {"gate_id": "release_closeout_review_complete", "status": "pass", "reason": "Required evidence packet directory is present.", "evidence_path": "docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-closeout-and-final-guardrails"}
-    ],
-    "non_actions": [
-        "does not claim MVP readiness",
-        "does not update Google Sheets",
-        "does not mutate source artifacts",
-        "does not run providers, hosted models, local models, external APIs, browser automation, deployment, or billing"
-    ],
-    "ready": true,
-    "schema_version": "self_operator.release_gate_report.v1",
-    "summary": "11/11 gates pass; eligible for release closeout review, with no readiness claim."
+  "earliest_missing_gate": null,
+  "final_status": "eligible_for_release_closeout_review",
+  "gates": [
+    {
+      "evidence_path": "docs/evals/runs/alpha-solver-post-level-3-level-10-self-operator-static-test-scaffold-implementation",
+      "gate_id": "implementation_foundation_complete",
+      "reason": "Required evidence packet directory is present.",
+      "required_next_action": "No action for this gate; preserve evidence boundary.",
+      "status": "pass"
+    },
+    {
+      "evidence_path": "docs/evals/runs/alpha-solver-post-level-3-level-11-self-operator-approval-stopstate-gate-foundation",
+      "gate_id": "approval_identity_fix_complete",
+      "reason": "Required evidence packet directory is present.",
+      "required_next_action": "No action for this gate; preserve evidence boundary.",
+      "status": "pass"
+    },
+    {
+      "evidence_path": "docs/evals/runs/alpha-solver-post-level-3-level-12-self-operator-local-harness-dry-run-wrapper",
+      "gate_id": "dry_run_wrapper_complete",
+      "reason": "Required evidence packet directory is present.",
+      "required_next_action": "No action for this gate; preserve evidence boundary.",
+      "status": "pass"
+    },
+    {
+      "evidence_path": "docs/evals/runs/alpha-solver-post-level-3-level-13-self-operator-manual-local-acceptance-packet",
+      "gate_id": "manual_acceptance_packet_complete",
+      "reason": "Required evidence packet directory is present.",
+      "required_next_action": "No action for this gate; preserve evidence boundary.",
+      "status": "pass"
+    },
+    {
+      "evidence_path": "docs/evals/runs/alpha-solver-post-level-3-level-13-self-operator-operator-supervised-local-acceptance-execution",
+      "gate_id": "operator_supervised_acceptance_executed",
+      "reason": "Required evidence packet directory is present.",
+      "required_next_action": "No action for this gate; preserve evidence boundary.",
+      "status": "pass"
+    },
+    {
+      "evidence_path": "docs/evals/runs/alpha-solver-post-level-3-level-13-self-operator-local-acceptance-result-import-tooling",
+      "gate_id": "result_import_complete",
+      "reason": "Required evidence packet directory is present.",
+      "required_next_action": "No action for this gate; preserve evidence boundary.",
+      "status": "pass"
+    },
+    {
+      "evidence_path": "docs/evals/runs/alpha-solver-post-level-3-to-level-14-self-operator-acceptance-interpretation-engine",
+      "gate_id": "acceptance_interpretation_complete",
+      "reason": "Required evidence packet directory is present.",
+      "required_next_action": "No action for this gate; preserve evidence boundary.",
+      "status": "pass"
+    },
+    {
+      "evidence_path": "docs/evals/runs/self-operator-release-gate-packets",
+      "gate_id": "p0_p1_defects_absent",
+      "reason": "No unresolved P0/P1 defect markers found in scanned release-gate evidence.",
+      "required_next_action": "No action for this gate; continue to preserve defect evidence boundaries.",
+      "status": "pass"
+    },
+    {
+      "evidence_path": "docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-mvp-runbook-finalization",
+      "gate_id": "mvp_runbook_finalized_or_updated",
+      "reason": "Required evidence packet directory is present.",
+      "required_next_action": "No action for this gate; preserve evidence boundary.",
+      "status": "pass"
+    },
+    {
+      "evidence_path": "docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-evidence-boundary-review",
+      "gate_id": "evidence_boundary_review_complete",
+      "reason": "Required evidence packet directory is present.",
+      "required_next_action": "No action for this gate; preserve evidence boundary.",
+      "status": "pass"
+    },
+    {
+      "evidence_path": "docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-release-closeout-and-final-guardrails",
+      "gate_id": "release_closeout_review_complete",
+      "reason": "Required evidence packet directory is present.",
+      "required_next_action": "No action for this gate; preserve evidence boundary.",
+      "status": "pass"
+    }
+  ],
+  "non_actions": [
+    "does not claim MVP readiness",
+    "does not update Google Sheets",
+    "does not mutate source artifacts",
+    "does not run providers, hosted models, local models, external APIs, browser automation, deployment, or billing"
+  ],
+  "ready": true,
+  "schema_version": "self_operator.release_gate_report.v1",
+  "summary": "11/11 gates pass; eligible for release closeout review, with no readiness claim."
 }
 ```
 

--- a/docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-execution-evidence-001/artifacts-index.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-execution-evidence-001/artifacts-index.md
@@ -6,21 +6,21 @@ and PR #496's predecessor packet is likewise markdown-only.
 
 ## Artifact 1 — Self Operator suite result (JUnit XML, summarized)
 
-- Producer: `python -m pytest tests/test_self_operator_*.py -q --junit-xml=<artifacts/self-operator-pytest-junit.xml>`
+- Producer: `python -m pytest tests/test_self_operator_*.py -q --junit-xml=artifacts/self-operator-pytest-junit.xml`
 - Summary: `collected=213 passed=213 failed=0 errors=0 skipped=0 time=1.429s`
 - Storage boundary: only aggregate counts and failing-test identifiers are recorded; no environment dump,
   no secrets, no provider payloads.
 
 ## Artifact 2 — Full-suite validation result (JUnit XML, summarized)
 
-- Producer: `env -u MODEL_PROVIDER -u MODEL_SET -u OPENAI_API_KEY -u OPENAI_BASE_URL python -m pytest -q --junit-xml=<artifacts/provider-env-unset-full-suite-junit.xml>`
+- Producer: `env -u MODEL_PROVIDER -u MODEL_SET -u OPENAI_API_KEY -u OPENAI_BASE_URL python -m pytest -q --junit-xml=artifacts/provider-env-unset-full-suite-junit.xml`
 - Summary: `collected=1216 passed=1211 failed=2 errors=0 skipped=3 time=37.751s`
 - Failing tests: `tests/test_smoke_quickstart.py::test_release_script`, `tests/test_tag_release.py::test_tag_release`
   (see `failure-analysis.md`).
 
 ## Artifact 3 — Release-gate JSON report (embedded verbatim)
 
-- Producer: `python scripts/check_self_operator_release_gate.py --repo-root . --output <artifacts/self-operator-release-gate-report.json>`
+- Producer: `python scripts/check_self_operator_release_gate.py --repo-root . --output artifacts/self-operator-release-gate-report.json`
 - Schema: `self_operator.release_gate_report.v1`; size 4549 bytes; exit code `0`.
 - Storage boundary: the report contains only in-repo evidence-directory paths and gate statuses; no
   secrets, credentials, provider payloads, or private data.

--- a/docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-execution-evidence-001/commands-run.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-execution-evidence-001/commands-run.md
@@ -25,7 +25,7 @@ The OpenAI SDK is **not** in these requirements and was not installed.
 ## 2. Self Operator release-gate checker CLI (local file inspection only)
 
 ```
-python scripts/check_self_operator_release_gate.py --repo-root .
+python scripts/check_self_operator_release_gate.py --repo-root . --output <artifacts/self-operator-release-gate-report.json>
 ```
 Exit code: `0`. `final_status: eligible_for_release_closeout_review`; `ready: true (does not claim MVP
 readiness)`; 11/11 gates `pass`. Full output and JSON in `execution-results.md` / `artifacts-index.md`.
@@ -65,17 +65,17 @@ tests/test_self_operator_stop_state.py
 Then run the suite over exactly those files:
 
 ```
-python -m pytest tests/test_self_operator_*.py -q
+python -m pytest tests/test_self_operator_*.py -q --junit-xml=<artifacts/self-operator-pytest-junit.xml>
 ```
-Exit code: `0`. Exact counts captured via JUnit XML (`--junit-xml`): **213 collected, 213 passed, 0
+Exit code: `0`. Exact counts captured via JUnit XML (`--junit-xml=<artifacts/self-operator-pytest-junit.xml>`): **213 collected, 213 passed, 0
 failed, 0 errors, 0 skipped** (1.43s).
 
 ## 4. Authoritative full-suite validation (provider env unset)
 
 ```
-env -u MODEL_PROVIDER -u MODEL_SET -u OPENAI_API_KEY -u OPENAI_BASE_URL python -m pytest -q
+env -u MODEL_PROVIDER -u MODEL_SET -u OPENAI_API_KEY -u OPENAI_BASE_URL python -m pytest -q --junit-xml=<artifacts/provider-env-unset-full-suite-junit.xml>
 ```
-Exit code: `1`. Exact counts via JUnit XML: **1216 collected, 1211 passed, 2 failed, 0 errors, 3
+Exit code: `1`. Exact counts via JUnit XML (`--junit-xml=<artifacts/provider-env-unset-full-suite-junit.xml>`): **1216 collected, 1211 passed, 2 failed, 0 errors, 3
 skipped** (37.75s). Consistent with the PR #496 recorded full-suite behavior, the provider-env-unset full
 suite still reports the same two unrelated failures (see `failure-analysis.md`).
 
@@ -92,6 +92,6 @@ Results are recorded in `execution-results.md` (Validation section).
 
 - No command called OpenAI, Anthropic, any hosted provider, any local model, or any external API.
 - No `/v1/solve` call, no dashboard, no browser automation, no Google Sheets, no deployment, no billing.
-- The release-gate CLI's default `--output` (a JSON file) was directed into an `artifacts/` path that the
+- The release-gate CLI's `--output <artifacts/self-operator-release-gate-report.json>` path was directed into an `artifacts/` path that the
   repo `.gitignore` excludes; the report content is therefore embedded in `artifacts-index.md` instead of
   committed as a separate file, keeping this packet markdown-only (consistent with PR #496).

--- a/docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-execution-evidence-001/commands-run.md
+++ b/docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-execution-evidence-001/commands-run.md
@@ -25,7 +25,7 @@ The OpenAI SDK is **not** in these requirements and was not installed.
 ## 2. Self Operator release-gate checker CLI (local file inspection only)
 
 ```
-python scripts/check_self_operator_release_gate.py --repo-root . --output <artifacts/self-operator-release-gate-report.json>
+python scripts/check_self_operator_release_gate.py --repo-root . --output artifacts/self-operator-release-gate-report.json
 ```
 Exit code: `0`. `final_status: eligible_for_release_closeout_review`; `ready: true (does not claim MVP
 readiness)`; 11/11 gates `pass`. Full output and JSON in `execution-results.md` / `artifacts-index.md`.
@@ -65,17 +65,17 @@ tests/test_self_operator_stop_state.py
 Then run the suite over exactly those files:
 
 ```
-python -m pytest tests/test_self_operator_*.py -q --junit-xml=<artifacts/self-operator-pytest-junit.xml>
+python -m pytest tests/test_self_operator_*.py -q --junit-xml=artifacts/self-operator-pytest-junit.xml
 ```
-Exit code: `0`. Exact counts captured via JUnit XML (`--junit-xml=<artifacts/self-operator-pytest-junit.xml>`): **213 collected, 213 passed, 0
+Exit code: `0`. Exact counts captured via JUnit XML (`--junit-xml=artifacts/self-operator-pytest-junit.xml`): **213 collected, 213 passed, 0
 failed, 0 errors, 0 skipped** (1.43s).
 
 ## 4. Authoritative full-suite validation (provider env unset)
 
 ```
-env -u MODEL_PROVIDER -u MODEL_SET -u OPENAI_API_KEY -u OPENAI_BASE_URL python -m pytest -q --junit-xml=<artifacts/provider-env-unset-full-suite-junit.xml>
+env -u MODEL_PROVIDER -u MODEL_SET -u OPENAI_API_KEY -u OPENAI_BASE_URL python -m pytest -q --junit-xml=artifacts/provider-env-unset-full-suite-junit.xml
 ```
-Exit code: `1`. Exact counts via JUnit XML (`--junit-xml=<artifacts/provider-env-unset-full-suite-junit.xml>`): **1216 collected, 1211 passed, 2 failed, 0 errors, 3
+Exit code: `1`. Exact counts via JUnit XML (`--junit-xml=artifacts/provider-env-unset-full-suite-junit.xml`): **1216 collected, 1211 passed, 2 failed, 0 errors, 3
 skipped** (37.75s). Consistent with the PR #496 recorded full-suite behavior, the provider-env-unset full
 suite still reports the same two unrelated failures (see `failure-analysis.md`).
 
@@ -92,6 +92,6 @@ Results are recorded in `execution-results.md` (Validation section).
 
 - No command called OpenAI, Anthropic, any hosted provider, any local model, or any external API.
 - No `/v1/solve` call, no dashboard, no browser automation, no Google Sheets, no deployment, no billing.
-- The release-gate CLI's `--output <artifacts/self-operator-release-gate-report.json>` path was directed into an `artifacts/` path that the
+- The release-gate CLI's `--output artifacts/self-operator-release-gate-report.json` path was directed into an `artifacts/` path that the
   repo `.gitignore` excludes; the report content is therefore embedded in `artifacts-index.md` instead of
   committed as a separate file, keeping this packet markdown-only (consistent with PR #496).


### PR DESCRIPTION
### Motivation
- Ensure recorded CLI commands in the Self Operator evidence packet exactly match the artifact producers so the packet is auditable and traceable.
- Provide the exact release-gate JSON emitted by the CLI so embedded evidence is verbatim and includes all fields such as `required_next_action`.

### Description
- Updated `docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-execution-evidence-001/commands-run.md` to record the release-gate CLI with `--output <artifacts/self-operator-release-gate-report.json>` and to include `--junit-xml=<artifacts/self-operator-pytest-junit.xml>` for the Self Operator pytest invocation and `--junit-xml=<artifacts/provider-env-unset-full-suite-junit.xml>` for the provider-env-unset full-suite invocation.
- Updated `docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-execution-evidence-001/artifacts-index.md` to use the same exact artifact producer command placeholders and replaced the embedded release-gate JSON with the exact CLI JSON shape emitted by `scripts/check_self_operator_release_gate.py` (including `required_next_action` fields).
- Files changed: `docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-execution-evidence-001/commands-run.md` and `docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-execution-evidence-001/artifacts-index.md`.
- Preservation: evidence-boundary and DEF-001 related language were preserved and no product/runtime/test/CI code was modified.

### Testing
- Ran `python scripts/check_local_llm_doc_paths.py` and it passed reporting the doc path/link checks.
- Ran `python scripts/check_local_llm_evidence_boundaries.py` and it passed the evidence-boundary static checks.
- Ran `python scripts/check_local_llm_packet_consistency.py` and it passed the packet consistency checks.
- Current commit SHA: `4886295a21a09ce7093142b29cdfcac99ac75487`, and no product, runtime, test, or CI code was changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2cdeb49ce4832999926eea22df2ba0)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR aligns the recorded CLI commands in the Self Operator evidence packet with the actual artifact-producing invocations, adding explicit `--output` and `--junit-xml` flags, and replaces the previously incomplete embedded release-gate JSON with the verbatim CLI output that includes `required_next_action` per gate.

- `commands-run.md`: The three key commands (release-gate checker, self-operator pytest, full-suite pytest) now carry their exact output-path flags, and inline prose references match.
- `artifacts-index.md`: Producer command placeholders updated to match; embedded JSON reformatted from 4-space to 2-space indentation and extended with `required_next_action` on every gate entry.

<h3>Confidence Score: 5/5</h3>

Documentation-only change with no product, runtime, test, or CI code modified; safe to merge.

Both changed files are markdown evidence-packet documents. The edits add explicit artifact paths to CLI flags and expand the embedded JSON to include `required_next_action` — purely additive documentation that cannot affect runtime behavior.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-execution-evidence-001/commands-run.md | Adds explicit --output and --junit-xml flags to the recorded CLI commands so they match the actual artifact producers; also updates inline prose to reference the full flag values. |
| docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-execution-evidence-001/artifacts-index.md | Updates producer command placeholders to match the exact flags used, and replaces the embedded release-gate JSON with the full CLI shape including the new required_next_action field per gate. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["commands-run.md\n(recorded CLI invocations)"] -->|"--output artifacts/self-operator-release-gate-report.json"| B["Artifact 3\nRelease-gate JSON report"]
    A -->|"--junit-xml=artifacts/self-operator-pytest-junit.xml"| C["Artifact 1\nSelf Operator JUnit XML"]
    A -->|"--junit-xml=artifacts/provider-env-unset-full-suite-junit.xml"| D["Artifact 2\nFull-suite JUnit XML"]
    B --> E["artifacts-index.md\n(producer commands + embedded JSON)"]
    C --> E
    D --> E
```

<sub>Reviews (2): Last reviewed commit: ["docs: use runnable evidence artifact pat..."](https://github.com/adonisdv23/alpha-solver/commit/6cac61c42f8569379a4c76e243a8eb7c4f0d8520) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37375498)</sub>

<!-- /greptile_comment -->