### PR TITLE
test: make git commit tests hermetic under commit signing

### DIFF
--- a/tests/helpers/git_repo.py
+++ b/tests/helpers/git_repo.py
@@ -1,0 +1,22 @@
+"""Helpers for tests that create throwaway Git repositories."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def init_unsigned_git_repo(repo: Path, *, user_email: str, user_name: str) -> None:
+    """Initialize a temporary Git repo that is isolated from signing config.
+
+    Some developer and CI environments enforce commit or tag signing globally.
+    Tests that create disposable repositories only need commits as fixtures, so
+    disable signing in the local repository config after ``git init`` instead of
+    relying on or mutating global Git configuration.
+    """
+
+    subprocess.run(["git", "init"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", user_email], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", user_name], cwd=repo, check=True)
+    subprocess.run(["git", "config", "commit.gpgsign", "false"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "tag.gpgsign", "false"], cwd=repo, check=True)

--- a/tests/test_git_repo_helpers.py
+++ b/tests/test_git_repo_helpers.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import subprocess
+
+from tests.helpers.git_repo import init_unsigned_git_repo
+
+
+def test_init_unsigned_git_repo_overrides_global_signing(tmp_path, monkeypatch):
+    global_config = tmp_path / "global-gitconfig"
+    global_config.write_text(
+        "[commit]\n"
+        "\tgpgsign = true\n"
+        "[tag]\n"
+        "\tgpgsign = true\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(global_config))
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    init_unsigned_git_repo(repo, user_email="ci@example.com", user_name="CI")
+
+    assert _git_config(repo, "--get", "commit.gpgsign") == "false"
+    assert _git_config(repo, "--get", "tag.gpgsign") == "false"
+
+    (repo / "README.md").write_text("fixture\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-m", "fixture"], cwd=repo, check=True)
+    subprocess.run(["git", "tag", "-a", "v0.0.1", "-m", "fixture"], cwd=repo, check=True)
+
+
+def _git_config(repo, *args: str) -> str:
+    return subprocess.run(
+        ["git", "config", *args],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=True,
+    ).stdout.strip()

--- a/tests/test_smoke_quickstart.py
+++ b/tests/test_smoke_quickstart.py
@@ -12,6 +12,7 @@ from fastapi.testclient import TestClient
 from alpha.executors.math_exec import evaluate
 from cli.alpha_solver_cli import ObsResult, solve
 from service.app import app
+from tests.helpers.git_repo import init_unsigned_git_repo
 
 SMOKE_DECK_PATH = Path("data/scenarios/decks/smoke.jsonl")
 SMOKE_RECORDS = [
@@ -139,9 +140,7 @@ def test_smoke_deck_pass_rate_and_obs_card():
 def test_release_script(tmp_path: Path):
     repo = tmp_path / "repo"
     repo.mkdir()
-    subprocess.run(["git", "init"], cwd=repo, check=True)
-    subprocess.run(["git", "config", "user.email", "ci@example.com"], cwd=repo, check=True)
-    subprocess.run(["git", "config", "user.name", "CI"], cwd=repo, check=True)
+    init_unsigned_git_repo(repo, user_email="ci@example.com", user_name="CI")
 
     docs_dir = repo / "docs"
     scripts_dir = repo / "scripts"

--- a/tests/test_tag_release.py
+++ b/tests/test_tag_release.py
@@ -2,6 +2,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from tests.helpers.git_repo import init_unsigned_git_repo
+
 
 def test_tag_release(tmp_path):
     repo = tmp_path
@@ -9,9 +11,7 @@ def test_tag_release(tmp_path):
     pkg.mkdir()
     init = pkg / "__init__.py"
     init.write_text('__version__ = "0.0.1"\n')
-    subprocess.run(["git", "init"], cwd=repo, check=True)
-    subprocess.run(["git", "config", "user.email", "a@b.com"], cwd=repo, check=True)
-    subprocess.run(["git", "config", "user.name", "a"], cwd=repo, check=True)
+    init_unsigned_git_repo(repo, user_email="a@b.com", user_name="a")
     subprocess.run(["git", "add", "alpha/__init__.py"], cwd=repo, check=True)
     subprocess.run(["git", "commit", "-m", "init"], cwd=repo, check=True)
     script = Path(__file__).resolve().parent.parent / "scripts" / "tag_release.py"


### PR DESCRIPTION
### Motivation
- Some tests create throwaway Git repositories and fail in environments where global `commit.gpgsign=true` causes commits/tags to attempt signing with no available key, breaking hermetic test runs.

### Description
- Add `tests/helpers/git_repo.py` with `init_unsigned_git_repo()` which runs `git init`, sets `user.email`/`user.name`, and disables `commit.gpgsign` and `tag.gpgsign` in the repository local config.
- Add `tests/test_git_repo_helpers.py` which forces a global `gpgsign = true` via `GIT_CONFIG_GLOBAL` and verifies that the helper overrides signing so commits and annotated tags succeed.
- Update `tests/test_tag_release.py` and `tests/test_smoke_quickstart.py` to use the new helper for their temporary repos so fixture commits/tags remain hermetic.
- No production scripts or runtime behavior were modified.

### Testing
- Reproduced the failure and validated the fix with `GIT_CONFIG_GLOBAL` set by running `python -m pytest -q tests/test_git_repo_helpers.py tests/test_tag_release.py::test_tag_release tests/test_smoke_quickstart.py::test_release_script`, which passed.
- Ran the same targeted tests without `GIT_CONFIG_GLOBAL` and they passed as expected.
- Ran `python -m ruff check` on the modified files and the linter checks passed.
- Ran a full `python -m pytest -q` which failed due to unrelated live-provider behavior causing external calls, not the git-signing changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dc8aa047883299761c098ba5e2e28)