### PR TITLE
Add incident response & rollback minimums packet (ALPHA-SOLVER-INCIDENT-RESPONSE-ROLLBACK-MINIMUMS-001)

### DIFF
--- a/docs/evals/runs/alpha-solver-incident-response-rollback-minimums-001/README.md
+++ b/docs/evals/runs/alpha-solver-incident-response-rollback-minimums-001/README.md
@@ -27,7 +27,7 @@ This docs-only packet defines minimum operator actions for leaked keys, runaway 
 | `credential-leak-response.md` | Immediate stop actions for leaked credentials and key compromise. |
 | `data-exposure-response.md` | Unsafe output, dashboard exposure, public abuse, and data disclosure response. |
 | `operator-communications.md` | Operator communication templates for incident start, updates, rollback, and closeout. |
-| `selected-next-lane.md` | Recommended next lane after this packet. |
+| `selected-next-lane.md` | Incident-response/public-exposure-local recommended follow-up after this packet; not the repo-global selected next lane. |
 | `evidence-boundary.md` | What this packet proves and does not prove. |
 | `non-actions.md` | Explicit non-actions and forbidden claims. |
 
@@ -46,4 +46,4 @@ The incident-response and rollback minimums are captured as an operator runbook 
 
 ## Boundary
 
-This packet may be used as an incident-response minimums reference. It must not be used as evidence of production readiness, public readiness, provider readiness, runtime readiness, dashboard readiness, `/v1/solve` readiness, DEF-002 closure, security/privacy completion, or operator approval for exposure.
+This packet may be used as an incident-response minimums reference. Its recommended follow-up is incident-response/public-exposure-local only and does not replace the repo-global selected next lane, which remains controlled by `docs/CURRENT_STATE.md` and `docs/LANE_REGISTRY.md`. It must not be used as evidence of production readiness, public readiness, provider readiness, runtime readiness, dashboard readiness, `/v1/solve` readiness, DEF-002 closure, security/privacy completion, provider-call authorization, deployment authorization, or operator approval for exposure.

--- a/docs/evals/runs/alpha-solver-incident-response-rollback-minimums-001/README.md
+++ b/docs/evals/runs/alpha-solver-incident-response-rollback-minimums-001/README.md
@@ -1,0 +1,49 @@
+# ALPHA-SOLVER-INCIDENT-RESPONSE-ROLLBACK-MINIMUMS-001
+
+Verdict: `INCIDENT_RESPONSE_MINIMUMS_CAPTURED`
+
+This docs-only packet defines minimum operator actions for leaked keys, runaway provider spend, unsafe output, public abuse, dashboard exposure, data disclosure, and rollback. It is an incident-response and rollback evidence lane only; it does not deploy, expose surfaces, call providers, access credentials, or claim readiness.
+
+## Source context read
+
+- `docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/`
+- `docs/evals/runs/alpha-solver-def-002-gap-closure-plan-001/`
+- `docs/evals/runs/alpha-solver-def-002-credential-storage-hardening-001/`
+- `docs/AUDIT_LOGGING.md`
+- `docs/AUTH_JWT.md`
+- `docs/DASHBOARD_AUTH.md`
+- `docs/EVIDENCE_PACK.md`
+- `docs/SECRETS_REDACTION.md`
+- `docs/OAUTH_SECRETS.md`
+- `docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/logging-redaction-review.md`
+
+## Packet files
+
+| File | Purpose |
+| --- | --- |
+| `incident-classes.md` | Incident classes, severity levels, and escalation minimums. |
+| `rollback-checklist.md` | Rollback triggers, owner roles, minimum rollback checklist, and validation boundaries. |
+| `provider-spend-response.md` | Immediate stop actions for runaway provider spend or abuse. |
+| `credential-leak-response.md` | Immediate stop actions for leaked credentials and key compromise. |
+| `data-exposure-response.md` | Unsafe output, dashboard exposure, public abuse, and data disclosure response. |
+| `operator-communications.md` | Operator communication templates for incident start, updates, rollback, and closeout. |
+| `selected-next-lane.md` | Recommended next lane after this packet. |
+| `evidence-boundary.md` | What this packet proves and does not prove. |
+| `non-actions.md` | Explicit non-actions and forbidden claims. |
+
+## Decision
+
+The incident-response and rollback minimums are captured as an operator runbook baseline. Public exposure remains **NO-GO** until the missing pre-exposure items in this packet and the earlier public exposure readiness gate are closed or explicitly accepted by an authorized operator decision.
+
+## Minimum no-go gaps before public exposure
+
+- Named incident commander, rollback owner, communications owner, and evidence custodian are not yet assigned for a real environment.
+- Provider project billing caps, hard quotas, per-tenant cost controls, alerting, and kill-switch proof remain absent.
+- Public auth, tenancy, CORS, default credential hardening, and `/v1/solve` exposure decisions remain unresolved.
+- Dashboard route inventory, role boundary, CSRF/session exposure proof, and provider-key settings exposure policy remain unresolved.
+- Data classification precedence, provider data-sharing disclosure, telemetry retention/access policy, and redaction residual acceptance remain unresolved.
+- Rollback drills, abuse simulations, credential revocation drills, and public-incident tabletop evidence are not captured.
+
+## Boundary
+
+This packet may be used as an incident-response minimums reference. It must not be used as evidence of production readiness, public readiness, provider readiness, runtime readiness, dashboard readiness, `/v1/solve` readiness, DEF-002 closure, security/privacy completion, or operator approval for exposure.

--- a/docs/evals/runs/alpha-solver-incident-response-rollback-minimums-001/credential-leak-response.md
+++ b/docs/evals/runs/alpha-solver-incident-response-rollback-minimums-001/credential-leak-response.md
@@ -1,0 +1,42 @@
+# Credential leak response
+
+## Trigger conditions
+
+Use this response for any suspected exposure of provider keys, API keys, JWT signing material, dashboard signing secrets, dashboard passwords, OAuth secrets, session cookies, tenant credentials, local secret files, or secret-like values in logs, traces, screenshots, tickets, chats, commits, artifacts, or evidence packets.
+
+## Immediate stop actions
+
+1. Treat live or unknown-status credentials as compromised.
+2. Declare SEV-0 when the credential may be live, public, externally shared, or provider-billable; otherwise declare at least SEV-1.
+3. Revoke or disable the credential at the issuing system before continuing non-containment investigation.
+4. Rotate replacement credentials through an approved secret channel only. Do not paste replacements into docs, chat, logs, PRs, or evidence.
+5. Invalidate sessions or tokens derived from the leaked secret, including dashboard sessions if the dashboard signing secret or password may be involved.
+6. Disable affected provider/runtime/dashboard/API surface until rotation and access review are complete.
+7. Search only approved evidence stores for copies of the leaked value. Do not broaden exposure by pasting the secret into new search tools or tickets.
+
+## Evidence preservation and redaction
+
+Preserve:
+
+- where the secret was observed, using a link or artifact ID where access-controlled;
+- who could access the location, in role/group terms when possible;
+- first-known exposure time and removal time;
+- credential type, issuing system, and environment in redacted form;
+- revocation, rotation, and session invalidation timestamps;
+- confirmation that replacement credentials were not committed or printed.
+
+Redact:
+
+- all but the minimum non-sensitive identifier needed to distinguish the secret, such as provider name plus last four characters only when policy permits;
+- screenshots before attaching them to evidence;
+- logs with the repository redaction policy and an operator review for pattern-redaction misses.
+
+Never preserve in this packet:
+
+- full keys, tokens, cookies, JWTs, signing secrets, passwords, refresh tokens, private keys, or raw secret files.
+
+## Repository-specific notes
+
+- Existing credential-storage hardening evidence covers restrictive file modes for dashboard-managed provider keys, not encryption-at-rest or full migration of historical plaintext copies.
+- Dashboard docs still identify default dashboard credential semantics as a public-exposure blocker until the default credential hardening lane is complete.
+- OAuth scaffold docs describe test-only secret behavior and must not be treated as a production secret-management approval.

--- a/docs/evals/runs/alpha-solver-incident-response-rollback-minimums-001/data-exposure-response.md
+++ b/docs/evals/runs/alpha-solver-incident-response-rollback-minimums-001/data-exposure-response.md
@@ -1,0 +1,58 @@
+# Data exposure, unsafe output, public abuse, and dashboard exposure response
+
+## Trigger conditions
+
+Use this response for suspected or confirmed disclosure of prompts, completions, provider payloads, tenant data, audit events, telemetry, evidence artifacts, dashboard content, provider-key settings, unsafe output, CORS/browser abuse, or public access to an unintended API/dashboard route.
+
+## Immediate stop actions
+
+1. Declare severity using `incident-classes.md`; default to SEV-0 for active public disclosure or reachable dashboard/provider-key settings exposure.
+2. Remove public access first:
+   - disable ingress, route, deployment, dashboard mount, or public DNS path;
+   - disable affected API key/session/JWT path;
+   - block abusive principals, tenants, IPs, origins, or user agents where available;
+   - disable provider-backed execution if the route can spend money or transmit prompt data.
+3. Freeze risky deployments and config changes except incident containment.
+4. Preserve redacted evidence: route, method, status, request ID, tenant/principal class, timestamps, deployment version, and minimal description of disclosed data class.
+5. Do not copy raw prompt, completion, tenant, provider payload, or credential content into public tickets, PRs, or this packet.
+
+## Unsafe output minimums
+
+For unsafe output incidents, record:
+
+- prompt category, not raw prompt, unless restricted disclosure handling is approved;
+- output risk class, not raw output, unless restricted disclosure handling is approved;
+- whether SAFE-OUT should have been returned;
+- route/model/provider configuration in redacted form;
+- whether the output was public, internal, or operator-only;
+- containment action and rollback decision.
+
+## Dashboard exposure minimums
+
+For dashboard exposure incidents, record:
+
+- whether default password, missing explicit signing secret, CSRF, session, role, route inventory, or provider-key settings were involved;
+- whether provider keys or settings pages were reachable;
+- whether sessions, signing secrets, or dashboard passwords were rotated;
+- whether the dashboard was disabled at the app, ingress, or deployment layer;
+- whether access logs show external access.
+
+## Data disclosure minimums
+
+For data disclosure incidents, record:
+
+- data class and owner, using the data-classification source of truth once reconciled;
+- affected tenant/operator population or the reason it is unknown;
+- exposure channel and access group;
+- containment and artifact removal timestamps;
+- notification/legal/privacy owner decision, if applicable.
+
+## Public abuse minimums
+
+For abuse incidents, record:
+
+- abuse vector and affected surface;
+- authentication state of abusive traffic;
+- rate-limit, quota, CORS, and tenant-control status;
+- provider-spend risk and whether provider-spend response was invoked;
+- blocks applied and monitoring follow-up.

--- a/docs/evals/runs/alpha-solver-incident-response-rollback-minimums-001/evidence-boundary.md
+++ b/docs/evals/runs/alpha-solver-incident-response-rollback-minimums-001/evidence-boundary.md
@@ -10,6 +10,8 @@
 
 ## What this packet does not prove
 
+- It does not replace the repo-global selected next lane; repo-global selected-next control remains in `docs/CURRENT_STATE.md` and `docs/LANE_REGISTRY.md`.
+- It does not authorize public exposure, provider calls, deployments, production readiness, public readiness, security/privacy completion, or DEF-002 closeout.
 - It does not prove public readiness.
 - It does not prove production readiness.
 - It does not prove runtime readiness.

--- a/docs/evals/runs/alpha-solver-incident-response-rollback-minimums-001/evidence-boundary.md
+++ b/docs/evals/runs/alpha-solver-incident-response-rollback-minimums-001/evidence-boundary.md
@@ -1,0 +1,43 @@
+# Evidence boundary
+
+## What this packet proves
+
+- Incident classes and severity levels have been documented.
+- Minimum immediate stop actions for provider spend, exposure, and leaked credentials have been documented.
+- Evidence preservation and redaction rules have been documented.
+- Rollback triggers, owner roles, and a rollback communication template have been documented.
+- Missing items before public exposure have been identified at a runbook level.
+
+## What this packet does not prove
+
+- It does not prove public readiness.
+- It does not prove production readiness.
+- It does not prove runtime readiness.
+- It does not prove provider readiness or provider billing safety.
+- It does not prove dashboard readiness.
+- It does not prove `/v1/solve` readiness.
+- It does not prove DEF-002 closure.
+- It does not prove security/privacy completion.
+- It does not prove incident drills were run.
+- It does not prove credential rotation, spend caps, kill switches, alerting, rollback, or abuse controls work in any deployed environment.
+- It does not accept residual risk.
+
+## Evidence preservation rules
+
+- Preserve timelines, owner decisions, route names, deployment versions, request IDs, redacted principal/tenant identifiers, and containment actions.
+- Prefer metadata and hashes over raw sensitive payloads.
+- Store restricted evidence only in approved access-controlled systems, not in repository docs.
+- Redact screenshots before attaching them to PRs, docs, tickets, or chat.
+- Re-review redaction manually because pattern-based redaction can miss novel secret formats.
+
+## Forbidden evidence in this packet
+
+- Full credentials, tokens, cookies, JWTs, signing secrets, passwords, private keys, refresh tokens, raw secret files, raw prompts, raw completions, raw provider payloads, raw tenant data, unrestricted logs, or environment dumps.
+
+## Allowed verdicts
+
+- `INCIDENT_RESPONSE_MINIMUMS_CAPTURED`
+- `INCIDENT_RESPONSE_BLOCKED_OPERATOR_DECISION_REQUIRED`
+- `STOP_INCONCLUSIVE`
+
+This packet uses `INCIDENT_RESPONSE_MINIMUMS_CAPTURED` because the docs-only minimums were captured without making readiness claims.

--- a/docs/evals/runs/alpha-solver-incident-response-rollback-minimums-001/incident-classes.md
+++ b/docs/evals/runs/alpha-solver-incident-response-rollback-minimums-001/incident-classes.md
@@ -1,0 +1,31 @@
+# Incident classes and severity levels
+
+## Severity levels
+
+| Severity | Definition | Minimum escalation | Minimum operator action |
+| --- | --- | --- | --- |
+| SEV-0 | Confirmed or strongly suspected active public harm, active data disclosure, active credential abuse, uncontrolled provider spend, or externally exposed dashboard/API with unsafe access. | Immediate incident commander plus rollback owner. Page security, infra, and product operator. | Stop exposure or provider spend first, preserve evidence second, communicate status third. |
+| SEV-1 | Credible high-risk incident with limited scope or contained blast radius: leaked non-production key, unsafe output reported by a trusted operator, abuse pattern not yet causing runaway spend, or dashboard exposure blocked by auth but misconfigured. | Incident commander and evidence custodian within the same response window. | Contain affected surface, rotate or revoke suspect credentials, capture redacted evidence, decide rollback. |
+| SEV-2 | Potential incident, near miss, suspicious telemetry, failed control, or redaction finding without confirmed external disclosure or spend. | Responsible operator plus evidence custodian. | Freeze risky changes, collect redacted evidence, decide whether to escalate. |
+| SEV-3 | Documentation gap, drill finding, incomplete owner assignment, or stale runbook that does not indicate active compromise. | Lane owner or docs operator. | Update runbook/evidence; no runtime action unless new facts raise severity. |
+
+If severity is uncertain, classify one level higher until the incident commander records a reasoned downgrade.
+
+## Incident classes
+
+| Class | Examples | Default severity floor | Immediate stop priority |
+| --- | --- | --- | --- |
+| Leaked credentials | Provider key in logs, screenshots, issue comments, chat, artifact, dashboard response, env dump, or repository content. | SEV-1; SEV-0 if key may be live or abused. | Revoke/rotate key and invalidate sessions/tokens before broader investigation. |
+| Runaway provider spend | Unexpected provider billing spike, repeated provider calls, quota exhaustion, abuse-driven prompts, tenant overage, or unknown caller generating costs. | SEV-0 if spend is active or uncapped; otherwise SEV-1. | Disable provider path, revoke provider key, apply provider-side cap, block caller. |
+| Unsafe output | Output that could enable harm, disclose private data, bypass SAFE-OUT expectations, or materially mislead an operator. | SEV-1; SEV-0 if public or actively harmful. | Stop the affected surface and preserve minimal redacted prompt/output metadata. |
+| Public abuse | Credential stuffing, scraping, prompt flooding, spam, automated `/v1/solve` traffic, tenant abuse, or CORS/browser abuse. | SEV-1; SEV-0 if public traffic is active and controls are insufficient. | Block traffic, disable exposed route, revoke affected sessions/API keys, freeze rollout. |
+| Dashboard exposure | Dashboard reachable publicly, default password usable, settings/provider-key route exposed, CSRF/session failure, or role bypass. | SEV-0 when provider keys/settings are reachable; otherwise SEV-1. | Disable dashboard mount or ingress route immediately and rotate dashboard signing secret if session compromise is possible. |
+| Data disclosure | Prompt, provider payload, tenant data, audit artifact, trace/span, evidence packet, or log content disclosed beyond policy. | SEV-0 if external or active; SEV-1 if internal but unauthorized. | Stop sharing path, restrict artifact access, preserve redacted evidence, start disclosure assessment. |
+| Rollback failure | Rollback cannot be performed, previous known-good version unavailable, or rollback increases exposure. | Same severity as triggering incident; minimum SEV-1. | Freeze deployment and escalate to rollback owner plus incident commander. |
+
+## Cross-cutting escalation rules
+
+- Any incident involving real or suspected live credentials requires credential-leak response minimums.
+- Any incident involving provider-backed runtime calls requires provider-spend response minimums, even if the first symptom is not billing.
+- Any incident involving public API, dashboard, or `/v1/solve` exposure inherits the public exposure gate no-go posture until a later operator decision changes it.
+- Any incident evidence containing prompts, keys, tokens, tenant data, or provider payloads must follow the evidence-boundary redaction rules before being attached to docs or tickets.

--- a/docs/evals/runs/alpha-solver-incident-response-rollback-minimums-001/non-actions.md
+++ b/docs/evals/runs/alpha-solver-incident-response-rollback-minimums-001/non-actions.md
@@ -17,6 +17,8 @@ This docs-only lane did not perform the following actions:
 - Did not change auth, CORS, tenancy, provider, model, dashboard, SAFE-OUT, logging, or API behavior.
 - Did not rotate or revoke any real credentials.
 - Did not update Google Sheets or backlog workbooks.
+- Did not replace the repo-global selected next lane controlled by `docs/CURRENT_STATE.md` and `docs/LANE_REGISTRY.md`.
+- Did not authorize public exposure, provider calls, deployments, production readiness, public readiness, security/privacy completion, or DEF-002 closeout.
 - Did not run incident drills.
 - Did not claim public readiness.
 - Did not claim production readiness.

--- a/docs/evals/runs/alpha-solver-incident-response-rollback-minimums-001/non-actions.md
+++ b/docs/evals/runs/alpha-solver-incident-response-rollback-minimums-001/non-actions.md
@@ -1,0 +1,28 @@
+# Non-actions
+
+This docs-only lane did not perform the following actions:
+
+- Did not deploy anything.
+- Did not expose public API.
+- Did not expose `/v1/solve`.
+- Did not expose dashboard.
+- Did not call providers.
+- Did not use tokens.
+- Did not access credentials.
+- Did not print secrets.
+- Did not inspect real billing dashboards.
+- Did not run runtime smoke tests.
+- Did not start services.
+- Did not change runtime code.
+- Did not change auth, CORS, tenancy, provider, model, dashboard, SAFE-OUT, logging, or API behavior.
+- Did not rotate or revoke any real credentials.
+- Did not update Google Sheets or backlog workbooks.
+- Did not run incident drills.
+- Did not claim public readiness.
+- Did not claim production readiness.
+- Did not claim runtime readiness.
+- Did not claim provider readiness.
+- Did not claim dashboard readiness.
+- Did not claim `/v1/solve` readiness.
+- Did not claim DEF-002 closure.
+- Did not claim security/privacy completion.

--- a/docs/evals/runs/alpha-solver-incident-response-rollback-minimums-001/operator-communications.md
+++ b/docs/evals/runs/alpha-solver-incident-response-rollback-minimums-001/operator-communications.md
@@ -1,0 +1,62 @@
+# Operator communications
+
+## Communication rules
+
+- Use UTC timestamps.
+- State facts, unknowns, owner, next update time, and claims boundary.
+- Do not include secrets, raw prompts, raw completions, raw provider payloads, tenant data, cookies, JWTs, dashboard session values, or unrestricted screenshots.
+- Mark every public-exposure or provider-backed incident update as no-readiness evidence unless a later operator approval lane says otherwise.
+
+## Incident start template
+
+```text
+Incident declared: <UTC timestamp>
+Incident ID: <id>
+Severity: <SEV-0|SEV-1|SEV-2|SEV-3>
+Class: <credential leak|provider spend|unsafe output|public abuse|dashboard exposure|data disclosure|rollback failure|unknown>
+Incident commander: <name/role>
+Known affected surface: <surface or unknown>
+Immediate containment underway: <yes/no/details>
+Provider spend risk: <yes/no/unknown>
+Credential risk: <yes/no/unknown>
+Evidence custodian: <name/role>
+Next update by: <UTC timestamp>
+Claims boundary: This is an incident notice, not a readiness claim.
+```
+
+## Status update template
+
+```text
+Incident update: <UTC timestamp>
+Incident ID: <id>
+Severity: <current severity>
+Containment status: <not started|in progress|contained|blocked>
+Actions completed: <redacted bullets>
+Known impact: <redacted data classes/surfaces, not raw data>
+Unknowns: <bullets>
+Rollback status: <not evaluated|selected|in progress|complete|blocked|not selected with rationale>
+Next decision needed: <operator/security/privacy/infra>
+Next update by: <UTC timestamp>
+Claims boundary: No public, production, runtime, provider, dashboard, or /v1/solve readiness is claimed.
+```
+
+## Closeout template
+
+```text
+Incident closeout candidate: <UTC timestamp>
+Incident ID: <id>
+Final severity: <SEV-0|SEV-1|SEV-2|SEV-3>
+Containment completed: <UTC timestamp>
+Rollback/recovery decision: <summary>
+Credentials rotated/revoked: <yes/no/not applicable, no secret values>
+Provider spend stopped/capped: <yes/no/not applicable>
+Data disclosure decision owner: <name/role/not applicable>
+Evidence packet: <controlled link/path>
+Residual risks: <bullets>
+Required follow-up lanes: <bullets>
+Forbidden claims: This closeout does not claim public readiness, production readiness, runtime readiness, provider readiness, dashboard readiness, /v1/solve readiness, DEF-002 closure, or security/privacy completion.
+```
+
+## External notification placeholder
+
+External user, provider, legal, or regulator notification is outside this docs-only lane. If notification may be required, the incident commander must assign a security/privacy owner and avoid unapproved disclosure content in repository artifacts.

--- a/docs/evals/runs/alpha-solver-incident-response-rollback-minimums-001/provider-spend-response.md
+++ b/docs/evals/runs/alpha-solver-incident-response-rollback-minimums-001/provider-spend-response.md
@@ -1,0 +1,45 @@
+# Provider spend response
+
+## Trigger conditions
+
+Use this response when there is suspected or confirmed provider-cost abuse, provider billing anomaly, unknown provider traffic, unexpected provider enablement, tenant quota bypass, or any public abuse that could call a billable provider.
+
+## Immediate stop actions
+
+1. Declare at least SEV-1; declare SEV-0 if spend is active, uncapped, public, or attributable to unknown callers.
+2. Stop billable provider calls by the fastest available operator-controlled mechanism for the environment:
+   - disable the provider integration/configuration;
+   - remove or revoke the provider key;
+   - set provider-side hard budget/cap to zero or the minimum safe value;
+   - disable the affected deployment, route, job, tenant, or ingress rule;
+   - block abusive caller principals, API keys, IPs, or tenants where known.
+3. Freeze deployments and configuration changes except containment changes approved by the incident commander.
+4. Preserve billing screenshots, provider dashboard timestamps, request IDs, tenant IDs, deployment versions, and relevant redacted logs. Do not copy real provider keys into evidence.
+5. Start an operator update using `operator-communications.md`.
+
+## Minimum evidence to preserve
+
+- Incident start time, detection source, and person declaring the incident.
+- Provider name and project/account identifier in redacted form.
+- Approximate spend delta, quota impact, and whether the provider-side cap was active.
+- Affected route or surface, if known.
+- Request IDs, tenant IDs, principal IDs, or IPs only when redacted or policy-approved.
+- Exact containment actions and timestamps.
+
+## Do not preserve
+
+- Full provider API keys, dashboard secrets, JWTs, bearer tokens, cookies, session IDs, OAuth client secrets, refresh tokens, or raw environment dumps.
+- Raw prompts, completions, provider payloads, or tenant data unless an approved disclosure process requires them in a restricted evidence store.
+
+## Recovery minimums
+
+Provider-backed operation may not resume until an operator records:
+
+- provider key rotation or explicit confirmation that no key was exposed;
+- provider-side budget/cap and alert status;
+- tenant or principal-level quota and rate-control status;
+- abuse source blocked or accepted with documented rationale;
+- rollback or forward-fix decision;
+- evidence redaction review completed.
+
+This recovery checklist does not authorize public exposure or readiness claims.

--- a/docs/evals/runs/alpha-solver-incident-response-rollback-minimums-001/rollback-checklist.md
+++ b/docs/evals/runs/alpha-solver-incident-response-rollback-minimums-001/rollback-checklist.md
@@ -1,0 +1,66 @@
+# Rollback checklist
+
+## Rollback trigger
+
+Rollback is required or must be explicitly rejected by the incident commander when any of the following occurs:
+
+- active or suspected public exposure of dashboard, `/v1/solve`, API, provider-backed execution, or provider-key settings;
+- leaked live or unknown-status credential;
+- uncontrolled provider spend or unknown billable traffic;
+- unsafe output from a public or externally shared surface;
+- data disclosure beyond approved audience;
+- auth, tenancy, CORS, CSRF, session, or role bypass;
+- inability to prove the currently deployed version matches the approved evidence boundary.
+
+## Required owner roles
+
+| Role | Minimum responsibility |
+| --- | --- |
+| Incident commander | Owns severity, containment order, rollback decision, and incident closeout. |
+| Rollback owner | Executes rollback or disablement and records exact version/config changes. |
+| Evidence custodian | Preserves redacted evidence and prevents secret/raw-data spread. |
+| Communications owner | Sends operator updates and maintains the timeline. |
+| Security/privacy owner | Decides notification, access review, and credential/data handling requirements. |
+
+A single person may hold multiple roles only if the incident commander records that staffing constraint.
+
+## Rollback actions
+
+1. Identify last known-good version/configuration and why it is considered safer.
+2. Disable the risky surface if rollback cannot be completed immediately.
+3. Revoke or rotate exposed credentials before or during rollback if credentials may be compromised.
+4. Apply rollback or configuration disablement.
+5. Confirm the exposed route/surface/provider path is no longer reachable or billable using non-provider static checks or safe control-plane evidence where possible.
+6. Capture redacted evidence of the rollback timestamp, version, operator, and verification result.
+7. Keep deployment freeze active until incident commander approves unfreeze.
+
+## Communication template
+
+Use this minimum rollback message:
+
+```text
+Rollback status: <started|completed|blocked|not selected>
+Incident ID: <id>
+Severity: <SEV-0|SEV-1|SEV-2|SEV-3>
+Affected surface: <api|v1-solve|dashboard|provider|data|unknown>
+Rollback owner: <name/role>
+Action taken: <version/config disabled/route blocked/key revoked>
+Time action completed: <UTC timestamp>
+Evidence location: <redacted controlled link or packet path>
+Remaining risk: <known gaps or unknowns>
+Next update by: <UTC timestamp>
+Claims boundary: This message does not claim readiness or incident closure.
+```
+
+## Rollback completion criteria
+
+Rollback is complete only when:
+
+- the affected surface is disabled or returned to a documented safer state;
+- provider spend path is stopped when relevant;
+- leaked credentials are revoked/rotated when relevant;
+- redacted evidence is preserved;
+- operator communication has been sent;
+- remaining gaps and next actions are recorded.
+
+Rollback completion is not incident closure. Incident closure requires root-cause, residual risk, and re-enable decisions by authorized operators.

--- a/docs/evals/runs/alpha-solver-incident-response-rollback-minimums-001/selected-next-lane.md
+++ b/docs/evals/runs/alpha-solver-incident-response-rollback-minimums-001/selected-next-lane.md
@@ -1,13 +1,15 @@
 # Selected next lane
 
-Recommended incident-response/public-exposure next lane:
+Incident-response/public-exposure-local recommended follow-up:
 `ALPHA-SOLVER-PUBLIC-EXPOSURE-OWNER-ASSIGNMENT-AND-DRILL-PLAN-001`
+
+This is an incident-response/public-exposure-local recommendation only. It does not replace the repo-global selected next lane, which remains controlled by `docs/CURRENT_STATE.md` and `docs/LANE_REGISTRY.md`.
 
 ## Rationale
 
 This packet captures runbook minimums, but it does not assign real environment owners or prove the minimums through tabletop or control-plane drills. Before any public exposure can be reconsidered, operators need named owners and drill evidence for credential revocation, provider spend stop, dashboard disablement, data-disclosure evidence handling, and rollback communication.
 
-## Minimum scope for the next lane
+## Minimum scope for the local follow-up lane
 
 - Assign incident commander, rollback owner, communications owner, evidence custodian, and security/privacy owner roles for the target environment.
 - Define contact paths and escalation timing.
@@ -15,6 +17,10 @@ This packet captures runbook minimums, but it does not assign real environment o
 - Define the evidence store and redaction review process.
 - Keep public exposure, provider calls, deployments, and readiness claims out of scope.
 
+## Relationship to repo-global selected next lane
+
+This packet does not update or supersede the repo-global selected next lane. Operators must use `docs/CURRENT_STATE.md` and `docs/LANE_REGISTRY.md` as the controlling source for repo-global lane selection.
+
 ## Relationship to DEF-002 lanes
 
-This recommendation does not replace the DEF-002-local remediation sequence. Default credential hardening, CORS hardening, `/v1/solve` auth/tenancy, data classification, and supply-chain gaps remain required or decision-bound before public exposure.
+This local recommendation does not replace the DEF-002-local remediation sequence. Default credential hardening, CORS hardening, `/v1/solve` auth/tenancy, data classification, and supply-chain gaps remain required or decision-bound before public exposure.

--- a/docs/evals/runs/alpha-solver-incident-response-rollback-minimums-001/selected-next-lane.md
+++ b/docs/evals/runs/alpha-solver-incident-response-rollback-minimums-001/selected-next-lane.md
@@ -1,0 +1,20 @@
+# Selected next lane
+
+Recommended incident-response/public-exposure next lane:
+`ALPHA-SOLVER-PUBLIC-EXPOSURE-OWNER-ASSIGNMENT-AND-DRILL-PLAN-001`
+
+## Rationale
+
+This packet captures runbook minimums, but it does not assign real environment owners or prove the minimums through tabletop or control-plane drills. Before any public exposure can be reconsidered, operators need named owners and drill evidence for credential revocation, provider spend stop, dashboard disablement, data-disclosure evidence handling, and rollback communication.
+
+## Minimum scope for the next lane
+
+- Assign incident commander, rollback owner, communications owner, evidence custodian, and security/privacy owner roles for the target environment.
+- Define contact paths and escalation timing.
+- Plan no-provider, no-credential tabletop drills for leaked key, provider spend, dashboard exposure, and data disclosure scenarios.
+- Define the evidence store and redaction review process.
+- Keep public exposure, provider calls, deployments, and readiness claims out of scope.
+
+## Relationship to DEF-002 lanes
+
+This recommendation does not replace the DEF-002-local remediation sequence. Default credential hardening, CORS hardening, `/v1/solve` auth/tenancy, data classification, and supply-chain gaps remain required or decision-bound before public exposure.


### PR DESCRIPTION
### Motivation

- Capture a minimal operator runbook for incident response and rollback covering leaked credentials, runaway provider spend, unsafe output/public abuse, dashboard exposure, data disclosure, and rollback triggers.
- Provide a docs-only evidence packet that closes the identified runbook gap while preserving the repo's no-public-exposure / no-provider / no-credential boundaries. 

### Description

- Add a new docs packet at `docs/evals/runs/alpha-solver-incident-response-rollback-minimums-001/` containing `README.md`, `incident-classes.md`, `rollback-checklist.md`, `provider-spend-response.md`, `credential-leak-response.md`, `data-exposure-response.md`, `operator-communications.md`, `selected-next-lane.md`, `evidence-boundary.md`, and `non-actions.md`. 
- Define severity levels (`SEV-0`–`SEV-3`), incident classes, immediate stop actions for spend/credentials/exposure, evidence preservation and redaction rules, rollback owners/checklist and communication templates, and explicit non-claims. 
- Set the packet verdict to `INCIDENT_RESPONSE_MINIMUMS_CAPTURED` and recommend `ALPHA-SOLVER-PUBLIC-EXPOSURE-OWNER-ASSIGNMENT-AND-DRILL-PLAN-001` as the next lane. 

### Testing

- Ran focused static doc checks: `python scripts/check_local_llm_doc_paths.py`, `python scripts/check_local_llm_evidence_boundaries.py`, and `python scripts/check_local_llm_packet_consistency.py`, and all passed. 
- Ran `git diff --check` as a formatting/consistency check and observed no issues. 
- Added packet files were validated by the repository static checks and are present under the new packet directory.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2df5752fd88329a1ef2701504015af)