### PR TITLE
Add DEF-002 dependency supply-chain gate evidence packet

### DIFF
--- a/docs/evals/runs/alpha-solver-def-002-dependency-supply-chain-gate-001/README.md
+++ b/docs/evals/runs/alpha-solver-def-002-dependency-supply-chain-gate-001/README.md
@@ -1,0 +1,48 @@
+# ALPHA-SOLVER-DEF-002-DEPENDENCY-SUPPLY-CHAIN-GATE-001
+
+Verdict: `DEF_002_DEPENDENCY_SUPPLY_CHAIN_GATE_CAPTURED`
+
+This docs-only packet captures the current dependency provenance, pinning posture, lock/constraint strategy, update cadence, and release-boundary review rules for the DEF-002 dependency supply-chain finding.
+
+## Inputs read
+
+- `requirements.txt`
+- `requirements-dev.txt`
+- `requirements-test.txt`
+- `constraints.txt`
+- `pyproject.toml`
+- `clients/python/pyproject.toml`
+- `Dockerfile`
+- `infrastructure/Dockerfile`
+- `infrastructure/docker-compose.yml`
+- `infrastructure/docker-compose.prod.yml`
+- `.github/workflows/`
+- `docs/evals/runs/alpha-solver-def-002-security-privacy-review-packet-001/dependency-supply-chain-review.md`
+- `docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/`
+
+## Packet outputs
+
+| File | Purpose |
+| --- | --- |
+| `dependency-inventory.md` | Inventory of dependency declaration, resolver, container, workflow, and vendored/shim sources observed in this lane. |
+| `lock-strategy.md` | Decision on constraints, hash files, lockfiles, pinned requirements, update cadence, and review boundary. |
+| `validation-evidence.md` | Commands run and results. |
+| `residual-risks.md` | Remaining dependency assurance gaps and release blockers. |
+| `selected-next-lane.md` | Recommended next lane after this packet. |
+| `evidence-boundary.md` | Evidence limits and allowed/forbidden claims. |
+| `non-actions.md` | Actions explicitly not taken. |
+
+## Decision summary
+
+The smallest safe provenance artifact for this lane is this evidence packet plus an explicit acknowledgement that the repository already has a `constraints.txt` pin set used by selected CI/release workflows. This lane does **not** regenerate or broaden pins, does **not** add a hash-pinned lockfile, and does **not** upgrade dependencies.
+
+## Dependency decision
+
+- Keep `requirements.txt` and `pyproject.toml` as range-based compatibility declarations for now.
+- Treat `constraints.txt` as the current bounded install pin artifact for CI/release contexts that invoke `pip install ... -c constraints.txt`.
+- Do not introduce `requirements.lock`, `uv.lock`, `poetry.lock`, or `--require-hashes` in this lane because doing so safely requires a dedicated resolver, platform policy, and review of transitive artifacts.
+- Require future dependency updates to be reviewed as a narrow dependency lane with changelog/security notes and focused test evidence.
+
+## Boundary
+
+This packet captures supply-chain provenance and update policy only. It does not claim complete dependency assurance, production readiness, public readiness, DEF-002 closure, SBOM completeness, vulnerability absence, or transitive hash verification.

--- a/docs/evals/runs/alpha-solver-def-002-dependency-supply-chain-gate-001/README.md
+++ b/docs/evals/runs/alpha-solver-def-002-dependency-supply-chain-gate-001/README.md
@@ -45,4 +45,4 @@ The smallest safe provenance artifact for this lane is this evidence packet plus
 
 ## Boundary
 
-This packet captures supply-chain provenance and update policy only. It does not claim complete dependency assurance, production readiness, public readiness, DEF-002 closure, SBOM completeness, vulnerability absence, or transitive hash verification.
+This packet captures supply-chain provenance and update policy only. It does not claim complete dependency assurance, production readiness, public readiness, DEF-002 closure, SBOM completeness, vulnerability absence, transitive hash verification, or that no provider call occurred during validation. Validation evidence records an ambient full-suite provider-call exception from the prior `python -m pytest -q` run; it was not an intended lane action.

--- a/docs/evals/runs/alpha-solver-def-002-dependency-supply-chain-gate-001/dependency-inventory.md
+++ b/docs/evals/runs/alpha-solver-def-002-dependency-supply-chain-gate-001/dependency-inventory.md
@@ -1,0 +1,48 @@
+# Dependency inventory
+
+## Python runtime declarations
+
+| Source | Role | Observed declarations | Notes |
+| --- | --- | --- | --- |
+| `requirements.txt` | Primary pip install input for root Dockerfile and several CI jobs | `pytest`, `jsonschema`, `pyyaml`, `prometheus-client>=0.20,<1`, `fastapi>=0.111,<0.113`, `starlette<0.38`, `pydantic>=2.7,<3`, `httpx>=0.27,<0.28`, `uvicorn[standard]>=0.30,<0.32` | Mostly range based. Includes `pytest`, which is test tooling, in the primary requirements file. |
+| `pyproject.toml` | Package metadata and build-system declaration | Build requirements: `setuptools>=68`, `wheel`. Project dependencies overlap with `requirements.txt`: `jsonschema`, `pyyaml`, `prometheus-client>=0.20,<1`, `fastapi>=0.111,<0.113`, `starlette<0.38`, `pydantic>=2.7,<3`, `httpx>=0.27,<0.28`, `uvicorn[standard]>=0.30,<0.32`. Optional `test`/`dev`: `pytest`. | Runtime metadata is range based and should remain compatible with the root requirements source. |
+| `requirements-dev.txt` | Development install input | Includes `-r requirements.txt`, `pytest>=8,<9`, `pytest-cov`, `pre-commit`, `ruff`, `opentelemetry-api==1.24.0`, `opentelemetry-sdk==1.24.0`. | Mixed ranged and unpinned dev tools, with two exact OpenTelemetry pins. |
+| `requirements-test.txt` | Additional test install input | `opentelemetry-api`, `opentelemetry-sdk`, `pytest-cov`. | Unpinned test-only declarations. |
+| `clients/python/pyproject.toml` | Python SDK package metadata | Build requirement `setuptools>=67`; runtime dependency `requests`; Python `>=3.8`. | SDK dependency is unpinned and separate from the root application dependency set. |
+
+## Constraint / pin artifact
+
+| Source | Role | Observed pins |
+| --- | --- | --- |
+| `constraints.txt` | Current bounded pip constraints artifact used by selected CI, nightly, and release workflows | `fastapi==0.111.1`, `starlette==0.37.2`, `pydantic==2.11.7`, `httpx==0.27.2`, `uvicorn==0.31.1`, `prometheus-client==0.20.0`, `pytest==8.2.0`, `pytest-cov==5.0.0`, `pre-commit==4.6.0`, `ruff==0.6.9`, `opentelemetry-api==1.24.0`, `opentelemetry-sdk==1.24.0`. |
+
+`constraints.txt` is a pin artifact, not a complete lockfile. It does not include hashes and does not enumerate all transitive dependencies.
+
+## Container dependency sources
+
+| Source | Base image / install path | Dependency boundary |
+| --- | --- | --- |
+| `Dockerfile` | `python:3.12-slim`; upgrades pip; installs `-r requirements.txt` without constraints | Runtime image can resolve newer in-range releases than constrained CI/release jobs. |
+| `infrastructure/Dockerfile` | `python:3.11-slim`; installs `-r requirements.txt` without constraints | Placeholder/generic image path; also unconstrained at install time. |
+| `infrastructure/docker-compose.yml` | Builds `infrastructure/Dockerfile` and runs `python -m alpha.cli ...` | Inherits `infrastructure/Dockerfile` dependency resolution. |
+| `infrastructure/docker-compose.prod.yml` | Builds `infrastructure/Dockerfile` and runs `uvicorn service.app:app` | Inherits `infrastructure/Dockerfile` dependency resolution. |
+
+## Workflow dependency sources
+
+| Workflow | Dependency behavior |
+| --- | --- |
+| `.github/workflows/ci.yml` | Installs `requirements.txt` without `constraints.txt`. |
+| `.github/workflows/gates.yml` | Installs `requirements.txt pytest-json-report` without `constraints.txt`. |
+| `.github/workflows/nightly.yml` | Installs `requirements-dev.txt -c constraints.txt`. |
+| `.github/workflows/release.yml` | Installs `requirements-dev.txt -c constraints.txt`; builds release artifacts. |
+| `.github/workflows/reliability-slo.yml` | Installs `requirements.txt pytest-json-report` without `constraints.txt`; starts `redis:7`. |
+| `.github/workflows/tests.yml` | Installs `requirements.txt`, `requirements-test.txt`, pytest/pytest-cov, build, and ruff with `-c constraints.txt` where specified. |
+| `.github/workflows/docker-publish.yml` | Builds `infrastructure/Dockerfile`; registry push is a placeholder echo for tags. |
+
+## Vendored and shimmed dependency surface
+
+The DEF-002 security/privacy dependency review identified in-tree vendored or shim-like modules such as `slowapi/`, `prometheus_client/`, `prometheus_fastapi_instrumentator/`, `jsonschema/`, and `jsonlines_compat.py`. This lane records that they remain outside normal pip resolver and vulnerability-scanner coverage unless separately inventoried.
+
+## Provider SDK boundary
+
+No provider SDK was added by this lane. Provider dependencies remain limited to already declared packages and in-repo provider code observed through dependency manifests.

--- a/docs/evals/runs/alpha-solver-def-002-dependency-supply-chain-gate-001/dependency-inventory.md
+++ b/docs/evals/runs/alpha-solver-def-002-dependency-supply-chain-gate-001/dependency-inventory.md
@@ -24,8 +24,8 @@
 | --- | --- | --- |
 | `Dockerfile` | `python:3.12-slim`; upgrades pip; installs `-r requirements.txt` without constraints | Runtime image can resolve newer in-range releases than constrained CI/release jobs. |
 | `infrastructure/Dockerfile` | `python:3.11-slim`; installs `-r requirements.txt` without constraints | Placeholder/generic image path; also unconstrained at install time. |
-| `infrastructure/docker-compose.yml` | Builds `infrastructure/Dockerfile` and runs `python -m alpha.cli ...` | Inherits `infrastructure/Dockerfile` dependency resolution. |
-| `infrastructure/docker-compose.prod.yml` | Builds `infrastructure/Dockerfile` and runs `uvicorn service.app:app` | Inherits `infrastructure/Dockerfile` dependency resolution. |
+| `infrastructure/docker-compose.yml` | `api.build: ..` is a string build context from the `infrastructure/` directory, so Compose resolves the context to the repository root and uses the root `Dockerfile` unless overridden; this file does not set a `dockerfile:` override. Auxiliary services use `otel/opentelemetry-collector:latest`, `prom/prometheus:latest`, and `grafana/grafana-oss:latest`. | The API service inherits the root `Dockerfile` dependency resolution (`python:3.12-slim`, `requirements.txt` without constraints), not `infrastructure/Dockerfile`. Auxiliary image tags are not digest pinned. |
+| `infrastructure/docker-compose.prod.yml` | `api.build: ..` is a string build context from the `infrastructure/` directory, so Compose resolves the context to the repository root and uses the root `Dockerfile` unless overridden; this file does not set a `dockerfile:` override. Auxiliary services use `otel/opentelemetry-collector:latest`, `prom/prometheus:latest`, and `grafana/grafana-oss:latest`. | The API service inherits the root `Dockerfile` dependency resolution (`python:3.12-slim`, `requirements.txt` without constraints), not `infrastructure/Dockerfile`. Auxiliary image tags are not digest pinned. |
 
 ## Workflow dependency sources
 

--- a/docs/evals/runs/alpha-solver-def-002-dependency-supply-chain-gate-001/evidence-boundary.md
+++ b/docs/evals/runs/alpha-solver-def-002-dependency-supply-chain-gate-001/evidence-boundary.md
@@ -1,0 +1,24 @@
+# Evidence boundary
+
+## What this packet proves
+
+- Dependency declaration sources were inventoried from Python manifests, constraints, Dockerfiles, compose files, workflows, SDK metadata, and prior DEF-002 review context.
+- The current `constraints.txt` pin artifact was identified and classified as a constraints file, not a complete lockfile.
+- An update cadence and dependency review boundary were documented.
+- Residual risks for lock/hash/SBOM, unconstrained install paths, source drift, vendored/shimmed modules, base images, actions, and SDK dependencies were recorded.
+
+## What this packet does not prove
+
+- It does not prove complete dependency assurance.
+- It does not prove absence of vulnerable dependencies.
+- It does not prove transitive dependency pinning.
+- It does not prove package hash verification.
+- It does not prove SBOM completeness.
+- It does not prove vendored/shimmed module provenance.
+- It does not prove Docker image reproducibility.
+- It does not prove production readiness, public readiness, or release readiness.
+- It does not close DEF-002.
+
+## Allowed verdicts
+
+This packet uses `DEF_002_DEPENDENCY_SUPPLY_CHAIN_GATE_CAPTURED` because the provenance/update-policy gate was captured without dependency version churn. If future evidence cannot classify the dependency boundary, use `STOP_INCONCLUSIVE`. If an operator decision is needed before capture, use `DEF_002_DEPENDENCY_SUPPLY_CHAIN_BLOCKED_DECISION_REQUIRED`.

--- a/docs/evals/runs/alpha-solver-def-002-dependency-supply-chain-gate-001/evidence-boundary.md
+++ b/docs/evals/runs/alpha-solver-def-002-dependency-supply-chain-gate-001/evidence-boundary.md
@@ -2,7 +2,7 @@
 
 ## What this packet proves
 
-- Dependency declaration sources were inventoried from Python manifests, constraints, Dockerfiles, compose files, workflows, SDK metadata, and prior DEF-002 review context.
+- Dependency declaration sources were inventoried from Python manifests, constraints, Dockerfiles, compose files, workflows, SDK metadata, and prior DEF-002 review context, with compose `build: ..` API services classified as resolving to the root Dockerfile absent a `dockerfile:` override.
 - The current `constraints.txt` pin artifact was identified and classified as a constraints file, not a complete lockfile.
 - An update cadence and dependency review boundary were documented.
 - Residual risks for lock/hash/SBOM, unconstrained install paths, source drift, vendored/shimmed modules, base images, actions, and SDK dependencies were recorded.
@@ -16,6 +16,7 @@
 - It does not prove SBOM completeness.
 - It does not prove vendored/shimmed module provenance.
 - It does not prove Docker image reproducibility.
+- It does not prove that no provider call occurred during validation; `validation-evidence.md` records the observed ambient full-suite provider-call exception.
 - It does not prove production readiness, public readiness, or release readiness.
 - It does not close DEF-002.
 

--- a/docs/evals/runs/alpha-solver-def-002-dependency-supply-chain-gate-001/lock-strategy.md
+++ b/docs/evals/runs/alpha-solver-def-002-dependency-supply-chain-gate-001/lock-strategy.md
@@ -1,0 +1,46 @@
+# Lock and update strategy
+
+## Strategy decision
+
+Verdict for strategy selection: use the existing `constraints.txt` as the current minimal pin artifact, document its boundary, and defer any hash-pinned or transitive lockfile introduction to a dedicated dependency hardening lane.
+
+## Why not change dependency versions now
+
+This lane is a provenance and release-boundary gate. Upgrading, relaxing, or broadly regenerating dependencies would change runtime resolution behavior and require compatibility testing beyond this approved scope.
+
+## Current artifact classification
+
+| Artifact type | Current status | Decision |
+| --- | --- | --- |
+| Range declarations | Present in `requirements.txt`, `pyproject.toml`, `requirements-dev.txt`, `requirements-test.txt`, and SDK metadata. | Keep as compatibility declarations until a package-management source-of-truth lane decides otherwise. |
+| Constraints file | Present as `constraints.txt`. | Treat as the current bounded install pin artifact for jobs that opt into `-c constraints.txt`. |
+| Full lockfile | Not present. | Do not add in this lane. Needs tool choice and platform policy. |
+| Hash-pinned install file | Not present. | Do not add in this lane. Needs transitive resolution, platform tag review, and hash-refresh workflow. |
+| SBOM | Not observed in this lane. | Do not create in this lane; recommend later release-hardening lane. |
+
+## Required update cadence
+
+- **Routine cadence:** review dependency updates monthly or before each release candidate, whichever comes first.
+- **Security cadence:** review critical/high vulnerability advisories as soon as practical and route them through a narrow emergency dependency lane when needed.
+- **Release cadence:** before release artifacts are built from a release branch/tag, confirm whether the release workflow uses `constraints.txt` and record any intentionally unconstrained install paths.
+- **Vendored/shim cadence:** review in-tree vendored/shim modules at least once per release cycle or when related upstream advisories are published.
+
+## Review boundary for future updates
+
+A future dependency update lane should include:
+
+1. The package names and old/new versions.
+2. Whether each change is runtime, dev-only, test-only, container base image, workflow action, or SDK-only.
+3. Links or notes for changelog/security rationale.
+4. Confirmation that no provider SDK was added unless already required and justified.
+5. Focused tests for affected runtime surfaces plus `python -m pytest -q` when practical.
+6. A statement of whether `constraints.txt`, package metadata, Docker installs, and workflow installs remain aligned.
+
+## Release-boundary rule
+
+A release should not claim complete dependency assurance unless a later lane provides at least one of these explicitly reviewed artifacts:
+
+- a complete transitive lockfile for the chosen installer and supported platform set,
+- a hash-pinned requirements artifact with documented refresh procedure,
+- a generated SBOM plus vulnerability-audit evidence, or
+- an explicit operator risk-acceptance packet that states why those controls are deferred.

--- a/docs/evals/runs/alpha-solver-def-002-dependency-supply-chain-gate-001/non-actions.md
+++ b/docs/evals/runs/alpha-solver-def-002-dependency-supply-chain-gate-001/non-actions.md
@@ -1,0 +1,20 @@
+# Non-actions
+
+This docs-only lane did not perform these actions:
+
+- Did not upgrade dependencies.
+- Did not downgrade dependencies.
+- Did not regenerate `constraints.txt`.
+- Did not add a provider SDK.
+- Did not add a new runtime dependency.
+- Did not add a lockfile.
+- Did not add hash-pinned requirements.
+- Did not create an SBOM.
+- Did not run a network vulnerability audit.
+- Did not change runtime behavior.
+- Did not change Dockerfiles, workflows, package metadata, or dependency manifests.
+- Did not deploy.
+- Did not call providers.
+- Did not use tokens.
+- Did not access credentials.
+- Did not claim production readiness, public readiness, complete dependency assurance, vulnerability absence, release readiness, or DEF-002 closure.

--- a/docs/evals/runs/alpha-solver-def-002-dependency-supply-chain-gate-001/non-actions.md
+++ b/docs/evals/runs/alpha-solver-def-002-dependency-supply-chain-gate-001/non-actions.md
@@ -14,7 +14,7 @@ This docs-only lane did not perform these actions:
 - Did not change runtime behavior.
 - Did not change Dockerfiles, workflows, package metadata, or dependency manifests.
 - Did not deploy.
-- Did not call providers.
+- Did not perform intentional provider calls as a docs-only lane action; validation evidence records one ambient full-suite provider-call exception from the prior `python -m pytest -q` run.
 - Did not use tokens.
 - Did not access credentials.
 - Did not claim production readiness, public readiness, complete dependency assurance, vulnerability absence, release readiness, or DEF-002 closure.

--- a/docs/evals/runs/alpha-solver-def-002-dependency-supply-chain-gate-001/residual-risks.md
+++ b/docs/evals/runs/alpha-solver-def-002-dependency-supply-chain-gate-001/residual-risks.md
@@ -1,0 +1,24 @@
+# Residual risks
+
+## Remaining gaps
+
+| ID | Residual risk | Boundary |
+| --- | --- | --- |
+| DR-01 | `constraints.txt` is not a complete transitive lockfile and has no hashes. | Fresh installs can still depend on resolver behavior for transitive packages and cannot verify package file hashes. |
+| DR-02 | Several install paths do not apply `constraints.txt`. | Root and infrastructure Dockerfiles plus some workflows install range declarations directly. |
+| DR-03 | Dependency declarations are split across root requirements, package metadata, dev/test files, SDK metadata, Dockerfiles, compose files, and workflows. | Drift can occur without a source-of-truth policy. |
+| DR-04 | Vendored/shimmed in-tree modules are not covered by declared dependency scanning. | Their upstream provenance, version, and patch status require a separate inventory. |
+| DR-05 | Container base images and GitHub Actions are not pinned by digest/SHA. | Image/action upstream changes can affect build behavior. |
+| DR-06 | No SBOM or vulnerability-audit artifact is recorded by this lane. | Absence of known vulnerabilities is not proven. |
+| DR-07 | Python SDK dependency `requests` is unpinned in `clients/python/pyproject.toml`. | SDK install behavior remains resolver-dependent. |
+
+## Release impact
+
+These residual risks remain blockers for any claim of complete dependency assurance. They do not by themselves change runtime code in this lane, but they must be closed or explicitly accepted before public/production readiness claims.
+
+## Operator decision points
+
+- Select package-management source of truth: requirements plus constraints, project metadata plus generated constraints, or a lockfile tool.
+- Decide whether Docker and all workflows must enforce `constraints.txt` before release.
+- Decide whether hash pinning is required for runtime releases.
+- Decide whether vendored/shim modules should be removed, replaced, or separately tracked.

--- a/docs/evals/runs/alpha-solver-def-002-dependency-supply-chain-gate-001/residual-risks.md
+++ b/docs/evals/runs/alpha-solver-def-002-dependency-supply-chain-gate-001/residual-risks.md
@@ -5,10 +5,10 @@
 | ID | Residual risk | Boundary |
 | --- | --- | --- |
 | DR-01 | `constraints.txt` is not a complete transitive lockfile and has no hashes. | Fresh installs can still depend on resolver behavior for transitive packages and cannot verify package file hashes. |
-| DR-02 | Several install paths do not apply `constraints.txt`. | Root and infrastructure Dockerfiles plus some workflows install range declarations directly. |
+| DR-02 | Several install paths do not apply `constraints.txt`. | The root `Dockerfile`, the standalone `infrastructure/Dockerfile`, compose API builds that resolve to the root `Dockerfile`, and some workflows install range declarations directly. |
 | DR-03 | Dependency declarations are split across root requirements, package metadata, dev/test files, SDK metadata, Dockerfiles, compose files, and workflows. | Drift can occur without a source-of-truth policy. |
 | DR-04 | Vendored/shimmed in-tree modules are not covered by declared dependency scanning. | Their upstream provenance, version, and patch status require a separate inventory. |
-| DR-05 | Container base images and GitHub Actions are not pinned by digest/SHA. | Image/action upstream changes can affect build behavior. |
+| DR-05 | Container base images, compose auxiliary images, and GitHub Actions are not pinned by digest/SHA. | Image/action upstream changes can affect build behavior; compose auxiliary services use `latest` tags in the inspected files. |
 | DR-06 | No SBOM or vulnerability-audit artifact is recorded by this lane. | Absence of known vulnerabilities is not proven. |
 | DR-07 | Python SDK dependency `requests` is unpinned in `clients/python/pyproject.toml`. | SDK install behavior remains resolver-dependent. |
 

--- a/docs/evals/runs/alpha-solver-def-002-dependency-supply-chain-gate-001/selected-next-lane.md
+++ b/docs/evals/runs/alpha-solver-def-002-dependency-supply-chain-gate-001/selected-next-lane.md
@@ -1,0 +1,19 @@
+# Selected next lane
+
+Recommended next supply-chain lane:
+`ALPHA-SOLVER-DEF-002-DEPENDENCY-SUPPLY-CHAIN-LOCK-HASH-SBOM-DECISION-001`
+
+## Rationale
+
+This packet captures provenance and update policy but intentionally does not introduce a full lockfile, hash-pinned requirements, SBOM, or vulnerability-audit artifact. The next supply-chain lane should make the operator/tooling decision needed to close or explicitly defer those controls.
+
+## Suggested scope
+
+- Choose the dependency source of truth.
+- Decide whether `constraints.txt` becomes mandatory for Docker and all CI/release installs.
+- Decide whether to generate a full transitive lockfile, hash-pinned requirements artifact, SBOM, or a documented risk acceptance.
+- Inventory vendored/shimmed modules with provenance and replacement/removal decisions.
+
+## Boundary
+
+This selected next lane is a recommendation only. It does not authorize public exposure, provider calls, deployment, dependency upgrades, or DEF-002 closeout.

--- a/docs/evals/runs/alpha-solver-def-002-dependency-supply-chain-gate-001/validation-evidence.md
+++ b/docs/evals/runs/alpha-solver-def-002-dependency-supply-chain-gate-001/validation-evidence.md
@@ -18,9 +18,22 @@
 - The installed local environment did not report broken Python package requirements.
 - The existing constraints file pins overlap the root runtime requirements without violating their declared ranges.
 - Full pytest did not pass in this environment; observed failures are recorded above and are outside this packet's docs-only dependency-provenance changes.
-- This lane did not perform a network vulnerability audit, SBOM generation, Docker build, or provider call intentionally. The full-suite run did exercise an existing test path that made an HTTP request to OpenAI in the local environment; this lane did not add or authorize provider-calling behavior.
+- This lane did not perform a network vulnerability audit, SBOM generation, Docker build, or intentional provider call.
+- Provider-call exception: the full-suite `python -m pytest -q` validation run exercised an existing test path that made an HTTP request to OpenAI in the ambient local environment. This was observed validation behavior, not an intended docs-only lane action, and this packet does not hide or convert that exception into a no-provider-call claim.
+- Follow-up validation for this fix intentionally avoids full pytest because the prior full-suite run showed provider-backed tests can execute under ambient configuration.
 
 ## Static docs check summary
 
 - All required evidence packet files are present.
 - New packet Markdown files passed a focused trailing-whitespace check.
+
+## Review-fix validation
+
+| Command | Result | Notes |
+| --- | --- | --- |
+| `python scripts/check_local_llm_doc_paths.py` | Pass | Local LLM/post-Level/OpenAI doc path/link check passed. |
+| `python scripts/check_local_llm_evidence_boundaries.py` | Pass | Evidence-boundary static check passed. |
+| `python scripts/check_local_llm_packet_consistency.py` | Pass | Packet consistency check passed. |
+| `git diff --check` | Pass | No whitespace errors reported. |
+
+Full pytest was intentionally not rerun for this review fix because the prior validation evidence showed provider-backed tests can execute under ambient configuration.

--- a/docs/evals/runs/alpha-solver-def-002-dependency-supply-chain-gate-001/validation-evidence.md
+++ b/docs/evals/runs/alpha-solver-def-002-dependency-supply-chain-gate-001/validation-evidence.md
@@ -1,0 +1,26 @@
+# Validation evidence
+
+## Commands run
+
+| Command | Result | Notes |
+| --- | --- | --- |
+| `python -m pip check` | Pass | Installed environment reported no broken requirements. |
+| `python -m pip list --format=json > /tmp/alpha_solver_pip_list.json` | Pass | Captured installed environment package list outside the repo to avoid committing environment-specific noise. |
+| `python -m pip freeze > /tmp/alpha_solver_pip_freeze.txt` | Pass | Captured installed environment freeze outside the repo for local validation only. |
+| `python - <<'PY' ... packaging specifier check ... PY` | Pass | Verified `constraints.txt` pinned values satisfy root `requirements.txt` specifiers for overlapping packages. |
+| `python -m pytest -q tests/test_requirements_parity.py` | Fail | Requested focused parity check could not run because `tests/test_requirements_parity.py` is not present in this checkout. |
+| `python -m pytest -q` | Fail | Full suite completed with 5 failures unrelated to this docs-only packet: three provider model expectation failures in `tests/test_api_endpoints.py`, one cost tracking failure in `tests/test_cost_tracking.py`, and one security validation failure in `tests/test_security.py`. |
+| `python - <<'PY' ... packet file check ... PY` | Pass | Verified all required packet files exist. |
+| `python - <<'PY' ... markdown no trailing whitespace check ... PY` | Pass | Checked new packet Markdown files for trailing whitespace. |
+
+## Dependency check summary
+
+- The installed local environment did not report broken Python package requirements.
+- The existing constraints file pins overlap the root runtime requirements without violating their declared ranges.
+- Full pytest did not pass in this environment; observed failures are recorded above and are outside this packet's docs-only dependency-provenance changes.
+- This lane did not perform a network vulnerability audit, SBOM generation, Docker build, or provider call intentionally. The full-suite run did exercise an existing test path that made an HTTP request to OpenAI in the local environment; this lane did not add or authorize provider-calling behavior.
+
+## Static docs check summary
+
+- All required evidence packet files are present.
+- New packet Markdown files passed a focused trailing-whitespace check.


### PR DESCRIPTION
### Motivation
- Capture DEF-002 dependency provenance, pinning posture, and a release-boundary decision without changing runtime behavior or upgrading dependencies.
- Provide a minimal, auditable evidence packet that classifies the existing `constraints.txt` as the bounded pin artifact and documents residual risks and review boundaries.
- Defer full lock/hash/SBOM decisions to a dedicated supply-chain lane so runtime resolution and transitive changes are not introduced here.

### Description
- Add a docs-only evidence packet at `docs/evals/runs/alpha-solver-def-002-dependency-supply-chain-gate-001/` containing `README.md`, `dependency-inventory.md`, `lock-strategy.md`, `validation-evidence.md`, `residual-risks.md`, `selected-next-lane.md`, `evidence-boundary.md`, and `non-actions.md` that record the gate verdict and decisions.
- Record the decision to treat `constraints.txt` as the current minimal pin artifact for CI/release jobs and explicitly not to add a lockfile, `--require-hashes`, or upgrade pins in this lane.
- Document update cadence, required review boundary for future dependency lanes, a recommended next lane `ALPHA-SOLVER-DEF-002-DEPENDENCY-SUPPLY-CHAIN-LOCK-HASH-SBOM-DECISION-001`, and a list of residual risks (unconstrained install paths, vendored/shimmed modules, no SBOM, unpinned base images/actions, etc.).
- Commit only documentation artifacts; no runtime code, Dockerfiles, workflows, or dependency manifests were modified.

### Testing
- Ran `python -m pip check`, `python -m pip list --format=json > /tmp/alpha_solver_pip_list.json`, and `python -m pip freeze > /tmp/alpha_solver_pip_freeze.txt`, all of which passed. 
- Verified packaging specifier overlap with a small Python check that confirmed `constraints.txt` pinned values satisfy overlapping `requirements.txt` specifiers, which passed. 
- Verified packet presence and formatting checks (packet files present and no trailing whitespace), which passed. 
- Ran `python -m pytest -q` which completed but reported 5 existing test failures unrelated to this docs-only change (three provider model expectation failures in `tests/test_api_endpoints.py`, one cost-tracking failure in `tests/test_cost_tracking.py`, and one security validation failure in `tests/test_security.py`). 
- Attempted `python -m pytest -q tests/test_requirements_parity.py` which failed because the parity test file is not present in this checkout; this focused parity check was therefore not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2df5668304832991a13db49a216de8)