### PR TITLE
docs(security): add public exposure readiness gate

### DIFF
--- a/docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/README.md
+++ b/docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/README.md
@@ -1,0 +1,45 @@
+# ALPHA-SOLVER-PUBLIC-EXPOSURE-READINESS-GATE-001
+
+Verdict: `PUBLIC_EXPOSURE_READINESS_GATE_CAPTURED_NO_GO`
+
+This docs-only packet defines the conditions that must be satisfied before any public API, `POST /v1/solve`, dashboard, or externally shared runtime surface can be exposed. It is a gate document only and does not expose anything.
+
+## Inputs read
+
+- `docs/CURRENT_STATE.md`
+- `docs/LANE_REGISTRY.md`
+- `docs/EVIDENCE_INDEX.md`
+- `docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/`
+- `docs/evals/runs/alpha-solver-def-002-gap-closure-plan-001/`
+- `service/app.py`
+- `service/middleware/`
+- `service/auth/`
+- `service/tenancy/`
+- `alpha/webapp/routes/auth.py`
+- dashboard routes under `alpha/webapp/routes/`
+- provider/settings/secret handling paths under `alpha/webapp/routes/settings.py`, `service/auth/secret_store.py`, and related provider configuration paths
+
+## Packet outputs
+
+| File | Purpose |
+| --- | --- |
+| `readiness-gate.md` | Overall readiness decision matrix |
+| `api-exposure-gate.md` | Public API auth and exposure criteria |
+| `v1-solve-gate.md` | `/v1/solve` criteria |
+| `dashboard-exposure-gate.md` | Dashboard exposure criteria |
+| `auth-tenancy-cors-gate.md` | Cross-cutting auth, tenancy, and CORS criteria |
+| `secrets-and-provider-cost-gate.md` | Secret storage and provider billing/cost criteria |
+| `data-sharing-telemetry-gate.md` | Data sharing, telemetry, redaction, and prompt handling criteria |
+| `no-go-blockers.md` | Blocking conditions that prevent exposure |
+| `operator-approval-template.md` | Operator go/no-go checklist template |
+| `selected-next-lane.md` | Recommended next lane |
+| `evidence-boundary.md` | Evidence limits and forbidden claims |
+| `non-actions.md` | Actions explicitly not taken |
+
+## Decision
+
+Public exposure is **NO-GO**. The gate is captured, but it is not passed. The expected next lane remains a DEF-002 gap-closure lane, normally `ALPHA-SOLVER-DEF-002-CREDENTIAL-STORAGE-HARDENING-001`, not an exposure lane.
+
+## Boundary
+
+This packet does not claim public readiness, production readiness, runtime readiness, provider readiness, dashboard readiness, `/v1/solve` readiness, security/privacy completion, or DEF-002 closure.

--- a/docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/README.md
+++ b/docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/README.md
@@ -38,7 +38,7 @@ This docs-only packet defines the conditions that must be satisfied before any p
 
 ## Decision
 
-Public exposure is **NO-GO**. The gate is captured, but it is not passed. The expected next lane remains a DEF-002 gap-closure lane, normally `ALPHA-SOLVER-DEF-002-CREDENTIAL-STORAGE-HARDENING-001`, not an exposure lane.
+Public exposure is **NO-GO**. The gate is captured, but it is not passed. PR #521 merged the accepted credential-storage hardening evidence packet for `ALPHA-SOLVER-DEF-002-CREDENTIAL-STORAGE-HARDENING-001`, so this packet no longer routes operators back to that completed RR-02 lane. The expected public-exposure-readiness/security remediation track is now DEF-002-local RR-03 default credential hardening: `ALPHA-SOLVER-DEF-002-DEFAULT-CREDENTIALS-HARDENING-001`, not an exposure lane.
 
 ## Boundary
 

--- a/docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/api-exposure-gate.md
+++ b/docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/api-exposure-gate.md
@@ -1,0 +1,26 @@
+# API exposure gate
+
+## Required conditions
+
+1. Public API auth model is explicitly selected and documented.
+2. Every externally reachable API route has authenticated negative tests.
+3. Anonymous access is denied except deliberately documented health/static endpoints.
+4. Scope/role requirements are documented per route.
+5. Rate limits and abuse controls are keyed to authenticated principal/tenant, not only source IP.
+6. CORS permits only approved origins and credential semantics are tested.
+7. Logs and errors do not reveal tokens, prompts beyond approved policy, secrets, or tenant data.
+
+## Current classification
+
+| Condition | Status | Rationale |
+| --- | --- | --- |
+| Explicit auth model | Fail now | `/v1/solve` uses an API-key dependency while separate JWT/API-key middleware exists; DEF-002 RR-09 requires a product/security decision before exposure. |
+| Route-by-route auth tests | Unknown / requires implementation | This packet did not run route tests and does not prove full external route coverage. |
+| Anonymous denial | Unknown / requires implementation | Must be proven for all public routes, including dashboard-adjacent routes if mounted. |
+| Scope/role boundaries | Unknown / requires implementation | Middleware supports scopes, but public route scope policy is not captured as exposure evidence. |
+| Rate limits | Fail now | Current `/v1/solve` limiter is not sufficient exposure evidence for per-tenant abuse/cost controls. |
+| CORS | Fail now | DEF-002 records permissive/default CORS risk. |
+
+## Gate result
+
+No public API exposure is allowed until every condition is pass-now or explicitly accepted by a later operator risk-acceptance lane where acceptance is allowed.

--- a/docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/auth-tenancy-cors-gate.md
+++ b/docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/auth-tenancy-cors-gate.md
@@ -1,0 +1,24 @@
+# Auth, tenancy, and CORS gate
+
+## Pass criteria
+
+- A single public auth model is selected for API and dashboard surfaces, with documented exceptions.
+- JWT/API-key/session boundaries are not mixed accidentally across API and dashboard routes.
+- Tenant identity is mandatory for billable/provider-backed work.
+- Tenant quotas and rate limits are enforced before provider calls.
+- CORS has no wildcard credentialed public default and has tests for allowed/denied origins.
+- Auth, tenant, and CORS failures produce safe responses and audit events.
+
+## Current classification
+
+| Area | Status | Rationale |
+| --- | --- | --- |
+| API auth implementation pieces | Pass now for code existence | `AuthMiddleware`, API-key validation, JWT utilities, and `/v1/solve` API-key dependency exist. |
+| Public auth decision | Fail now | DEF-002 RR-09 remains open and must be decided/proven. |
+| Tenant enforcement | Fail now | Tenant middleware exists but public `/v1/solve` enforcement is not proven in the mounted app. |
+| CORS | Fail now | DEF-002 RR-01 remains a must-fix item. |
+| Cross-surface separation | Unknown / requires implementation | Need tests proving API credentials cannot operate dashboard routes and dashboard sessions cannot bypass API rules. |
+
+## No-go rule
+
+No external surface can be exposed until public auth, tenant, and CORS behavior is intentionally selected, implemented where needed, and tested.

--- a/docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/dashboard-exposure-gate.md
+++ b/docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/dashboard-exposure-gate.md
@@ -1,0 +1,26 @@
+# Dashboard exposure gate
+
+## Required pass criteria
+
+- Dashboard is disabled by default for public deployments unless explicit non-default credentials and signing secret are configured.
+- Passwords/secrets are never default-usable in public exposure mode.
+- Sessions are signed, finite-lived, secure-cookie-compatible, and backed by a rotation/custody plan.
+- CSRF protection is enforced for state-changing routes.
+- Route inventory states exactly which dashboard routes are mounted and which are forbidden.
+- Provider-key settings routes are not public unless protected by role/CSRF/session/storage controls.
+- Role boundaries separate operator/admin settings from preview/run access.
+
+## Current classification
+
+| Item | Status | Notes |
+| --- | --- | --- |
+| Service-app dashboard mounting guard | Pass now for current service app only | `service/app.py` mounts login + expert preview only when a non-default password and explicit secret key are set. |
+| Shared auth/session machinery | Pass now for implementation existence only | Sessions, CSRF token, lockout, and protected prefixes exist in `alpha/webapp/routes/auth.py`. |
+| Default password public safety | Fail now as broader product gate | The shared dashboard auth module still defines a known fallback password, and DEF-002 RR-03 requires hardening. |
+| Settings/provider-key route exposure | Fail now | Settings routes manage provider keys and require explicit exposure decision, role boundary, CSRF proof, and hardened secret storage. |
+| Role boundary | Unknown / requires implementation | No exposure-grade role model is captured by this packet. |
+| Route inventory tests | Unknown / requires implementation | Need tests proving only intended routes are mounted in public mode. |
+
+## Gate result
+
+Dashboard public exposure is not allowed. Current service-app fail-closed mounting is useful but not sufficient for broad dashboard readiness.

--- a/docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/data-sharing-telemetry-gate.md
+++ b/docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/data-sharing-telemetry-gate.md
@@ -1,0 +1,26 @@
+# Data sharing, telemetry, redaction, and prompt-content gate
+
+## Pass criteria
+
+- Data classification source of truth is reconciled and referenced by public docs.
+- Operator/end-user disclosure states what prompt/context data is sent to providers, when, and under which opt-in.
+- Telemetry fields are enumerated, redacted, and retention-scoped.
+- Prompt logging policy is explicit: raw prompts are not logged unless specifically approved and protected.
+- Redaction tests cover expected deployment secret/token formats.
+- Evidence payload hygiene rules prevent secrets from being submitted to artifacts.
+- Audit/evidence logs identify decision events without exposing secrets or raw credentials.
+
+## Current classification
+
+| Item | Status | Notes |
+| --- | --- | --- |
+| Default local boundary | Pass now | Current docs and code preserve an offline/local default unless provider is explicitly enabled. |
+| Provider data sharing disclosure | Fail now | DEF-002 RR-04 remains an operator acceptance item after must-fix closure. |
+| Data classification reconciliation | Fail now | DEF-002 RR-05 remains must-fix. |
+| Redaction limits | Unknown / requires implementation | RR-A1 is only a residual candidate for later operator review; not accepted here. |
+| Telemetry retention/access policy | Unknown / requires implementation | Needs public-surface policy and tests/evidence. |
+| Audit/evidence logging coverage | Unknown / requires implementation | Some audit paths exist, but exposure-grade coverage and retention are not proven. |
+
+## Gate result
+
+Data sharing and telemetry boundaries are not ready for public exposure.

--- a/docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/evidence-boundary.md
+++ b/docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/evidence-boundary.md
@@ -1,0 +1,23 @@
+# Evidence boundary
+
+## What this packet proves
+
+- A public exposure readiness gate has been documented.
+- Current blockers have been mapped to pass/fail/unknown/residual/no-go categories.
+- The recommended next security lane is a DEF-002 gap-closure lane, not exposure.
+
+## What this packet does not prove
+
+- It does not prove public readiness.
+- It does not prove production readiness.
+- It does not prove runtime readiness.
+- It does not prove provider readiness or OpenAI validation.
+- It does not prove `/v1/solve` readiness.
+- It does not prove dashboard readiness.
+- It does not close DEF-002.
+- It does not accept residual risk.
+- It does not prove security/privacy completion.
+
+## Allowed verdicts
+
+This packet uses `PUBLIC_EXPOSURE_READINESS_GATE_CAPTURED_NO_GO`. If future evidence is inconclusive, use `STOP_INCONCLUSIVE`. If blockers are remediated but require explicit operator approval, use `PUBLIC_EXPOSURE_READINESS_GATE_CAPTURED_OPERATOR_DECISION_REQUIRED`.

--- a/docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/no-go-blockers.md
+++ b/docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/no-go-blockers.md
@@ -1,0 +1,20 @@
+# No-go blockers
+
+Public exposure must not proceed while any of these blockers remain open.
+
+1. DEF-002 is open and not closed by operator-approved evidence.
+2. RR-02 plaintext provider-secret storage is not remediated or explicitly blocked by a no-persistence design.
+3. RR-03 known/default dashboard/API credential semantics are not hardened.
+4. RR-01 CORS defaults are not hardened and tested for public exposure.
+5. RR-09 `/v1/solve` auth/tenancy decision is not closed with tests.
+6. Public provider-cost caps, tenant quotas, kill switch, and alerting are not proven.
+7. Dashboard route inventory and role boundary are not proven.
+8. Provider data-sharing disclosure and operator/end-user acceptance are not captured.
+9. Data classification registry/precedence is not reconciled.
+10. Dependency lock/hash and vendored dependency provenance gaps remain open.
+11. Rollback and incident-response minimums for public abuse, leaked keys, over-billing, and data exposure are absent.
+12. Operator public-exposure approval has not been captured.
+
+## Forbidden claims while blockers remain
+
+Do not claim public readiness, production readiness, runtime readiness, provider readiness, dashboard readiness, `/v1/solve` readiness, security/privacy completion, DEF-002 closure, broad-user readiness, benchmark validation, or value evidence.

--- a/docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/no-go-blockers.md
+++ b/docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/no-go-blockers.md
@@ -3,7 +3,7 @@
 Public exposure must not proceed while any of these blockers remain open.
 
 1. DEF-002 is open and not closed by operator-approved evidence.
-2. RR-02 plaintext provider-secret storage is not remediated or explicitly blocked by a no-persistence design.
+2. RR-02 credential storage was hardened by the accepted credential-storage hardening evidence packet, but DEF-002 remains open and RR-02 residual limitations still require operator awareness before exposure.
 3. RR-03 known/default dashboard/API credential semantics are not hardened.
 4. RR-01 CORS defaults are not hardened and tested for public exposure.
 5. RR-09 `/v1/solve` auth/tenancy decision is not closed with tests.

--- a/docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/non-actions.md
+++ b/docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/non-actions.md
@@ -1,0 +1,18 @@
+# Non-actions
+
+This docs-only lane did not perform these actions:
+
+- Did not expose public API.
+- Did not expose `/v1/solve`.
+- Did not expose dashboard.
+- Did not deploy.
+- Did not change runtime code.
+- Did not change auth, CORS, tenancy, provider, model, dashboard, or API code.
+- Did not call providers.
+- Did not use tokens.
+- Did not access credentials.
+- Did not print secrets.
+- Did not claim readiness.
+- Did not claim security/privacy completion.
+- Did not claim production readiness.
+- Did not update Google Sheets or backlog workbooks.

--- a/docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/operator-approval-template.md
+++ b/docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/operator-approval-template.md
@@ -1,0 +1,29 @@
+# Operator approval template
+
+This template is for a future lane only. It is not completed by this packet.
+
+## Operator decision
+
+- Decision: `GO` / `NO-GO` / `DEFER`
+- Operator name/role: `<redacted or named per policy>`
+- Date: `<YYYY-MM-DD>`
+- Environment/surface: `<API / /v1/solve / dashboard / other>`
+- Evidence packet reviewed: `<packet paths>`
+
+## Required checklist
+
+- [ ] DEF-002 closeout or explicit operator deferral packet reviewed.
+- [ ] API auth model selected and negative tests passed.
+- [ ] `/v1/solve` auth, tenant, rate, CORS, SAFE-OUT, logging, and cost-cap tests passed.
+- [ ] Dashboard auth/session/CSRF/default-credential/role/route tests passed.
+- [ ] Secret storage and masked display/audit tests passed with synthetic values.
+- [ ] Provider billing/project/cost caps and kill switch verified for this environment.
+- [ ] Data-sharing and telemetry disclosures approved.
+- [ ] Redaction and prompt-content handling reviewed.
+- [ ] Dependency lock/hash/provenance checks passed or accepted.
+- [ ] Rollback and incident-response runbooks exist and are assigned.
+- [ ] Forbidden claims list reviewed and accepted.
+
+## Approval statement
+
+I approve exposure only for the exact surface and environment named above, with the cited evidence packets and residual risks. Any other surface remains no-go.

--- a/docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/readiness-gate.md
+++ b/docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/readiness-gate.md
@@ -4,7 +4,7 @@ Verdict: `PUBLIC_EXPOSURE_READINESS_GATE_CAPTURED_NO_GO`
 
 ## Overall decision
 
-Public exposure must not proceed. Current source-of-truth docs state that public/runtime/provider exposure, `/v1/solve`, and dashboards are not authorized, and DEF-002 remains open. The DEF-002 gap plan lists must-fix items before closeout, including credential storage, default credentials, CORS defaults, `/v1/solve` auth/tenancy, data classification, and supply-chain hardening.
+Public exposure must not proceed. Current source-of-truth docs state that public/runtime/provider exposure, `/v1/solve`, and dashboards are not authorized, and DEF-002 remains open. The DEF-002 gap plan lists must-fix items before closeout. RR-02 credential storage has been hardened by the accepted credential-storage hardening evidence packet, but DEF-002 remains open pending default credentials, CORS defaults, `/v1/solve` auth/tenancy, data classification, supply-chain hardening, and residual-risk decisions.
 
 ## Gate matrix
 
@@ -13,7 +13,7 @@ Public exposure must not proceed. Current source-of-truth docs state that public
 | API auth model | API-key dependency exists for `/v1/solve`; JWT/API-key middleware exists as reusable code. | Public exposure model is not selected or proven end-to-end. | Decide API-key-only vs JWT/tenant middleware and prove it with negative tests. | None accepted here. | Yes. |
 | `/v1/solve` | Sanitizes query; returns SAFE-OUT on HTTP exceptions; has local default/provider opt-in boundary. | Tenant middleware is not shown mounted for the route; DEF-002 RR-09 remains open. | Per-tenant rate/cost/logging/CORS/provider-budget proof. | None accepted here. | Yes. |
 | Dashboard | Service app mounts only login plus supervised expert preview when non-default password and explicit secret are set. | Broader dashboard settings/request routes include provider-secret management and are not approved for public exposure. | Role boundaries and full route inventory tests. | None accepted here. | Yes. |
-| Secrets | Masked display/audit paths and restrictive file modes exist in settings code. | Plaintext JSON storage risk is the DEF-002 first remediation candidate. | Protected at-rest storage/no-persistence design and migration evidence. | None accepted here. | Yes. |
+| Secrets | RR-02 credential storage was hardened by the accepted credential-storage hardening evidence packet; masked display/audit paths and restrictive file modes exist in settings code. | DEF-002 remains open; RR-03 default credential hardening and remaining secret/operator controls are not complete. | Additional secret-manager/encryption/migration evidence may be required by future operator policy. | None accepted here. | Yes. |
 | Provider cost | OpenAI provider branch is explicit opt-in; prior attestation covers project/billing boundary only. | No public-exposure cost caps are proven for arbitrary traffic. | Hard caps, quotas, billing guardrails, alerting, rollback. | None accepted here. | Yes. |
 | Telemetry/data sharing | Current docs forbid readiness claims and provider validation claims. | Public data-sharing disclosure and telemetry boundary are not complete. | User/operator disclosure, retention policy, prompt logging/redaction tests. | Provider data sharing may later be residual, not accepted here. | Yes. |
 | Audit/evidence | Auth middleware records auth denies/logins; settings audit masks secrets. | Exposure-grade immutable audit coverage is not proven. | Define required audit events, retention, redaction, access review. | None accepted here. | Yes. |

--- a/docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/readiness-gate.md
+++ b/docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/readiness-gate.md
@@ -1,0 +1,31 @@
+# Public exposure readiness gate
+
+Verdict: `PUBLIC_EXPOSURE_READINESS_GATE_CAPTURED_NO_GO`
+
+## Overall decision
+
+Public exposure must not proceed. Current source-of-truth docs state that public/runtime/provider exposure, `/v1/solve`, and dashboards are not authorized, and DEF-002 remains open. The DEF-002 gap plan lists must-fix items before closeout, including credential storage, default credentials, CORS defaults, `/v1/solve` auth/tenancy, data classification, and supply-chain hardening.
+
+## Gate matrix
+
+| Area | Pass now | Fail now | Unknown / requires implementation | Accepted residual risk | No-go blocker |
+| --- | --- | --- | --- | --- | --- |
+| API auth model | API-key dependency exists for `/v1/solve`; JWT/API-key middleware exists as reusable code. | Public exposure model is not selected or proven end-to-end. | Decide API-key-only vs JWT/tenant middleware and prove it with negative tests. | None accepted here. | Yes. |
+| `/v1/solve` | Sanitizes query; returns SAFE-OUT on HTTP exceptions; has local default/provider opt-in boundary. | Tenant middleware is not shown mounted for the route; DEF-002 RR-09 remains open. | Per-tenant rate/cost/logging/CORS/provider-budget proof. | None accepted here. | Yes. |
+| Dashboard | Service app mounts only login plus supervised expert preview when non-default password and explicit secret are set. | Broader dashboard settings/request routes include provider-secret management and are not approved for public exposure. | Role boundaries and full route inventory tests. | None accepted here. | Yes. |
+| Secrets | Masked display/audit paths and restrictive file modes exist in settings code. | Plaintext JSON storage risk is the DEF-002 first remediation candidate. | Protected at-rest storage/no-persistence design and migration evidence. | None accepted here. | Yes. |
+| Provider cost | OpenAI provider branch is explicit opt-in; prior attestation covers project/billing boundary only. | No public-exposure cost caps are proven for arbitrary traffic. | Hard caps, quotas, billing guardrails, alerting, rollback. | None accepted here. | Yes. |
+| Telemetry/data sharing | Current docs forbid readiness claims and provider validation claims. | Public data-sharing disclosure and telemetry boundary are not complete. | User/operator disclosure, retention policy, prompt logging/redaction tests. | Provider data sharing may later be residual, not accepted here. | Yes. |
+| Audit/evidence | Auth middleware records auth denies/logins; settings audit masks secrets. | Exposure-grade immutable audit coverage is not proven. | Define required audit events, retention, redaction, access review. | None accepted here. | Yes. |
+| Supply chain | Dependency review packet exists. | Lock/hash and vendored provenance findings remain open. | Close RR-06/RR-07/RR-08 or explicit operator deferral. | None accepted here. | Yes. |
+| Rollback/incident response | None sufficient observed for public exposure. | Minimum public incident runbook is absent from this gate evidence. | Rollback, key rotation, abuse shutdown, notification, evidence-capture runbooks. | None accepted here. | Yes. |
+| Operator approval | Template created by this packet. | No approval captured. | Operator must complete checklist after no-go blockers close. | Later only. | Yes. |
+
+
+## Status legend
+
+- **Pass now**: evidence observed in the referenced repo state and sufficient for this gate item.
+- **Fail now**: observed repo state violates or does not satisfy the required public-exposure condition.
+- **Unknown / requires implementation**: condition needs new implementation, tests, operator evidence, or external process evidence.
+- **Accepted residual risk**: may be accepted only by a later explicit operator risk-acceptance packet. None are accepted by this lane.
+- **No-go blocker**: exposure must not proceed while this item remains open.

--- a/docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/secrets-and-provider-cost-gate.md
+++ b/docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/secrets-and-provider-cost-gate.md
@@ -1,0 +1,34 @@
+# Secrets and provider-cost gate
+
+## Secret storage/display pass criteria
+
+- No plaintext provider tokens are stored unless an operator explicitly accepts a no-persistence or encrypted-at-rest design.
+- Secret files/directories have restrictive permissions where file storage remains.
+- UI/API displays only masked values.
+- Audit logs never contain raw secrets.
+- Migration handling for existing plaintext files is documented and tested with synthetic values.
+- No code path prints environment variables or credential values.
+
+## Provider token and billing/cost pass criteria
+
+- Provider calls are default-off and require explicit operator opt-in.
+- Per-tenant and global spend/request/token caps are enforced before calls.
+- A kill switch can disable provider calls immediately.
+- Billing/project boundary is attested for the intended public environment.
+- Cost telemetry is redacted, auditable, and alertable.
+
+## Current classification
+
+| Item | Status | Notes |
+| --- | --- | --- |
+| Masked dashboard display/audit | Pass now for existing settings behavior | Settings service masks stored keys for display and audit entries. |
+| Restrictive file modes | Pass now for current file backend behavior | Settings storage code creates private parent/file modes on POSIX. |
+| Plaintext storage | Fail now | DEF-002 RR-02 identifies plaintext provider key storage as the first gap-closure remediation target. |
+| Default credential hardening | Fail now | DEF-002 RR-03 remains open. |
+| Provider default-off | Pass now | `/v1/solve` provider branch requires explicit OpenAI provider opt-in. |
+| Public cost caps | Fail now | Public traffic cost caps, tenant quotas, alerts, and shutdown are not proven. |
+| Billing boundary | Unknown / requires implementation | Prior attestation applies to a bounded smoke boundary, not public exposure. |
+
+## Gate result
+
+Secrets and provider-cost controls are no-go blockers until DEF-002 credential/default-credential lanes and public cost-cap evidence are complete.

--- a/docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/secrets-and-provider-cost-gate.md
+++ b/docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/secrets-and-provider-cost-gate.md
@@ -23,7 +23,7 @@
 | --- | --- | --- |
 | Masked dashboard display/audit | Pass now for existing settings behavior | Settings service masks stored keys for display and audit entries. |
 | Restrictive file modes | Pass now for current file backend behavior | Settings storage code creates private parent/file modes on POSIX. |
-| Plaintext storage | Fail now | DEF-002 RR-02 identifies plaintext provider key storage as the first gap-closure remediation target. |
+| RR-02 credential storage hardening | Pass now for the narrow accepted RR-02 evidence boundary | PR #521 merged `ALPHA-SOLVER-DEF-002-CREDENTIAL-STORAGE-HARDENING-001`, which hardens file/directory permission behavior for the existing file-backed dashboard credential path; DEF-002 remains open. |
 | Default credential hardening | Fail now | DEF-002 RR-03 remains open. |
 | Provider default-off | Pass now | `/v1/solve` provider branch requires explicit OpenAI provider opt-in. |
 | Public cost caps | Fail now | Public traffic cost caps, tenant quotas, alerts, and shutdown are not proven. |
@@ -31,4 +31,4 @@
 
 ## Gate result
 
-Secrets and provider-cost controls are no-go blockers until DEF-002 credential/default-credential lanes and public cost-cap evidence are complete.
+Secrets and provider-cost controls remain no-go blockers until RR-03 default credential hardening, remaining DEF-002 lanes, residual-risk decisions, and public cost-cap evidence are complete. RR-02 credential storage hardening alone does not authorize exposure.

--- a/docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/selected-next-lane.md
+++ b/docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/selected-next-lane.md
@@ -1,13 +1,26 @@
 # Selected next lane
 
-Recommended next lane: `ALPHA-SOLVER-DEF-002-CREDENTIAL-STORAGE-HARDENING-001`
+Recommended DEF-002-local next remediation lane:
+`ALPHA-SOLVER-DEF-002-DEFAULT-CREDENTIALS-HARDENING-001`
 
 ## Rationale
 
-The public exposure gate is captured as no-go. The safest next step is the DEF-002-local first remediation lane already selected by the DEF-002 gap-closure plan, because credential storage is the highest-risk concrete blocker.
+The public exposure gate remains captured as no-go. PR #521 merged the accepted
+credential-storage hardening evidence packet,
+`ALPHA-SOLVER-DEF-002-CREDENTIAL-STORAGE-HARDENING-001`, which records
+`DEF_002_RR_02_CREDENTIAL_STORAGE_HARDENED` for the narrow RR-02 file-backed
+dashboard credential-storage boundary. DEF-002 as a whole remains open.
+
+The next public-exposure-readiness/security remediation step should therefore
+follow the DEF-002-local sequence to RR-03 default credential hardening:
+`ALPHA-SOLVER-DEF-002-DEFAULT-CREDENTIALS-HARDENING-001`.
 
 ## Boundary
 
-This selection is not an exposure lane. It does not authorize public API, `/v1/solve`, dashboard, provider calls, token use, deployment, production readiness, or DEF-002 closeout.
+This is a DEF-002-local recommendation only. It does not replace the repo-global
+selected next lane, which remains controlled by `docs/CURRENT_STATE.md` and
+`docs/LANE_REGISTRY.md`.
 
-The repo-global selected next lane in the current state documents remains `LOCAL-OPENAI-TOKEN-SMOKE-CAPTURE-RETRY-002`; this packet records the recommended public-exposure-readiness/security next lane if the operator chooses the DEF-002 remediation track.
+This selection is not an exposure lane. It does not authorize public API,
+`/v1/solve`, dashboard, provider calls, token use, deployment, production
+readiness, security/privacy completion, public readiness, or DEF-002 closeout.

--- a/docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/selected-next-lane.md
+++ b/docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/selected-next-lane.md
@@ -1,0 +1,13 @@
+# Selected next lane
+
+Recommended next lane: `ALPHA-SOLVER-DEF-002-CREDENTIAL-STORAGE-HARDENING-001`
+
+## Rationale
+
+The public exposure gate is captured as no-go. The safest next step is the DEF-002-local first remediation lane already selected by the DEF-002 gap-closure plan, because credential storage is the highest-risk concrete blocker.
+
+## Boundary
+
+This selection is not an exposure lane. It does not authorize public API, `/v1/solve`, dashboard, provider calls, token use, deployment, production readiness, or DEF-002 closeout.
+
+The repo-global selected next lane in the current state documents remains `LOCAL-OPENAI-TOKEN-SMOKE-CAPTURE-RETRY-002`; this packet records the recommended public-exposure-readiness/security next lane if the operator chooses the DEF-002 remediation track.

--- a/docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/v1-solve-gate.md
+++ b/docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/v1-solve-gate.md
@@ -1,0 +1,29 @@
+# `/v1/solve` gate
+
+## Required pass criteria
+
+- Auth: selected API auth model rejects unauthenticated, malformed, revoked, wrong-scope, and wrong-tenant requests.
+- Rate limit: rate and quota enforcement is per authenticated tenant/principal with tests for exhaustion and reset behavior.
+- Tenancy: tenant identity is mandatory, logged safely, and isolated across requests, model-set selection, quotas, and evidence.
+- CORS: browser access is allowed only from approved origins; credential behavior is explicitly tested.
+- Logging: request logs include request id and safe metadata only; no secrets, raw tokens, or unapproved prompt content.
+- SAFE-OUT: expected error paths return safe, non-sensitive responses.
+- Provider-cost boundaries: provider path is opt-in, cost-capped, quota-enforced, and kill-switchable.
+
+## Current classification
+
+| Item | Status | Notes |
+| --- | --- | --- |
+| Sanitization | Pass now | Handler sanitizes the query before solving. |
+| API-key dependency | Pass now for local dependency existence only | Dependency exists, but it is not enough for public exposure. |
+| SAFE-OUT for HTTP exceptions | Pass now for that exception class only | Handler wraps HTTP exceptions with SAFE-OUT content. |
+| Provider default-off | Pass now for default boundary | Provider branch requires explicit `MODEL_PROVIDER=openai`. |
+| Auth model readiness | Fail now | DEF-002 RR-09 remains open. |
+| Tenancy readiness | Fail now | Tenant middleware/utilities exist, but public `/v1/solve` tenant enforcement is not captured as mounted/proven. |
+| Rate/cost readiness | Fail now | Public abuse and provider-cost caps are not proven. |
+| CORS readiness | Fail now | CORS default hardening remains a DEF-002 must-fix lane. |
+| Logging/redaction readiness | Unknown / requires implementation | Needs negative tests and prompt-content policy evidence. |
+
+## Gate result
+
+`/v1/solve` exposure is a no-go blocker until RR-09 and related CORS/cost/logging evidence are closed.


### PR DESCRIPTION
### Motivation

- Define a formal gate that enumerates exact pass/fail/unknown/no-go criteria before any public API, `POST /v1/solve`, dashboard, or externally shared runtime surface can be exposed. 
- Capture findings from the DEF-002 security/privacy review and existing service/dashboard/auth/secret code paths so exposure decisions are evidence-bound and operator-controlled. 
- Prevent accidental exposure by routing the next remediation work toward the DEF-002 credential-storage hardening lane rather than an exposure lane. 

### Description

- Add a docs-only packet under `docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/` containing `README.md`, `readiness-gate.md`, `api-exposure-gate.md`, `v1-solve-gate.md`, `dashboard-exposure-gate.md`, `auth-tenancy-cors-gate.md`, `secrets-and-provider-cost-gate.md`, `data-sharing-telemetry-gate.md`, `no-go-blockers.md`, `operator-approval-template.md`, `selected-next-lane.md`, `evidence-boundary.md`, and `non-actions.md`. 
- Record the gate verdict as `PUBLIC_EXPOSURE_READINESS_GATE_CAPTURED_NO_GO` and enumerate explicit no-go blockers (DEF-002 findings including plaintext provider-secret storage, default credentials, CORS, `/v1/solve` auth/tenancy, provider-cost caps, telemetry/disclosure, supply-chain, incident response, and missing operator approval). 
- Recommend `ALPHA-SOLVER-DEF-002-CREDENTIAL-STORAGE-HARDENING-001` as the next security lane and assert strict non-actions and boundary rules (docs-only, no runtime changes, no provider calls, no tokens/secrets accessed or printed). 

### Testing

- Ran `python scripts/check_local_llm_doc_paths.py` and the doc-path checker passed. 
- Ran `python scripts/check_local_llm_evidence_boundaries.py` and the evidence-boundary static check passed. 
- Ran `python scripts/check_local_llm_packet_consistency.py` and the packet-consistency check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2de8fba26883299d7be80d1406c13d)