### PR TITLE
docs(runtime): add Alpha Solver runtime entrypoint map

### DIFF
--- a/docs/evals/runs/alpha-solver-runtime-entrypoint-map-001/README.md
+++ b/docs/evals/runs/alpha-solver-runtime-entrypoint-map-001/README.md
@@ -24,7 +24,7 @@ Read-only documentation only. No runtime code, tests, CI, service/dashboard/prov
 | `duplicate-surface-map.md` | Overlapping `alpha/`, `service/`, dashboard, portable, and CLI surfaces. |
 | `consolidation-candidates.md` | Staged consolidation candidates only; no implementation authorization. |
 | `do-not-consolidate-yet.md` | No-touch zones until value proof and security boundaries are proven. |
-| `selected-next-lane.md` | Exactly one low-risk next lane selected by this packet. |
+| `selected-next-lane.md` | Runtime-map-local recommended follow-up candidate; does not change the repo-global selected next lane. |
 | `evidence-boundary.md` | Evidence reviewed and claim boundaries. |
 | `non-actions.md` | Explicit non-actions and safety confirmations. |
 
@@ -33,3 +33,5 @@ Read-only documentation only. No runtime code, tests, CI, service/dashboard/prov
 The repository contains multiple runtime-shaped surfaces: the FastAPI service app, `/v1/solve`, a fail-closed mounted dashboard preview, standalone dashboard route modules, the modular/reference `alpha_solver_entry.py` and `alpha-solver-v91-python.py` CLI/import path, the portable monolith contract, provider adapters, evidence API router, middleware components, config/settings paths, and observability dashboards. These are not one consolidated public product surface.
 
 The highest-risk boundaries remain public exposure prerequisites: default API key and CORS defaults, `/v1/solve` not using the separate JWT/tenant middleware stack, dashboard settings routes capable of storing provider keys when mounted outside the bundled fail-closed service path, and OpenAI provider calls gated by environment but live-capable when explicitly enabled.
+
+This packet does **not** change the repo-global selected next lane. The repo-global selected next lane remains controlled by `docs/CURRENT_STATE.md` and `docs/LANE_REGISTRY.md`; this packet only records `ALPHA-SOLVER-RUNTIME-ENTRYPOINT-DOCS-CROSS-LINK-001` as a runtime-map-local recommended follow-up candidate.

--- a/docs/evals/runs/alpha-solver-runtime-entrypoint-map-001/README.md
+++ b/docs/evals/runs/alpha-solver-runtime-entrypoint-map-001/README.md
@@ -1,0 +1,35 @@
+# Alpha Solver Runtime Entrypoint Map 001
+
+Lane: `ALPHA-SOLVER-RUNTIME-ENTRYPOINT-MAP-001`
+
+Verdict: `RUNTIME_ENTRYPOINT_MAP_CAPTURED`
+
+## Purpose
+
+This packet maps Alpha Solver runtime, service, dashboard, provider, API, CLI, and portable-contract entrypoints before any architecture consolidation or public exposure decision.
+
+## Scope
+
+Read-only documentation only. No runtime code, tests, CI, service/dashboard/provider/model/auth code, credentials, tokens, provider calls, deployment, or `/v1/solve` exposure were changed or exercised.
+
+## Files in this packet
+
+| File | Purpose |
+|---|---|
+| `entrypoint-inventory.md` | Product/runtime entrypoints and status classification. |
+| `boundary-map.md` | Auth, CORS, tenancy, rate-limit, settings, secret, provider, telemetry, and evidence boundaries. |
+| `provider-call-paths.md` | Static provider-call paths and non-call paths. |
+| `auth-tenancy-cors-map.md` | Exposure-layer auth, tenancy, and CORS wiring. |
+| `dashboard-and-v1-solve-map.md` | Dashboard mounting and `/v1/solve` surface map. |
+| `duplicate-surface-map.md` | Overlapping `alpha/`, `service/`, dashboard, portable, and CLI surfaces. |
+| `consolidation-candidates.md` | Staged consolidation candidates only; no implementation authorization. |
+| `do-not-consolidate-yet.md` | No-touch zones until value proof and security boundaries are proven. |
+| `selected-next-lane.md` | Exactly one low-risk next lane selected by this packet. |
+| `evidence-boundary.md` | Evidence reviewed and claim boundaries. |
+| `non-actions.md` | Explicit non-actions and safety confirmations. |
+
+## Summary
+
+The repository contains multiple runtime-shaped surfaces: the FastAPI service app, `/v1/solve`, a fail-closed mounted dashboard preview, standalone dashboard route modules, the modular/reference `alpha_solver_entry.py` and `alpha-solver-v91-python.py` CLI/import path, the portable monolith contract, provider adapters, evidence API router, middleware components, config/settings paths, and observability dashboards. These are not one consolidated public product surface.
+
+The highest-risk boundaries remain public exposure prerequisites: default API key and CORS defaults, `/v1/solve` not using the separate JWT/tenant middleware stack, dashboard settings routes capable of storing provider keys when mounted outside the bundled fail-closed service path, and OpenAI provider calls gated by environment but live-capable when explicitly enabled.

--- a/docs/evals/runs/alpha-solver-runtime-entrypoint-map-001/auth-tenancy-cors-map.md
+++ b/docs/evals/runs/alpha-solver-runtime-entrypoint-map-001/auth-tenancy-cors-map.md
@@ -1,0 +1,12 @@
+# Auth, Tenancy, and CORS Map
+
+| Surface | Auth | Tenancy | CORS | Rate limit | Classification |
+|---|---|---|---|---|---|
+| `POST /v1/solve` | API key via configured header and `validate_api_key`; default key path exists through config. | No mounted tenant middleware in bundled app; request context may carry tenant/model-set hints but is not enforcement. | App-level CORS applies; default origin is wildcard. | `rate_limiter` dependency. | active / unsafe-to-expose |
+| Bundled dashboard preview | Dashboard password/session/CSRF only when fail-closed env requirements pass. | No tenant enforcement found at mount. | App-level CORS applies. | Live preview has provider-specific cap; dashboard auth has lockout. | active support / unsafe-to-expose |
+| Standalone dashboard settings/request/run/jobs routers | Depend on caller mounting auth/security. | None intrinsic. | Depends on caller app. | Mock routes have no product rate limit. | unknown / unsafe-to-expose |
+| `AuthMiddleware` component | JWT RS256/API-key support with scopes and audit. | Principal includes tenant; optional per-tenant limiter. | N/A. | Optional. | active component / not bundled solve path |
+| `TenantMiddleware` component | None by itself. | Requires/extracts tenant and uses `TenantLimiter`. | N/A. | Tenant limiter. | active component / not bundled solve path |
+| Evidence API router | No intrinsic auth in router. | None intrinsic. | Depends on caller app. | None intrinsic. | component / unsafe if mounted unauthenticated |
+
+Conclusion: the repository has reusable auth/tenancy components, but `/v1/solve` exposure currently maps to the simpler API-key/rate-limit boundary rather than the full JWT/tenant middleware boundary.

--- a/docs/evals/runs/alpha-solver-runtime-entrypoint-map-001/boundary-map.md
+++ b/docs/evals/runs/alpha-solver-runtime-entrypoint-map-001/boundary-map.md
@@ -1,0 +1,12 @@
+# Boundary Map
+
+| Boundary | Entrypoints affected | Static finding | Exposure note |
+|---|---|---|---|
+| Auth | `/v1/solve`; middleware stack; dashboard | `/v1/solve` uses API-key validation in `rate_limiter`; separate `AuthMiddleware` supports JWT/API key but is not mounted on bundled app. Dashboard uses session cookies/CSRF. | Public exposure blocked until intended auth model is confirmed and defaults remediated. |
+| CORS | FastAPI app | `CORSMiddleware` is installed with configured origins and `allow_credentials=True`; config default origin is `*`. | Unsafe public default. |
+| Tenancy | Middleware components; provider telemetry | Tenant middleware and limiter exist and tests exercise them; bundled `/v1/solve` does not mount tenant middleware. | Do not claim tenant isolation for `/v1/solve`. |
+| Rate limit | `/v1/solve`; AuthMiddleware; TenantLimiter | `/v1/solve` has sliding-window per API key/client limiter. AuthMiddleware has optional per-tenant rate limit. TenantLimiter exists separately. | Multiple rate-limit systems overlap. |
+| Settings/secrets | Dashboard settings route; OpenAI provider env | Dashboard settings route stores provider keys in a file backend; OpenAI provider reads `OPENAI_API_KEY` env. | Do not access secrets; settings route should remain unmounted publicly. |
+| Provider | `/v1/solve`; expert preview; `alpha/providers/openai.py` | OpenAI path only when explicit env selects OpenAI; provider client posts to Responses API. Expert preview has extra live-preview guard. | No provider was called. |
+| Telemetry | Service logging, metrics, provider telemetry, observability CLI | Request IDs, Prometheus server, OpenTelemetry fallback, provider events/accounting exist. | Telemetry is boundary metadata, not value proof. |
+| Evidence | `service/evidence/api.py`, store/collector, eval packets | Evidence router accepts caller-provided manifests/metrics; docs packets are evidence artifacts. | Evidence API must not receive secrets. |

--- a/docs/evals/runs/alpha-solver-runtime-entrypoint-map-001/consolidation-candidates.md
+++ b/docs/evals/runs/alpha-solver-runtime-entrypoint-map-001/consolidation-candidates.md
@@ -1,0 +1,29 @@
+# Consolidation Candidates
+
+These are staged strategy candidates only. They are not implementation tasks in this PR.
+
+## Stage 0 — Keep mapping authoritative
+
+- Keep this packet as the runtime entrypoint inventory for future architecture decisions.
+- Require future runtime exposure PRs to cite which entrypoint(s) they touch.
+
+## Stage 1 — Documentation-only alignment
+
+- Add a concise public/non-public entrypoint table to `docs/ENTRYPOINTS.md` or a successor architecture doc.
+- Cross-link the DEF-002 security/privacy packet and this runtime map.
+- Document that bundled `/v1/solve` currently uses API-key/rate-limit controls, not the separate JWT/tenant middleware stack.
+
+## Stage 2 — Low-risk config clarification
+
+- Confirm intended auth/tenancy model for `/v1/solve` without changing code.
+- Confirm whether standalone dashboard settings/request/run/jobs routes are legacy/demo-only or future product surfaces.
+
+## Stage 3 — Only after value/security proof
+
+- Consider unifying rate-limit semantics and telemetry labels.
+- Consider explicit mount manifests for dashboard/evidence/service routers.
+- Consider portable-vs-modular behavior drift tests before any contract consolidation.
+
+## Not authorized here
+
+No rewrite, runtime consolidation, route exposure, provider validation, credential migration, auth refactor, or dashboard enablement is authorized by this packet.

--- a/docs/evals/runs/alpha-solver-runtime-entrypoint-map-001/consolidation-candidates.md
+++ b/docs/evals/runs/alpha-solver-runtime-entrypoint-map-001/consolidation-candidates.md
@@ -1,6 +1,6 @@
 # Consolidation Candidates
 
-These are staged strategy candidates only. They are not implementation tasks in this PR.
+These are staged strategy candidates only. They are not implementation tasks in this PR and do not alter the repo-global selected next lane controlled by `docs/CURRENT_STATE.md` and `docs/LANE_REGISTRY.md`.
 
 ## Stage 0 — Keep mapping authoritative
 
@@ -10,7 +10,7 @@ These are staged strategy candidates only. They are not implementation tasks in 
 ## Stage 1 — Documentation-only alignment
 
 - Add a concise public/non-public entrypoint table to `docs/ENTRYPOINTS.md` or a successor architecture doc.
-- Cross-link the DEF-002 security/privacy packet and this runtime map.
+- Cross-link the DEF-002 security/privacy packet and this runtime map only through a runtime-map-local recommended follow-up candidate; do not present that candidate as the repo-global selected next lane.
 - Document that bundled `/v1/solve` currently uses API-key/rate-limit controls, not the separate JWT/tenant middleware stack.
 
 ## Stage 2 — Low-risk config clarification

--- a/docs/evals/runs/alpha-solver-runtime-entrypoint-map-001/dashboard-and-v1-solve-map.md
+++ b/docs/evals/runs/alpha-solver-runtime-entrypoint-map-001/dashboard-and-v1-solve-map.md
@@ -1,0 +1,21 @@
+# Dashboard and `/v1/solve` Map
+
+## `/v1/solve`
+
+- Route: `POST /v1/solve` on `service.app`.
+- Input: `SolveRequest` with `query`, optional `strategy`, and optional `context`.
+- Controls: API-key validation through the route dependency, sliding-window rate limit, query sanitizer, request ID middleware, SAFE-OUT exception handling, and provider SAFE-OUT paths.
+- Provider branch: only when `MODEL_PROVIDER=openai`.
+- Local branch: calls the modular/reference `_tree_of_thought` path through `alpha_solver_entry.py`.
+- Missing from bundled route: separate JWT middleware, tenant middleware, evidence API, and full dashboard settings route.
+
+## Dashboard
+
+- Bundled mount is fail-closed unless a non-default `ALPHA_DASHBOARD_PASSWORD` and explicit `ALPHA_DASHBOARD_SECRET_KEY` are set.
+- Bundled mount includes only dashboard auth and expert preview, not full settings/request/run/jobs routes.
+- Expert preview is supervised-only by wording and has a separate live OpenAI guard/cap.
+- Standalone dashboard modules are product-shaped and should not be assumed safe merely because they exist.
+
+## Exposure decision
+
+This packet does not expose `/v1/solve` or dashboard routes and does not claim either is ready. Both remain unsafe-to-expose until the intended security model, CORS policy, secret storage, provider disclosure, tenancy behavior, and operational controls are resolved.

--- a/docs/evals/runs/alpha-solver-runtime-entrypoint-map-001/do-not-consolidate-yet.md
+++ b/docs/evals/runs/alpha-solver-runtime-entrypoint-map-001/do-not-consolidate-yet.md
@@ -1,0 +1,16 @@
+# Do Not Consolidate Yet
+
+Do not consolidate these zones until value proof, security proof, and operator authorization exist:
+
+1. `alpha_solver_portable.py` portable standalone contract.
+2. `/v1/solve` runtime behavior and provider/local branching.
+3. Provider client/request/accounting/SAFE-OUT machinery.
+4. Dashboard auth/session/CSRF and expert preview guard.
+5. Dashboard settings secret storage and audit file paths.
+6. Auth/JWT/API-key middleware and tenant middleware.
+7. Evidence API/store/collector semantics.
+8. Budget guard, determinism, observability, replay, routing, SAFE-OUT, and SolverEnvelope behavior.
+9. Legacy/reference entrypoints `alpha-solver-v91-python.py` and `alpha_solver_entry.py`.
+10. CI/tests that encode current behavior.
+
+Reason: these surfaces are security-sensitive, contract-sensitive, or evidence-sensitive, and the repository state explicitly does not yet support broad runtime/provider/public-readiness claims.

--- a/docs/evals/runs/alpha-solver-runtime-entrypoint-map-001/duplicate-surface-map.md
+++ b/docs/evals/runs/alpha-solver-runtime-entrypoint-map-001/duplicate-surface-map.md
@@ -1,0 +1,11 @@
+# Duplicate and Overlapping Surface Map
+
+| Overlap | Surfaces | Risk |
+|---|---|---|
+| API auth | `/v1/solve` API-key dependency vs `AuthMiddleware` JWT/API-key stack | Operators may assume JWT/tenant middleware protects `/v1/solve` when it is not mounted there. |
+| Rate limiting | `/v1/solve` in-memory limiter, `AuthMiddleware` optional limiter, `TenantLimiter` | Multiple implementations can diverge in semantics and observability. |
+| Dashboard routes | Bundled fail-closed auth+preview vs standalone settings/request/run/jobs routers | Standalone routers can look public-ready but are not bundled in the safer mount. |
+| Provider entry | `/v1/solve` provider branch, expert preview guard, OpenAI client, local-LLM adapter, fake provider | Provider-capable code exists in several layers with different guard semantics. |
+| Solver behavior | `alpha_solver_portable.py` contract, `alpha-solver-v91-python.py`, `alpha_solver_entry.py`, service local fallback | Portable prompt contract and modular runtime may drift if consolidated without tests/spec. |
+| Evidence | Eval packet docs vs `service/evidence/api.py` runtime router | Evidence artifacts are documentation; evidence API is mutable runtime storage and needs auth if exposed. |
+| Observability | Service logs/metrics, provider telemetry/accounting, Grafana dashboards, CLI replay/record flags | Observability surfaces do not share one explicit runtime authority. |

--- a/docs/evals/runs/alpha-solver-runtime-entrypoint-map-001/entrypoint-inventory.md
+++ b/docs/evals/runs/alpha-solver-runtime-entrypoint-map-001/entrypoint-inventory.md
@@ -1,0 +1,23 @@
+# Entrypoint Inventory
+
+Status terms: **active** means importable/mounted in current code or directly executable; **test-only** means primarily exercised in tests; **docs-only** means documentation/observability artifact only; **legacy** means reference/back-compat path; **unknown** means runtime role needs confirmation; **unsafe-to-expose** means do not expose without remediation/explicit operator decision.
+
+| Entrypoint / surface | Evidence | Classification | Notes |
+|---|---|---:|---|
+| FastAPI app object `service.app:app` | `service/app.py` constructs `FastAPI`, middleware, health/OpenAPI-ish routes, dashboard conditional mount, and `/v1/solve`. | active / unsafe-to-expose | Runnable app surface, but not public-ready. |
+| `POST /v1/solve` | `service/app.py` route depends on `rate_limiter`, sanitizes query, then branches to OpenAI provider only when `MODEL_PROVIDER=openai`; otherwise local ToT. | active / unsafe-to-expose | Main product API shape; exposure remains unauthorized. |
+| Dashboard bundled mount | `service/app.py` mounts only dashboard auth plus `expert_preview` when non-default dashboard password and explicit secret are configured. | active / unsafe-to-expose | Fail-closed by default; preview can become provider-backed if env enables it. |
+| `alpha/webapp/routes/auth.py` | Login/session/CSRF middleware and router. | active support / unsafe-to-expose alone | Safe only when mounted with explicit password/secret expectations. |
+| `alpha/webapp/routes/expert_preview.py` | `/dashboard/expert-preview` route and live OpenAI preview guard. | active support / unsafe-to-expose | Bundled dashboard route; guarded but live-capable. |
+| `alpha/webapp/routes/settings.py` | Settings UI for provider API keys with file-backed secrets and audit log. | unknown / unsafe-to-expose | Not mounted by bundled service app; risky if mounted elsewhere. |
+| `alpha/webapp/routes/requests.py`, `jobs.py`, `run.py` | Mock request/job/demo routes. | unknown / test/demo-only | Not mounted by bundled service app; can look product-like. |
+| `alpha_solver_entry.py` | Imports `alpha-solver-v91-python.py`, exposes `AlphaSolver`, `_tree_of_thought`, `get_solver`. | active legacy/reference | Used by service local fallback and tests. |
+| `alpha-solver-v91-python.py` | `_tree_of_thought` implementation and CLI `main()`. | active legacy/reference | Direct CLI executable; emits JSON. |
+| `alpha_solver_portable.py` | Portable spec monolith with argparse and behavior contract. | active portable-contract / unsafe-to-consolidate | Canonical standalone behavior contract, not a service API. |
+| `alpha/providers/openai.py` | Live OpenAI Responses API client using `OPENAI_API_KEY`. | active provider path / unsafe-to-call here | Tests may inject fake clients; real call requires explicit env/key. |
+| `alpha/providers/fake.py` | Fake provider. | test-only | Local deterministic provider test utility. |
+| `service/evidence/api.py` | Separate evidence router with `/evidence` endpoints. | active component / unknown mount | Router exists; not mounted on `service.app` in inspected path. |
+| Auth/JWT/API-key middleware modules | `service/middleware/auth_middleware.py`, `jwt_middleware.py`, `service/auth/*`. | active component / unknown mount | Exists but not wired onto bundled `/v1/solve`. |
+| Tenant middleware / limiter | `service/middleware/tenant_middleware.py`, `service/tenancy/*`. | active component / unknown mount | Tested separately; not mounted on bundled `/v1/solve`. |
+| Prometheus/Grafana dashboards | `dashboards/*`, `infrastructure/grafana/...`. | docs/ops-only | Observability artifacts, not request entrypoints. |
+| Tests hitting service/dashboard/provider/portable | `tests/test_api_auth_ratelimit.py`, `tests/test_client_sdk.py`, `tests/test_local_llm_provider_adapter.py`, provider/security tests. | test-only | Validate slices; do not imply public readiness. |

--- a/docs/evals/runs/alpha-solver-runtime-entrypoint-map-001/evidence-boundary.md
+++ b/docs/evals/runs/alpha-solver-runtime-entrypoint-map-001/evidence-boundary.md
@@ -1,0 +1,21 @@
+# Evidence Boundary
+
+## Evidence inspected
+
+- Runtime/service code: `service/app.py`, `service/security.py`, `service/middleware/*`, `service/auth/*`, `service/evidence/*`, `service/tenancy/*`.
+- Dashboard code: `alpha/webapp/routes/*`, templates by path inventory only.
+- Provider/settings code: `alpha/providers/*`, `alpha/local_llm/provider_adapter.py`, `alpha/core/config.py`, model-set/settings paths.
+- Portable/reference entrypoints: `alpha_solver_portable.py`, `alpha_solver_entry.py`, `alpha-solver-v91-python.py`.
+- Tests by static inventory and targeted path/name review for service, dashboard, provider, tenancy, rate-limit, and portable behavior.
+- Docs: `docs/CURRENT_STATE.md`, `docs/LANE_REGISTRY.md`, and `docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/`.
+
+## Evidence limits
+
+- Static review only; no app was started for exposure validation.
+- No providers were called.
+- No tokens or credentials were accessed.
+- No claims are made about production readiness, public MVP readiness, security closure, provider validation, value proof, dashboard readiness, `/v1/solve` readiness, or benchmark superiority.
+
+## Verdict basis
+
+`RUNTIME_ENTRYPOINT_MAP_CAPTURED` is selected because committed repository evidence is sufficient to map current entrypoints and boundaries at documentation level. It does not mean those entrypoints are safe to expose.

--- a/docs/evals/runs/alpha-solver-runtime-entrypoint-map-001/non-actions.md
+++ b/docs/evals/runs/alpha-solver-runtime-entrypoint-map-001/non-actions.md
@@ -1,0 +1,19 @@
+# Non-Actions
+
+This packet did not:
+
+- Change runtime code.
+- Change tests.
+- Change CI.
+- Modify service, dashboard, provider, model, or auth code.
+- Expose API, dashboard, or `/v1/solve`.
+- Start a public service.
+- Call providers or external LLMs.
+- Use tokens.
+- Access credentials or secret files.
+- Print secrets or environment dumps.
+- Claim readiness, production status, public MVP status, provider validation, security closure, or value proof.
+- Propose a rewrite as an implementation task.
+- Modify backlog workbooks.
+
+Validation is limited to static documentation checks requested by the lane.

--- a/docs/evals/runs/alpha-solver-runtime-entrypoint-map-001/provider-call-paths.md
+++ b/docs/evals/runs/alpha-solver-runtime-entrypoint-map-001/provider-call-paths.md
@@ -1,0 +1,26 @@
+# Provider Call Paths
+
+## Live-capable provider path
+
+1. `POST /v1/solve` receives query and context.
+2. `sanitize_query` rejects length/control/import-like patterns.
+3. `_is_openai_provider_enabled()` returns true only when `MODEL_PROVIDER` is `openai`.
+4. The service builds a `ProviderRequest` with prompt, model set, request ID, route, and tenant/provider metadata where available.
+5. `_get_provider_client()` returns an `OpenAIProviderClient`.
+6. `_execute_provider_call()` emits provider started/completed/failed/timeout telemetry and accounting.
+7. `OpenAIProviderClient.execute()` reads `OPENAI_API_KEY` unless injected, then posts to `/responses` on the configured base URL.
+
+## Dashboard preview path
+
+The bundled dashboard mounts only auth plus expert preview. When provider is OpenAI, `alpha/webapp/routes/expert_preview.py` requires `ALPHA_LIVE_PREVIEW_ENABLED` and a positive request cap before allowing live preview flow. This is still unsafe to expose as a public product surface.
+
+## Non-call paths
+
+- Default `MODEL_PROVIDER=local` path uses local `_tree_of_thought` behavior and must not be treated as provider validation.
+- `alpha/local_llm/provider_adapter.py` is local-LLM adapter plumbing and does not prove provider readiness.
+- `alpha/webapp/routes/requests.py` simulates provider latency; it is not a live provider integration.
+- Tests can inject fake transports/clients and do not imply external network calls.
+
+## Provider boundary confirmation
+
+This packet made no provider calls, used no tokens, did not inspect credentials, and did not print environment secrets.

--- a/docs/evals/runs/alpha-solver-runtime-entrypoint-map-001/selected-next-lane.md
+++ b/docs/evals/runs/alpha-solver-runtime-entrypoint-map-001/selected-next-lane.md
@@ -1,0 +1,26 @@
+# Selected Next Lane
+
+Exactly one next lane selected by this map:
+
+`ALPHA-SOLVER-RUNTIME-ENTRYPOINT-DOCS-CROSS-LINK-001`
+
+## Purpose
+
+Documentation-only cross-link and operator navigation lane that updates the central entrypoint/current-state docs to point to this packet and clarifies that runtime/public exposure remains unauthorized.
+
+## Why this lane
+
+The map reveals several product-shaped entrypoints whose status can be misread. The lowest-risk follow-up is to make the central docs point to the map before any code consolidation or exposure decision.
+
+## Boundaries
+
+- Docs-only.
+- No runtime, tests, CI, service, dashboard, provider, model, or auth code changes.
+- No provider calls, tokens, credentials, deployment, dashboard mounting, or `/v1/solve` exposure.
+- No readiness claims.
+
+## Not selected
+
+- Auth/CORS remediation lane — valuable but code/config-changing and outside this docs map.
+- Dashboard settings secret migration — code-changing and requires operator decision.
+- Provider smoke/value experiment — already governed by current lane registry and not replaced by this map.

--- a/docs/evals/runs/alpha-solver-runtime-entrypoint-map-001/selected-next-lane.md
+++ b/docs/evals/runs/alpha-solver-runtime-entrypoint-map-001/selected-next-lane.md
@@ -1,26 +1,31 @@
-# Selected Next Lane
+# Runtime-Map-Local Recommended Follow-up Candidate
 
-Exactly one next lane selected by this map:
+This packet names exactly one **runtime-map-local recommended follow-up candidate**:
 
 `ALPHA-SOLVER-RUNTIME-ENTRYPOINT-DOCS-CROSS-LINK-001`
 
+This packet does **not** change the repo-global selected next lane. The repo-global selected next lane remains controlled by `docs/CURRENT_STATE.md` and `docs/LANE_REGISTRY.md`.
+
+At the time of this packet update, those central source-of-truth docs continue to identify `LOCAL-OPENAI-TOKEN-SMOKE-CAPTURE-RETRY-002` as the repo-global authoritative selected next lane.
+
 ## Purpose
 
-Documentation-only cross-link and operator navigation lane that updates the central entrypoint/current-state docs to point to this packet and clarifies that runtime/public exposure remains unauthorized.
+Documentation-only cross-link and operator navigation candidate that would update central entrypoint/current-state documentation to point to this packet while preserving the repo-global selected next lane and clarifying that runtime/public exposure remains unauthorized.
 
-## Why this lane
+## Why this candidate
 
-The map reveals several product-shaped entrypoints whose status can be misread. The lowest-risk follow-up is to make the central docs point to the map before any code consolidation or exposure decision.
+The map reveals several product-shaped entrypoints whose status can be misread. A local docs-only cross-link candidate is a low-risk follow-up for this runtime map, but it is not selected as the repo-global next lane and does not supersede the central lane registry.
 
 ## Boundaries
 
 - Docs-only.
-- No runtime, tests, CI, service, dashboard, provider, model, or auth code changes.
+- No runtime, tests, CI, service, dashboard, provider, model, API, auth, tenancy, CORS, or credential-handling implementation changes.
 - No provider calls, tokens, credentials, deployment, dashboard mounting, or `/v1/solve` exposure.
-- No readiness claims.
+- No runtime consolidation, exposure decision, security implementation, or readiness claim.
 
-## Not selected
+## Not selected by this packet as repo-global next work
 
+- `ALPHA-SOLVER-RUNTIME-ENTRYPOINT-DOCS-CROSS-LINK-001` — recommended only as a runtime-map-local follow-up candidate, not as the repo-global selected next lane.
 - Auth/CORS remediation lane — valuable but code/config-changing and outside this docs map.
 - Dashboard settings secret migration — code-changing and requires operator decision.
-- Provider smoke/value experiment — already governed by current lane registry and not replaced by this map.
+- Provider smoke/value experiment — already governed by the central source-of-truth docs and not replaced by this map.


### PR DESCRIPTION
### Motivation

- Capture a read-only, evidence-bound map of Alpha Solver runtime surfaces and entrypoints to inform architecture, security, and exposure decisions without changing runtime behavior. 
- Classify each entrypoint (service API, dashboard, provider adapters, portable contract, CLI/reference paths, evidence API, middleware) for safe handling and operator guidance. 
- Identify high-risk boundaries (auth, CORS, tenancy, secrets, provider call paths, evidence intake) and list explicit no-touch zones until value and security proof exist. 
- Propose staged consolidation candidates and choose a single low-risk docs-only next lane to make the map discoverable in central docs before any code changes. 

### Description

- Added a documentation packet at `docs/evals/runs/alpha-solver-runtime-entrypoint-map-001/` containing `README.md`, `entrypoint-inventory.md`, `boundary-map.md`, `provider-call-paths.md`, `auth-tenancy-cors-map.md`, `dashboard-and-v1-solve-map.md`, `duplicate-surface-map.md`, `consolidation-candidates.md`, `do-not-consolidate-yet.md`, `selected-next-lane.md`, `evidence-boundary.md`, and `non-actions.md` describing the inventory, boundaries, call paths, overlaps, and policy recommendations. 
- The packet classifies surfaces such as the FastAPI app (`service.app`), `POST /v1/solve`, bundled dashboard preview, standalone dashboard routers, `alpha_solver_portable.py`, `alpha_solver_entry.py` / `alpha-solver-v91-python.py`, `alpha/providers/*`, `service/evidence/api.py`, and auth/tenant middleware as `active`, `test-only`, `legacy`, `unknown`, or `unsafe-to-expose` as appropriate. 
- Mapped static boundaries for auth, CORS, tenancy, rate-limiting, secret storage, provider telemetry/SAFE-OUT, and evidence ingestion, and enumerated duplicate/overlapping surfaces and explicit do-not-consolidate zones. 
- Selected exactly one next lane (`ALPHA-SOLVER-RUNTIME-ENTRYPOINT-DOCS-CROSS-LINK-001`) as a docs-only follow-up and listed staged consolidation candidates without authorizing any runtime, provider, or exposure changes. 

### Testing

- Ran the repo static doc and packet validators: `python scripts/check_local_llm_doc_paths.py` which passed. 
- Ran the evidence-boundary validator: `python scripts/check_local_llm_evidence_boundaries.py` which passed. 
- Ran the packet consistency checker: `python scripts/check_local_llm_packet_consistency.py` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dd201416c8329817ed6ea3c5b72c7)