### PR TITLE
docs(security): add DEF-002 security privacy review packet

### DIFF
--- a/docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/README.md
+++ b/docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/README.md
@@ -1,0 +1,69 @@
+# ALPHA-SOLVER-DEF-002-SECURITY-PRIVACY-REVIEW-PACKET-001
+
+Verdict: `DEF_002_REVIEW_CAPTURED_OPEN_GAPS`
+
+This is a **docs-only** product-level security/privacy review lane for DEF-002. It
+assesses Alpha Solver's security and privacy posture using **committed repository
+evidence only** and records a formal DEF-002 review packet.
+
+This lane inspected code and docs **read-only**. It did not modify runtime,
+product, provider, or model code; it did not modify tests or CI. It did not call
+providers, use tokens, access secrets, print environment variables, deploy, or
+expose `/v1/solve`.
+
+## What this packet decides
+
+- It **captures** a structured security/privacy review across the 14 required
+  focus areas (see `security-privacy-scope.md`).
+- It records concrete, file-and-line-cited evidence for each area.
+- It enumerates open hardening gaps in `risk-register.md`.
+- It records candidate operator-acceptable residual risks in
+  `accepted-residual-risks.md` (proposed, not accepted here).
+- It explicitly **does not** mark DEF-002 closed.
+
+## Verdict rationale (summary)
+
+Reviewable, committed code evidence is present for every required focus area, so
+the review is not blocked by missing evidence. However, several open hardening
+gaps remain that require remediation rather than mere operator acceptance:
+
+- secrets-at-rest are stored in **plaintext** by the dashboard `FileSecretsBackend`;
+- CORS default is wildcard origin (`*`) combined with `allow_credentials=True`;
+- default API auth key (`dev-secret`) and default dashboard password
+  (`alpha-dashboard`) ship as insecure development defaults;
+- two divergent `data_classification.yaml` registries disagree on rules;
+- dependencies have no lockfile / hash pinning and the repo vendors several
+  third-party libraries.
+
+Because open gaps remain, the verdict is `DEF_002_REVIEW_CAPTURED_OPEN_GAPS` and
+the selected next lane drives gap closure. See `def-002-verdict.md`.
+
+## Selected next lane
+
+`ALPHA-SOLVER-DEF-002-GAP-CLOSURE-PLAN-001` (open gaps remain). See
+`selected-next-lane.md`.
+
+## Files in this packet
+
+| File | Purpose |
+| --- | --- |
+| `repo-state-verification.md` | Branch, HEAD, and read-only verification context |
+| `security-privacy-scope.md` | The 14 required focus areas and review scope |
+| `data-flow-review.md` | Request/data-flow and local-vs-provider execution boundary |
+| `credential-handling-review.md` | Secrets-at-rest, FileSecretsBackend, auth keys, JWT |
+| `logging-redaction-review.md` | Logging, redaction, telemetry prompt-content risk |
+| `provider-data-sharing-review.md` | Provider/API data-sharing boundaries |
+| `dashboard-v1-solve-exposure-review.md` | Dashboard exposure and `/v1/solve` exposure |
+| `dependency-supply-chain-review.md` | Dependency and supply-chain surface |
+| `risk-register.md` | Open gaps / findings register |
+| `accepted-residual-risks.md` | Proposed residual risks for operator acceptance |
+| `def-002-verdict.md` | Formal verdict and closure-gating rationale |
+| `forbidden-claims.md` | Claims this packet must not be used to assert |
+| `non-actions.md` | Actions explicitly not taken (hard boundaries) |
+| `selected-next-lane.md` | The selected downstream lane |
+
+## Boundaries
+
+This packet does not claim DEF-002 resolved, security/privacy completion, runtime
+readiness, production readiness, or `/v1/solve`/dashboard readiness. See
+`forbidden-claims.md`.

--- a/docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/accepted-residual-risks.md
+++ b/docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/accepted-residual-risks.md
@@ -1,0 +1,47 @@
+# Accepted residual risks (proposed — not accepted here)
+
+This file records residual risks that are **candidates** for operator risk
+acceptance. This docs-only review lane does **not** accept them. Acceptance is the
+job of a separate operator lane
+(`ALPHA-SOLVER-DEF-002-OPERATOR-RISK-ACCEPTANCE-001`), and only after the
+gap-closure items in `risk-register.md` are addressed or explicitly deferred by
+the operator.
+
+## Proposed residual risks
+
+### RR-04 — Inherent provider data-sharing when a provider is enabled
+
+- **Risk:** When a remote provider is explicitly enabled, user prompt text is
+  transmitted to a third-party provider (`service/app.py:266`, `:987`, `:1002`).
+- **Why it may be acceptable:** It is intrinsic to provider-backed inference,
+  off by default (`MODEL_PROVIDER=local`), and gated behind explicit operator
+  opt-in. Telemetry and failure paths are content-free.
+- **Acceptance precondition:** an operator-facing data-sharing/retention
+  disclosure (which provider, what is sent, retention) is documented before
+  provider use, and end users are informed.
+
+### RR-A1 — Pattern-based redaction coverage limits
+
+- **Risk:** `alpha/self_operator/redaction.py` redaction is keyword/regex driven;
+  secret formats outside the keyword/regex set may not be redacted.
+- **Why it may be acceptable:** redaction is deterministic, offline, and covers
+  the common assignment/bearer/secret-keyword cases; it is defense-in-depth on
+  top of the content-free telemetry/SAFE-OUT allowlists.
+- **Acceptance precondition:** operator acknowledges the coverage limitation and
+  the keyword/regex set is reviewed for the deployment's secret formats.
+
+### Operational residuals (deployment responsibilities)
+
+- **JWT keystore management:** the RS256 public-key YAML keystore
+  (`service/auth/jwt_utils.py`) must be managed and rotated securely at the
+  deployment layer.
+- **Evidence payload hygiene:** callers of the evidence API
+  (`service/evidence/api.py`) must not place secret material into evidence
+  payloads; the API does not enforce this.
+
+## What is NOT proposed for acceptance
+
+The following remain **gap-closure** items and are explicitly **not** offered for
+residual acceptance in this packet: RR-01 (CORS), RR-02 (plaintext
+secrets-at-rest), RR-03 (default credentials), RR-05 (divergent classification
+registries), RR-06/RR-07/RR-08 (dependency/supply-chain). See `risk-register.md`.

--- a/docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/credential-handling-review.md
+++ b/docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/credential-handling-review.md
@@ -1,0 +1,93 @@
+# Credential-handling review
+
+Covers: secrets-at-rest, `FileSecretsBackend`, API-key auth, JWT verification,
+tenancy, audit, and evidence-API credential exposure.
+
+## Secrets-at-rest: `FileSecretsBackend`
+
+- `alpha/webapp/routes/settings.py:62` defines `FileSecretsBackend`, a
+  "Simple file-based secrets backend storing JSON data."
+- `set()` writes provider keys to disk via `_write()`
+  (`settings.py:73-95`) using `json.dump(data, file, indent=2, sort_keys=True)`.
+  Values are stored **in cleartext**; there is no encryption, no OS keyring, and
+  no envelope/at-rest protection.
+- The default storage path is `~/.alpha_solver/dashboard_api_keys.json`
+  (`_resolve_path("ALPHA_DASHBOARD_SECRETS_PATH", "dashboard_api_keys.json")`,
+  `settings.py:22-34`, `settings.py:170`). The directory is created with default
+  permissions (`self.path.parent.mkdir(parents=True, exist_ok=True)`,
+  `settings.py:93`) — no explicit `0600`/`0700` mode is set.
+
+**Finding (SEC-1):** Provider API keys are persisted to disk in plaintext with no
+at-rest encryption and no explicit restrictive file permissions. Tracked in
+`risk-register.md` as RR-02.
+
+### Mitigating controls observed
+
+- The UI and audit log only ever render a masked form. `mask_secret`
+  (`settings.py:115-122`) returns `****` for short/empty keys and `****<last4>`
+  otherwise. `SettingsService.list_masked` (`settings.py:135-138`) yields only
+  masked values, and `AuditLogger.log` records the masked key only
+  (`settings.py:146-150`, `set_key` at `settings.py:140-149`).
+- The persisted location defaults outside the repository / version control
+  (under the user home), per the `_resolve_path` docstring (`settings.py:24-34`).
+
+These reduce *display/log* leakage but do not address at-rest plaintext storage.
+
+## API-key authentication
+
+- `ServiceAuthConfig` (`alpha/core/config.py:17-26`) enables API-key auth by
+  default (`SERVICE_AUTH_ENABLED` defaults `"true"`), reads the header name from
+  `SERVICE_AUTH_HEADER` (default `X-API-Key`), and loads keys from
+  `SERVICE_AUTH_KEYS` / `API_KEY`, **defaulting to `dev-secret`**.
+- `service/middleware/auth_middleware.py` enforces JWT **or** API-key auth, with
+  `exempt_paths`, optional `scope_map`, and an internal rate limiter.
+- `service/auth/api_keys.py` provides the `APIKeyStore` used by the middleware.
+
+**Finding (SEC-3):** The default API key is the well-known literal `dev-secret`.
+If a deployment does not override `SERVICE_AUTH_KEYS`/`API_KEY`, the API is
+effectively unauthenticated to anyone who knows the default. Tracked as RR-03.
+
+## JWT verification
+
+- `service/auth/jwt_utils.py` restricts algorithms to `ALLOWED_ALGS = {"RS256"}`
+  (line 13) — asymmetric only, which avoids the classic `alg:none` and HS/RS
+  confusion downgrade. It applies a bounded `LEWAY_SECONDS = 60` clock skew.
+- Keys are loaded from a YAML keystore mapping `kid -> PEM public key`
+  (`AuthKeyStore`, `jwt_utils.py:26-60`), with mtime/size-based reload and a
+  forced-miss reload cooldown to bound key-rotation churn.
+
+**Observation:** JWT handling is conservative (RS256-only, public-key keystore,
+bounded leeway). No gap recorded here beyond ensuring the keystore file itself is
+managed securely at deployment time (operational, noted in
+`accepted-residual-risks.md`).
+
+## Tenancy
+
+- `service/tenancy/context.py`, `service/tenancy/limiter.py`, and
+  `service/middleware/tenant_middleware.py` provide per-tenant context and
+  limiting. Provider telemetry carries an explicit `tenant` field
+  (`alpha/providers/telemetry.py`), enabling per-tenant attribution without
+  embedding tenant secrets in logs.
+
+## Audit and evidence APIs
+
+- The audit log is **tamper-evident**: `service/audit/hash_chain.py` chains each
+  entry with `SHA256(canonical_json(entry) + prev_hash)` and `verify_chain`
+  returns the first corrupt index, providing integrity verification.
+- The dashboard `AuditLogger` records only masked keys (`settings.py:146-150`), so
+  the audit trail does not itself become a secret sink.
+- The evidence API (`service/evidence/api.py`) accepts a `manifest`,
+  `simulation_lines`, `metrics`, and `tags` and delegates to `store`. It does not
+  itself handle credentials, but callers are responsible for not placing secret
+  material into evidence payloads (operational note in
+  `accepted-residual-risks.md`).
+
+## Summary of credential gaps
+
+| ID | Gap | Severity |
+| --- | --- | --- |
+| RR-02 | Plaintext provider secrets at rest (`FileSecretsBackend`), no explicit file mode | High |
+| RR-03 | Default API key `dev-secret` ships as an insecure default | High |
+
+Strong controls: RS256-only JWT, masked display/audit, tamper-evident audit
+chain, per-tenant attribution.

--- a/docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/dashboard-v1-solve-exposure-review.md
+++ b/docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/dashboard-v1-solve-exposure-review.md
@@ -1,0 +1,77 @@
+# Dashboard and `/v1/solve` exposure review
+
+Covers: dashboard mounting/exposure, `/v1/solve` exposure surface, and the
+auth/rate-limit controls in front of them.
+
+> Boundary note: this review reads the exposure-relevant code only. It does not
+> start the service, mount the dashboard, or exercise `/v1/solve`.
+
+## Dashboard exposure
+
+- The dashboard is mounted **fail-closed**. `service/app.py:183-188`
+  (`_dashboard_enabled`) requires **both** a non-default
+  `ALPHA_DASHBOARD_PASSWORD` and an explicit `ALPHA_DASHBOARD_SECRET_KEY` before
+  mounting. Otherwise the routes are not mounted (return 404), a warning is
+  logged, and the JSON API keeps working (`service/app.py:200-207`).
+- The mount is intentionally minimal: only auth (login/session + CSRF) plus the
+  supervised expert-preview page are installed via `_mount_dashboard`
+  (`service/app.py:193-196`). The full settings/run/jobs dashboard routes are not
+  mounted by the bundled app (comment at `service/app.py:170-182`).
+- Dashboard security (auth + CSRF) is installed through
+  `dashboard_auth.install_dashboard_security` (`alpha/webapp/routes/auth.py`).
+
+**Control (strong):** fail-closed mounting prevents the dashboard from sitting
+behind the well-known default password or an ephemeral signing secret.
+
+**Finding (DASH-1):** The default dashboard password constant is the well-known
+literal `alpha-dashboard` (`DEFAULT_DASHBOARD_PASSWORD`,
+`alpha/webapp/routes/auth.py:42`). The fail-closed check specifically rejects this
+default, which mitigates it; the residual is that the default exists in source and
+operators must set a strong password. Tracked as RR-03 (shared with the
+`dev-secret` default-credential theme).
+
+## `/v1/solve` exposure surface
+
+- Route: `@app.post("/v1/solve", dependencies=[Depends(rate_limiter)])`
+  (`service/app.py:943`). A rate limiter is applied as a route dependency.
+- Input is sanitized first: `query = sanitize_query(req.query)`
+  (`service/app.py:945`).
+- Authentication: the service supports API-key auth (`ServiceAuthConfig`,
+  enabled by default, `alpha/core/config.py:17-26`) and JWT/API-key middleware
+  (`service/middleware/auth_middleware.py`). `request.state.api_key` is set on the
+  authenticated path (`service/app.py:928`).
+- Rate limiting: `ServiceRateLimitConfig` (`alpha/core/config.py:29-41`) is
+  enabled by default with a sliding window (default 60s window, 120 requests),
+  and `record_rate_limit` telemetry is available.
+- Failure handling: errors route through `record_safe_out(request.url.path)` and
+  SAFE-OUT responses (`service/app.py:894-895`, `922`, and provider error paths),
+  so `/v1/solve` does not leak stack traces or raw provider errors to clients.
+
+**Boundary note:** This packet does **not** expose `/v1/solve` and does not change
+its exposure. The hard boundary "Do not expose `/v1/solve`" is respected; this is
+a read-only assessment of the existing surface.
+
+**Finding (SOLVE-1):** `/v1/solve` is protected by API-key auth + rate limiting,
+but the *default* API key is `dev-secret` (see `credential-handling-review.md`,
+RR-03). The exposure control is only as strong as the deployment overriding the
+default key. CORS in front of the API also defaults to wildcard (RR-01).
+
+## Auth / JWT / tenancy / audit / evidence at the exposure layer
+
+- JWT verification is RS256-only with a bounded leeway
+  (`service/auth/jwt_utils.py`), reducing algorithm-downgrade risk.
+- Tenancy middleware and limiter scope requests per tenant
+  (`service/middleware/tenant_middleware.py`, `service/tenancy/limiter.py`).
+- Audit entries are tamper-evident (`service/audit/hash_chain.py`).
+- The evidence API (`service/evidence/api.py`) is a separate router; callers must
+  avoid placing secret material in evidence payloads (operational note).
+
+## Summary
+
+| Surface | Control | Residual |
+| --- | --- | --- |
+| Dashboard | Fail-closed mount, minimal routes, CSRF | Default password constant in source (RR-03) |
+| `/v1/solve` | API-key auth + rate limit + SAFE-OUT + input sanitize | Default `dev-secret` key (RR-03); wildcard CORS (RR-01) |
+
+The exposure architecture is sound; the residuals are insecure defaults that a
+deployment must override, plus the CORS default.

--- a/docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/dashboard-v1-solve-exposure-review.md
+++ b/docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/dashboard-v1-solve-exposure-review.md
@@ -36,13 +36,17 @@ operators must set a strong password. Tracked as RR-03 (shared with the
   (`service/app.py:943`). A rate limiter is applied as a route dependency.
 - Input is sanitized first: `query = sanitize_query(req.query)`
   (`service/app.py:945`).
-- Authentication: the service supports API-key auth (`ServiceAuthConfig`,
-  enabled by default, `alpha/core/config.py:17-26`) and JWT/API-key middleware
-  (`service/middleware/auth_middleware.py`). `request.state.api_key` is set on the
-  authenticated path (`service/app.py:928`).
+- Authentication actually mounted on this route: API-key auth via
+  `validate_api_key(request, cfg)`, invoked inside the `rate_limiter` route
+  dependency (`service/app.py:927`). `validate_api_key` (`service/security.py:19-27`)
+  checks the configured `X-API-Key` header against `cfg.auth.keys` and raises
+  `401` on mismatch when auth is enabled. `request.state.api_key` is set on the
+  authenticated path (`service/app.py:928`). No JWT or tenant middleware is mounted
+  on the bundled app for this route (see the exposure-layer section below).
 - Rate limiting: `ServiceRateLimitConfig` (`alpha/core/config.py:29-41`) is
   enabled by default with a sliding window (default 60s window, 120 requests),
-  and `record_rate_limit` telemetry is available.
+  enforced by the same `rate_limiter` dependency, with `record_rate_limit`
+  telemetry.
 - Failure handling: errors route through `record_safe_out(request.url.path)` and
   SAFE-OUT responses (`service/app.py:894-895`, `922`, and provider error paths),
   so `/v1/solve` does not leak stack traces or raw provider errors to clients.
@@ -58,20 +62,60 @@ default key. CORS in front of the API also defaults to wildcard (RR-01).
 
 ## Auth / JWT / tenancy / audit / evidence at the exposure layer
 
-- JWT verification is RS256-only with a bounded leeway
-  (`service/auth/jwt_utils.py`), reducing algorithm-downgrade risk.
-- Tenancy middleware and limiter scope requests per tenant
-  (`service/middleware/tenant_middleware.py`, `service/tenancy/limiter.py`).
-- Audit entries are tamper-evident (`service/audit/hash_chain.py`).
-- The evidence API (`service/evidence/api.py`) is a separate router; callers must
-  avoid placing secret material in evidence payloads (operational note).
+It is important to distinguish controls **actually mounted on the bundled
+`/v1/solve` route** from security machinery that **exists elsewhere in the repo
+but is not confirmed wired onto this exposure path**. The bundled service app
+(`service/app.py`) mounts only `_RequestSpanMiddleware`, `_SimpleTracingMiddleware`,
+`CORSMiddleware`, and an `add_request_id` HTTP middleware (`service/app.py:149-166`,
+`:884`). It does **not** add `AuthMiddleware`, a JWT middleware, or a tenant
+middleware.
+
+### Controls actually mounted on `/v1/solve`
+
+- **Route dependency / rate limiter:** `Depends(rate_limiter)`
+  (`service/app.py:943`), enforcing the sliding-window rate limit.
+- **API-key auth path:** `validate_api_key(request, cfg)` invoked inside
+  `rate_limiter` (`service/app.py:927`; `service/security.py:19-27`) — header
+  `X-API-Key` checked against `cfg.auth.keys`, `401` on mismatch when auth is
+  enabled.
+- **Input sanitization:** `sanitize_query(req.query)` (`service/app.py:945`;
+  `service/security.py:30+`).
+- **SAFE-OUT / error handling:** the HTTP exception handler and `add_request_id`
+  wrapper degrade failures to SAFE-OUT responses via `record_safe_out(...)`
+  (`service/app.py:884-922`), so the route does not leak stack traces or raw
+  provider errors.
+
+### Controls that exist elsewhere but are NOT confirmed mounted on this route
+
+- **JWT middleware / RS256 verification** — `service/middleware/jwt_middleware.py`,
+  `service/middleware/auth_middleware.py`, `service/auth/jwt_utils.py` (RS256-only,
+  bounded leeway). Not added to the bundled app; not an active `/v1/solve`
+  protection here.
+- **Tenant middleware / per-tenant limiter** — `service/middleware/tenant_middleware.py`,
+  `service/tenancy/limiter.py`, `service/tenancy/context.py`. Not mounted on the
+  bundled app; per-tenant scoping is not enforced on this exposure path.
+- **Evidence API controls** — `service/evidence/api.py` is a separate router; it
+  is not part of the `/v1/solve` request path.
+- **Audit hash-chain machinery** — `service/audit/hash_chain.py` provides
+  tamper-evident audit integrity, but it is not invoked by the bundled
+  `/v1/solve` handler.
+
+**Finding (SOLVE-2):** The bundled `/v1/solve` route appears to rely on API-key
+auth plus rate limiting, **not** mounted JWT/tenant middleware. The JWT and
+tenant middleware exist in the repository but are not wired onto this exposure
+path in `service/app.py`. Before public/runtime exposure, the intended
+auth/tenancy model for `/v1/solve` must be explicitly confirmed or wired. Tracked
+in `risk-register.md` as RR-09. This packet does not expose `/v1/solve` and makes
+no readiness claim.
 
 ## Summary
 
-| Surface | Control | Residual |
-| --- | --- | --- |
-| Dashboard | Fail-closed mount, minimal routes, CSRF | Default password constant in source (RR-03) |
-| `/v1/solve` | API-key auth + rate limit + SAFE-OUT + input sanitize | Default `dev-secret` key (RR-03); wildcard CORS (RR-01) |
+| Surface | Mounted controls | Exists-but-not-mounted | Residual |
+| --- | --- | --- | --- |
+| Dashboard | Fail-closed mount, minimal routes, CSRF | — | Default password constant in source (RR-03) |
+| `/v1/solve` | API-key auth (`validate_api_key`) + rate limit + input sanitize + SAFE-OUT | JWT middleware, tenant middleware, evidence API, audit hash-chain | Default `dev-secret` key (RR-03); wildcard CORS (RR-01); unconfirmed auth/tenancy model (RR-09) |
 
-The exposure architecture is sound; the residuals are insecure defaults that a
-deployment must override, plus the CORS default.
+The mounted exposure controls are API-key auth and rate limiting with input
+sanitization and SAFE-OUT. The residuals are insecure defaults a deployment must
+override, the CORS default, and the unconfirmed/unmounted JWT-and-tenancy model
+for `/v1/solve`.

--- a/docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/data-flow-review.md
+++ b/docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/data-flow-review.md
@@ -1,0 +1,78 @@
+# Data-flow review
+
+Covers: request/data flow, local-vs-provider execution boundary, CORS at the
+data-flow level, and the data-classification registries.
+
+## Request entry and shape
+
+- The primary product API is `POST /v1/solve` (`service/app.py:943`). The handler
+  accepts a `SolveRequest` and immediately runs `query = sanitize_query(req.query)`
+  (`service/app.py:945`) before any further processing.
+- Optional `context` params and `strategy` flow through
+  (`service/app.py:946-948`). `request.state.strategy` is set for telemetry.
+
+## Local-vs-provider execution boundary
+
+- Alpha Solver is **offline-first**. `.env.example` documents
+  `MODEL_PROVIDER=local` as "the verified safe default for offline/local checks"
+  that "does not require provider API keys."
+- The provider branch in `/v1/solve` only runs when
+  `_is_openai_provider_enabled()` is true (`service/app.py:950`, helper at
+  `service/app.py:211`). When it is not
+  enabled, the request is served locally and the prompt is not forwarded to any
+  external provider.
+- The optional local-LLM runtime path is **default-off** and constrained to
+  loopback. `.env.example` documents it requires `localhost / loopback`, an exact
+  local model name, a finite timeout, and **no provider keys**, and states it "is
+  not exposed through `/v1/solve` or dashboard preview by this implementation."
+
+This is a strong default-safe posture: by default no prompt content leaves the
+host. See `provider-data-sharing-review.md` for the enabled-provider path.
+
+## CORS at the data-flow boundary
+
+- `ServiceCorsConfig.origins` defaults to `os.getenv("SERVICE_CORS_ORIGINS", "*")`
+  (`alpha/core/config.py:47-48`). The default is wildcard `*`.
+- `service/app.py:161-166` installs `CORSMiddleware` with
+  `allow_origins=cfg.cors.origins`, `allow_credentials=True`,
+  `allow_methods=["*"]`, and `allow_headers=["*"]`.
+- The config class docstring itself flags this: "CORS configuration (lock down in
+  production)." (`alpha/core/config.py:45`).
+
+**Finding (CORS-1):** A wildcard origin combined with `allow_credentials=True` is
+a permissive default. Browsers reject literal `*` when credentials are allowed,
+but the combination is a misconfiguration smell and, depending on how origins are
+later set, can broaden cross-origin credentialed access. Tracked in
+`risk-register.md` as RR-01.
+
+## Data classification registries
+
+Two registries exist and **disagree**:
+
+- `config/data_classification.yaml`:
+  ```
+  rules:
+    - match: "pii|secret|token"
+      action: "instructions_only"
+  ```
+- `registries/data_classification.yaml`:
+  ```
+  version: "0.1.0"
+  rules:
+    - { match: "phi", action: "mask" }
+    - { match: "pii", action: "deny" }
+  ```
+
+The two files define different match sets and different actions for overlapping
+categories (e.g. `pii` maps to `instructions_only` in one and `deny` in the
+other). There is no single authoritative classification policy.
+
+**Finding (CLASS-1):** Divergent / duplicated data-classification registries with
+no documented precedence. A reviewer cannot determine which policy is
+authoritative for runtime enforcement. Tracked in `risk-register.md` as RR-05.
+
+## Summary
+
+The default execution boundary is conservative and offline-first. The data-flow
+gaps are (a) the permissive CORS default and (b) the inconsistent
+data-classification registries.

--- a/docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/def-002-verdict.md
+++ b/docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/def-002-verdict.md
@@ -1,0 +1,67 @@
+# DEF-002 verdict
+
+## Verdict
+
+`DEF_002_REVIEW_CAPTURED_OPEN_GAPS`
+
+## Allowed verdicts considered
+
+- `DEF_002_REVIEW_CAPTURED_OPEN_GAPS` — **selected.**
+- `DEF_002_READY_FOR_OPERATOR_RISK_ACCEPTANCE` — not selected (gap-closure items
+  remain, not just acceptance).
+- `DEF_002_BLOCKED_BY_MISSING_EVIDENCE` — not selected (committed code evidence
+  exists for every required focus area).
+- `STOP_INCONCLUSIVE` — not selected (the review reached a conclusion).
+
+## Rationale
+
+1. **Evidence is present and reviewable.** Committed source exists for all 14
+   required focus areas — CORS, secrets-at-rest/`FileSecretsBackend`, credential
+   handling, provider data-sharing, logging/redaction, provider telemetry,
+   dashboard exposure, `/v1/solve` exposure, auth/JWT/API-keys/tenancy/audit/
+   evidence, data-classification registries, dependency/supply-chain, and the
+   local-vs-provider boundary. The review was therefore **not** blocked by
+   missing evidence.
+
+2. **Open gaps remain.** `risk-register.md` records seven gap-closure findings
+   (RR-01, RR-02, RR-03, RR-05, RR-06, RR-07, RR-08), including High-severity
+   plaintext secrets-at-rest (RR-02) and insecure default credentials (RR-03).
+   These require code/config remediation, not mere operator acceptance.
+
+3. **Acceptance is not yet appropriate.** Because gap-closure items are open,
+   the packet is not `READY_FOR_OPERATOR_RISK_ACCEPTANCE`. Residual-risk
+   candidates (RR-04, RR-A1) are recorded as proposals only.
+
+## Closure gating (DEF-002 is NOT closed)
+
+DEF-002 is **not** marked closed. Per the lane's closure rule, closure requires
+all required evidence present **and** the packet explicitly supporting closure.
+Here, required evidence is present but the packet documents open High/Medium gaps,
+so it explicitly does **not** support closure.
+
+To reach closure in a future lane, at minimum:
+
+- RR-02 plaintext secrets-at-rest remediated (encryption/keyring/at-rest
+  protection + restrictive file mode), or operator-accepted with compensating
+  controls;
+- RR-03 insecure default credentials removed/forced-override;
+- RR-01 CORS default tightened;
+- RR-05 data-classification registries reconciled to one authoritative policy;
+- RR-06/RR-07/RR-08 dependency/supply-chain tracking established (single source
+  of truth, lockfile/hash pinning, vendored-lib inventory);
+- residual risks (RR-04, RR-A1) formally accepted by an operator.
+
+## Validation status
+
+The three offline doc-hardening validators are run after authoring this packet
+and must be green:
+
+- `python scripts/check_local_llm_doc_paths.py`
+- `python scripts/check_local_llm_evidence_boundaries.py`
+- `python scripts/check_local_llm_packet_consistency.py`
+
+See `repo-state-verification.md` for scope notes.
+
+## Selected next lane
+
+`ALPHA-SOLVER-DEF-002-GAP-CLOSURE-PLAN-001` — see `selected-next-lane.md`.

--- a/docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/def-002-verdict.md
+++ b/docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/def-002-verdict.md
@@ -23,10 +23,12 @@
    local-vs-provider boundary. The review was therefore **not** blocked by
    missing evidence.
 
-2. **Open gaps remain.** `risk-register.md` records seven gap-closure findings
-   (RR-01, RR-02, RR-03, RR-05, RR-06, RR-07, RR-08), including High-severity
-   plaintext secrets-at-rest (RR-02) and insecure default credentials (RR-03).
-   These require code/config remediation, not mere operator acceptance.
+2. **Open gaps remain.** `risk-register.md` records eight gap-closure findings
+   (RR-01, RR-02, RR-03, RR-05, RR-06, RR-07, RR-08, RR-09), including
+   High-severity plaintext secrets-at-rest (RR-02) and insecure default
+   credentials (RR-03), and the unconfirmed/unmounted JWT-and-tenancy model for
+   `/v1/solve` (RR-09). These require code/config remediation, not mere operator
+   acceptance.
 
 3. **Acceptance is not yet appropriate.** Because gap-closure items are open,
    the packet is not `READY_FOR_OPERATOR_RISK_ACCEPTANCE`. Residual-risk
@@ -49,6 +51,8 @@ To reach closure in a future lane, at minimum:
 - RR-05 data-classification registries reconciled to one authoritative policy;
 - RR-06/RR-07/RR-08 dependency/supply-chain tracking established (single source
   of truth, lockfile/hash pinning, vendored-lib inventory);
+- RR-09 intended `/v1/solve` auth/tenancy model explicitly confirmed or wired
+  (JWT/tenant middleware mounted, or API-key-only model documented as intended);
 - residual risks (RR-04, RR-A1) formally accepted by an operator.
 
 ## Validation status

--- a/docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/dependency-supply-chain-review.md
+++ b/docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/dependency-supply-chain-review.md
@@ -1,0 +1,72 @@
+# Dependency and supply-chain review
+
+Covers: declared dependencies, pinning discipline, lockfile/hash posture, and
+vendored third-party code.
+
+## Declared dependencies
+
+- `requirements.txt` (runtime):
+  `pytest`, `jsonschema`, `pyyaml`, `prometheus-client>=0.20,<1`,
+  `fastapi>=0.111,<0.113`, `starlette<0.38`, `pydantic>=2.7,<3`,
+  `httpx>=0.27,<0.28`, `uvicorn[standard]>=0.30,<0.32`.
+- `requirements-dev.txt`: pulls `requirements.txt` plus `pytest>=8,<9`,
+  `pytest-cov`, `pre-commit`, `ruff`, and pinned
+  `opentelemetry-api==1.24.0` / `opentelemetry-sdk==1.24.0`.
+- `pyproject.toml` declares an overlapping but **not identical** dependency set
+  (`dependencies` at lines 17-26) with the same range style.
+
+**Finding (DEP-1):** Dependency declarations are duplicated across
+`requirements.txt` and `pyproject.toml` and are not guaranteed to stay in sync
+(`requirements.txt` lists `jsonschema`/`pyyaml`/`pytest` that the `pyproject`
+`dependencies` block does not). Drift risk. Tracked in `risk-register.md` as
+RR-06.
+
+## Pinning / lockfile / hash posture
+
+- Runtime dependencies use **version ranges**, not exact pins, and there is **no
+  lockfile** (no `requirements.lock`, `poetry.lock`, `pip-tools` compiled file,
+  or hash-pinned `--require-hashes` manifest) in the dependency manifests.
+- This means a fresh install can resolve to newer in-range releases than were
+  reviewed, and installs are not protected against compromised-but-in-range
+  package versions (no hash verification).
+
+**Finding (DEP-2):** No lockfile and no hash pinning for runtime dependencies.
+This is the primary supply-chain surface. Tracked as RR-07.
+
+## Vendored third-party code
+
+The repository contains directories that appear to **vendor / shim** third-party
+libraries at the repo root, e.g. `slowapi/`, `prometheus_client/`,
+`prometheus_fastapi_instrumentator/`, `jsonschema/`, and a `jsonlines_compat.py`
+shim. Vendored copies:
+
+- decouple the code from upstream security patching (no dependency resolver will
+  bump them), and
+- are not covered by dependency-scanning of declared requirements.
+
+**Finding (DEP-3):** Vendored/shimmed third-party modules are present in-tree.
+Their provenance, version, and patch status are not tracked by the dependency
+manifests, creating an unscanned supply-chain surface. Tracked as RR-08.
+
+> Note: this review did not deeply audit the contents of each vendored module
+> (out of scope for a posture review) — it records the *surface* and the tracking
+> gap. A follow-up inventory belongs in the gap-closure lane.
+
+## Build / packaging
+
+- Build backend is `setuptools` (`pyproject.toml:2-3`), `requires-python >= 3.12`.
+- No automated dependency-audit (e.g. `pip-audit`) or SBOM generation was
+  identified in scope; CI was **not** inspected for modification and is **not**
+  changed by this lane.
+
+## Summary
+
+| ID | Gap | Severity |
+| --- | --- | --- |
+| RR-06 | Duplicated, potentially drifting dependency declarations | Low |
+| RR-07 | No lockfile / no hash pinning (range-only) | Medium |
+| RR-08 | In-tree vendored libs with untracked provenance/patch status | Medium |
+
+The supply-chain posture is the weakest-tracked area: ranges without a lockfile
+plus vendored copies. None requires a code change in *this* docs-only lane; all
+feed the gap-closure plan.

--- a/docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/forbidden-claims.md
+++ b/docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/forbidden-claims.md
@@ -1,0 +1,29 @@
+# Forbidden claims
+
+This packet is a captured security/privacy **review with open gaps**. It must not
+be used to assert any of the following unless a separate committed evidence source
+directly supports the claim:
+
+- DEF-002 resolved / DEF-002 closed
+- security/privacy review complete / security/privacy completion
+- all risks remediated
+- residual risks accepted (this packet only *proposes* candidates)
+- CORS hardened / secrets-at-rest encrypted / default credentials removed
+- provider validation / hosted validation / OpenAI validation
+- local model validation
+- runtime readiness
+- public MVP readiness
+- production readiness
+- benchmark validation / benchmark superiority
+- broad-user readiness
+- autonomous readiness
+- `/v1/solve` readiness / `/v1/solve` exposed
+- dashboard readiness / dashboard exposed
+- supply-chain validated / dependencies pinned
+
+## What this packet *does* support claiming
+
+- A structured, evidence-cited DEF-002 security/privacy review was captured.
+- Specific open gaps were identified and registered (`risk-register.md`).
+- The verdict is `DEF_002_REVIEW_CAPTURED_OPEN_GAPS` and the next lane is gap
+  closure.

--- a/docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/logging-redaction-review.md
+++ b/docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/logging-redaction-review.md
@@ -1,0 +1,82 @@
+# Logging and redaction review
+
+Covers: structured logging, deterministic redaction, and provider telemetry
+prompt-content risk.
+
+## Structured request logging
+
+- The service uses a JSON formatter (`JsonFormatter`, `service/app.py:76-89`) and
+  configures `logging.basicConfig(level=logging.INFO, ...)`, routing
+  `uvicorn.access` through the same handler.
+- The per-request log record (`service/app.py:901-909`) emits **request metadata
+  only** — `request_id`, `path`, `client` host, `duration_ms`, and `strategy`. It
+  does **not** log the raw `query`/prompt or provider payloads.
+- On error, `logger.exception("request error", extra={"request_id": req_id})`
+  (`service/app.py:894`) records the request id without echoing user content,
+  and the response path calls `record_safe_out(...)` so failures degrade to a
+  SAFE-OUT rather than leaking internals.
+
+**Observation:** Default request logging is metric-oriented and does not persist
+prompt content. No raw-prompt logging gap was found on the request path.
+
+## Deterministic redaction (Self Operator artifacts)
+
+`alpha/self_operator/redaction.py` provides deterministic, **local** redaction:
+
+- `SECRET_KEYWORDS` covers `api_key`, `apikey`, `token`, `secret`, `password`,
+  `credential(s)` (line 9).
+- `_SECRET_ASSIGNMENT_RE` redacts `key = value` style secret assignments; a
+  `_BEARER_RE` redacts `Bearer <token>` (8+ chars); `_PLACEHOLDER_SECRET_RE`
+  collapses `fake/placeholder/example` secret markers.
+- `redact_value` recursively redacts mappings/lists/tuples, replacing values for
+  secret-named keys with `REDACTION_TEXT = "[REDACTED_SELF_OPERATOR_SECRET]"`
+  and redacting string values in place. `contains_secret_marker` lets callers
+  detect secret-like content before emission.
+
+**Observation:** Redaction is deterministic and offline (regex-based, no network,
+no model). It is keyword/pattern driven, so novel secret formats not matching the
+keyword/regex set could pass through — a known limitation of pattern redaction
+(noted in `accepted-residual-risks.md`, RR-A1).
+
+## Provider telemetry prompt-content risk
+
+`alpha/providers/telemetry.py` is **allowlist-based** by construction:
+
+- `_ALLOWED_FIELDS` (lines 23-44) is an explicit set of safe metadata:
+  `event`, `provider`, `model`, `model_set`, `route`, `request_id`, `status`,
+  `tenant`, `retry_count`, `latency_ms`, token counts, `estimated_cost_usd`,
+  `cost_source`, `finish_reason`, `error_category`, `retryable`, `status_code`,
+  `safe_message`, `provider_request_id`. **No prompt/response content field
+  exists.**
+- `build_provider_event` constructs an event from explicit safe keyword args
+  only and drops `None` values; `emit_provider_event` re-filters through
+  `_ALLOWED_FIELDS` before logging/sinking. The module docstring states it
+  "never inspects provider request/response payloads, exception objects,
+  dataclass `__dict__` values, or raw provider metadata."
+
+**Observation:** Provider telemetry cannot carry prompt or completion content
+because no content field is in the allowlist and the emitter re-filters. This is
+a strong control against telemetry prompt-content leakage.
+
+## Provider SAFE-OUT (failure path)
+
+`alpha/providers/safeout.py` is similarly allowlist-built. The SAFE-OUT body is
+constructed from **safe `ProviderError` fields only** — `provider`, `category`,
+`retryable`, `request_id`, `retry_count`, `status_code`, and `safe_message`
+(`build_provider_safe_out_body`, lines 37-52). Its docstring states it "never
+inspects raw provider payloads, raw metadata, environment/config dumps, or
+exception objects beyond the normalized `ProviderError` safe fields."
+
+**Observation:** The provider failure path does not leak raw provider error
+bodies, stack traces, or environment/config dumps to the client.
+
+## Summary
+
+Logging and redaction controls are a relative strength of the codebase:
+
+- request logs carry metrics, not prompt content;
+- provider telemetry and SAFE-OUT are allowlist-built and content-free;
+- Self Operator artifacts get deterministic offline secret redaction.
+
+The only residual is the inherent limitation of pattern-based redaction (RR-A1),
+proposed for residual-risk acceptance rather than gap closure.

--- a/docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/non-actions.md
+++ b/docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/non-actions.md
@@ -1,0 +1,27 @@
+# Non-actions (hard boundaries respected)
+
+This lane is docs-only. The following were explicitly **not** done:
+
+- Did **not** call providers or any external LLM.
+- Did **not** use tokens or trigger any billed/free provider usage.
+- Did **not** access, read, or decrypt secrets; did not open or read
+  `~/.alpha_solver/dashboard_api_keys.json` or any secrets file.
+- Did **not** print, echo, or dump environment variables.
+- Did **not** deploy or start the service.
+- Did **not** expose, mount, or exercise `/v1/solve`.
+- Did **not** mount or exercise the dashboard.
+- Did **not** modify runtime, product, provider, or model code.
+- Did **not** modify tests or CI configuration.
+- Did **not** modify the data-classification registries or any config under
+  review.
+- Did **not** remediate any finding (remediation belongs to the gap-closure lane).
+- Did **not** run benchmarks, evals, or browser automation.
+
+## What was done
+
+- Read committed source files read-only.
+- Authored this documentation packet under
+  `docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/`.
+- Ran the three offline doc-hardening validators to confirm they remain green
+  (`check_local_llm_doc_paths.py`, `check_local_llm_evidence_boundaries.py`,
+  `check_local_llm_packet_consistency.py`).

--- a/docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/provider-data-sharing-review.md
+++ b/docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/provider-data-sharing-review.md
@@ -1,0 +1,61 @@
+# Provider / API data-sharing boundary review
+
+Covers: what user data crosses the provider boundary, under what gating, and what
+telemetry the provider integration emits.
+
+## When data crosses the provider boundary
+
+- By default, **no** prompt content is shared externally. The default provider is
+  `local` (`.env.example`), and the provider branch in `/v1/solve` runs only when
+  `_is_openai_provider_enabled()` is true (`service/app.py:950`).
+- When the OpenAI provider is explicitly enabled, the user `query` is forwarded
+  as the provider prompt. The handler builds a provider request with
+  `prompt=query` (`service/app.py:266`) and, for the expert route, sends derived
+  prompts (`_expert_step_one_prompt(query)` at `service/app.py:987`,
+  `_expert_step_two_prompt(query, preview)` at `service/app.py:1002`).
+
+**Data-sharing fact:** With the provider enabled, the user's query/prompt text is
+transmitted to the external provider. This is intrinsic to provider-backed
+inference and is the central data-sharing boundary for DEF-002. It is gated
+behind explicit operator opt-in, not on by default.
+
+## What the integration emits about provider calls
+
+- Provider lifecycle telemetry is **content-free** by construction (see
+  `logging-redaction-review.md`): `alpha/providers/telemetry.py` `_ALLOWED_FIELDS`
+  contains no prompt/response field, and `emit_provider_event` re-filters through
+  the allowlist before logging.
+- Provider failures degrade through `alpha/providers/safeout.py`, which builds the
+  client-facing body from safe `ProviderError` fields only and never echoes raw
+  provider payloads, metadata, or environment/config dumps.
+
+## Accounting / cost
+
+- `alpha/providers/accounting.py` participates in cost/usage accounting; the app
+  exposes a `provider_accounting_sink` on app state (`service/app.py`, around the
+  startup block). Cost fields surfaced via telemetry are numeric metadata
+  (`estimated_cost_usd`, token counts), not content.
+
+## Boundary assessment
+
+| Aspect | Disposition |
+| --- | --- |
+| Default behavior | Offline; no external data sharing (strong) |
+| Provider-enabled prompt transmission | Inherent; gated behind explicit opt-in |
+| Telemetry content leakage | Prevented by allowlist (strong) |
+| Failure-path payload leakage | Prevented by SAFE-OUT allowlist (strong) |
+
+**Finding (PROV-1):** When a provider is enabled, prompt content leaves the host
+to a third-party provider. This is expected for provider-backed inference but
+must be governed by an explicit data-processing/disclosure note to operators and
+end users (e.g., which provider, what is sent, retention). No such committed
+end-user-facing data-sharing disclosure was identified in scope. Tracked in
+`risk-register.md` as RR-04 and considered for operator acceptance in
+`accepted-residual-risks.md`.
+
+## Summary
+
+The provider boundary is conservative by default and the surrounding telemetry /
+failure paths are content-free. The open item is a governance/disclosure gap
+around the inherent prompt transmission when a provider is enabled, not a code
+leakage defect.

--- a/docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/repo-state-verification.md
+++ b/docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/repo-state-verification.md
@@ -1,0 +1,57 @@
+# Repo-state verification
+
+## Branch and revision
+
+- Working branch: `claude/def-002-security-privacy-review-wt6fja`.
+- Review baseline commit (HEAD at review time): `f5711182a592c0a76bc556f8ec68e77228024112`
+  (`docs(openai): add project billing boundary attestation retry packet (#512)`).
+- Working tree was clean before this packet was authored.
+
+## Read-only verification context
+
+This lane is a documentation review. All findings below are derived from reading
+committed source files. No runtime was started, no provider was contacted, no
+secret or environment variable was read or printed, and no route was exercised.
+
+## Validators (offline, documentation hardening)
+
+The three offline doc-hardening validators were confirmed green at the review
+baseline before authoring this packet, and are re-run after authoring:
+
+- `python scripts/check_local_llm_doc_paths.py`
+- `python scripts/check_local_llm_evidence_boundaries.py`
+- `python scripts/check_local_llm_packet_consistency.py`
+
+These validators are marker-scoped (they scan local-LLM / `alpha-solver-post-*`
+/ OpenAI packet directories and the operator guide). This packet's directory
+name is outside those scan markers, so the packet is not itself scanned; the
+validators must nonetheless remain green, which is verified in
+`def-002-verdict.md`.
+
+## Primary evidence files inspected (read-only)
+
+| Area | File(s) |
+| --- | --- |
+| CORS / auth / rate-limit config | `alpha/core/config.py` |
+| Service app, middleware, `/v1/solve` | `service/app.py` |
+| Secrets backend / dashboard settings | `alpha/webapp/routes/settings.py` |
+| Dashboard auth / fail-closed mount | `alpha/webapp/routes/auth.py`, `service/app.py` |
+| JWT verification | `service/auth/jwt_utils.py`, `service/middleware/jwt_middleware.py` |
+| API-key / auth middleware | `service/middleware/auth_middleware.py`, `service/auth/api_keys.py` |
+| Tenancy | `service/tenancy/context.py`, `service/tenancy/limiter.py`, `service/middleware/tenant_middleware.py` |
+| Audit | `service/audit/audit_log.py`, `service/audit/hash_chain.py`, `service/audit/exporter.py` |
+| Evidence API | `service/evidence/api.py`, `service/evidence/store.py`, `service/evidence/collector.py` |
+| Redaction | `alpha/self_operator/redaction.py` |
+| Provider telemetry / SAFE-OUT | `alpha/providers/telemetry.py`, `alpha/providers/safeout.py` |
+| Data classification | `config/data_classification.yaml`, `registries/data_classification.yaml` |
+| Dependency surface | `requirements.txt`, `requirements-dev.txt`, `pyproject.toml`, `.env.example` |
+
+## Prior DEF-002 context
+
+The prior packet
+`docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-def-002-def-003-evidence-boundary-001/def-002-security-privacy-boundary.md`
+recorded that DEF-002 remained **open** and enumerated the minimum future
+evidence required (scope, data-flow, credential handling, logging/redaction,
+provider data-sharing, dashboard and `/v1/solve` exposure, operator approval
+boundary, threat model / risk register, accepted residual risks, forbidden
+claims). This lane performs that review against committed evidence.

--- a/docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/risk-register.md
+++ b/docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/risk-register.md
@@ -1,0 +1,42 @@
+# Risk register (open gaps)
+
+Severity scale: High / Medium / Low. Disposition: **Gap-closure** (requires a code
+or config change, owned by the gap-closure lane) or **Residual** (candidate for
+operator risk acceptance, see `accepted-residual-risks.md`).
+
+All findings are derived from committed source read read-only. This packet records
+them; it does not remediate them (docs-only).
+
+| ID | Area | Finding | Evidence | Severity | Disposition |
+| --- | --- | --- | --- | --- | --- |
+| RR-01 | CORS | Default origin `*` combined with `allow_credentials=True`, wildcard methods/headers. Permissive default ("lock down in production"). | `alpha/core/config.py:45-48`; `service/app.py:161-166` | Medium | Gap-closure |
+| RR-02 | Secrets-at-rest | `FileSecretsBackend` persists provider API keys as plaintext JSON; no at-rest encryption; no explicit restrictive file mode. | `alpha/webapp/routes/settings.py:62-95`, `:170` | High | Gap-closure |
+| RR-03 | Default credentials | Default API key `dev-secret`; default dashboard password `alpha-dashboard` present in source. | `alpha/core/config.py:22-26`; `alpha/webapp/routes/auth.py:42` | High | Gap-closure |
+| RR-04 | Provider data-sharing | With a provider enabled, user prompt text is transmitted to a third party; no committed end-user data-sharing/retention disclosure identified in scope. | `service/app.py:266`, `:987`, `:1002` | Medium | Residual (operator) |
+| RR-05 | Data classification | Two divergent `data_classification.yaml` registries with conflicting rules; no documented precedence/authoritative policy. | `config/data_classification.yaml`; `registries/data_classification.yaml` | Medium | Gap-closure |
+| RR-06 | Dependencies | Dependency declarations duplicated and potentially drifting between `requirements.txt` and `pyproject.toml`. | `requirements.txt`; `pyproject.toml:17-26` | Low | Gap-closure |
+| RR-07 | Supply chain | No lockfile and no hash pinning; range-only runtime dependencies. | `requirements.txt`; `pyproject.toml` | Medium | Gap-closure |
+| RR-08 | Supply chain | In-tree vendored/shimmed third-party libs with untracked provenance/patch status. | repo root: `slowapi/`, `prometheus_client/`, `prometheus_fastapi_instrumentator/`, `jsonschema/`, `jsonlines_compat.py` | Medium | Gap-closure |
+
+## Strong controls observed (not gaps — recorded for balance)
+
+| Control | Evidence |
+| --- | --- |
+| Offline-first default; provider gated behind opt-in | `.env.example`; `service/app.py:950` |
+| Local-LLM path default-off, loopback-only, not exposed via `/v1/solve`/dashboard | `.env.example` |
+| Provider telemetry is allowlist-built, content-free | `alpha/providers/telemetry.py:23-44`, `:104-115` |
+| Provider SAFE-OUT built from safe fields only | `alpha/providers/safeout.py:37-52` |
+| Request logging carries metrics, not prompt content | `service/app.py:901-909` |
+| Deterministic offline secret redaction for Self Operator artifacts | `alpha/self_operator/redaction.py` |
+| Dashboard fail-closed mount (non-default password + secret key required) | `service/app.py:183-207` |
+| RS256-only JWT with bounded leeway | `service/auth/jwt_utils.py:13`, `:14` |
+| Tamper-evident audit hash chain | `service/audit/hash_chain.py` |
+| Masked secret display + masked audit entries | `alpha/webapp/routes/settings.py:115-150` |
+
+## Disposition summary
+
+- **Gap-closure required:** RR-01, RR-02, RR-03, RR-05, RR-06, RR-07, RR-08.
+- **Operator residual-risk candidates:** RR-04 (and the inherent redaction-coverage
+  limitation RR-A1 in `accepted-residual-risks.md`).
+
+Because gap-closure items remain open, DEF-002 is **not** closed by this packet.

--- a/docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/risk-register.md
+++ b/docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/risk-register.md
@@ -17,6 +17,7 @@ them; it does not remediate them (docs-only).
 | RR-06 | Dependencies | Dependency declarations duplicated and potentially drifting between `requirements.txt` and `pyproject.toml`. | `requirements.txt`; `pyproject.toml:17-26` | Low | Gap-closure |
 | RR-07 | Supply chain | No lockfile and no hash pinning; range-only runtime dependencies. | `requirements.txt`; `pyproject.toml` | Medium | Gap-closure |
 | RR-08 | Supply chain | In-tree vendored/shimmed third-party libs with untracked provenance/patch status. | repo root: `slowapi/`, `prometheus_client/`, `prometheus_fastapi_instrumentator/`, `jsonschema/`, `jsonlines_compat.py` | Medium | Gap-closure |
+| RR-09 | `/v1/solve` exposure auth model | Bundled `/v1/solve` relies on API-key auth + rate limiting; JWT and tenant middleware exist in-repo but are not mounted on the bundled app. Intended auth/tenancy model for `/v1/solve` must be explicitly confirmed or wired before public/runtime exposure. | `service/app.py:149-166`, `:884`, `:927`, `:943`; `service/security.py:19-27`; unmounted: `service/middleware/jwt_middleware.py`, `service/middleware/auth_middleware.py`, `service/middleware/tenant_middleware.py` | Medium | Gap-closure |
 
 ## Strong controls observed (not gaps — recorded for balance)
 
@@ -35,7 +36,7 @@ them; it does not remediate them (docs-only).
 
 ## Disposition summary
 
-- **Gap-closure required:** RR-01, RR-02, RR-03, RR-05, RR-06, RR-07, RR-08.
+- **Gap-closure required:** RR-01, RR-02, RR-03, RR-05, RR-06, RR-07, RR-08, RR-09.
 - **Operator residual-risk candidates:** RR-04 (and the inherent redaction-coverage
   limitation RR-A1 in `accepted-residual-risks.md`).
 

--- a/docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/security-privacy-scope.md
+++ b/docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/security-privacy-scope.md
@@ -1,0 +1,60 @@
+# Security/privacy review scope
+
+## Objective
+
+Assess Alpha Solver's product-level security and privacy posture using committed
+repository evidence, and produce a formal DEF-002 review packet. This lane may
+inspect code and docs read-only and must not modify runtime/provider behavior.
+
+## In scope (14 required focus areas)
+
+1. **CORS defaults** — `data-flow-review.md`, `dashboard-v1-solve-exposure-review.md`.
+2. **Secrets-at-rest and FileSecretsBackend** — `credential-handling-review.md`.
+3. **Credential handling** — `credential-handling-review.md`.
+4. **Provider / API data-sharing boundaries** — `provider-data-sharing-review.md`.
+5. **Logging and redaction** — `logging-redaction-review.md`.
+6. **Provider telemetry prompt-content risk** — `logging-redaction-review.md`,
+   `provider-data-sharing-review.md`.
+7. **Dashboard exposure** — `dashboard-v1-solve-exposure-review.md`.
+8. **`/v1/solve` exposure** — `dashboard-v1-solve-exposure-review.md`.
+9. **Auth, JWT, API keys, tenancy, audit, evidence APIs** —
+   `credential-handling-review.md`, `dashboard-v1-solve-exposure-review.md`.
+10. **`data_classification.yaml` and related registries** — `data-flow-review.md`.
+11. **Dependency / supply-chain surface** — `dependency-supply-chain-review.md`.
+12. **Local vs provider execution boundaries** — `data-flow-review.md`,
+    `provider-data-sharing-review.md`.
+13. **Residual risks** — `risk-register.md`, `accepted-residual-risks.md`.
+14. **Claim boundaries** — `forbidden-claims.md`, `def-002-verdict.md`.
+
+## Out of scope (hard boundaries)
+
+This lane does not, and this packet does not authorize anyone to:
+
+- call providers or use tokens;
+- access or read secrets;
+- print or dump environment variables;
+- deploy;
+- expose `/v1/solve`;
+- modify runtime / product / provider / model code;
+- modify tests or CI.
+
+## Method
+
+For each focus area the reviewer:
+
+1. located the authoritative committed source file(s);
+2. read the relevant implementation read-only;
+3. recorded observed controls and observed gaps with `file:line` citations;
+4. assigned each gap a severity and a disposition (gap-closure vs. proposed
+   residual-risk acceptance) in `risk-register.md`.
+
+## Posture summary
+
+Alpha Solver is **offline-first**. The default model provider is `local`
+(`.env.example`), and remote/provider execution is gated behind explicit
+environment opt-in. Several defensive controls are well-built (allowlist-based
+provider telemetry and SAFE-OUT, deterministic secret redaction for Self
+Operator artifacts, fail-closed dashboard mounting, tamper-evident audit hash
+chain). The open gaps concentrate in insecure defaults (CORS, dev auth key,
+dashboard password), plaintext secrets-at-rest, registry inconsistency, and the
+dependency/supply-chain surface.

--- a/docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/selected-next-lane.md
+++ b/docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/selected-next-lane.md
@@ -1,0 +1,29 @@
+# Selected next lane
+
+Selected next lane: `ALPHA-SOLVER-DEF-002-GAP-CLOSURE-PLAN-001`
+
+## Why this lane
+
+The verdict is `DEF_002_REVIEW_CAPTURED_OPEN_GAPS` (see `def-002-verdict.md`).
+Open gap-closure findings remain in `risk-register.md` (RR-01, RR-02, RR-03,
+RR-05, RR-06, RR-07, RR-08). Per the lane selection rule:
+
+- **If open gaps remain → `ALPHA-SOLVER-DEF-002-GAP-CLOSURE-PLAN-001`.** ← selected
+- If only operator acceptance remains → `ALPHA-SOLVER-DEF-002-OPERATOR-RISK-ACCEPTANCE-001`.
+- If complete → `ALPHA-SOLVER-DEF-002-CLOSEOUT-001`.
+
+Because remediation work (not merely acceptance) is required, the gap-closure
+plan lane is selected.
+
+## Handoff to the gap-closure lane
+
+Inputs the gap-closure lane should consume from this packet:
+
+- `risk-register.md` — the prioritized open gaps with evidence and severity.
+- `accepted-residual-risks.md` — items to route to operator acceptance rather
+  than code change.
+- `def-002-verdict.md` — the closure-gating preconditions.
+
+Suggested gap-closure ordering (High first): RR-02 (plaintext secrets-at-rest),
+RR-03 (default credentials), then RR-01 (CORS), RR-05 (classification
+registries), RR-07/RR-08 (supply-chain), RR-06 (dependency-declaration drift).

--- a/docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/selected-next-lane.md
+++ b/docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/selected-next-lane.md
@@ -25,5 +25,6 @@ Inputs the gap-closure lane should consume from this packet:
 - `def-002-verdict.md` — the closure-gating preconditions.
 
 Suggested gap-closure ordering (High first): RR-02 (plaintext secrets-at-rest),
-RR-03 (default credentials), then RR-01 (CORS), RR-05 (classification
-registries), RR-07/RR-08 (supply-chain), RR-06 (dependency-declaration drift).
+RR-03 (default credentials), then RR-01 (CORS), RR-09 (confirm/wire the
+`/v1/solve` auth/tenancy model), RR-05 (classification registries), RR-07/RR-08
+(supply-chain), RR-06 (dependency-declaration drift).


### PR DESCRIPTION
## Summary

Docs-only DEF-002 security/privacy review lane (`ALPHA-SOLVER-DEF-002-SECURITY-PRIVACY-REVIEW-PACKET-001`) assessing Alpha Solver's product-level security and privacy posture from **committed repository evidence**.

- **Verdict:** `DEF_002_REVIEW_CAPTURED_OPEN_GAPS` — DEF-002 is **not** marked closed.
- **Selected next lane:** `ALPHA-SOLVER-DEF-002-GAP-CLOSURE-PLAN-001` (open gaps remain).

Adds 15 files under `docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/` covering all 14 required focus areas with `file:line`-cited evidence.

## Key findings (open gaps — see `risk-register.md`)

| ID | Finding | Severity |
| --- | --- | --- |
| RR-02 | `FileSecretsBackend` persists provider keys as plaintext JSON, no at-rest encryption / explicit file mode (`alpha/webapp/routes/settings.py:62-95`) | High |
| RR-03 | Insecure default credentials: API key `dev-secret` (`alpha/core/config.py:22-26`), dashboard password `alpha-dashboard` (`alpha/webapp/routes/auth.py:42`) | High |
| RR-01 | CORS default origin `*` with `allow_credentials=True` (`service/app.py:161-166`) | Medium |
| RR-05 | Divergent `data_classification.yaml` registries with conflicting rules | Medium |
| RR-07/08 | No lockfile/hash pinning; in-tree vendored libs with untracked provenance | Medium |
| RR-04 | Inherent prompt transmission when a provider is enabled (proposed residual) | Medium |

## Strong controls recorded
Offline-first default (provider gated behind opt-in), allowlist-built content-free provider telemetry/SAFE-OUT, deterministic offline secret redaction, fail-closed dashboard mount, RS256-only JWT, tamper-evident audit hash chain, masked secret display/audit.

## Boundaries
Read-only review. No provider calls, no tokens, no secret access, no env dumps, no deploy, no `/v1/solve` exposure, no runtime/test/CI changes. All three offline doc-hardening validators (`check_local_llm_doc_paths`, `check_local_llm_evidence_boundaries`, `check_local_llm_packet_consistency`) remain green.

https://claude.ai/code/session_01G6Ur3ezWje4H4DRYhRoE5W

---
_Generated by [Claude Code](https://claude.ai/code/session_01G6Ur3ezWje4H4DRYhRoE5W)_