### PR TITLE
docs(specs): add spec contamination reconciliation

### DIFF
--- a/.specs/AS-145.md
+++ b/.specs/AS-145.md
@@ -1,5 +1,17 @@
 # CODE SPEC — AS-145 · Tool Adapters: Playwright + GSheets (MVP hardening) (RES_05)
 
+> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
+> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
+> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
+> titled feature or its own `## Code Targets`. The intended spec body for this feature is
+> therefore **missing**. The contaminated body is preserved **unchanged** below for
+> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
+>
+> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
+> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
+> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
+> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+
 ## Goal
 Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
 

--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -2,85 +2,88 @@
 
 Simple registry of the Markdown specs stored in `.specs/`. File names are canonical; titles mirror the first header inside each spec (or a filename-derived label when absent).
 
-| File | Title |
-| --- | --- |
-| `ALPHA-ANSWER-STRUCTURE-V2-001.md` | ALPHA-ANSWER-STRUCTURE-V2-001 |
-| `ALPHA-BREVITY-CONTROL-001.md` | ALPHA-BREVITY-CONTROL-001 |
-| `ALPHA-CLARIFY-THRESHOLD-001.md` | ALPHA-CLARIFY-THRESHOLD-001 · Answer Execution Prompts with Assumptions When Sufficient |
-| `ALPHA-FORMAT-PRESERVATION-001.md` | ALPHA-FORMAT-PRESERVATION-001 · Expert Answer Format Preservation |
-| `ALPHA-LIVE-EXPERT-STEP1-PARSE-001.md` | ALPHA-LIVE-EXPERT-STEP1-PARSE-001 · Recover Actionable Execution Prompts When Step 1 Metadata Is Missing |
-| `ALPHA-PRIMARY-ANSWER-EMPTY-001.md` | ALPHA-PRIMARY-ANSWER-EMPTY-001 · Ensure Answer-with-Assumptions Returns a Primary Deliverable |
-| `ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001.md` | ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001 - Side-by-Side Evidence Packet Contract |
-| `AS-145.md` | CODE SPEC — AS-145 · Tool Adapters: Playwright + GSheets (MVP hardening) (RES_05) |
-| `AS-148.md` | CODE SPEC — AS-148 · Policy & PII Gateway (DR_TRACK_A) |
-| `AUTH-SESSION-001.md` | AUTH-SESSION-001 · Dashboard Login + Session |
-| `CLARIFY-SURFACE-001.md` | CLARIFY-SURFACE-001 · Expert Route Clarify Surface |
-| `DASHBOARD-LOGIN-REDIRECT-001.md` | DASHBOARD-LOGIN-REDIRECT-001 · Configurable Dashboard Login Redirect |
-| `DEPLOY-CLOUDRUN-CONFIG-001.md` | DEPLOY-CLOUDRUN-CONFIG-001 · Cloud Run MVP Preview Deployment Config |
-| `DEPLOY-CLOUDRUN-DASHBOARD-SECRET-GUARD-001.md` | DEPLOY-CLOUDRUN-DASHBOARD-SECRET-GUARD-001 · Require Dashboard Secret for Bundled Cloud Run Preview Mount |
-| `DEPLOY-LIVE-SPEND-GUARD-001.md` | DEPLOY-LIVE-SPEND-GUARD-001 · Live Provider Spend Guard for Expert Preview |
-| `DISC-MRG-068.md` | DISC-MRG-068 · Prompt Quality Scoring and Regression Harness |
-| `DISC-MRG-069.md` | DISC-MRG-069 · Universal Response Quality Rubric |
-| `EPIC_RAG_001.md` | EPIC_RAG_001 · RAG & Semantic Cache Pack |
-| `EVAL-ARTIFACT-PRESERVE-001.md` | EVAL-ARTIFACT-PRESERVE-001 · Preserve Evaluation Artifacts for Comparison Runs |
-| `EVAL-BEHAVIORAL-DEMO-001.md` | EVAL-BEHAVIORAL-DEMO-001 · Operator Behavioral Demo Checklist for MVP Preview |
-| `EVAL-DEMO-EVIDENCE-001.md` | EVAL-DEMO-EVIDENCE-001 · Operator Demo Evidence Template |
-| `EVAL-DEMO-FINDINGS-001.md` | EVAL-DEMO-FINDINGS-001 · First Operator Demo Findings |
-| `EVAL-DEMO-POST-FIX-FINDINGS-001.md` | EVAL-DEMO-POST-FIX-FINDINGS-001 · Post-Fix Operator Retest Findings |
-| `EVAL-DEMO-POST-FIX-RETEST-001.md` | EVAL-DEMO-POST-FIX-RETEST-001 · Post-Fix Operator Retest Packet |
-| `EVAL-DEMO-RUN-PACKET-001.md` | EVAL-DEMO-RUN-PACKET-001 · One-Page Operator Demo Run Packet |
-| `EVAL-DIFFERENTIATION-RUN-001.md` | EVAL-DIFFERENTIATION-RUN-001 · Controlled Alpha-vs-Plain Run Scaffold |
-| `HIGHER-HEADROOM-EVAL-001.md` | HIGHER-HEADROOM-EVAL-001 · Higher-Headroom Alpha-vs-Plain Prompt Set |
-| `FINOPS-BUDGET-001.md` | FINOPS-BUDGET-001 · Budget Guardrails |
-| `LOCAL-LLM-RUNTIME-INTEGRATION-001.md` | LOCAL-LLM-RUNTIME-INTEGRATION-001 · Local LLM Runtime Integration Implementation Contract |
-| `LOCAL-LLM-SOLVER-ORCHESTRATION-001.md` | LOCAL-LLM-SOLVER-ORCHESTRATION-001 · Local LLM Solver Orchestration Integration Contract |
-| `MCP-001.md` | CODE SPEC — MCP-001 · MCP Registry Loader & Wiring (MCP) |
-| `MCP-002.md` | CODE SPEC — MCP-002 · Router decision rule (MCP) |
-| `MCP-003.md` | CODE SPEC — MCP-003 · MCP OAuth/Secrets scaffold (auth surface) (MCP) |
-| `MCP-004.md` | CODE SPEC — MCP-004 · Sandbox Limits (policy guardrail) (MCP) |
-| `MCP-005.md` | CODE SPEC — MCP-005 · Error Taxonomy (MCP) |
-| `MCP-006.md` | CODE SPEC — MCP-006 · Retry & Backoff (MCP) |
-| `MCP-007.md` | CODE SPEC — MCP-007 · MCP Observability hooks (MCP) |
-| `MCP-008.md` | MCP-008 · Domainless MCP Tool Allowlist Enforcement |
-| `MVP-CLOSEOUT-001.md` | MVP-CLOSEOUT-001 · MVP Tester Handoff and Readiness Packet |
-| `MVP-READINESS-CHECKPOINT-001.md` | MVP-READINESS-CHECKPOINT-001 · Operator-Test-Ready MVP Preview Checkpoint |
-| `NEW-009.md` | CODE SPEC — NEW-009 · Clarify Templates Pack (RES_02) |
-| `NEW-010.md` | CODE SPEC — NEW-010 · Section-Specific Prompt Decks (RES_01) |
-| `NEW-011.md` | CODE SPEC — NEW-011 · Weight-Tuning Harness (RES-03 scoring) (RES_03) |
-| `NEW-012.md` | CODE SPEC — NEW-012 · Budget CLI + CI Guard (RES_07) |
-| `NEW-013.md` | CODE SPEC — NEW-013 · Replay CLI + Trace Diff (text viewer) (RES_07) |
-| `NEW-014.md` | CODE SPEC — NEW-014 · Evidence Pack Store (catalog + retrieval) (RES_07) |
-| `NEW-015.md` | CODE SPEC — NEW-015 · Determinism Harness (exact replay & drift detector) (RES_07) |
-| `NEW-016.md` | CODE SPEC — NEW-016 · Grafana Dashboards Pack (metrics + sample boards) (RES_07) |
-| `NEW-017.md` | CODE SPEC — NEW-017 · Prompt Quality Pack (rubrics + evaluator) (RES_01) |
-| `NEW-024.md` | CODE SPEC — NEW-024 · JWT Service-to-Service Authentication (DR_TRACK_A) |
-| `NEW-045.md` | Spec: NEW-045 · Pilot Readiness & Release v0.1 |
-| `NEW-HEALTH-001.md` | NEW-HEALTH-001 · Health Check Endpoints |
-| `NEW-RATE-001.md` | NEW-RATE-001 · API Rate Limiting |
-| `OBS-ALERTS-001.md` | CODE SPEC — OBS-ALERTS-001 · Prometheus Alerts + CI Validation (RES_Dash) |
-| `OUTPUT-DIFF-A3-LIVE-CAPTURE-MODELSET-001.md` | OUTPUT-DIFF-A3-LIVE-CAPTURE-MODELSET-001 · A3 Live Capture Model Set |
-| `OUTPUT-DIFF-B1-LIFT-REPORTING-HARDENING-001.md` | OUTPUT-DIFF-B1-LIFT-REPORTING-HARDENING-001 · Output Differentiation Reporting Hardening |
-| `OUTPUT-DIFF-MEASUREMENT-HARDENING-001.md` | OUTPUT-DIFF-MEASUREMENT-HARDENING-001 · Output Differentiation Measurement Hardening |
-| `PROVIDER-BUDGET-001.md` | PROVIDER-BUDGET-001 · Post-call Provider Cost Accounting |
-| `PROVIDER-EXPERT-PASS-001.md` | PROVIDER-EXPERT-PASS-001 · Opt-in Expert Provider Pass |
-| `PROVIDER-OPENAI-001.md` | PROVIDER-OPENAI-001 · Real OpenAI Provider Execution |
-| `PROVIDER-SAFEOUT-001.md` | PROVIDER-SAFEOUT-001 · Structured Provider SAFE-OUT Responses |
-| `RES-03.md` | CODE SPEC — RES-03 · Decision Rules & Scoring (RES) |
-| `RES-04.md` | CODE SPEC — RES-04 · Confidence & Budget Gates (RES) |
-| `RES-05.md` | CODE SPEC — RES-05 · Tool Adapters (Playwright, GSheets) — MVP stubs (RES) |
-| `RES-06.md` | CODE SPEC — RES-06 · Scenario Pack & Showcase (record/replay + rubric) (RES) |
-| `RES-07.md` | CODE SPEC — RES-07 · Observability (route_explain + JSONL replay) (RES) |
-| `RES-08.md` | CODE SPEC — RES-08 · Budget Simulator + Evidence Pack (RES) |
-| `REVIEW-P0P1.md` | CODE SPEC — REVIEW-P0P1 · P0 + P1 Bulk Review (MVP Readiness) (RES_06) |
-| `SOLVE-EXPERT-EMPTY-ANSWER-GUARD-001.md` | SOLVE-EXPERT-EMPTY-ANSWER-GUARD-001 · Expert Route Empty Primary Answer Guard |
-| `SOLVE-PROVIDER-FINAL-ANSWER-EMPTY-GUARD-001.md` | SOLVE-PROVIDER-FINAL-ANSWER-EMPTY-GUARD-001 · Provider Final Answer Empty Output Guard |
-| `SOLVE-SANITIZER-FALSE-POSITIVE-001.md` | SOLVE-SANITIZER-FALSE-POSITIVE-001 · Narrow Import-Substring Sanitizer Fix |
-| `UI-JOBS-001.md` | UI-JOBS-001 · Dashboard Job History & Metrics (RES_Dash) |
-| `UI-PREVIEW-001.md` | UI-PREVIEW-001 · Authenticated Expert Preview UI |
-| `UI-PREVIEW-LOADING-STATE-001.md` | UI-PREVIEW-LOADING-STATE-001 · Expert Preview Loading State |
-| `UI-PREVIEW-LOCAL-SMOKE-001.md` | UI-PREVIEW-LOCAL-SMOKE-001 · Local-provider Expert Preview Smoke Fix |
-| `UI-PREVIEW-RESPONSE-LAYOUT-001.md` | UI-PREVIEW-RESPONSE-LAYOUT-001 · Expert Preview Long Response Layout |
-| `UI-PREVIEW-REQUEST-METRICS-001.md` | UI-PREVIEW-REQUEST-METRICS-001 · Expert Preview Request Metrics Panel |
-| `UI-KEYS-001.md` | UI-KEYS-001 · Dashboard: API Keys Management |
-| `UI-REQ-001.md` | UI-REQ-001 · Dashboard Request Submission UI |
-| `UI-RUN-001.md` | UI-RUN-001 · Dashboard One-click Demo Run |
+> **Health status added 2026-06-13** by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001`. Specs marked `SPEC_CONTAMINATED` carry the `MCP-005` Error-Taxonomy body under the wrong title and must not be used as implementation scope — see [`../docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and [`../docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+
+
+| File | Title | Health |
+| --- | --- | --- |
+| `ALPHA-ANSWER-STRUCTURE-V2-001.md` | ALPHA-ANSWER-STRUCTURE-V2-001 | ✅ `SPEC_OK` |
+| `ALPHA-BREVITY-CONTROL-001.md` | ALPHA-BREVITY-CONTROL-001 | ✅ `SPEC_OK` |
+| `ALPHA-CLARIFY-THRESHOLD-001.md` | ALPHA-CLARIFY-THRESHOLD-001 · Answer Execution Prompts with Assumptions When Sufficient | ✅ `SPEC_OK` |
+| `ALPHA-FORMAT-PRESERVATION-001.md` | ALPHA-FORMAT-PRESERVATION-001 · Expert Answer Format Preservation | ✅ `SPEC_OK` |
+| `ALPHA-LIVE-EXPERT-STEP1-PARSE-001.md` | ALPHA-LIVE-EXPERT-STEP1-PARSE-001 · Recover Actionable Execution Prompts When Step 1 Metadata Is Missing | ✅ `SPEC_OK` |
+| `ALPHA-PRIMARY-ANSWER-EMPTY-001.md` | ALPHA-PRIMARY-ANSWER-EMPTY-001 · Ensure Answer-with-Assumptions Returns a Primary Deliverable | ✅ `SPEC_OK` |
+| `ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001.md` | ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001 - Side-by-Side Evidence Packet Contract | ✅ `SPEC_OK` |
+| `AS-145.md` | CODE SPEC — AS-145 · Tool Adapters: Playwright + GSheets (MVP hardening) (RES_05) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
+| `AS-148.md` | CODE SPEC — AS-148 · Policy & PII Gateway (DR_TRACK_A) | ✅ `SPEC_OK` |
+| `AUTH-SESSION-001.md` | AUTH-SESSION-001 · Dashboard Login + Session | ✅ `SPEC_OK` |
+| `CLARIFY-SURFACE-001.md` | CLARIFY-SURFACE-001 · Expert Route Clarify Surface | ✅ `SPEC_OK` |
+| `DASHBOARD-LOGIN-REDIRECT-001.md` | DASHBOARD-LOGIN-REDIRECT-001 · Configurable Dashboard Login Redirect | ✅ `SPEC_OK` |
+| `DEPLOY-CLOUDRUN-CONFIG-001.md` | DEPLOY-CLOUDRUN-CONFIG-001 · Cloud Run MVP Preview Deployment Config | ✅ `SPEC_OK` |
+| `DEPLOY-CLOUDRUN-DASHBOARD-SECRET-GUARD-001.md` | DEPLOY-CLOUDRUN-DASHBOARD-SECRET-GUARD-001 · Require Dashboard Secret for Bundled Cloud Run Preview Mount | ✅ `SPEC_OK` |
+| `DEPLOY-LIVE-SPEND-GUARD-001.md` | DEPLOY-LIVE-SPEND-GUARD-001 · Live Provider Spend Guard for Expert Preview | ✅ `SPEC_OK` |
+| `DISC-MRG-068.md` | DISC-MRG-068 · Prompt Quality Scoring and Regression Harness | ✅ `SPEC_OK` |
+| `DISC-MRG-069.md` | DISC-MRG-069 · Universal Response Quality Rubric | ✅ `SPEC_OK` |
+| `EPIC_RAG_001.md` | EPIC_RAG_001 · RAG & Semantic Cache Pack | ✅ `SPEC_OK` |
+| `EVAL-ARTIFACT-PRESERVE-001.md` | EVAL-ARTIFACT-PRESERVE-001 · Preserve Evaluation Artifacts for Comparison Runs | ✅ `SPEC_OK` |
+| `EVAL-BEHAVIORAL-DEMO-001.md` | EVAL-BEHAVIORAL-DEMO-001 · Operator Behavioral Demo Checklist for MVP Preview | ✅ `SPEC_OK` |
+| `EVAL-DEMO-EVIDENCE-001.md` | EVAL-DEMO-EVIDENCE-001 · Operator Demo Evidence Template | ✅ `SPEC_OK` |
+| `EVAL-DEMO-FINDINGS-001.md` | EVAL-DEMO-FINDINGS-001 · First Operator Demo Findings | ✅ `SPEC_OK` |
+| `EVAL-DEMO-POST-FIX-FINDINGS-001.md` | EVAL-DEMO-POST-FIX-FINDINGS-001 · Post-Fix Operator Retest Findings | ✅ `SPEC_OK` |
+| `EVAL-DEMO-POST-FIX-RETEST-001.md` | EVAL-DEMO-POST-FIX-RETEST-001 · Post-Fix Operator Retest Packet | ✅ `SPEC_OK` |
+| `EVAL-DEMO-RUN-PACKET-001.md` | EVAL-DEMO-RUN-PACKET-001 · One-Page Operator Demo Run Packet | ✅ `SPEC_OK` |
+| `EVAL-DIFFERENTIATION-RUN-001.md` | EVAL-DIFFERENTIATION-RUN-001 · Controlled Alpha-vs-Plain Run Scaffold | ✅ `SPEC_OK` |
+| `HIGHER-HEADROOM-EVAL-001.md` | HIGHER-HEADROOM-EVAL-001 · Higher-Headroom Alpha-vs-Plain Prompt Set | ✅ `SPEC_OK` |
+| `FINOPS-BUDGET-001.md` | FINOPS-BUDGET-001 · Budget Guardrails | ✅ `SPEC_OK` |
+| `LOCAL-LLM-RUNTIME-INTEGRATION-001.md` | LOCAL-LLM-RUNTIME-INTEGRATION-001 · Local LLM Runtime Integration Implementation Contract | ✅ `SPEC_OK` |
+| `LOCAL-LLM-SOLVER-ORCHESTRATION-001.md` | LOCAL-LLM-SOLVER-ORCHESTRATION-001 · Local LLM Solver Orchestration Integration Contract | ✅ `SPEC_OK` |
+| `MCP-001.md` | CODE SPEC — MCP-001 · MCP Registry Loader & Wiring (MCP) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
+| `MCP-002.md` | CODE SPEC — MCP-002 · Router decision rule (MCP) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
+| `MCP-003.md` | CODE SPEC — MCP-003 · MCP OAuth/Secrets scaffold (auth surface) (MCP) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
+| `MCP-004.md` | CODE SPEC — MCP-004 · Sandbox Limits (policy guardrail) (MCP) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
+| `MCP-005.md` | CODE SPEC — MCP-005 · Error Taxonomy (MCP) | ✅ `SPEC_OK` (canonical — DO_NOT_TOUCH) |
+| `MCP-006.md` | CODE SPEC — MCP-006 · Retry & Backoff (MCP) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
+| `MCP-007.md` | CODE SPEC — MCP-007 · MCP Observability hooks (MCP) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
+| `MCP-008.md` | MCP-008 · Domainless MCP Tool Allowlist Enforcement | ✅ `SPEC_OK` |
+| `MVP-CLOSEOUT-001.md` | MVP-CLOSEOUT-001 · MVP Tester Handoff and Readiness Packet | 🟡 `SPEC_NEEDS_OPERATOR_DECISION` |
+| `MVP-READINESS-CHECKPOINT-001.md` | MVP-READINESS-CHECKPOINT-001 · Operator-Test-Ready MVP Preview Checkpoint | 🟡 `SPEC_NEEDS_OPERATOR_DECISION` |
+| `NEW-009.md` | CODE SPEC — NEW-009 · Clarify Templates Pack (RES_02) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
+| `NEW-010.md` | CODE SPEC — NEW-010 · Section-Specific Prompt Decks (RES_01) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
+| `NEW-011.md` | CODE SPEC — NEW-011 · Weight-Tuning Harness (RES-03 scoring) (RES_03) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
+| `NEW-012.md` | CODE SPEC — NEW-012 · Budget CLI + CI Guard (RES_07) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
+| `NEW-013.md` | CODE SPEC — NEW-013 · Replay CLI + Trace Diff (text viewer) (RES_07) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
+| `NEW-014.md` | CODE SPEC — NEW-014 · Evidence Pack Store (catalog + retrieval) (RES_07) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
+| `NEW-015.md` | CODE SPEC — NEW-015 · Determinism Harness (exact replay & drift detector) (RES_07) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
+| `NEW-016.md` | CODE SPEC — NEW-016 · Grafana Dashboards Pack (metrics + sample boards) (RES_07) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
+| `NEW-017.md` | CODE SPEC — NEW-017 · Prompt Quality Pack (rubrics + evaluator) (RES_01) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
+| `NEW-024.md` | CODE SPEC — NEW-024 · JWT Service-to-Service Authentication (DR_TRACK_A) | ✅ `SPEC_OK` |
+| `NEW-045.md` | Spec: NEW-045 · Pilot Readiness & Release v0.1 | ✅ `SPEC_OK` |
+| `NEW-HEALTH-001.md` | NEW-HEALTH-001 · Health Check Endpoints | ✅ `SPEC_OK` |
+| `NEW-RATE-001.md` | NEW-RATE-001 · API Rate Limiting | ✅ `SPEC_OK` |
+| `OBS-ALERTS-001.md` | CODE SPEC — OBS-ALERTS-001 · Prometheus Alerts + CI Validation (RES_Dash) | ✅ `SPEC_OK` |
+| `OUTPUT-DIFF-A3-LIVE-CAPTURE-MODELSET-001.md` | OUTPUT-DIFF-A3-LIVE-CAPTURE-MODELSET-001 · A3 Live Capture Model Set | ✅ `SPEC_OK` |
+| `OUTPUT-DIFF-B1-LIFT-REPORTING-HARDENING-001.md` | OUTPUT-DIFF-B1-LIFT-REPORTING-HARDENING-001 · Output Differentiation Reporting Hardening | ✅ `SPEC_OK` |
+| `OUTPUT-DIFF-MEASUREMENT-HARDENING-001.md` | OUTPUT-DIFF-MEASUREMENT-HARDENING-001 · Output Differentiation Measurement Hardening | ✅ `SPEC_OK` |
+| `PROVIDER-BUDGET-001.md` | PROVIDER-BUDGET-001 · Post-call Provider Cost Accounting | ✅ `SPEC_OK` |
+| `PROVIDER-EXPERT-PASS-001.md` | PROVIDER-EXPERT-PASS-001 · Opt-in Expert Provider Pass | ✅ `SPEC_OK` |
+| `PROVIDER-OPENAI-001.md` | PROVIDER-OPENAI-001 · Real OpenAI Provider Execution | ✅ `SPEC_OK` |
+| `PROVIDER-SAFEOUT-001.md` | PROVIDER-SAFEOUT-001 · Structured Provider SAFE-OUT Responses | ✅ `SPEC_OK` |
+| `RES-03.md` | CODE SPEC — RES-03 · Decision Rules & Scoring (RES) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
+| `RES-04.md` | CODE SPEC — RES-04 · Confidence & Budget Gates (RES) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
+| `RES-05.md` | CODE SPEC — RES-05 · Tool Adapters (Playwright, GSheets) — MVP stubs (RES) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
+| `RES-06.md` | CODE SPEC — RES-06 · Scenario Pack & Showcase (record/replay + rubric) (RES) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
+| `RES-07.md` | CODE SPEC — RES-07 · Observability (route_explain + JSONL replay) (RES) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
+| `RES-08.md` | CODE SPEC — RES-08 · Budget Simulator + Evidence Pack (RES) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
+| `REVIEW-P0P1.md` | CODE SPEC — REVIEW-P0P1 · P0 + P1 Bulk Review (MVP Readiness) (RES_06) | ✅ `SPEC_OK` |
+| `SOLVE-EXPERT-EMPTY-ANSWER-GUARD-001.md` | SOLVE-EXPERT-EMPTY-ANSWER-GUARD-001 · Expert Route Empty Primary Answer Guard | ✅ `SPEC_OK` |
+| `SOLVE-PROVIDER-FINAL-ANSWER-EMPTY-GUARD-001.md` | SOLVE-PROVIDER-FINAL-ANSWER-EMPTY-GUARD-001 · Provider Final Answer Empty Output Guard | ✅ `SPEC_OK` |
+| `SOLVE-SANITIZER-FALSE-POSITIVE-001.md` | SOLVE-SANITIZER-FALSE-POSITIVE-001 · Narrow Import-Substring Sanitizer Fix | ✅ `SPEC_OK` |
+| `UI-JOBS-001.md` | UI-JOBS-001 · Dashboard Job History & Metrics (RES_Dash) | ✅ `SPEC_OK` |
+| `UI-PREVIEW-001.md` | UI-PREVIEW-001 · Authenticated Expert Preview UI | ✅ `SPEC_OK` |
+| `UI-PREVIEW-LOADING-STATE-001.md` | UI-PREVIEW-LOADING-STATE-001 · Expert Preview Loading State | ✅ `SPEC_OK` |
+| `UI-PREVIEW-LOCAL-SMOKE-001.md` | UI-PREVIEW-LOCAL-SMOKE-001 · Local-provider Expert Preview Smoke Fix | ✅ `SPEC_OK` |
+| `UI-PREVIEW-RESPONSE-LAYOUT-001.md` | UI-PREVIEW-RESPONSE-LAYOUT-001 · Expert Preview Long Response Layout | ✅ `SPEC_OK` |
+| `UI-PREVIEW-REQUEST-METRICS-001.md` | UI-PREVIEW-REQUEST-METRICS-001 · Expert Preview Request Metrics Panel | ✅ `SPEC_OK` |
+| `UI-KEYS-001.md` | UI-KEYS-001 · Dashboard: API Keys Management | ✅ `SPEC_OK` |
+| `UI-REQ-001.md` | UI-REQ-001 · Dashboard Request Submission UI | ✅ `SPEC_OK` |
+| `UI-RUN-001.md` | UI-RUN-001 · Dashboard One-click Demo Run | ✅ `SPEC_OK` |

--- a/.specs/MCP-001.md
+++ b/.specs/MCP-001.md
@@ -1,6 +1,16 @@
 # CODE SPEC — MCP-001 · MCP Registry Loader & Wiring (MCP)
 
-> Hygiene note: The Goal, Acceptance Criteria, Design, and Tests sections below appear copied from MCP-005 · Error Taxonomy and do not match this spec’s registry loader/wiring title/code targets. Treat this spec as requiring reconciliation before using it for implementation scope.
+> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
+> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
+> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
+> titled feature or its own `## Code Targets`. The intended spec body for this feature is
+> therefore **missing**. The contaminated body is preserved **unchanged** below for
+> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
+>
+> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
+> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
+> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
+> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
 
 ## Goal
 Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.

--- a/.specs/MCP-002.md
+++ b/.specs/MCP-002.md
@@ -1,5 +1,17 @@
 # CODE SPEC — MCP-002 · Router decision rule (MCP)
 
+> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
+> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
+> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
+> titled feature or its own `## Code Targets`. The intended spec body for this feature is
+> therefore **missing**. The contaminated body is preserved **unchanged** below for
+> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
+>
+> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
+> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
+> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
+> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+
 ## Goal
 Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
 

--- a/.specs/MCP-003.md
+++ b/.specs/MCP-003.md
@@ -1,5 +1,17 @@
 # CODE SPEC — MCP-003 · MCP OAuth/Secrets scaffold (auth surface) (MCP)
 
+> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
+> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
+> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
+> titled feature or its own `## Code Targets`. The intended spec body for this feature is
+> therefore **missing**. The contaminated body is preserved **unchanged** below for
+> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
+>
+> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
+> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
+> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
+> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+
 ## Goal
 Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
 

--- a/.specs/MCP-004.md
+++ b/.specs/MCP-004.md
@@ -1,5 +1,17 @@
 # CODE SPEC — MCP-004 · Sandbox Limits (policy guardrail) (MCP)
 
+> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
+> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
+> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
+> titled feature or its own `## Code Targets`. The intended spec body for this feature is
+> therefore **missing**. The contaminated body is preserved **unchanged** below for
+> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
+>
+> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
+> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
+> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
+> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+
 ## Goal
 Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
 

--- a/.specs/MCP-006.md
+++ b/.specs/MCP-006.md
@@ -1,5 +1,17 @@
 # CODE SPEC — MCP-006 · Retry & Backoff (MCP)
 
+> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
+> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
+> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
+> titled feature or its own `## Code Targets`. The intended spec body for this feature is
+> therefore **missing**. The contaminated body is preserved **unchanged** below for
+> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
+>
+> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
+> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
+> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
+> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+
 ## Goal
 Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
 

--- a/.specs/MCP-007.md
+++ b/.specs/MCP-007.md
@@ -1,5 +1,17 @@
 # CODE SPEC — MCP-007 · MCP Observability hooks (MCP)
 
+> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
+> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
+> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
+> titled feature or its own `## Code Targets`. The intended spec body for this feature is
+> therefore **missing**. The contaminated body is preserved **unchanged** below for
+> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
+>
+> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
+> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
+> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
+> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+
 ## Goal
 Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
 

--- a/.specs/NEW-009.md
+++ b/.specs/NEW-009.md
@@ -1,5 +1,17 @@
 # CODE SPEC — NEW-009 · Clarify Templates Pack (RES_02)
 
+> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
+> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
+> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
+> titled feature or its own `## Code Targets`. The intended spec body for this feature is
+> therefore **missing**. The contaminated body is preserved **unchanged** below for
+> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
+>
+> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
+> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
+> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
+> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+
 ## Goal
 Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
 

--- a/.specs/NEW-010.md
+++ b/.specs/NEW-010.md
@@ -1,5 +1,17 @@
 # CODE SPEC — NEW-010 · Section-Specific Prompt Decks (RES_01)
 
+> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
+> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
+> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
+> titled feature or its own `## Code Targets`. The intended spec body for this feature is
+> therefore **missing**. The contaminated body is preserved **unchanged** below for
+> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
+>
+> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
+> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
+> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
+> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+
 ## Goal
 Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
 

--- a/.specs/NEW-011.md
+++ b/.specs/NEW-011.md
@@ -1,5 +1,17 @@
 # CODE SPEC — NEW-011 · Weight-Tuning Harness (RES-03 scoring) (RES_03)
 
+> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
+> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
+> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
+> titled feature or its own `## Code Targets`. The intended spec body for this feature is
+> therefore **missing**. The contaminated body is preserved **unchanged** below for
+> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
+>
+> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
+> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
+> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
+> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+
 ## Goal
 Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
 

--- a/.specs/NEW-012.md
+++ b/.specs/NEW-012.md
@@ -1,5 +1,17 @@
 # CODE SPEC — NEW-012 · Budget CLI + CI Guard (RES_07)
 
+> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
+> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
+> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
+> titled feature or its own `## Code Targets`. The intended spec body for this feature is
+> therefore **missing**. The contaminated body is preserved **unchanged** below for
+> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
+>
+> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
+> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
+> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
+> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+
 ## Goal
 Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
 

--- a/.specs/NEW-013.md
+++ b/.specs/NEW-013.md
@@ -1,5 +1,17 @@
 # CODE SPEC — NEW-013 · Replay CLI + Trace Diff (text viewer) (RES_07)
 
+> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
+> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
+> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
+> titled feature or its own `## Code Targets`. The intended spec body for this feature is
+> therefore **missing**. The contaminated body is preserved **unchanged** below for
+> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
+>
+> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
+> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
+> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
+> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+
 ## Goal
 Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
 

--- a/.specs/NEW-014.md
+++ b/.specs/NEW-014.md
@@ -1,5 +1,17 @@
 # CODE SPEC — NEW-014 · Evidence Pack Store (catalog + retrieval) (RES_07)
 
+> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
+> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
+> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
+> titled feature or its own `## Code Targets`. The intended spec body for this feature is
+> therefore **missing**. The contaminated body is preserved **unchanged** below for
+> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
+>
+> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
+> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
+> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
+> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+
 ## Goal
 Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
 

--- a/.specs/NEW-015.md
+++ b/.specs/NEW-015.md
@@ -1,5 +1,17 @@
 # CODE SPEC — NEW-015 · Determinism Harness (exact replay & drift detector) (RES_07)
 
+> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
+> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
+> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
+> titled feature or its own `## Code Targets`. The intended spec body for this feature is
+> therefore **missing**. The contaminated body is preserved **unchanged** below for
+> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
+>
+> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
+> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
+> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
+> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+
 ## Goal
 Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
 

--- a/.specs/NEW-016.md
+++ b/.specs/NEW-016.md
@@ -1,6 +1,16 @@
 # CODE SPEC — NEW-016 · Grafana Dashboards Pack (metrics + sample boards) (RES_07)
 
-> Hygiene note: The Goal, Acceptance Criteria, Design, and Tests sections below appear copied from MCP-005 · Error Taxonomy and do not match this spec’s Grafana dashboard title/code targets. Treat this spec as requiring reconciliation before using it for implementation scope.
+> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
+> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
+> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
+> titled feature or its own `## Code Targets`. The intended spec body for this feature is
+> therefore **missing**. The contaminated body is preserved **unchanged** below for
+> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
+>
+> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
+> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
+> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
+> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
 
 ## Goal
 Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.

--- a/.specs/NEW-017.md
+++ b/.specs/NEW-017.md
@@ -1,5 +1,17 @@
 # CODE SPEC — NEW-017 · Prompt Quality Pack (rubrics + evaluator) (RES_01)
 
+> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
+> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
+> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
+> titled feature or its own `## Code Targets`. The intended spec body for this feature is
+> therefore **missing**. The contaminated body is preserved **unchanged** below for
+> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
+>
+> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
+> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
+> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
+> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+
 ## Goal
 Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
 

--- a/.specs/RES-03.md
+++ b/.specs/RES-03.md
@@ -1,5 +1,17 @@
 # CODE SPEC — RES-03 · Decision Rules & Scoring (RES)
 
+> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
+> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
+> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
+> titled feature or its own `## Code Targets`. The intended spec body for this feature is
+> therefore **missing**. The contaminated body is preserved **unchanged** below for
+> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
+>
+> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
+> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
+> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
+> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+
 ## Goal
 Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
 

--- a/.specs/RES-04.md
+++ b/.specs/RES-04.md
@@ -1,5 +1,17 @@
 # CODE SPEC — RES-04 · Confidence & Budget Gates (RES)
 
+> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
+> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
+> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
+> titled feature or its own `## Code Targets`. The intended spec body for this feature is
+> therefore **missing**. The contaminated body is preserved **unchanged** below for
+> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
+>
+> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
+> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
+> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
+> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+
 ## Goal
 Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
 

--- a/.specs/RES-05.md
+++ b/.specs/RES-05.md
@@ -1,5 +1,17 @@
 # CODE SPEC — RES-05 · Tool Adapters (Playwright, GSheets) — MVP stubs (RES)
 
+> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
+> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
+> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
+> titled feature or its own `## Code Targets`. The intended spec body for this feature is
+> therefore **missing**. The contaminated body is preserved **unchanged** below for
+> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
+>
+> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
+> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
+> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
+> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+
 ## Goal
 Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
 

--- a/.specs/RES-06.md
+++ b/.specs/RES-06.md
@@ -1,5 +1,17 @@
 # CODE SPEC — RES-06 · Scenario Pack & Showcase (record/replay + rubric) (RES)
 
+> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
+> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
+> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
+> titled feature or its own `## Code Targets`. The intended spec body for this feature is
+> therefore **missing**. The contaminated body is preserved **unchanged** below for
+> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
+>
+> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
+> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
+> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
+> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+
 ## Goal
 Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
 

--- a/.specs/RES-07.md
+++ b/.specs/RES-07.md
@@ -1,5 +1,17 @@
 # CODE SPEC — RES-07 · Observability (route_explain + JSONL replay) (RES)
 
+> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
+> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
+> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
+> titled feature or its own `## Code Targets`. The intended spec body for this feature is
+> therefore **missing**. The contaminated body is preserved **unchanged** below for
+> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
+>
+> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
+> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
+> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
+> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+
 ## Goal
 Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
 

--- a/.specs/RES-08.md
+++ b/.specs/RES-08.md
@@ -1,5 +1,17 @@
 # CODE SPEC — RES-08 · Budget Simulator + Evidence Pack (RES)
 
+> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
+> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
+> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
+> titled feature or its own `## Code Targets`. The intended spec body for this feature is
+> therefore **missing**. The contaminated body is preserved **unchanged** below for
+> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
+>
+> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
+> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
+> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
+> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+
 ## Goal
 Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
 

--- a/docs/SPECS_HEALTH_AUDIT.md
+++ b/docs/SPECS_HEALTH_AUDIT.md
@@ -1,86 +1,219 @@
 # Specs Health Audit
 
-> Created by lane `ALPHA-SOLVER-CURRENT-STATE-DOCS-BACKLOG-ARCHIVE-ISSUE-REGISTER-001`.
-> Verification date **2026-06-13**. Audited `.specs/` against committed file
-> bodies. Classifications: `SPEC_OK` · `SPEC_CONTAMINATED` · `SPEC_STALE` ·
-> `SPEC_NEEDS_OPERATOR_DECISION` · `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
-> **Contaminated specs are NOT rewritten from memory** here.
+> Owner lane: `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001`.
+> Supersedes the initial audit from
+> `ALPHA-SOLVER-CURRENT-STATE-DOCS-BACKLOG-ARCHIVE-ISSUE-REGISTER-001`.
+> Verification date **2026-06-13**. Audited `.specs/` against committed file bodies
+> (read-only hashing; no spec rewritten from memory; no spec deleted).
+>
+> Classifications used: `SPEC_OK` · `SPEC_CONTAMINATED` · `SPEC_DUPLICATE_BODY` ·
+> `SPEC_STALE` · `SPEC_NEEDS_OPERATOR_DECISION` · `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
 
-## Headline finding (CONFIRMED, broader than the audit input)
+Companion docs: [`SPECS_RECONCILIATION_PLAN.md`](SPECS_RECONCILIATION_PLAN.md) ·
+evidence packet [`docs/evals/runs/alpha-solver-spec-contamination-reconciliation-001/`](evals/runs/alpha-solver-spec-contamination-reconciliation-001/).
 
-The audit hypothesis ("MCP-002 or NEW-010 contain MCP-005 Error Taxonomy content
-under unrelated titles") is **CONFIRMED** — and the contamination is **systemic**.
+## Headline finding (CONFIRMED — systemic)
 
-A grep for the Error-Taxonomy signature phrase `"Create a stable MCP error
-taxonomy"` matches **23 files** in `.specs/`. `MCP-005` is the legitimate source
-(`# CODE SPEC — MCP-005 · Error Taxonomy (MCP)`). The other **22** files carry
-the same `Goal` / `Acceptance Criteria` / `Design` / `Tests` body under unrelated
-titles; typically only the **`## Code Targets`** line differs and matches each
-file's real (titled) feature.
+The hypothesis that `.specs/` files carry the **MCP-005 Error Taxonomy** body under
+unrelated titles is **CONFIRMED and systemic**. The task's specific question is
+answered: **`MCP-002` and `NEW-010` both carry the MCP-005 body** under their own
+(unrelated) titles, as do 20 other specs.
 
-### Verified examples
+- **83** `.md` files in `.specs/` (81 specs + 2 registry/meta files `INDEX.md`, `README.md`).
+- **23** files contain the Error-Taxonomy signature `"Create a stable MCP error taxonomy"`.
+- **1** is the legitimate source: `MCP-005 · Error Taxonomy (MCP)`.
+- **22** carry that same `Goal`/`Acceptance Criteria`/`Design`/`Tests` body under unrelated
+  titles — only the `## Code Targets` line differs and matches each file's real feature.
 
-| File | Title (as written) | Body content | Code Targets (file-specific) |
-|------|---------------------|--------------|------------------------------|
-| `.specs/MCP-005.md` | Error Taxonomy (MCP) | Error Taxonomy (canonical) | `service/mcp/error_taxonomy.py` |
-| `.specs/MCP-002.md` | Router decision rule (MCP) | **Error Taxonomy body** | `registries/mcp/registry_lookup.py` |
-| `.specs/NEW-010.md` | Section-Specific Prompt Decks (RES_01) | **Error Taxonomy body** | `service/prompts/decks.yaml; selector.py; renderer.py` |
+### Method (reproducible, read-only)
 
-The mismatch (title + Code Targets describe feature X, but Goal/Design/Tests
-describe the Error Taxonomy) means the **intended spec content for the titled
-feature is effectively missing** in each contaminated file.
+For every `.specs/*.md`, the body was normalized by removing the H1 title line and the
+`## Code Targets` section, then SHA-1 hashed and clustered. Result: **exactly one**
+multi-file body cluster — the MCP-005 Error Taxonomy body, shared by 21 files
+byte-for-byte; 2 further files (`MCP-001`, `NEW-016`) carry the same body plus a prior
+hygiene note. **No other duplicate or near-duplicate body cluster exists** among the
+remaining specs, so cross-contamination is limited to the Error-Taxonomy body.
+Reproduce with:
 
-## Classification
+```bash
+grep -rl "Create a stable MCP error taxonomy" .specs/   # -> 23 files (MCP-005 + 22)
+```
 
-### SPEC_CONTAMINATED (22 files — carry the MCP-005 body under unrelated titles)
+### Decisive finding for remediation: the titled features exist in committed code
 
-`MCP-001`, `MCP-002`, `MCP-003`, `MCP-004`, `MCP-006`, `MCP-007`,
-`NEW-009`, `NEW-010`, `NEW-011`, `NEW-012`, `NEW-013`, `NEW-014`, `NEW-015`,
-`NEW-016`, `NEW-017`, `RES-03`, `RES-04`, `RES-05`, `RES-06`, `RES-07`, `RES-08`,
-`AS-145`.
+Every one of the 22 contaminated specs lists `## Code Targets` whose **implementation
+and test files are all present in the repo**. The authentic feature each spec was
+*supposed* to document therefore exists in committed code+tests — so the real spec can
+be **reconstructed from an authoritative in-repo source** (code + tests), not from
+memory. This is why the selected follow-up is source reconstruction, not index cleanup.
 
-Each of these is also **`SPEC_NEEDS_SOURCE_RECONSTRUCTION`** for its titled
-feature: the real feature spec must be recovered from an authoritative source,
-not reconstructed from memory.
+## Action taken by this lane (non-destructive)
 
-### SPEC_OK / canonical
+All 22 contaminated specs now carry a standardized non-authoritative banner
+immediately under their title:
 
-`.specs/MCP-005.md` — the legitimate Error Taxonomy spec; its Code Targets
-(`service/mcp/error_taxonomy.py`, `tests/test_mcp_errors.py`) exist in the repo.
-**DO_NOT_TOUCH** as the taxonomy source of truth.
+```text
+⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).
+```
 
-### SPEC_NEEDS_OPERATOR_DECISION
+The contaminated body is **preserved unchanged** beneath the banner for forensic /
+reconstruction use. `MCP-005` (canonical) was **not** modified. No spec was deleted.
 
-- Whether the 22 contaminated files should be (a) reconstructed from an external
-  authoritative source, (b) marked deprecated/historical, or (c) deleted as
-  duplicates — requires an operator decision. (No deletion is performed here.)
-- MVP spec/doc overlap (`.specs/MVP-READINESS-CHECKPOINT-001.md` vs
-  `docs/MVP_READINESS_CHECKPOINT.md`; `.specs/MVP-CLOSEOUT-001.md`) — see
-  [`ARCHIVE_INDEX.md`](ARCHIVE_INDEX.md) (ISS-010).
+## Classification summary
 
-### SPEC_STALE
+| Classification | Count | Members |
+|----------------|-------|---------|
+| `SPEC_OK` | 57 | 56 clean specs + `MCP-005` (canonical, `DO_NOT_TOUCH`) |
+| `SPEC_CONTAMINATED` (+ `SPEC_NEEDS_SOURCE_RECONSTRUCTION`) | 22 | see detail table |
+| `SPEC_NEEDS_OPERATOR_DECISION` | 2 | `MVP-READINESS-CHECKPOINT-001`, `MVP-CLOSEOUT-001` (doc overlap, ISS-010) |
+| `SPEC_DUPLICATE_BODY` | 0 distinct | the 22 are a duplicate-body set, tracked under `SPEC_CONTAMINATED` |
+| `SPEC_STALE` | 0 confirmed | not exhaustively assessed beyond contamination scope (see Boundaries) |
+| `META` (not a spec) | 2 | `INDEX.md`, `README.md` |
 
-Not separately assessed beyond the contamination scope in this lane; the stale
-**roadmap** (not a `.specs/` file) is handled in [`ROADMAP.md`](ROADMAP.md) (ISS-002).
+> Note: the 22 contaminated specs are simultaneously `SPEC_DUPLICATE_BODY` (they share
+> one body) and `SPEC_CONTAMINATED` (that body is foreign to their title). They are
+> filed under `SPEC_CONTAMINATED` as the primary, actionable classification, with
+> `SPEC_NEEDS_SOURCE_RECONSTRUCTION` as the remediation path.
 
-## Recommended follow-up lane
+## Contaminated specs — detail (22)
 
-Because contamination is confirmed and systemic, recommend:
+| Spec | Titled feature (authentic) | Impl targets present | Test targets present |
+|------|----------------------------|----------------------|----------------------|
+| `MCP-001` | MCP Registry Loader & Wiring (MCP) | ✅ | ✅ |
+| `MCP-002` | Router decision rule (MCP) | ✅ | ✅ |
+| `MCP-003` | MCP OAuth/Secrets scaffold (auth surface) (MCP) | ✅ | ✅ |
+| `MCP-004` | Sandbox Limits (policy guardrail) (MCP) | ✅ | ✅ |
+| `MCP-006` | Retry & Backoff (MCP) | ✅ | ✅ |
+| `MCP-007` | MCP Observability hooks (MCP) | ✅ | ✅ |
+| `NEW-009` | Clarify Templates Pack (RES_02) | ✅ | ✅ |
+| `NEW-010` | Section-Specific Prompt Decks (RES_01) | ✅ | ✅ |
+| `NEW-011` | Weight-Tuning Harness (RES-03 scoring) (RES_03) | ✅ | ✅ |
+| `NEW-012` | Budget CLI + CI Guard (RES_07) | ✅ | ✅ |
+| `NEW-013` | Replay CLI + Trace Diff (text viewer) (RES_07) | ✅ | ✅ |
+| `NEW-014` | Evidence Pack Store (catalog + retrieval) (RES_07) | ✅ | ✅ |
+| `NEW-015` | Determinism Harness (exact replay & drift detector) (RES_07) | ✅ | ✅ |
+| `NEW-016` | Grafana Dashboards Pack (metrics + sample boards) (RES_07) | ✅ | ✅ |
+| `NEW-017` | Prompt Quality Pack (rubrics + evaluator) (RES_01) | ✅ | ✅ |
+| `RES-03` | Decision Rules & Scoring (RES) | ✅ | ✅ |
+| `RES-04` | Confidence & Budget Gates (RES) | ✅ | ✅ |
+| `RES-05` | Tool Adapters (Playwright, GSheets) — MVP stubs (RES) | ✅ | ✅ |
+| `RES-06` | Scenario Pack & Showcase (record/replay + rubric) (RES) | ✅ | ✅ |
+| `RES-07` | Observability (route_explain + JSONL replay) (RES) | ✅ | ✅ |
+| `RES-08` | Budget Simulator + Evidence Pack (RES) | ✅ | ✅ |
+| `AS-145` | Tool Adapters: Playwright + GSheets (MVP hardening) (RES_05) | ✅ | ✅ |
 
-**`ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001`**
+All 22 → `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`. Per-spec
+reconstruction routing is in [`SPECS_RECONCILIATION_PLAN.md`](SPECS_RECONCILIATION_PLAN.md).
 
-Scope for that lane (not done here):
-- Enumerate all 22 contaminated specs and their intended (titled) features.
-- For each, recover the real spec from an **authoritative source** (operator /
-  original PR / external doc) — never reconstruct from memory.
-- Preserve the canonical `MCP-005` taxonomy untouched.
-- Record which specs were reconstructed, deprecated, or pending source.
+## Full specs health index (all 83 files)
+
+This table is the specs health index requested by the lane. `META` rows are the two
+registry files, not specs.
+
+| # | Spec file | Classification | Note |
+|---|-----------|----------------|------|
+| 1 | `ALPHA-ANSWER-STRUCTURE-V2-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 2 | `ALPHA-BREVITY-CONTROL-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 3 | `ALPHA-CLARIFY-THRESHOLD-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 4 | `ALPHA-FORMAT-PRESERVATION-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 5 | `ALPHA-LIVE-EXPERT-STEP1-PARSE-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 6 | `ALPHA-PRIMARY-ANSWER-EMPTY-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 7 | `ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 8 | `AS-145` | `SPEC_CONTAMINATED` | MCP-005 body under wrong title; banner added; → reconstruction |
+| 9 | `AS-148` | `SPEC_OK` | Unique body; no contamination detected |
+| 10 | `AUTH-SESSION-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 11 | `CLARIFY-SURFACE-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 12 | `DASHBOARD-LOGIN-REDIRECT-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 13 | `DEPLOY-CLOUDRUN-CONFIG-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 14 | `DEPLOY-CLOUDRUN-DASHBOARD-SECRET-GUARD-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 15 | `DEPLOY-LIVE-SPEND-GUARD-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 16 | `DISC-MRG-068` | `SPEC_OK` | Unique body; no contamination detected |
+| 17 | `DISC-MRG-069` | `SPEC_OK` | Unique body; no contamination detected |
+| 18 | `EPIC_RAG_001` | `SPEC_OK` | Unique body; no contamination detected |
+| 19 | `EVAL-ARTIFACT-PRESERVE-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 20 | `EVAL-BEHAVIORAL-DEMO-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 21 | `EVAL-DEMO-EVIDENCE-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 22 | `EVAL-DEMO-FINDINGS-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 23 | `EVAL-DEMO-POST-FIX-FINDINGS-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 24 | `EVAL-DEMO-POST-FIX-RETEST-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 25 | `EVAL-DEMO-RUN-PACKET-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 26 | `EVAL-DIFFERENTIATION-RUN-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 27 | `FINOPS-BUDGET-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 28 | `HIGHER-HEADROOM-EVAL-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 29 | `INDEX` | `META` | Registry/index file — not a spec |
+| 30 | `LOCAL-LLM-RUNTIME-INTEGRATION-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 31 | `LOCAL-LLM-SOLVER-ORCHESTRATION-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 32 | `MCP-001` | `SPEC_CONTAMINATED` | MCP-005 body under wrong title; banner added; → reconstruction |
+| 33 | `MCP-002` | `SPEC_CONTAMINATED` | MCP-005 body under wrong title; banner added; → reconstruction |
+| 34 | `MCP-003` | `SPEC_CONTAMINATED` | MCP-005 body under wrong title; banner added; → reconstruction |
+| 35 | `MCP-004` | `SPEC_CONTAMINATED` | MCP-005 body under wrong title; banner added; → reconstruction |
+| 36 | `MCP-005` | `SPEC_OK (canonical)` | Legitimate Error Taxonomy source — **DO_NOT_TOUCH** |
+| 37 | `MCP-006` | `SPEC_CONTAMINATED` | MCP-005 body under wrong title; banner added; → reconstruction |
+| 38 | `MCP-007` | `SPEC_CONTAMINATED` | MCP-005 body under wrong title; banner added; → reconstruction |
+| 39 | `MCP-008` | `SPEC_OK` | Unique body; no contamination detected |
+| 40 | `MVP-CLOSEOUT-001` | `SPEC_NEEDS_OPERATOR_DECISION` | Spec/doc overlap with `docs/` (ISS-010) |
+| 41 | `MVP-READINESS-CHECKPOINT-001` | `SPEC_NEEDS_OPERATOR_DECISION` | Spec/doc overlap with `docs/` (ISS-010) |
+| 42 | `NEW-009` | `SPEC_CONTAMINATED` | MCP-005 body under wrong title; banner added; → reconstruction |
+| 43 | `NEW-010` | `SPEC_CONTAMINATED` | MCP-005 body under wrong title; banner added; → reconstruction |
+| 44 | `NEW-011` | `SPEC_CONTAMINATED` | MCP-005 body under wrong title; banner added; → reconstruction |
+| 45 | `NEW-012` | `SPEC_CONTAMINATED` | MCP-005 body under wrong title; banner added; → reconstruction |
+| 46 | `NEW-013` | `SPEC_CONTAMINATED` | MCP-005 body under wrong title; banner added; → reconstruction |
+| 47 | `NEW-014` | `SPEC_CONTAMINATED` | MCP-005 body under wrong title; banner added; → reconstruction |
+| 48 | `NEW-015` | `SPEC_CONTAMINATED` | MCP-005 body under wrong title; banner added; → reconstruction |
+| 49 | `NEW-016` | `SPEC_CONTAMINATED` | MCP-005 body under wrong title; banner added; → reconstruction |
+| 50 | `NEW-017` | `SPEC_CONTAMINATED` | MCP-005 body under wrong title; banner added; → reconstruction |
+| 51 | `NEW-024` | `SPEC_OK` | Unique body; no contamination detected |
+| 52 | `NEW-045` | `SPEC_OK` | Unique body; no contamination detected |
+| 53 | `NEW-HEALTH-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 54 | `NEW-RATE-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 55 | `OBS-ALERTS-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 56 | `OUTPUT-DIFF-A3-LIVE-CAPTURE-MODELSET-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 57 | `OUTPUT-DIFF-B1-LIFT-REPORTING-HARDENING-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 58 | `OUTPUT-DIFF-MEASUREMENT-HARDENING-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 59 | `PROVIDER-BUDGET-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 60 | `PROVIDER-EXPERT-PASS-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 61 | `PROVIDER-OPENAI-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 62 | `PROVIDER-SAFEOUT-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 63 | `README` | `META` | Registry/index file — not a spec |
+| 64 | `RES-03` | `SPEC_CONTAMINATED` | MCP-005 body under wrong title; banner added; → reconstruction |
+| 65 | `RES-04` | `SPEC_CONTAMINATED` | MCP-005 body under wrong title; banner added; → reconstruction |
+| 66 | `RES-05` | `SPEC_CONTAMINATED` | MCP-005 body under wrong title; banner added; → reconstruction |
+| 67 | `RES-06` | `SPEC_CONTAMINATED` | MCP-005 body under wrong title; banner added; → reconstruction |
+| 68 | `RES-07` | `SPEC_CONTAMINATED` | MCP-005 body under wrong title; banner added; → reconstruction |
+| 69 | `RES-08` | `SPEC_CONTAMINATED` | MCP-005 body under wrong title; banner added; → reconstruction |
+| 70 | `REVIEW-P0P1` | `SPEC_OK` | Unique body; no contamination detected |
+| 71 | `SOLVE-EXPERT-EMPTY-ANSWER-GUARD-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 72 | `SOLVE-PROVIDER-FINAL-ANSWER-EMPTY-GUARD-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 73 | `SOLVE-SANITIZER-FALSE-POSITIVE-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 74 | `UI-JOBS-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 75 | `UI-KEYS-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 76 | `UI-PREVIEW-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 77 | `UI-PREVIEW-LOADING-STATE-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 78 | `UI-PREVIEW-LOCAL-SMOKE-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 79 | `UI-PREVIEW-REQUEST-METRICS-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 80 | `UI-PREVIEW-RESPONSE-LAYOUT-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 81 | `UI-REQ-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 82 | `UI-RUN-001` | `SPEC_OK` | Unique body; no contamination detected |
+| 83 | `alpha-local-llm-provider-integration-spec` | `SPEC_OK` | Unique body; no contamination detected |
+
+## `SPEC_NEEDS_OPERATOR_DECISION`
+
+- **Disposition of the 22 contaminated specs** — reconstruct from code+tests (A),
+  deprecate/archive (B), or delete as duplicates (C). This lane performs **no**
+  deletion and **no** reconstruction; it only marks + indexes. The decision is the
+  gate for `ALPHA-SOLVER-SPEC-SOURCE-RECONSTRUCTION-001`.
+- **MVP spec/doc overlap** — `.specs/MVP-READINESS-CHECKPOINT-001.md` vs
+  `docs/MVP_READINESS_CHECKPOINT.md`, and `.specs/MVP-CLOSEOUT-001.md` vs
+  `docs/MVP_TESTER_HANDOFF.md` — tracked as ISS-010 in
+  [`ARCHIVE_INDEX.md`](ARCHIVE_INDEX.md); not resolved here.
 
 ## Boundaries
 
-- This audit **did not** rewrite, delete, or reconstruct any spec.
-- No runtime/provider behavior was inspected for correctness; this is a docs
-  integrity audit only.
-- Finding does not affect smoke or public-exposure gating (ISS-001 is P2 docs
-  integrity), but the specs cannot be trusted as feature documentation until
-  reconciled.
+- No spec was rewritten from memory; no original intended spec was invented.
+- No spec was deleted; contaminated bodies are preserved verbatim under a banner.
+- `MCP-005` (canonical taxonomy) was not touched.
+- No runtime/product code, tests, or CI were modified; no provider calls; no tokens.
+- `SPEC_STALE` was not exhaustively assessed beyond the contamination scope; the only
+  duplicate-body cluster in `.specs/` is the Error-Taxonomy one (verified by hashing).
+- This is a docs-integrity audit; it makes no runtime/provider/readiness claim.
+

--- a/docs/SPECS_HEALTH_AUDIT.md
+++ b/docs/SPECS_HEALTH_AUDIT.md
@@ -27,17 +27,27 @@ answered: **`MCP-002` and `NEW-010` both carry the MCP-005 body** under their ow
 
 ### Method (reproducible, read-only)
 
-For every `.specs/*.md`, the body was normalized by removing the H1 title line and the
-`## Code Targets` section, then SHA-1 hashed and clustered. Result: **exactly one**
-multi-file body cluster — the MCP-005 Error Taxonomy body, shared by 21 files
-byte-for-byte; 2 further files (`MCP-001`, `NEW-016`) carry the same body plus a prior
-hygiene note. **No other duplicate or near-duplicate body cluster exists** among the
-remaining specs, so cross-contamination is limited to the Error-Taxonomy body.
-Reproduce with:
+For every `.specs/*.md`, the body was normalized by removing (a) the H1 title line,
+(b) a leading blockquote block before the first `## ` header — i.e. the
+non-authoritative banner or any prior hygiene note — and (c) the `## Code Targets`
+section, then SHA-1 hashed and clustered. Excluding the title, banner/note, and
+targets isolates the *copied body*, so the hash is stable before and after the
+banners were added. Result: **exactly one** multi-file body cluster — the MCP-005
+Error Taxonomy body. Under this rule **all 23 taxonomy-bearing specs (canonical
+`MCP-005` + 22 contaminated) hash to `a7c9ca95240e`** in the committed state
+(`MCP-001` and `NEW-016` included). **No other duplicate or near-duplicate body
+cluster exists** among the remaining specs, so cross-contamination is limited to
+the Error-Taxonomy body. Reproduce with:
 
 ```bash
 grep -rl "Create a stable MCP error taxonomy" .specs/   # -> 23 files (MCP-005 + 22)
+python docs/evals/runs/alpha-solver-spec-contamination-reconciliation-001/reproduce-body-hash.py
+# -> all 23 share normalized body hash a7c9ca95240e; RESULT: PASS
 ```
+
+The exact normalization rule and a runnable implementation live in the evidence
+packet: [`contamination-evidence.md`](evals/runs/alpha-solver-spec-contamination-reconciliation-001/contamination-evidence.md)
+and [`reproduce-body-hash.py`](evals/runs/alpha-solver-spec-contamination-reconciliation-001/reproduce-body-hash.py).
 
 ### Decisive finding for remediation: the titled features exist in committed code
 

--- a/docs/SPECS_RECONCILIATION_PLAN.md
+++ b/docs/SPECS_RECONCILIATION_PLAN.md
@@ -1,0 +1,82 @@
+# Specs Reconciliation Plan
+
+> Owner lane: `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` (2026-06-13).
+> Companion to [`SPECS_HEALTH_AUDIT.md`](SPECS_HEALTH_AUDIT.md).
+> This plan **routes** reconciliation; it performs **no** spec rewrite, reconstruction,
+> or deletion. Those happen (if approved) in the next lane.
+
+## Problem
+
+22 `.specs/*.md` files carry the **MCP-005 Error Taxonomy** body under unrelated titles
+(`SPEC_CONTAMINATED`). Their authentic per-feature spec text is therefore missing. This
+lane has marked all 22 non-authoritative (banner under title, body preserved) and
+indexed them; what remains is to recover the real spec text for each.
+
+## Reconciliation principles (hard rules)
+
+1. **Never reconstruct a spec from memory** and never invent an "original intent".
+2. Reconstruct **only** from an authoritative in-repo source: the feature's committed
+   **code + tests** (the `## Code Targets`), and/or the originating PR / external doc.
+3. **Preserve** contaminated bodies (do not delete); supersede them in place.
+4. Keep `MCP-005` (canonical) untouched as the taxonomy source of truth.
+5. Filenames are stable identifiers — **do not rename or move** specs (`.specs/README.md`).
+
+## Feasibility (verified)
+
+For all 22, every `## Code Targets` implementation **and** test file is present in the
+repo. Reconstruction from committed code+tests is therefore feasible for the whole set;
+none is blocked on a missing source. The disposition (reconstruct vs deprecate) is an
+operator decision (below).
+
+## Per-spec reconciliation routing (22)
+
+`Reconstruct from` lists the in-repo authoritative source to derive the real spec from.
+
+| Spec | Titled feature | Reconstruct from (impl) | Reconstruct from (tests) |
+|------|----------------|-------------------------|--------------------------|
+| `MCP-001` | MCP Registry Loader & Wiring (MCP) | `registries/mcp/loader.py`, `service/mcp/wiring.py` | `tests/test_mcp_loader.py` |
+| `MCP-002` | Router decision rule (MCP) | `registries/mcp/registry_lookup.py` | `tests/test_mcp_router_rule.py` |
+| `MCP-003` | MCP OAuth/Secrets scaffold (auth surface) (MCP) | `service/mcp/policy_auth.py` | `tests/test_mcp_auth.py` |
+| `MCP-004` | Sandbox Limits (policy guardrail) (MCP) | `service/mcp/sandbox_limits.py` | `tests/test_mcp_sandbox.py` |
+| `MCP-006` | Retry & Backoff (MCP) | `service/mcp/retry_backoff.py` | `tests/test_mcp_retry.py` |
+| `MCP-007` | MCP Observability hooks (MCP) | `service/mcp/observability.py` | `tests/test_mcp_observability.py` |
+| `NEW-009` | Clarify Templates Pack (RES_02) | `service/clarify/trigger.py`, `service/clarify/templates.yaml`, `service/clarify/render.py` | `tests/test_clarify.py` |
+| `NEW-010` | Section-Specific Prompt Decks (RES_01) | `service/prompts/decks.yaml`, `service/prompts/selector.py`, `service/prompts/renderer.py` | `tests/test_prompt_decks.py` |
+| `NEW-011` | Weight-Tuning Harness (RES-03 scoring) (RES_03) | `service/scoring/tuning.py`, `config/tuning.yaml` | `tests/test_weight_tuning.py` |
+| `NEW-012` | Budget CLI + CI Guard (RES_07) | `service/budget/guard.py`, `service/budget/cli.py` | `tests/test_budget_cli_guard.py` |
+| `NEW-013` | Replay CLI + Trace Diff (text viewer) (RES_07) | `service/observability/replay_cli.py`, `service/observability/diff.py` | `tests/test_replay_cli_diff.py` |
+| `NEW-014` | Evidence Pack Store (catalog + retrieval) (RES_07) | `service/evidence/store.py`, `service/evidence/index.jsonl`, `service/evidence/api.py` | `tests/test_evidence_store.py` |
+| `NEW-015` | Determinism Harness (exact replay & drift detector) (RES_07) | `service/determinism/harness.py`, `service/determinism/report.py`, `config/determinism.yaml` | `tests/test_determinism.py` |
+| `NEW-016` | Grafana Dashboards Pack (metrics + sample boards) (RES_07) | `service/metrics/exporter.py`, `dashboards/alpha_observability.json`, `dashboards/cost_budget.json` | `tests/test_metrics_dashboards.py` |
+| `NEW-017` | Prompt Quality Pack (rubrics + evaluator) (RES_01) | `service/prompts/quality/rubrics.yaml`, `service/prompts/quality/evaluator.py`, `service/prompts/quality/report.py` | `tests/test_prompt_quality.py` |
+| `RES-03` | Decision Rules & Scoring (RES) | `service/scoring/decision_rules.py`, `config/decision_rules.yaml` | `tests/test_decision_rules.py` |
+| `RES-04` | Confidence & Budget Gates (RES) | `service/gating/gates.py`, `alpha_solver_cli.py` | `tests/test_gates.py` |
+| `RES-05` | Tool Adapters (Playwright, GSheets) — MVP stubs (RES) | `service/adapters/base.py`, `service/adapters/playwright_adapter.py`, `service/adapters/gsheets_adapter.py` | `tests/test_adapters_playwright.py`, `tests/test_adapters_gsheets.py` |
+| `RES-06` | Scenario Pack & Showcase (record/replay + rubric) (RES) | `service/scenarios/runner.py`, `service/scenarios/rubric.py`, `scenarios/pack.yaml` | `tests/test_scenarios.py` |
+| `RES-07` | Observability (route_explain + JSONL replay) (RES) | `service/observability/logger.py`, `service/observability/replay.py` | `tests/test_observability.py` |
+| `RES-08` | Budget Simulator + Evidence Pack (RES) | `service/budget/simulator.py`, `service/evidence/collector.py`, `config/cost_models.yaml` | `tests/test_budget_simulator.py`, `tests/test_evidence_pack.py` |
+| `AS-145` | Tool Adapters: Playwright + GSheets (MVP hardening) (RES_05) | `service/adapters/base.py`, `service/adapters/playwright_adapter.py`, `service/adapters/gsheets_adapter.py` | `tests/test_adapters_playwright_hardened.py`, `tests/test_adapters_gsheets_hardened.py` |
+
+## Operator decision required (disposition)
+
+Choose one disposition per spec (or one for the whole set) before the reconstruction lane acts:
+
+- **A. Reconstruct** the real spec from committed code+tests (recommended — sources exist).
+- **B. Deprecate/Archive** the spec as historical (if the feature is frozen/retired).
+- **C. Delete** as a duplicate (NOT performed by these lanes without explicit operator
+  instruction; `.specs/README.md` forbids casual removal).
+
+## Next lane
+
+`ALPHA-SOLVER-SPEC-SOURCE-RECONSTRUCTION-001` — for each spec dispositioned **A**,
+draft the real `Goal / Motivation / Acceptance Criteria / Definition of Done /
+Code Targets / Test Plan` strictly from its committed code+tests, replacing the
+contaminated body while keeping the filename. One spec per reviewable change; cite the
+source files in each diff.
+
+## What this lane did NOT do
+
+- Did not rewrite, reconstruct, or delete any spec body.
+- Did not modify `MCP-005` or any runtime/product code, test, or CI file.
+- Did not call any provider; used no tokens; made no readiness claim.
+

--- a/docs/evals/runs/alpha-solver-spec-contamination-reconciliation-001/README.md
+++ b/docs/evals/runs/alpha-solver-spec-contamination-reconciliation-001/README.md
@@ -1,0 +1,48 @@
+# ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001
+
+Docs/specs integrity lane. Audits and reconciles `.specs/*.md` files that carry
+copied or mismatched content — specifically specs carrying the **MCP-005 Error
+Taxonomy** body under unrelated titles.
+
+- **Lane:** `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001`
+- **Date:** 2026-06-13
+- **Verdict:** **`SPEC_CONTAMINATION_RECONCILIATION_CAPTURED`**
+- **Selected next lane:** `ALPHA-SOLVER-SPEC-SOURCE-RECONSTRUCTION-001`
+- **Scope:** docs/specs-integrity only. No runtime/product code, tests, or CI
+  changed. No provider calls, no tokens. No spec deleted. No spec rewritten from
+  memory.
+
+## What this lane produced
+
+Source-of-truth docs (repo root `docs/`):
+
+- [`docs/SPECS_HEALTH_AUDIT.md`](../../../SPECS_HEALTH_AUDIT.md) — updated; full
+  83-file health index + contamination evidence.
+- [`docs/SPECS_RECONCILIATION_PLAN.md`](../../../SPECS_RECONCILIATION_PLAN.md) —
+  new; per-spec reconstruction routing + operator disposition options.
+
+Spec-tree changes:
+
+- 22 contaminated `.specs/*.md` files marked **non-authoritative** with a
+  standardized banner (body preserved verbatim).
+- [`.specs/INDEX.md`](../../../../.specs/INDEX.md) — added a `Health` column.
+
+## Packet contents
+
+`repo-state-verification.md`, `methodology.md`, `contamination-evidence.md`,
+`per-spec-classification.md`, `code-target-existence.md`, `marking-actions.md`,
+`reconciliation-summary.md`, `claim-boundary.md`, `forbidden-claims.md`,
+`non-actions.md`, `selected-next-lane.md`, `verdict.md`.
+
+## Headline
+
+The hypothesis is **CONFIRMED and systemic**: `MCP-002`, `NEW-010`, and 20 other
+specs carry the `MCP-005` Error-Taxonomy body under unrelated titles. `MCP-005`
+is the single legitimate source and is left untouched. Every contaminated spec's
+titled feature exists in committed code+tests, so reconstruction (next lane) is
+feasible from an authoritative in-repo source — never from memory.
+
+## Non-claims
+
+This lane does **not** claim runtime, provider, security/privacy, readiness, or
+value/quality outcomes. It is a docs-integrity audit. See `forbidden-claims.md`.

--- a/docs/evals/runs/alpha-solver-spec-contamination-reconciliation-001/claim-boundary.md
+++ b/docs/evals/runs/alpha-solver-spec-contamination-reconciliation-001/claim-boundary.md
@@ -1,0 +1,20 @@
+# Claim boundary
+
+This lane is **docs/specs integrity** only. It claims only that it:
+
+- verified live GitHub `main`/PR state read-only,
+- detected and confirmed (by body hashing over committed files) that 22 `.specs/`
+  files carry the `MCP-005` Error-Taxonomy body under unrelated titles,
+- marked those 22 specs non-authoritative without altering their body text,
+- updated `docs/SPECS_HEALTH_AUDIT.md`, created `docs/SPECS_RECONCILIATION_PLAN.md`,
+  and added a health column to `.specs/INDEX.md`,
+- recorded a single selected next lane.
+
+It explicitly does **not** establish provider behavior, runtime behavior,
+security/privacy posture, readiness, or value/quality. It does **not** assert that
+any contaminated feature is correctly implemented — only that code+test files with
+the named paths exist (which makes reconstruction feasible).
+
+Boundary phrasing used throughout: **non-authoritative**, **not implementation
+scope**, **preserved unchanged**, **not reconstructed**, **operator decision
+required**, **does not claim**.

--- a/docs/evals/runs/alpha-solver-spec-contamination-reconciliation-001/code-target-existence.md
+++ b/docs/evals/runs/alpha-solver-spec-contamination-reconciliation-001/code-target-existence.md
@@ -1,0 +1,35 @@
+# Code-target existence (reconstruction feasibility)
+
+For every contaminated spec, all `## Code Targets` — implementation **and** test
+files — are present in the repository. The authentic feature each spec was meant
+to document therefore exists in committed code+tests, so its real spec can be
+**reconstructed from an authoritative in-repo source** (next lane), not from memory.
+
+| Spec | # Code Targets | On disk |
+|------|----------------|---------|
+| `MCP-001` | 3 | ✅ all present |
+| `MCP-002` | 2 | ✅ all present |
+| `MCP-003` | 2 | ✅ all present |
+| `MCP-004` | 2 | ✅ all present |
+| `MCP-006` | 2 | ✅ all present |
+| `MCP-007` | 2 | ✅ all present |
+| `NEW-009` | 4 | ✅ all present |
+| `NEW-010` | 4 | ✅ all present |
+| `NEW-011` | 3 | ✅ all present |
+| `NEW-012` | 3 | ✅ all present |
+| `NEW-013` | 3 | ✅ all present |
+| `NEW-014` | 4 | ✅ all present |
+| `NEW-015` | 4 | ✅ all present |
+| `NEW-016` | 4 | ✅ all present |
+| `NEW-017` | 4 | ✅ all present |
+| `RES-03` | 3 | ✅ all present |
+| `RES-04` | 3 | ✅ all present |
+| `RES-05` | 5 | ✅ all present |
+| `RES-06` | 4 | ✅ all present |
+| `RES-07` | 3 | ✅ all present |
+| `RES-08` | 5 | ✅ all present |
+| `AS-145` | 5 | ✅ all present |
+
+**Conclusion:** reconstruction is feasible for all 22 → selected next lane is
+`ALPHA-SOLVER-SPEC-SOURCE-RECONSTRUCTION-001` (source reconstruction), not the
+documentation-only `ALPHA-SOLVER-SPECS-INDEX-CLEANUP-001`.

--- a/docs/evals/runs/alpha-solver-spec-contamination-reconciliation-001/contamination-evidence.md
+++ b/docs/evals/runs/alpha-solver-spec-contamination-reconciliation-001/contamination-evidence.md
@@ -1,0 +1,44 @@
+# Contamination evidence
+
+`MCP-005` is the canonical Error-Taxonomy spec. The 22 specs below carry that same
+`Goal`/`Acceptance Criteria`/`Design`/`Tests` body under unrelated titles; only the
+`## Code Targets` line differs (and correctly matches each file's real feature).
+
+Canonical: `MCP-005` body hash = `a7c9ca95240e` (`service/mcp/error_taxonomy.py`,
+`tests/test_mcp_errors.py`).
+
+The two specifically named in the lane brief are confirmed:
+
+- **`MCP-002`** — title "Router decision rule (MCP)", body = MCP-005 Error Taxonomy.
+- **`NEW-010`** — title "Section-Specific Prompt Decks (RES_01)", body = MCP-005
+  Error Taxonomy.
+
+| Spec | Titled feature (authentic) | Normalized body hash | Relationship to MCP-005 |
+|------|----------------------------|----------------------|-------------------------|
+| `MCP-001` | MCP Registry Loader & Wiring (MCP) | `d8f98b83401a` | + prior hygiene note |
+| `MCP-002` | Router decision rule (MCP) | `a7c9ca95240e` | body == MCP-005 |
+| `MCP-003` | MCP OAuth/Secrets scaffold (auth surface) (MCP) | `a7c9ca95240e` | body == MCP-005 |
+| `MCP-004` | Sandbox Limits (policy guardrail) (MCP) | `a7c9ca95240e` | body == MCP-005 |
+| `MCP-006` | Retry & Backoff (MCP) | `a7c9ca95240e` | body == MCP-005 |
+| `MCP-007` | MCP Observability hooks (MCP) | `a7c9ca95240e` | body == MCP-005 |
+| `NEW-009` | Clarify Templates Pack (RES_02) | `a7c9ca95240e` | body == MCP-005 |
+| `NEW-010` | Section-Specific Prompt Decks (RES_01) | `a7c9ca95240e` | body == MCP-005 |
+| `NEW-011` | Weight-Tuning Harness (RES-03 scoring) (RES_03) | `a7c9ca95240e` | body == MCP-005 |
+| `NEW-012` | Budget CLI + CI Guard (RES_07) | `a7c9ca95240e` | body == MCP-005 |
+| `NEW-013` | Replay CLI + Trace Diff (text viewer) (RES_07) | `a7c9ca95240e` | body == MCP-005 |
+| `NEW-014` | Evidence Pack Store (catalog + retrieval) (RES_07) | `a7c9ca95240e` | body == MCP-005 |
+| `NEW-015` | Determinism Harness (exact replay & drift detector) (RES_07) | `a7c9ca95240e` | body == MCP-005 |
+| `NEW-016` | Grafana Dashboards Pack (metrics + sample boards) (RES_07) | `e51b49782566` | + prior hygiene note |
+| `NEW-017` | Prompt Quality Pack (rubrics + evaluator) (RES_01) | `a7c9ca95240e` | body == MCP-005 |
+| `RES-03` | Decision Rules & Scoring (RES) | `a7c9ca95240e` | body == MCP-005 |
+| `RES-04` | Confidence & Budget Gates (RES) | `a7c9ca95240e` | body == MCP-005 |
+| `RES-05` | Tool Adapters (Playwright, GSheets) — MVP stubs (RES) | `a7c9ca95240e` | body == MCP-005 |
+| `RES-06` | Scenario Pack & Showcase (record/replay + rubric) (RES) | `a7c9ca95240e` | body == MCP-005 |
+| `RES-07` | Observability (route_explain + JSONL replay) (RES) | `a7c9ca95240e` | body == MCP-005 |
+| `RES-08` | Budget Simulator + Evidence Pack (RES) | `a7c9ca95240e` | body == MCP-005 |
+| `AS-145` | Tool Adapters: Playwright + GSheets (MVP hardening) (RES_05) | `a7c9ca95240e` | body == MCP-005 |
+
+21 files (canonical `MCP-005` plus 20 contaminated specs) share body hash
+`a7c9ca95240e` byte-for-byte. `MCP-001` and `NEW-016` carry the same Error-Taxonomy
+body but hash differently only because a prior pass already prepended a hygiene
+note. No other duplicate body cluster exists anywhere in `.specs/`.

--- a/docs/evals/runs/alpha-solver-spec-contamination-reconciliation-001/contamination-evidence.md
+++ b/docs/evals/runs/alpha-solver-spec-contamination-reconciliation-001/contamination-evidence.md
@@ -1,11 +1,9 @@
 # Contamination evidence
 
 `MCP-005` is the canonical Error-Taxonomy spec. The 22 specs below carry that same
-`Goal`/`Acceptance Criteria`/`Design`/`Tests` body under unrelated titles; only the
-`## Code Targets` line differs (and correctly matches each file's real feature).
-
-Canonical: `MCP-005` body hash = `a7c9ca95240e` (`service/mcp/error_taxonomy.py`,
-`tests/test_mcp_errors.py`).
+`Goal` / `Acceptance Criteria` / `Design` / `Tests` body under unrelated titles;
+only the `## Code Targets` line differs (and correctly matches each file's real
+feature).
 
 The two specifically named in the lane brief are confirmed:
 
@@ -13,32 +11,89 @@ The two specifically named in the lane brief are confirmed:
 - **`NEW-010`** — title "Section-Specific Prompt Decks (RES_01)", body = MCP-005
   Error Taxonomy.
 
+## Normalization rule (Approach B — reproducible against the committed PR state)
+
+The hash below isolates the **copied contaminated body**, so it is identical for
+`MCP-005` and for every contaminated copy, and is **stable before and after** the
+non-authoritative banners were added. For each `.specs/*.md`, remove — in order:
+
+1. the **H1 title** line (first line starting with `# `);
+2. a **leading blockquote block** appearing before the first `## ` section header —
+   this excludes the newly added `⚠️ NON-AUTHORITATIVE` banner **and** any prior
+   hygiene note, neither of which is part of the copied body;
+3. the **`## Code Targets`** section (its header through the line before the next
+   `## ` header) — this is the one section that legitimately differs per file.
+
+Then collapse runs of blank lines, strip surrounding whitespace, and take the
+SHA-1 (first 12 hex) of the remainder.
+
+Because the rule excludes the title, the banner/hygiene note, and Code Targets,
+the surviving text is exactly the `Goal`/`Acceptance Criteria`/`Design`/`Tests`
+block that was copied from `MCP-005`. Under this rule **all 23 taxonomy-bearing
+specs (canonical `MCP-005` + 22 contaminated) hash to `a7c9ca95240e`** in the
+final committed state.
+
+## Reproduce
+
+```bash
+# 1. enumerate the taxonomy-bearing specs (23 = MCP-005 + 22 contaminated)
+grep -rl "Create a stable MCP error taxonomy" .specs/ | sort
+
+# 2. recompute the normalized contaminated-body hash for all of them
+python docs/evals/runs/alpha-solver-spec-contamination-reconciliation-001/reproduce-body-hash.py
+# -> distinct normalized body hashes: ['a7c9ca95240e'];  RESULT: PASS
+```
+
+The committed helper [`reproduce-body-hash.py`](reproduce-body-hash.py) implements
+exactly the rule above (offline; reads only `.specs/`; no providers; no tokens).
+
+## Evidence table
+
+Canonical: `MCP-005` (`service/mcp/error_taxonomy.py`, `tests/test_mcp_errors.py`),
+normalized body hash `a7c9ca95240e`.
+
 | Spec | Titled feature (authentic) | Normalized body hash | Relationship to MCP-005 |
 |------|----------------------------|----------------------|-------------------------|
-| `MCP-001` | MCP Registry Loader & Wiring (MCP) | `d8f98b83401a` | + prior hygiene note |
-| `MCP-002` | Router decision rule (MCP) | `a7c9ca95240e` | body == MCP-005 |
-| `MCP-003` | MCP OAuth/Secrets scaffold (auth surface) (MCP) | `a7c9ca95240e` | body == MCP-005 |
-| `MCP-004` | Sandbox Limits (policy guardrail) (MCP) | `a7c9ca95240e` | body == MCP-005 |
-| `MCP-006` | Retry & Backoff (MCP) | `a7c9ca95240e` | body == MCP-005 |
-| `MCP-007` | MCP Observability hooks (MCP) | `a7c9ca95240e` | body == MCP-005 |
-| `NEW-009` | Clarify Templates Pack (RES_02) | `a7c9ca95240e` | body == MCP-005 |
-| `NEW-010` | Section-Specific Prompt Decks (RES_01) | `a7c9ca95240e` | body == MCP-005 |
-| `NEW-011` | Weight-Tuning Harness (RES-03 scoring) (RES_03) | `a7c9ca95240e` | body == MCP-005 |
-| `NEW-012` | Budget CLI + CI Guard (RES_07) | `a7c9ca95240e` | body == MCP-005 |
-| `NEW-013` | Replay CLI + Trace Diff (text viewer) (RES_07) | `a7c9ca95240e` | body == MCP-005 |
-| `NEW-014` | Evidence Pack Store (catalog + retrieval) (RES_07) | `a7c9ca95240e` | body == MCP-005 |
-| `NEW-015` | Determinism Harness (exact replay & drift detector) (RES_07) | `a7c9ca95240e` | body == MCP-005 |
-| `NEW-016` | Grafana Dashboards Pack (metrics + sample boards) (RES_07) | `e51b49782566` | + prior hygiene note |
-| `NEW-017` | Prompt Quality Pack (rubrics + evaluator) (RES_01) | `a7c9ca95240e` | body == MCP-005 |
-| `RES-03` | Decision Rules & Scoring (RES) | `a7c9ca95240e` | body == MCP-005 |
-| `RES-04` | Confidence & Budget Gates (RES) | `a7c9ca95240e` | body == MCP-005 |
-| `RES-05` | Tool Adapters (Playwright, GSheets) — MVP stubs (RES) | `a7c9ca95240e` | body == MCP-005 |
-| `RES-06` | Scenario Pack & Showcase (record/replay + rubric) (RES) | `a7c9ca95240e` | body == MCP-005 |
-| `RES-07` | Observability (route_explain + JSONL replay) (RES) | `a7c9ca95240e` | body == MCP-005 |
-| `RES-08` | Budget Simulator + Evidence Pack (RES) | `a7c9ca95240e` | body == MCP-005 |
-| `AS-145` | Tool Adapters: Playwright + GSheets (MVP hardening) (RES_05) | `a7c9ca95240e` | body == MCP-005 |
+| `MCP-001` | MCP Registry Loader & Wiring (MCP) | `a7c9ca95240e` | copy of MCP-005 Error-Taxonomy body |
+| `MCP-002` | Router decision rule (MCP) | `a7c9ca95240e` | copy of MCP-005 Error-Taxonomy body |
+| `MCP-003` | MCP OAuth/Secrets scaffold (auth surface) (MCP) | `a7c9ca95240e` | copy of MCP-005 Error-Taxonomy body |
+| `MCP-004` | Sandbox Limits (policy guardrail) (MCP) | `a7c9ca95240e` | copy of MCP-005 Error-Taxonomy body |
+| `MCP-006` | Retry & Backoff (MCP) | `a7c9ca95240e` | copy of MCP-005 Error-Taxonomy body |
+| `MCP-007` | MCP Observability hooks (MCP) | `a7c9ca95240e` | copy of MCP-005 Error-Taxonomy body |
+| `NEW-009` | Clarify Templates Pack (RES_02) | `a7c9ca95240e` | copy of MCP-005 Error-Taxonomy body |
+| `NEW-010` | Section-Specific Prompt Decks (RES_01) | `a7c9ca95240e` | copy of MCP-005 Error-Taxonomy body |
+| `NEW-011` | Weight-Tuning Harness (RES-03 scoring) (RES_03) | `a7c9ca95240e` | copy of MCP-005 Error-Taxonomy body |
+| `NEW-012` | Budget CLI + CI Guard (RES_07) | `a7c9ca95240e` | copy of MCP-005 Error-Taxonomy body |
+| `NEW-013` | Replay CLI + Trace Diff (text viewer) (RES_07) | `a7c9ca95240e` | copy of MCP-005 Error-Taxonomy body |
+| `NEW-014` | Evidence Pack Store (catalog + retrieval) (RES_07) | `a7c9ca95240e` | copy of MCP-005 Error-Taxonomy body |
+| `NEW-015` | Determinism Harness (exact replay & drift detector) (RES_07) | `a7c9ca95240e` | copy of MCP-005 Error-Taxonomy body |
+| `NEW-016` | Grafana Dashboards Pack (metrics + sample boards) (RES_07) | `a7c9ca95240e` | copy of MCP-005 Error-Taxonomy body |
+| `NEW-017` | Prompt Quality Pack (rubrics + evaluator) (RES_01) | `a7c9ca95240e` | copy of MCP-005 Error-Taxonomy body |
+| `RES-03` | Decision Rules & Scoring (RES) | `a7c9ca95240e` | copy of MCP-005 Error-Taxonomy body |
+| `RES-04` | Confidence & Budget Gates (RES) | `a7c9ca95240e` | copy of MCP-005 Error-Taxonomy body |
+| `RES-05` | Tool Adapters (Playwright, GSheets) — MVP stubs (RES) | `a7c9ca95240e` | copy of MCP-005 Error-Taxonomy body |
+| `RES-06` | Scenario Pack & Showcase (record/replay + rubric) (RES) | `a7c9ca95240e` | copy of MCP-005 Error-Taxonomy body |
+| `RES-07` | Observability (route_explain + JSONL replay) (RES) | `a7c9ca95240e` | copy of MCP-005 Error-Taxonomy body |
+| `RES-08` | Budget Simulator + Evidence Pack (RES) | `a7c9ca95240e` | copy of MCP-005 Error-Taxonomy body |
+| `AS-145` | Tool Adapters: Playwright + GSheets (MVP hardening) (RES_05) | `a7c9ca95240e` | copy of MCP-005 Error-Taxonomy body |
 
-21 files (canonical `MCP-005` plus 20 contaminated specs) share body hash
-`a7c9ca95240e` byte-for-byte. `MCP-001` and `NEW-016` carry the same Error-Taxonomy
-body but hash differently only because a prior pass already prepended a hygiene
-note. No other duplicate body cluster exists anywhere in `.specs/`.
+All 22 contaminated specs and the canonical `MCP-005` share the single normalized
+body hash `a7c9ca95240e`. There is **no other** duplicate body cluster anywhere in
+`.specs/`.
+
+> Note on `MCP-001` and `NEW-016`: a prior pass (commit `a07d6b0`, #464) had
+> already prepended a weaker hygiene note to these two, which is why an earlier
+> draft of this packet recorded different raw hashes for them. This lane replaced
+> those notes with the standardized banner, and the normalization rule above
+> excludes any leading blockquote — so in the committed state both hash to
+> `a7c9ca95240e` like the rest. No earlier-stage hashes are relied upon; the only
+> authoritative figure is the reproducible `a7c9ca95240e` over the committed files.
+
+## Evidence boundary (unchanged)
+
+- Contaminated specs are marked **non-authoritative**; their bodies are
+  **preserved unchanged** (the contaminated body is what the hash is computed over).
+- No original intended spec is reconstructed or invented here.
+- No spec is deleted. `MCP-005` remains canonical and untouched.
+- Source reconstruction (recovering each real spec from committed code+tests)
+  remains a **future lane**, `ALPHA-SOLVER-SPEC-SOURCE-RECONSTRUCTION-001`.

--- a/docs/evals/runs/alpha-solver-spec-contamination-reconciliation-001/forbidden-claims.md
+++ b/docs/evals/runs/alpha-solver-spec-contamination-reconciliation-001/forbidden-claims.md
@@ -1,0 +1,17 @@
+# Forbidden claims (not made)
+
+This lane does **not** claim, and nothing in it should be read as claiming:
+
+- that any contaminated feature is correctly or completely implemented
+- that the existing code+tests for a titled feature are correct or passing
+- provider validation / OpenAI validation
+- runtime readiness / production readiness / public MVP readiness
+- security/privacy completion
+- benchmark validation or superiority
+- value or quality outcomes
+- that any spec was reconstructed (none was) or that the missing spec text is known
+
+Existence of a `## Code Targets` path means only that a file with that path is in
+the repo — it is **not** evidence of correctness, coverage, or behavior. The real
+spec text for each contaminated file remains **missing** until a future
+reconstruction lane recovers it from those committed sources.

--- a/docs/evals/runs/alpha-solver-spec-contamination-reconciliation-001/marking-actions.md
+++ b/docs/evals/runs/alpha-solver-spec-contamination-reconciliation-001/marking-actions.md
@@ -1,0 +1,26 @@
+# Marking actions (non-destructive)
+
+Each of the 22 contaminated specs received a standardized banner immediately under
+its H1 title; the contaminated body is preserved **unchanged** beneath it:
+
+```text
+> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
+> The Goal / Acceptance Criteria / Design / Tests sections below are a verbatim
+> copy of `MCP-005 · Error Taxonomy (MCP)` and do not describe this spec's titled
+> feature or its own Code Targets. ... Body preserved unchanged for forensic /
+> source-reconstruction purposes. Classification: SPEC_CONTAMINATED +
+> SPEC_NEEDS_SOURCE_RECONSTRUCTION.
+```
+
+- `MCP-001` and `NEW-016` already had a weaker prior hygiene note; it was replaced
+  by the standardized banner so all 22 are consistent. No information was lost.
+- `MCP-005` (canonical) was **not** modified.
+- `.specs/INDEX.md` gained a `Health` column and a pointer to the audit.
+- No spec body text was added, removed, or rewritten (banner is metadata only).
+
+## Verification
+
+- `grep -rl "NON-AUTHORITATIVE — CONTAMINATED SPEC" .specs/` → 22 files.
+- `grep -rl "Create a stable MCP error taxonomy" .specs/` → 23 files (22 + MCP-005):
+  the contaminated bodies are still present (preserved), confirming non-destruction.
+- `git diff --stat .specs/MCP-005.md` → empty (canonical untouched).

--- a/docs/evals/runs/alpha-solver-spec-contamination-reconciliation-001/methodology.md
+++ b/docs/evals/runs/alpha-solver-spec-contamination-reconciliation-001/methodology.md
@@ -3,13 +3,20 @@
 1. **Enumerate**: list all `.specs/*.md` (83 files).
 2. **Signature scan**: grep the Error-Taxonomy signature phrase
    `"Create a stable MCP error taxonomy"` → 23 files.
-3. **Body normalization + hashing**: for each spec, drop the H1 title line and the
-   `## Code Targets` section, normalize whitespace, SHA-1 hash, and cluster. This
-   isolates *body* identity from the (legitimately file-specific) title + targets.
+3. **Body normalization + hashing**: for each spec, drop (a) the H1 title line,
+   (b) a leading blockquote block before the first `## ` header — the
+   non-authoritative banner or any prior hygiene note — and (c) the
+   `## Code Targets` section; normalize whitespace; SHA-1 hash; cluster. Excluding
+   the title, banner/note, and targets isolates the *copied body* and keeps the
+   hash stable before and after bannering. The exact rule and a runnable
+   implementation are in [`contamination-evidence.md`](contamination-evidence.md)
+   and [`reproduce-body-hash.py`](reproduce-body-hash.py).
 4. **Cluster analysis**: exactly **one** multi-file body cluster exists — the
-   MCP-005 Error-Taxonomy body. 21 files share it byte-for-byte; `MCP-001` and
-   `NEW-016` carry the same body plus a prior hygiene note (so hash differs). No
-   other duplicate/near-duplicate body cluster exists among the remaining specs.
+   MCP-005 Error-Taxonomy body. Under the rule above, **all 23 taxonomy-bearing
+   specs (canonical `MCP-005` + 22 contaminated) hash to `a7c9ca95240e`** in the
+   committed state (`MCP-001` and `NEW-016` included — the rule excludes their
+   replaced hygiene note). No other duplicate/near-duplicate body cluster exists
+   among the remaining specs.
 5. **Canonical identification**: `MCP-005 · Error Taxonomy (MCP)` is the single
    legitimate source (title, body, and `## Code Targets`
    `service/mcp/error_taxonomy.py` all agree).
@@ -24,6 +31,8 @@
 ```bash
 grep -rl "Create a stable MCP error taxonomy" .specs/ | sort   # 23 files
 # MCP-005 is canonical; the other 22 are contaminated.
+python docs/evals/runs/alpha-solver-spec-contamination-reconciliation-001/reproduce-body-hash.py
+# -> all 23 share normalized body hash a7c9ca95240e; RESULT: PASS
 ```
 
 All steps are read-only over committed files. No spec content was inferred,

--- a/docs/evals/runs/alpha-solver-spec-contamination-reconciliation-001/methodology.md
+++ b/docs/evals/runs/alpha-solver-spec-contamination-reconciliation-001/methodology.md
@@ -1,0 +1,30 @@
+# Methodology (reproducible, read-only)
+
+1. **Enumerate**: list all `.specs/*.md` (83 files).
+2. **Signature scan**: grep the Error-Taxonomy signature phrase
+   `"Create a stable MCP error taxonomy"` → 23 files.
+3. **Body normalization + hashing**: for each spec, drop the H1 title line and the
+   `## Code Targets` section, normalize whitespace, SHA-1 hash, and cluster. This
+   isolates *body* identity from the (legitimately file-specific) title + targets.
+4. **Cluster analysis**: exactly **one** multi-file body cluster exists — the
+   MCP-005 Error-Taxonomy body. 21 files share it byte-for-byte; `MCP-001` and
+   `NEW-016` carry the same body plus a prior hygiene note (so hash differs). No
+   other duplicate/near-duplicate body cluster exists among the remaining specs.
+5. **Canonical identification**: `MCP-005 · Error Taxonomy (MCP)` is the single
+   legitimate source (title, body, and `## Code Targets`
+   `service/mcp/error_taxonomy.py` all agree).
+6. **Code-target existence check**: for every contaminated spec, test whether its
+   `## Code Targets` (impl + test files) exist in the repo — feeds the
+   reconstruction-feasibility finding.
+7. **Provenance (informational)**: `git log` shows the contaminated bodies and the
+   two prior hygiene notes both present as of commit `a07d6b0` (#464).
+
+## Reproduce
+
+```bash
+grep -rl "Create a stable MCP error taxonomy" .specs/ | sort   # 23 files
+# MCP-005 is canonical; the other 22 are contaminated.
+```
+
+All steps are read-only over committed files. No spec content was inferred,
+reconstructed, or invented during the audit.

--- a/docs/evals/runs/alpha-solver-spec-contamination-reconciliation-001/non-actions.md
+++ b/docs/evals/runs/alpha-solver-spec-contamination-reconciliation-001/non-actions.md
@@ -1,0 +1,17 @@
+# Non-actions
+
+What this lane did **not** do (by design):
+
+- Did not rewrite, reconstruct, or invent any spec body from memory.
+- Did not delete any spec or any evidence packet.
+- Did not modify `MCP-005` (canonical Error-Taxonomy spec).
+- Did not edit runtime/product code, provider/model code, tests, or CI.
+- Did not call any provider; used no tokens; ran no evals; ran no product runtime.
+- Did not access credentials or print secrets.
+- Did not resolve the reconstruct/deprecate/delete disposition (operator-gated,
+  handed to the next lane).
+- Did not rename or move any spec (filenames are stable identifiers).
+
+What it did: read-only GitHub/repo verification; body-hash contamination analysis
+over committed files; non-destructive marking of 22 contaminated specs; creation/
+update of the specs health index, reconciliation plan, and this evidence packet.

--- a/docs/evals/runs/alpha-solver-spec-contamination-reconciliation-001/per-spec-classification.md
+++ b/docs/evals/runs/alpha-solver-spec-contamination-reconciliation-001/per-spec-classification.md
@@ -1,0 +1,22 @@
+# Per-spec classification
+
+Full classification of all 83 `.specs/*.md` files is the index table in
+[`docs/SPECS_HEALTH_AUDIT.md`](../../../SPECS_HEALTH_AUDIT.md#full-specs-health-index-all-83-files).
+
+Summary:
+
+| Classification | Count |
+|----------------|-------|
+| `SPEC_OK` (incl. `MCP-005` canonical) | 57 |
+| `SPEC_CONTAMINATED` (+ `SPEC_NEEDS_SOURCE_RECONSTRUCTION`) | 22 |
+| `SPEC_NEEDS_OPERATOR_DECISION` | 2 |
+| `META` (registry files, not specs) | 2 |
+
+- `SPEC_CONTAMINATED` = the 22 listed in `contamination-evidence.md`.
+- `SPEC_NEEDS_SOURCE_RECONSTRUCTION` = the same 22 (remediation path; code+tests exist).
+- `SPEC_DUPLICATE_BODY` = the same 22 form one duplicate-body set; filed under
+  `SPEC_CONTAMINATED` as the primary actionable label.
+- `SPEC_NEEDS_OPERATOR_DECISION` = `MVP-READINESS-CHECKPOINT-001`,
+  `MVP-CLOSEOUT-001` (spec/doc overlap, ISS-010).
+- `SPEC_STALE` = none confirmed; staleness was not exhaustively assessed beyond
+  the contamination scope (the only duplicate-body cluster is the taxonomy one).

--- a/docs/evals/runs/alpha-solver-spec-contamination-reconciliation-001/reconciliation-summary.md
+++ b/docs/evals/runs/alpha-solver-spec-contamination-reconciliation-001/reconciliation-summary.md
@@ -1,0 +1,12 @@
+# Reconciliation summary
+
+Routing only — no spec reconstructed, rewritten, or deleted here. Full per-spec
+routing: [`docs/SPECS_RECONCILIATION_PLAN.md`](../../../SPECS_RECONCILIATION_PLAN.md).
+
+1. **Confirmed** systemic contamination (22 specs carry the MCP-005 body).
+2. **Marked** all 22 non-authoritative; preserved their bodies; indexed all 83.
+3. **Established feasibility**: all 22 titled features exist in committed code+tests.
+4. **Deferred** the actual reconstruction and the reconstruct/deprecate/delete
+   disposition to `ALPHA-SOLVER-SPEC-SOURCE-RECONSTRUCTION-001` (operator-gated).
+
+The taxonomy source of truth (`MCP-005`) remains untouched and authoritative.

--- a/docs/evals/runs/alpha-solver-spec-contamination-reconciliation-001/repo-state-verification.md
+++ b/docs/evals/runs/alpha-solver-spec-contamination-reconciliation-001/repo-state-verification.md
@@ -1,0 +1,31 @@
+# Repo-state verification
+
+Read-only verification performed 2026-06-13 (no provider calls; no secrets read).
+Repo: `adonisdv23/Alpha-Solver`. Lane branch: `claude/nifty-einstein-nlvyu8`.
+
+## Base
+
+- Local `HEAD` = `c799a73` = **`main` #514** ("docs(audit): add DEF-003 Fable
+  audit custody packet"), confirmed via the GitHub API as the latest commit on
+  `main`. `git merge-base --is-ancestor c799a73 HEAD` → true, so this lane builds
+  on current `main`.
+
+## Open PRs (no conflict)
+
+`list_pull_requests(state=open)` → **#516** only
+("test: make git commit tests hermetic under commit signing", branch
+`codex/fix-test-hermeticity-for-git-commit-signing`). It touches `tests/` and
+test helpers only — **no overlap** with this lane's `.specs/` and `docs/` files.
+
+## Targets present on `main`
+
+- `.specs/` contains 83 `.md` files (81 specs + `INDEX.md` + `README.md`). ✅
+- Prior `docs/SPECS_HEALTH_AUDIT.md` (from the current-state docs lane) present
+  and is superseded/updated here. ✅
+- `MCP-005.md` canonical Error-Taxonomy spec present; left unmodified. ✅
+
+## Environment note
+
+No `OPENAI_API_KEY` or other secret was read, printed, or used. This lane makes
+no provider precondition and performs no network calls beyond read-only GitHub
+state verification.

--- a/docs/evals/runs/alpha-solver-spec-contamination-reconciliation-001/reproduce-body-hash.py
+++ b/docs/evals/runs/alpha-solver-spec-contamination-reconciliation-001/reproduce-body-hash.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Reproduce the contaminated-body hash evidence for
+ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001.
+
+This is an offline evidence/reproduction helper. It is NOT runtime, product,
+provider, model, test, or CI code. It reads only committed `.specs/*.md` files,
+computes a normalized hash of the *copied contaminated body*, and asserts that
+the legitimate `MCP-005` Error-Taxonomy body and every contaminated copy share
+one hash. It calls no providers and uses no tokens.
+
+Run from the repository root:
+
+    python docs/evals/runs/alpha-solver-spec-contamination-reconciliation-001/reproduce-body-hash.py
+
+Expected: all 23 taxonomy-bearing specs (canonical `MCP-005` + 22 contaminated)
+print the single normalized body hash `a7c9ca95240e`.
+
+Normalization rule (see contamination-evidence.md) — for each spec, remove:
+  1. the H1 title line (first line starting with '# ');
+  2. a leading blockquote block before the first '## ' section header — this is
+     the non-authoritative banner OR any prior hygiene note;
+  3. the '## Code Targets' section (header through the line before the next '## ');
+then collapse blank-line runs, strip, and SHA-1 the remainder (first 12 hex).
+Excluding the title, banner/note, and Code Targets isolates the body that was
+actually copied from MCP-005, so the hash is stable before/after bannering.
+"""
+from __future__ import annotations
+
+import hashlib
+import re
+import sys
+from pathlib import Path
+
+SIGNATURE = "Create a stable MCP error taxonomy"
+EXPECTED_HASH = "a7c9ca95240e"
+
+
+def normalize_contaminated_body(text: str) -> str:
+    lines = text.split("\n")
+    # 1. drop the H1 title line
+    if lines and lines[0].startswith("# "):
+        lines = lines[1:]
+    # 2. drop a leading blockquote block (banner / prior hygiene note) before '## '
+    i = 0
+    while i < len(lines) and lines[i].strip() == "":
+        i += 1
+    if i < len(lines) and lines[i].lstrip().startswith(">"):
+        while i < len(lines) and (lines[i].lstrip().startswith(">") or lines[i].strip() == ""):
+            if lines[i].startswith("## "):
+                break
+            i += 1
+        lines = lines[i:]
+    # 3. drop the '## Code Targets' section
+    out: list[str] = []
+    skip = False
+    for ln in lines:
+        if re.match(r"^##\s+Code Targets\b", ln):
+            skip = True
+            continue
+        if skip:
+            if re.match(r"^##\s+", ln):
+                skip = False
+            else:
+                continue
+        out.append(ln.rstrip())
+    body = re.sub(r"\n{3,}", "\n\n", "\n".join(out)).strip()
+    return body
+
+
+def body_hash(text: str) -> str:
+    return hashlib.sha1(normalize_contaminated_body(text).encode("utf-8")).hexdigest()[:12]
+
+
+def main(argv: list[str] | None = None) -> int:
+    repo_root = Path(__file__).resolve().parents[4]
+    specs_dir = repo_root / ".specs"
+    taxonomy_specs = sorted(
+        p for p in specs_dir.glob("*.md")
+        if SIGNATURE in p.read_text(encoding="utf-8")
+    )
+    hashes = {p.name: body_hash(p.read_text(encoding="utf-8")) for p in taxonomy_specs}
+    distinct = sorted(set(hashes.values()))
+
+    print(f"taxonomy-bearing specs: {len(taxonomy_specs)} "
+          f"(canonical MCP-005 + {len(taxonomy_specs) - 1} contaminated)")
+    print(f"distinct normalized body hashes: {distinct}")
+    for name in sorted(hashes):
+        print(f"  {name:16s} {hashes[name]}")
+
+    ok = distinct == [EXPECTED_HASH]
+    print("\nRESULT:", "PASS" if ok else "FAIL",
+          f"- all share {EXPECTED_HASH}" if ok else f"- expected only [{EXPECTED_HASH}]")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/evals/runs/alpha-solver-spec-contamination-reconciliation-001/selected-next-lane.md
+++ b/docs/evals/runs/alpha-solver-spec-contamination-reconciliation-001/selected-next-lane.md
@@ -1,0 +1,26 @@
+# Selected next lane
+
+```text
+ALPHA-SOLVER-SPEC-SOURCE-RECONSTRUCTION-001
+```
+
+Exactly one next lane is selected. Per the lane brief's branching:
+
+- Contaminated specs **are confirmed** → select source reconstruction
+  (`ALPHA-SOLVER-SPEC-SOURCE-RECONSTRUCTION-001`), **not** the documentation-only
+  `ALPHA-SOLVER-SPECS-INDEX-CLEANUP-001`.
+- Feasibility is established here: every contaminated spec's titled feature exists
+  in committed code+tests, so reconstruction can use an authoritative in-repo
+  source rather than memory.
+
+## Scope handed to the next lane
+
+- For each of the 22 specs, draft the real
+  `Goal / Motivation / Acceptance Criteria / Definition of Done / Code Targets /
+  Test Plan` strictly from its committed code+tests; replace the contaminated body
+  in place; keep the filename.
+- Resolve the operator disposition first (reconstruct **A** / deprecate **B** /
+  delete **C**). Default recommendation: **A**.
+- Keep `MCP-005` untouched.
+
+This selection authorizes no provider call, runtime exposure, or readiness claim.

--- a/docs/evals/runs/alpha-solver-spec-contamination-reconciliation-001/verdict.md
+++ b/docs/evals/runs/alpha-solver-spec-contamination-reconciliation-001/verdict.md
@@ -1,0 +1,33 @@
+# Verdict
+
+```text
+SPEC_CONTAMINATION_RECONCILIATION_CAPTURED
+```
+
+## Why this verdict
+
+The lane's reconciliation work is **captured**: contamination is confirmed by
+reproducible body hashing, all 22 contaminated specs are marked non-authoritative
+(bodies preserved), the full 83-file specs health index and the per-spec
+reconciliation plan are written, and the canonical `MCP-005` is left untouched.
+
+## Allowed verdicts (this lane's selection in **bold**)
+
+- **`SPEC_CONTAMINATION_RECONCILIATION_CAPTURED`** ← selected
+- `SPEC_CONTAMINATION_CONFIRMED_OPERATOR_DECISION_REQUIRED` — not selected as the
+  primary verdict: contamination is confirmed, but this lane already performed the
+  permitted reconciliation (marking + indexing + planning). The remaining
+  operator decision is the **disposition** (reconstruct/deprecate/delete), which
+  is explicitly carried into `ALPHA-SOLVER-SPEC-SOURCE-RECONSTRUCTION-001`.
+- `SPECS_HEALTH_CLEAR` — false; contamination is present and systemic.
+- `STOP_INCONCLUSIVE` — false; the audit is conclusive.
+
+## Carried operator decision
+
+Final disposition of the 22 contaminated specs (reconstruct **A** / deprecate **B**
+/ delete **C**) requires operator sign-off and is the entry gate of the next lane.
+Default recommendation: **A** (reconstruct from committed code+tests).
+
+## Next lane
+
+`ALPHA-SOLVER-SPEC-SOURCE-RECONSTRUCTION-001`.


### PR DESCRIPTION
## Lane

`ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — docs/specs-integrity lane. Audits and reconciles `.specs/*.md` files carrying copied or mismatched content, specifically specs carrying the **MCP-005 Error Taxonomy** body under unrelated titles.

**Verdict:** `SPEC_CONTAMINATION_RECONCILIATION_CAPTURED` · **Next lane:** `ALPHA-SOLVER-SPEC-SOURCE-RECONSTRUCTION-001`

## Headline finding (CONFIRMED, systemic)

The hypothesis is confirmed: **`MCP-002`, `NEW-010`, and 20 other specs carry the `MCP-005` Error-Taxonomy body under unrelated titles**. Method: for each `.specs/*.md`, the body was normalized (drop H1 title + `## Code Targets`), SHA-1 hashed, and clustered — yielding **exactly one** multi-file body cluster (the taxonomy body). `MCP-005` is the sole canonical source.

Reproduce: `grep -rl "Create a stable MCP error taxonomy" .specs/` → 23 files (MCP-005 + 22 contaminated).

**Decisive for remediation:** every contaminated spec's `## Code Targets` (implementation **and** test files) are present in the repo, so the real spec can be reconstructed from an authoritative in-repo source (code+tests) in the next lane — never from memory.

## Changes

- **Marked all 22 contaminated specs non-authoritative** with a standardized `⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC` banner under each title. Contaminated bodies **preserved verbatim** (20 are pure insertions; `MCP-001`/`NEW-016` swapped a weaker prior note). **No spec rewritten from memory; no spec deleted.**
- **`docs/SPECS_HEALTH_AUDIT.md`** — updated; full **83-file health index** + contamination evidence + reproducible method.
- **`docs/SPECS_RECONCILIATION_PLAN.md`** — new; per-spec reconstruction routing (feature → committed code+tests) + operator disposition options.
- **`.specs/INDEX.md`** — added a `Health` column.
- **`docs/evals/runs/alpha-solver-spec-contamination-reconciliation-001/`** — 13-file evidence packet (methodology, contamination-evidence, code-target-existence, marking-actions, classification, verdict, claim-boundary, forbidden-claims, non-actions, selected-next-lane, …).

## Classification

| Classification | Count |
|----------------|-------|
| `SPEC_OK` (incl. `MCP-005` canonical, `DO_NOT_TOUCH`) | 57 |
| `SPEC_CONTAMINATED` (+ `SPEC_NEEDS_SOURCE_RECONSTRUCTION`) | 22 |
| `SPEC_NEEDS_OPERATOR_DECISION` (MVP doc overlap, ISS-010) | 2 |
| `META` (registry files) | 2 |

## Boundaries honored

No spec rewritten from memory · no original spec invented · no spec deleted · `MCP-005` untouched · no runtime/product code, tests, or CI changed · no provider calls · no tokens. This is a docs-integrity audit and makes no runtime/provider/readiness/value claim.

## Operator decision carried to next lane

Final disposition of the 22 contaminated specs — reconstruct (A, recommended; sources exist) / deprecate (B) / delete (C) — requires operator sign-off and is the entry gate of `ALPHA-SOLVER-SPEC-SOURCE-RECONSTRUCTION-001`.

https://claude.ai/code/session_0164TMZzsnixMne3xzk5LPmd

---
_Generated by [Claude Code](https://claude.ai/code/session_0164TMZzsnixMne3xzk5LPmd)_