### PR TITLE
docs(openai): extend static checks to OpenAI evidence packets

### DIFF
--- a/docs/evals/runs/openai-packet-checker-scope-001/README.md
+++ b/docs/evals/runs/openai-packet-checker-scope-001/README.md
@@ -1,0 +1,17 @@
+# OPENAI-PACKET-CHECKER-SCOPE-001
+
+Verdict: `OPENAI_PACKET_CHECKER_SCOPE_EXTENDED`
+
+This docs-only packet records the static checker scope hardening lane for OpenAI evidence packet directories.
+
+## Scope
+
+The lane extends local static documentation/evidence checkers to include these evidence packet families:
+
+- `docs/evals/runs/openai-*`
+- `docs/evals/runs/local-openai-*`
+- `docs/evals/runs/alpha-solver-openai-*`
+
+## Selected next lane
+
+`LOCAL-OPENAI-TOKEN-SMOKE-CAPTURE-RETRY-001`

--- a/docs/evals/runs/openai-packet-checker-scope-001/checker-scope-before-after.md
+++ b/docs/evals/runs/openai-packet-checker-scope-001/checker-scope-before-after.md
@@ -1,0 +1,19 @@
+# Checker Scope Before / After
+
+## Before
+
+- `scripts/check_local_llm_doc_paths.py` scanned local LLM docs and `alpha-solver-post-*` packets, but did not explicitly include OpenAI packet families in `is_scanned_doc` or reference marker detection.
+- `scripts/check_local_llm_evidence_boundaries.py` scanned local LLM docs and `alpha-solver-post-*` packets, but did not explicitly include OpenAI packet families in `is_relevant_doc`.
+- `scripts/check_local_llm_packet_consistency.py` discovered packet directories by marker list that omitted `openai-*`, `local-openai-*`, and `alpha-solver-openai-*` packet families.
+
+## After
+
+- `scripts/check_local_llm_doc_paths.py` includes `docs/evals/runs/openai-*`, `docs/evals/runs/local-openai-*`, and `docs/evals/runs/alpha-solver-openai-*` in default scanning and checked-reference detection.
+- `scripts/check_local_llm_evidence_boundaries.py` includes those OpenAI packet families in relevant docs.
+- `scripts/check_local_llm_packet_consistency.py` includes those OpenAI packet families in packet directory discovery.
+- Existing local LLM and `alpha-solver-post-*` scope remains in place.
+- Source-artifact exclusions remain in place.
+
+## Applicability note
+
+All three checkers are applicable to the required OpenAI packet directories after this change. No checker was intentionally excluded from any required packet.

--- a/docs/evals/runs/openai-packet-checker-scope-001/commands-run.md
+++ b/docs/evals/runs/openai-packet-checker-scope-001/commands-run.md
@@ -1,0 +1,29 @@
+# Commands Run
+
+```bash
+pwd && find .. -name AGENTS.md -print && git status --short && git log --oneline --decorate -n 20
+```
+
+```bash
+for d in docs/evals/runs/alpha-solver-openai-free-token-eval-smoke-harness-plan-001 docs/evals/runs/openai-data-sharing-operator-verification-001 docs/evals/runs/local-openai-token-smoke-capture-001 docs/evals/runs/openai-synthetic-smoke-prompt-fixture-001 docs/evals/runs/openai-data-sharing-operator-attestation-001; do [ -d "$d" ] && echo "OK $d" || echo "MISSING $d"; done
+```
+
+```bash
+python scripts/check_local_llm_doc_paths.py
+```
+
+```bash
+python scripts/check_local_llm_evidence_boundaries.py
+```
+
+```bash
+python scripts/check_local_llm_packet_consistency.py
+```
+
+```bash
+python -m pytest tests/test_local_llm_doc_paths.py tests/test_local_llm_evidence_boundaries.py tests/test_local_llm_packet_consistency.py -q
+```
+
+```bash
+python -m pytest -q
+```

--- a/docs/evals/runs/openai-packet-checker-scope-001/evidence-boundary.md
+++ b/docs/evals/runs/openai-packet-checker-scope-001/evidence-boundary.md
@@ -1,0 +1,7 @@
+# Evidence Boundary
+
+This packet is static documentation/checker evidence only.
+
+It establishes that local checker scope was extended to include OpenAI packet directories before any real OpenAI API smoke call is attempted.
+
+It does not establish provider validation, model behavior, API smoke success, token usage, billing behavior, benchmark evidence, product readiness, `/v1/solve` readiness, dashboard readiness, or production readiness.

--- a/docs/evals/runs/openai-packet-checker-scope-001/forbidden-claims.md
+++ b/docs/evals/runs/openai-packet-checker-scope-001/forbidden-claims.md
@@ -1,0 +1,14 @@
+# Forbidden Claims
+
+This lane does not claim:
+
+- OpenAI API validation.
+- Successful provider calls.
+- Token usage or billing evidence.
+- Model quality evidence.
+- Eval execution.
+- Runtime/provider/model behavior changes.
+- `/v1/solve` readiness.
+- Dashboard readiness.
+- Public MVP readiness.
+- Production readiness.

--- a/docs/evals/runs/openai-packet-checker-scope-001/non-actions.md
+++ b/docs/evals/runs/openai-packet-checker-scope-001/non-actions.md
@@ -1,0 +1,14 @@
+# Non-Actions
+
+This lane did not:
+
+- Call OpenAI.
+- Use tokens.
+- Call hosted providers.
+- Run evals.
+- Deploy anything.
+- Expose `/v1/solve`.
+- Expose dashboards.
+- Access credentials.
+- Update Google Sheets or backlog workbooks.
+- Modify runtime, provider, or model behavior.

--- a/docs/evals/runs/openai-packet-checker-scope-001/repo-state-verification.md
+++ b/docs/evals/runs/openai-packet-checker-scope-001/repo-state-verification.md
@@ -1,0 +1,22 @@
+# Repo State Verification
+
+Verified from local git history and working tree before implementation.
+
+## Required merged PR evidence
+
+Local `git log --oneline --decorate -n 20` showed:
+
+- PR #502: `0ce8cdb docs(eval): add OpenAI free-token smoke and eval harness plan (#502)`
+- PR #503: `f58a0cd docs(self-operator): add DEF-002 DEF-003 evidence boundary packet (#503)`
+- PR #504: `f8efc99 docs(openai): add data-sharing operator verification packet (#504)`
+- PR #505: `c74f78a docs(openai): add local token smoke capture packet (#505)`
+- PR #506: `f5bc500 docs(openai): add synthetic smoke prompt fixture packet (#506)`
+- PR #507: `93cca94 docs(openai): add operator pre-smoke attestation packet (#507)`
+
+## Required packet directories present
+
+- `docs/evals/runs/alpha-solver-openai-free-token-eval-smoke-harness-plan-001/`
+- `docs/evals/runs/openai-data-sharing-operator-verification-001/`
+- `docs/evals/runs/local-openai-token-smoke-capture-001/`
+- `docs/evals/runs/openai-synthetic-smoke-prompt-fixture-001/`
+- `docs/evals/runs/openai-data-sharing-operator-attestation-001/`

--- a/docs/evals/runs/openai-packet-checker-scope-001/selected-next-lane.md
+++ b/docs/evals/runs/openai-packet-checker-scope-001/selected-next-lane.md
@@ -1,0 +1,5 @@
+# Selected Next Lane
+
+Selected next lane: `LOCAL-OPENAI-TOKEN-SMOKE-CAPTURE-RETRY-001`
+
+Rationale: checker scope is extended to include OpenAI evidence packets, so the next provider-smoke lane should use the retry lane rather than the original `LOCAL-OPENAI-TOKEN-SMOKE-CAPTURE-001`, which already recorded a blocked missing-attestation attempt.

--- a/docs/evals/runs/openai-packet-checker-scope-001/validation-results.md
+++ b/docs/evals/runs/openai-packet-checker-scope-001/validation-results.md
@@ -1,0 +1,24 @@
+# Validation Results
+
+Final validation results are recorded for the committed change.
+
+## Passing required static checkers
+
+- `python scripts/check_local_llm_doc_paths.py` passed: `Local LLM/post-Level/OpenAI doc path/link check passed (1605 files scanned).`
+- `python scripts/check_local_llm_evidence_boundaries.py` passed: `Local LLM evidence-boundary static check passed (2006 files scanned).`
+- `python scripts/check_local_llm_packet_consistency.py` passed: `Local LLM packet consistency check passed (155 packet directories scanned).`
+
+## Focused tests
+
+- `python -m pytest tests/test_local_llm_doc_paths.py tests/test_local_llm_evidence_boundaries.py tests/test_local_llm_packet_consistency.py -q` passed: `31 passed`.
+
+## Full pytest
+
+- `python -m pytest -q` was run and failed in unrelated runtime/provider tests outside this docs/static-checker lane.
+- Observed failures:
+  - `tests/test_api_endpoints.py::test_solve_openai_provider_errors_return_safe_responses[timeout-504]`
+  - `tests/test_api_endpoints.py::test_solve_openai_provider_errors_return_safe_responses[rate_limit-429]`
+  - `tests/test_api_endpoints.py::test_solve_openai_provider_errors_return_safe_responses[network-503]`
+  - `tests/test_cost_tracking.py::test_cost_tracking`
+  - `tests/test_security.py::test_a3_1_prompt_subset_passes_solve_input_validation`
+- The full-suite output included live OpenAI HTTP logging from pre-existing test environment/provider configuration. This lane did not intentionally add provider calls or modify runtime/provider/model behavior.

--- a/scripts/check_local_llm_doc_paths.py
+++ b/scripts/check_local_llm_doc_paths.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-"""Offline path/link checker for local LLM and post-Level solver docs.
+"""Offline path/link checker for local LLM, post-Level, and OpenAI evidence packet docs.
 
 Purpose and limits:
 - This is a deterministic, offline documentation hardening check.
 - It scans local LLM solver orchestration operator docs, evidence index / Level 3 packet docs,
-  and alpha-solver-post-* Self Operator packet docs, excluding preserved source-artifact payload files.
-- It verifies repo-relative local LLM and alpha-solver-post-* doc packet paths and key
+  alpha-solver-post-* Self Operator packet docs, and OpenAI evidence packet docs, excluding preserved source-artifact payload files.
+- It verifies repo-relative local LLM, alpha-solver-post-*, and OpenAI doc packet paths and key
   source paths referenced by those docs exist in the checkout.
 - It detects simple stale selected-next-lane conflicts inside one document.
 - It does not call GitHub, access the network, run models/providers, start
@@ -37,6 +37,11 @@ LEVEL_3_SCAN_DIRS = (
 # exist, but preserved payload files inside it are intentionally not scanned.
 LEVEL_3_SOURCE_ARTIFACT_DIR = LEVEL_3_PACKET_DIR / "source-artifact"
 POST_PACKET_DIR_PREFIX = "docs/evals/runs/alpha-solver-post-"
+OPENAI_PACKET_DIR_PREFIXES = (
+    "docs/evals/runs/openai-",
+    "docs/evals/runs/local-openai-",
+    "docs/evals/runs/alpha-solver-openai-",
+)
 POST_PACKET_PARENT_DIR = Path("docs/evals/runs")
 COUNCIL_AUDIT_EVIDENCE_BUNDLE_DIR = Path(
     "docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-council-audit-evidence-bundle"
@@ -73,6 +78,14 @@ LOCAL_LLM_MARKERS = (
 POST_PACKET_MARKERS = (
     "alpha-solver-post-",
     "ALPHA-SOLVER-POST-",
+)
+OPENAI_PACKET_MARKERS = (
+    "openai-",
+    "OPENAI-",
+    "local-openai-",
+    "LOCAL-OPENAI-",
+    "alpha-solver-openai-",
+    "ALPHA-SOLVER-OPENAI-",
 )
 IGNORED_LINK_PREFIXES = (
     "http://",
@@ -193,6 +206,7 @@ def _looks_checked_reference(value: str) -> bool:
     return _looks_repo_relative(value) and (
         any(marker in value for marker in LOCAL_LLM_MARKERS)
         or any(marker in value for marker in POST_PACKET_MARKERS)
+        or any(marker in value for marker in OPENAI_PACKET_MARKERS)
     )
 
 
@@ -210,6 +224,8 @@ def is_scanned_doc(path: Path, root: Path = ROOT) -> bool:
         return False
     rel_text = rel.as_posix()
     if rel_text.startswith(POST_PACKET_DIR_PREFIX):
+        return True
+    if rel_text.startswith(OPENAI_PACKET_DIR_PREFIXES):
         return True
     return any(
         rel_text == base.as_posix() or rel_text.startswith(f"{base.as_posix()}/")
@@ -389,12 +405,12 @@ def main(argv: list[str] | None = None) -> int:
     paths = [path for path in paths if is_scanned_doc(path, ROOT)]
     findings = check_paths(paths, ROOT)
     if findings:
-        print("Local LLM/post-Level doc path/link check failed:", file=sys.stderr)
+        print("Local LLM/post-Level/OpenAI doc path/link check failed:", file=sys.stderr)
         for finding in findings:
             print(f"  {finding.format()}", file=sys.stderr)
         return 1
 
-    print(f"Local LLM/post-Level doc path/link check passed ({len(paths)} files scanned).")
+    print(f"Local LLM/post-Level/OpenAI doc path/link check passed ({len(paths)} files scanned).")
     return 0
 
 

--- a/scripts/check_local_llm_evidence_boundaries.py
+++ b/scripts/check_local_llm_evidence_boundaries.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-"""Static evidence-boundary checker for local LLM and post-Level solver docs.
+"""Static evidence-boundary checker for local LLM, post-Level, and OpenAI evidence packet docs.
 
 Purpose and limits:
 - This is a deterministic, offline documentation hardening check.
 - It scans local LLM solver orchestration evidence-boundary docs for risky
   promotional claim phrases and requires nearby boundary language.
-- It also scans alpha-solver-post-* Self Operator packet docs, including the Council audit evidence bundle.
+- It also scans alpha-solver-post-* Self Operator packet docs, including the Council audit evidence bundle, plus OpenAI evidence packet docs.
 - It also checks that the final Level 3 closeout packet preserves the accepted
   non-promotional boundary phrases.
 - It does not validate behavior, run benchmarks, call models/providers, read
@@ -27,6 +27,11 @@ DOCS_DIR_PREFIXES = (
 )
 LOCAL_ORCHESTRATION_DIR_MARKER = "local-llm-solver-orchestration"
 POST_PACKET_DIR_PREFIX = "docs/evals/runs/alpha-solver-post-"
+OPENAI_PACKET_DIR_PREFIXES = (
+    "docs/evals/runs/openai-",
+    "docs/evals/runs/local-openai-",
+    "docs/evals/runs/alpha-solver-openai-",
+)
 COUNCIL_AUDIT_EVIDENCE_BUNDLE_DIR = Path(
     "docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-council-audit-evidence-bundle"
 )
@@ -89,7 +94,9 @@ BOUNDARY_LANGUAGE_PATTERNS = tuple(
         r"\baccepted boundary\b",
         r"\bexcluded(?: evidence)? categories\b",
         r"\bnon(?:-|\s)?claims?\b",
+        r"\bnon[_-]claims?\b",
         r"\bnon(?:-|\s)?actions?\b",
+        r"\bnon[_-]actions?\b",
         r"\bnon(?:-|\s)?decision\b",
         r"\bnon(?:-|\s)?execution\b",
         r"\bnon(?:-|\s)?promotional\b",
@@ -170,6 +177,8 @@ def is_relevant_doc(path: Path) -> bool:
     if rel.startswith(DOCS_DIR_PREFIXES):
         return True
     if rel.startswith(POST_PACKET_DIR_PREFIX):
+        return True
+    if rel.startswith(OPENAI_PACKET_DIR_PREFIXES):
         return True
     return rel.startswith(RUNS_DIR.as_posix()) and LOCAL_ORCHESTRATION_DIR_MARKER in rel
 

--- a/scripts/check_local_llm_packet_consistency.py
+++ b/scripts/check_local_llm_packet_consistency.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Static packet-consistency checker for local LLM solver orchestration docs.
+"""Static packet-consistency checker for local LLM solver orchestration and OpenAI evidence packet docs.
 
 Purpose and limits:
 - This is a deterministic, offline documentation hardening check.
-- It scans only local LLM solver orchestration packet directories and the
-  local LLM solver orchestration operator guide selected-next-lane state.
+- It scans local LLM solver orchestration packet directories, OpenAI evidence packet directories,
+  and the local LLM solver orchestration operator guide selected-next-lane state.
 - It validates lane packet continuity files, blocker fallbacks, evidence
   boundary or blocked-claims files, final decision markers, and contradictory
   selected-next state.
@@ -35,6 +35,9 @@ PACKET_DIR_MARKERS = (
     "20260607-local-llm-controlled-usage-operator-run-001",
     "alpha-solver-post-level-3-",
     "alpha-solver-post-level-7-",
+    "openai-",
+    "local-openai-",
+    "alpha-solver-openai-",
 )
 SOURCE_ARTIFACT_MARKERS = (
     "/source-artifact/",

--- a/tests/test_local_llm_doc_paths.py
+++ b/tests/test_local_llm_doc_paths.py
@@ -130,6 +130,34 @@ def test_prior_preserved_selected_next_reference_remains_allowed(tmp_path: Path)
     assert findings == []
 
 
+def test_default_discovery_includes_openai_packet_docs(tmp_path: Path) -> None:
+    packet_dirs = [
+        Path("docs/evals/runs/openai-fixture"),
+        Path("docs/evals/runs/local-openai-fixture"),
+        Path("docs/evals/runs/alpha-solver-openai-fixture"),
+    ]
+    for packet_dir in packet_dirs:
+        _write(tmp_path / packet_dir / "README.md", "# Fixture\n")
+
+    docs = checker.iter_scanned_docs(tmp_path)
+
+    for packet_dir in packet_dirs:
+        assert packet_dir / "README.md" in docs
+
+
+def test_openai_packet_references_are_checked(tmp_path: Path) -> None:
+    _make_required_tree(tmp_path)
+    doc = _write(
+        tmp_path / "docs/evals/runs/openai-fixture/README.md",
+        "Broken OpenAI packet: `docs/evals/runs/openai-missing-packet/README.md`.\n",
+    )
+
+    findings = checker.check_paths([doc.relative_to(tmp_path)], tmp_path)
+
+    assert len(findings) == 1
+    assert "openai-missing-packet" in findings[0].reference
+
+
 def test_current_repo_local_llm_docs_still_pass() -> None:
     findings = checker.check_paths(checker.iter_scanned_docs())
 

--- a/tests/test_local_llm_evidence_boundaries.py
+++ b/tests/test_local_llm_evidence_boundaries.py
@@ -28,6 +28,9 @@ def test_relevant_docs_include_closeout_and_skip_source_artifacts():
             "docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-execution-001/source-artifact/run_level3_validation.sh"
         )
     )
+    assert is_relevant_doc(Path("docs/evals/runs/openai-fixture/README.md"))
+    assert is_relevant_doc(Path("docs/evals/runs/local-openai-fixture/README.md"))
+    assert is_relevant_doc(Path("docs/evals/runs/alpha-solver-openai-fixture/README.md"))
     assert not is_relevant_doc(Path("docs/RUNTIME_READINESS.md"))
 
 
@@ -39,6 +42,15 @@ def test_promotional_claim_without_boundary_language_is_flagged():
 
     assert len(findings) == 1
     assert findings[0].phrase == "production readiness"
+
+
+def test_yaml_non_claims_boundary_language_is_allowed():
+    findings = find_promotional_claim_findings(
+        Path("docs/evals/runs/openai-fixture/template.md"),
+        "```yaml\nnon_claims:\n  - production readiness\n```\n",
+    )
+
+    assert findings == []
 
 
 def test_promotional_claim_with_boundary_language_is_allowed():

--- a/tests/test_local_llm_packet_consistency.py
+++ b/tests/test_local_llm_packet_consistency.py
@@ -86,6 +86,26 @@ def test_current_repo_local_llm_packets_pass_packet_consistency_check():
     assert check_packet_consistency(packet_dirs) == []
 
 
+def test_default_discovery_includes_openai_packet_families(tmp_path):
+    packet_dirs = [
+        Path("docs/evals/runs/openai-fixture"),
+        Path("docs/evals/runs/local-openai-fixture"),
+        Path("docs/evals/runs/alpha-solver-openai-fixture"),
+    ]
+    for packet_dir in packet_dirs:
+        _write_packet(
+            tmp_path,
+            packet_dir,
+            selected_text="`OPENAI-FIXTURE-NEXT-001`\n",
+            boundary_name="non-actions.md",
+        )
+
+    discovered = iter_packet_dirs(tmp_path)
+
+    for packet_dir in packet_dirs:
+        assert packet_dir in discovered
+
+
 def test_default_discovery_includes_release_readiness_ladder_packet():
     packet_dirs = iter_packet_dirs()
 


### PR DESCRIPTION
### Motivation

- Ensure local static documentation/evidence checkers include the new OpenAI evidence packet families so OpenAI-related docs are validated before any provider-smoke lanes run. 
- Prevent stale/missing doc references and missing evidence-boundary language for `openai-*`, `local-openai-*`, and `alpha-solver-openai-*` packets without changing runtime/provider behavior or making any provider calls.

### Description

- Extended `scripts/check_local_llm_doc_paths.py` to treat `docs/evals/runs/openai-*`, `docs/evals/runs/local-openai-*`, and `docs/evals/runs/alpha-solver-openai-*` as scanned docs and to recognize OpenAI packet markers in checked references. 
- Extended `scripts/check_local_llm_evidence_boundaries.py` to include those OpenAI packet directories in relevant-doc discovery and to accept YAML-style `non_claims` / `non_actions` markers as boundary language. 
- Extended `scripts/check_local_llm_packet_consistency.py` to include OpenAI packet family markers when discovering packet directories. 
- Added focused unit tests for discovery and checking of OpenAI packet docs in the three test files, and added a docs-only evidence packet at `docs/evals/runs/openai-packet-checker-scope-001/` documenting scope, commands, validation results, forbidden claims, and the selected next lane `LOCAL-OPENAI-TOKEN-SMOKE-CAPTURE-RETRY-001`.

### Testing

- Ran the three checkers (`python scripts/check_local_llm_doc_paths.py`, `python scripts/check_local_llm_evidence_boundaries.py`, `python scripts/check_local_llm_packet_consistency.py`) and each passed and scanned OpenAI packet docs. 
- Ran focused tests for the three checkers (`python -m pytest tests/test_local_llm_doc_paths.py tests/test_local_llm_evidence_boundaries.py tests/test_local_llm_packet_consistency.py`) and they passed (`31 passed`). 
- Ran full test suite (`python -m pytest -q`) and observed unrelated runtime/provider test failures recorded in the evidence packet (several provider/runtime tests failed), but these failures are outside the docs/static-checker scope and were not caused by provider calls or behavior changes in this lane.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d0dc5b2c08329b988473773dcfada)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends three static documentation/evidence checkers (`check_local_llm_doc_paths.py`, `check_local_llm_evidence_boundaries.py`, `check_local_llm_packet_consistency.py`) to include OpenAI evidence packet families (`openai-*`, `local-openai-*`, `alpha-solver-openai-*`) and adds YAML-style `non_claims`/`non_actions` as accepted boundary-language markers. A companion docs-only evidence packet (`openai-packet-checker-scope-001`) records the scope change and selected next lane.

- **Static checker scope**: All three checkers now discover, scan, and validate OpenAI packet directories; existing local-LLM and `alpha-solver-post-*` scope is unchanged.
- **New boundary patterns**: `non[_-]claims?` and `non[_-]actions?` regexes are added to `BOUNDARY_LANGUAGE_PATTERNS` so YAML front-matter style markers satisfy boundary-language requirements.
- **Tests**: Focused unit tests verify discovery, reference checking, and boundary detection for all three OpenAI packet families (31 tests pass); one redundant minor style item exists in `PACKET_DIR_MARKERS` where `\"local-openai-\"` and `\"alpha-solver-openai-\"` are already subsumed by `\"openai-\"` via the substring check.

<h3>Confidence Score: 4/5</h3>

Safe to merge — all changes are confined to offline static checkers and documentation; no runtime, provider, or model behavior is touched.

The three checker scripts are extended cleanly and the new openai-packet-checker-scope-001 packet follows the established structure. Two minor style issues exist: a stale error message in find_missing_path_findings and redundant entries in PACKET_DIR_MARKERS. Neither affects correctness.

scripts/check_local_llm_doc_paths.py and scripts/check_local_llm_packet_consistency.py have minor inconsistencies worth cleaning up before the next similar extension.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/check_local_llm_doc_paths.py | Extended is_scanned_doc and _looks_checked_reference to include three OpenAI packet directory prefixes; stale error message in find_missing_path_findings still says local LLM/post-Level despite now covering OpenAI paths. |
| scripts/check_local_llm_evidence_boundaries.py | Added OPENAI_PACKET_DIR_PREFIXES and two new boundary-language regex patterns for YAML-style non_claims / non_actions markers; changes are correct and well-scoped. |
| scripts/check_local_llm_packet_consistency.py | Added openai-, local-openai-, and alpha-solver-openai- to PACKET_DIR_MARKERS; last two entries are redundant because the substring-in check already matches them via openai-. |
| tests/test_local_llm_doc_paths.py | Two focused tests added: discovery of OpenAI packet docs via iter_scanned_docs, and verification that references to missing OpenAI paths produce findings. |
| tests/test_local_llm_evidence_boundaries.py | Added relevance assertions for all three OpenAI prefixes and a new test confirming YAML-style non_claims: satisfies boundary-language detection. |
| tests/test_local_llm_packet_consistency.py | New test creates minimal fixture packets for all three OpenAI families and confirms iter_packet_dirs discovers them. |
| docs/evals/runs/openai-packet-checker-scope-001/README.md | Docs-only evidence packet recording the checker-scope extension lane; follows established packet structure with selected-next-lane and boundary files. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `scripts/check_local_llm_doc_paths.py`, line 297-302 ([link](https://github.com/adonisdv23/alpha-solver/blob/11fdcb925b79de8b076f32fc351db200ca835f4b/scripts/check_local_llm_doc_paths.py#L297-L302)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The error message in `find_missing_path_findings` still says "local LLM/post-Level" even though this function now also validates OpenAI packet references. A reviewer or CI log reader seeing a failure on an OpenAI packet path would get a misleading message.

   

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22adonisdv23%2Falpha-solver%22%20on%20the%20existing%20branch%20%22codex%2Fimplement-static-checker-scope-hardening%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fimplement-static-checker-scope-hardening%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fcheck_local_llm_doc_paths.py%0ALine%3A%20297-302%0A%0AComment%3A%0AThe%20error%20message%20in%20%60find_missing_path_findings%60%20still%20says%20%22local%20LLM%2Fpost-Level%22%20even%20though%20this%20function%20now%20also%20validates%20OpenAI%20packet%20references.%20A%20reviewer%20or%20CI%20log%20reader%20seeing%20a%20failure%20on%20an%20OpenAI%20packet%20path%20would%20get%20a%20misleading%20message.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Finding%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20path%3Dreference.path%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20line%3Dreference.line%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20reference%3Dreference.target%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20message%3D%22referenced%20local%20LLM%2Fpost-Level%2FOpenAI%20repo%20path%20does%20not%20exist%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=adonisdv23%2Falpha-solver&pr=508&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fcheck_local_llm_doc_paths.py%0ALine%3A%20297-302%0A%0AComment%3A%0AThe%20error%20message%20in%20%60find_missing_path_findings%60%20still%20says%20%22local%20LLM%2Fpost-Level%22%20even%20though%20this%20function%20now%20also%20validates%20OpenAI%20packet%20references.%20A%20reviewer%20or%20CI%20log%20reader%20seeing%20a%20failure%20on%20an%20OpenAI%20packet%20path%20would%20get%20a%20misleading%20message.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Finding%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20path%3Dreference.path%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20line%3Dreference.line%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20reference%3Dreference.target%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20message%3D%22referenced%20local%20LLM%2Fpost-Level%2FOpenAI%20repo%20path%20does%20not%20exist%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=adonisdv23%2Falpha-solver&pr=508&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22adonisdv23%2Falpha-solver%22%20on%20the%20existing%20branch%20%22codex%2Fimplement-static-checker-scope-hardening%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fimplement-static-checker-scope-hardening%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Fcheck_local_llm_doc_paths.py%3A297-302%0AThe%20error%20message%20in%20%60find_missing_path_findings%60%20still%20says%20%22local%20LLM%2Fpost-Level%22%20even%20though%20this%20function%20now%20also%20validates%20OpenAI%20packet%20references.%20A%20reviewer%20or%20CI%20log%20reader%20seeing%20a%20failure%20on%20an%20OpenAI%20packet%20path%20would%20get%20a%20misleading%20message.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Finding%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20path%3Dreference.path%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20line%3Dreference.line%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20reference%3Dreference.target%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20message%3D%22referenced%20local%20LLM%2Fpost-Level%2FOpenAI%20repo%20path%20does%20not%20exist%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fcheck_local_llm_packet_consistency.py%3A38-41%0A%60%22local-openai-%22%60%20and%20%60%22alpha-solver-openai-%22%60%20are%20already%20matched%20by%20%60%22openai-%22%60%20because%20%60PACKET_DIR_MARKERS%60%20uses%20a%20substring-%60in%60%20test%20%28%60any%28marker%20in%20rel%20%E2%80%A6%29%60%29.%20Both%20strings%20contain%20%60%22openai-%22%60%2C%20so%20the%20last%20two%20entries%20are%20dead%20code.%20They%20don't%20cause%20a%20bug%20but%20silently%20make%20future%20marker%20audits%20harder.%0A%0A%60%60%60suggestion%0A%20%20%20%20%22openai-%22%2C%0A%29%0A%60%60%60%0A%0A&repo=adonisdv23%2Falpha-solver&pr=508&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Fcheck_local_llm_doc_paths.py%3A297-302%0AThe%20error%20message%20in%20%60find_missing_path_findings%60%20still%20says%20%22local%20LLM%2Fpost-Level%22%20even%20though%20this%20function%20now%20also%20validates%20OpenAI%20packet%20references.%20A%20reviewer%20or%20CI%20log%20reader%20seeing%20a%20failure%20on%20an%20OpenAI%20packet%20path%20would%20get%20a%20misleading%20message.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Finding%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20path%3Dreference.path%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20line%3Dreference.line%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20reference%3Dreference.target%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20message%3D%22referenced%20local%20LLM%2Fpost-Level%2FOpenAI%20repo%20path%20does%20not%20exist%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fcheck_local_llm_packet_consistency.py%3A38-41%0A%60%22local-openai-%22%60%20and%20%60%22alpha-solver-openai-%22%60%20are%20already%20matched%20by%20%60%22openai-%22%60%20because%20%60PACKET_DIR_MARKERS%60%20uses%20a%20substring-%60in%60%20test%20%28%60any%28marker%20in%20rel%20%E2%80%A6%29%60%29.%20Both%20strings%20contain%20%60%22openai-%22%60%2C%20so%20the%20last%20two%20entries%20are%20dead%20code.%20They%20don't%20cause%20a%20bug%20but%20silently%20make%20future%20marker%20audits%20harder.%0A%0A%60%60%60suggestion%0A%20%20%20%20%22openai-%22%2C%0A%29%0A%60%60%60%0A%0A&repo=adonisdv23%2Falpha-solver&pr=508&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs(openai): extend static checks to Op..."](https://github.com/adonisdv23/alpha-solver/commit/11fdcb925b79de8b076f32fc351db200ca835f4b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37384239)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->