### PR TITLE
Reconstruct 22 contaminated specs from committed code and tests

### DIFF
--- a/.specs/AS-145.md
+++ b/.specs/AS-145.md
@@ -1,45 +1,43 @@
 # CODE SPEC — AS-145 · Tool Adapters: Playwright + GSheets (MVP hardening) (RES_05)
 
-> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
-> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
-> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
-> titled feature or its own `## Code Targets`. The intended spec body for this feature is
-> therefore **missing**. The contaminated body is preserved **unchanged** below for
-> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
->
-> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
-> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
-> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
-> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+> Reconstructed by lane `ALPHA-SOLVER-SPEC-SOURCE-RECONSTRUCTION-001` from committed code and tests only. This file replaces a non-authoritative contaminated MCP-005 body. Do not infer implementation quality from this reconstruction.
 
 ## Goal
-Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
+
+Harden Playwright and GSheets adapters with domain allowlists, sanitization, transient retries, idempotency, and route explain details.
 
 ## Acceptance Criteria
-- All taxonomy tests pass.
-- Deterministic mapping for timeouts, connectivity, auth, 429, schema validation, sandbox, cancelled, unknown.
-- `to_json()` serializes; `to_route_explain()` yields small dict; `is_retryable()` correct.
 
-## Code Targets
-service/adapters/base.py; service/adapters/playwright_adapter.py; service/adapters/gsheets_adapter.py; tests/test_adapters_playwright_hardened.py; tests/test_adapters_gsheets_hardened.py
+- Playwright extracts h1, first paragraph, and meta description from allowed domains.
+- Disallowed domains raise non-retryable DOMAIN_NOT_ALLOWED.
+- HTML/script content and whitespace are sanitized.
+- GSheets append is idempotent by range/key, sanitizes cell values, and retries transient errors.
+- Route explanations expose allowlist/sanitized fields or sanitized cells, attempts, idempotency, and latency; MVP success rate is at least 95%.
 
 ## Design
-- ErrorClass enum (TOOL_NOT_FOUND, SCHEMA_VALIDATION, AUTH, RATE_LIMIT, TIMEOUT, CANCELLED,
-  CONNECTIVITY, RETRYABLE, NON_RETRYABLE, SANDBOX_VIOLATION, SECURITY, UNKNOWN)
-- MCPError dataclass(cls, message, code|None, retryable:bool, root:str, meta:dict|None)
-- map_exception(exc) -> MCPError (rules as above); add meta["secondary"]="RETRYABLE" when applicable
-- Helpers: to_route_explain(mcp_error), is_retryable(mcp_error)
-- No external deps; tests use fake exceptions (no httpx import)
 
-## Tests (must add)
-tests/test_mcp_errors.py:
-- test_timeout_maps_retryable
-- test_connectivity_maps_retryable
-- test_rate_limit_429_retryable
-- test_auth_nonretryable
-- test_schema_validation_nonretryable
-- test_sandbox_violation_nonretryable
-- test_cancelled_nonretryable
-- test_unknown_default
-- test_to_route_explain_truncates_message
-- test_to_json_is_serializable
+- Source of truth for this reconstruction is limited to the committed implementation and test targets listed in `## Reconstruction Sources`.
+- Runtime behavior is represented by the implementation files in `## Code Targets`; expected observable behavior is represented by the listed tests.
+- No provider calls, tokens, external services, or runtime code changes are required by this spec reconstruction.
+- MCP-005 remains the canonical source for MCP error taxonomy names and semantics wherever error classes are referenced.
+- Unspecified behavior is not reconstructed; it remains unknown or requires an operator decision.
+
+## Tests
+
+Run the focused tests listed in `## Code Targets` for this spec. These tests define the reconstructed acceptance boundary and should be kept focused on the committed behavior summarized above.
+
+## Reconstruction Note
+
+This spec was reconstructed on 2026-06-14 by reading the contaminated spec's `## Code Targets` section and the committed source/test files named there. The prior MCP-005 Error Taxonomy body was treated as non-authoritative contamination and was not used to infer this feature's intent. Unknown: credentials and live service authorization are not defined.
+
+## Reconstruction Sources
+
+- `service/adapters/base.py`
+- `service/adapters/playwright_adapter.py`
+- `service/adapters/gsheets_adapter.py`
+- `tests/test_adapters_playwright_hardened.py`
+- `tests/test_adapters_gsheets_hardened.py`
+
+## Code Targets
+
+service/adapters/base.py; service/adapters/playwright_adapter.py; service/adapters/gsheets_adapter.py; tests/test_adapters_playwright_hardened.py; tests/test_adapters_gsheets_hardened.py

--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -2,7 +2,7 @@
 
 Simple registry of the Markdown specs stored in `.specs/`. File names are canonical; titles mirror the first header inside each spec (or a filename-derived label when absent).
 
-> **Health status added 2026-06-13** by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001`. Specs marked `SPEC_CONTAMINATED` carry the `MCP-005` Error-Taxonomy body under the wrong title and must not be used as implementation scope — see [`../docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and [`../docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+> **Health status added 2026-06-13** by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001`. **Updated 2026-06-14** by lane `ALPHA-SOLVER-SPEC-SOURCE-RECONSTRUCTION-001`: the 22 formerly contaminated specs are now marked `SPEC_RECONSTRUCTED_FROM_SOURCE` after replacement from committed code and tests only. See [`../docs/evals/runs/alpha-solver-spec-source-reconstruction-001/`](../docs/evals/runs/alpha-solver-spec-source-reconstruction-001/).
 
 
 | File | Title | Health |
@@ -14,7 +14,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `ALPHA-LIVE-EXPERT-STEP1-PARSE-001.md` | ALPHA-LIVE-EXPERT-STEP1-PARSE-001 · Recover Actionable Execution Prompts When Step 1 Metadata Is Missing | ✅ `SPEC_OK` |
 | `ALPHA-PRIMARY-ANSWER-EMPTY-001.md` | ALPHA-PRIMARY-ANSWER-EMPTY-001 · Ensure Answer-with-Assumptions Returns a Primary Deliverable | ✅ `SPEC_OK` |
 | `ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001.md` | ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001 - Side-by-Side Evidence Packet Contract | ✅ `SPEC_OK` |
-| `AS-145.md` | CODE SPEC — AS-145 · Tool Adapters: Playwright + GSheets (MVP hardening) (RES_05) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
+| `AS-145.md` | CODE SPEC — AS-145 · Tool Adapters: Playwright + GSheets (MVP hardening) (RES_05) | ✅ `SPEC_RECONSTRUCTED_FROM_SOURCE` |
 | `AS-148.md` | CODE SPEC — AS-148 · Policy & PII Gateway (DR_TRACK_A) | ✅ `SPEC_OK` |
 | `AUTH-SESSION-001.md` | AUTH-SESSION-001 · Dashboard Login + Session | ✅ `SPEC_OK` |
 | `CLARIFY-SURFACE-001.md` | CLARIFY-SURFACE-001 · Expert Route Clarify Surface | ✅ `SPEC_OK` |
@@ -37,25 +37,25 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `FINOPS-BUDGET-001.md` | FINOPS-BUDGET-001 · Budget Guardrails | ✅ `SPEC_OK` |
 | `LOCAL-LLM-RUNTIME-INTEGRATION-001.md` | LOCAL-LLM-RUNTIME-INTEGRATION-001 · Local LLM Runtime Integration Implementation Contract | ✅ `SPEC_OK` |
 | `LOCAL-LLM-SOLVER-ORCHESTRATION-001.md` | LOCAL-LLM-SOLVER-ORCHESTRATION-001 · Local LLM Solver Orchestration Integration Contract | ✅ `SPEC_OK` |
-| `MCP-001.md` | CODE SPEC — MCP-001 · MCP Registry Loader & Wiring (MCP) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
-| `MCP-002.md` | CODE SPEC — MCP-002 · Router decision rule (MCP) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
-| `MCP-003.md` | CODE SPEC — MCP-003 · MCP OAuth/Secrets scaffold (auth surface) (MCP) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
-| `MCP-004.md` | CODE SPEC — MCP-004 · Sandbox Limits (policy guardrail) (MCP) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
+| `MCP-001.md` | CODE SPEC — MCP-001 · MCP Registry Loader & Wiring (MCP) | ✅ `SPEC_RECONSTRUCTED_FROM_SOURCE` |
+| `MCP-002.md` | CODE SPEC — MCP-002 · Router decision rule (MCP) | ✅ `SPEC_RECONSTRUCTED_FROM_SOURCE` |
+| `MCP-003.md` | CODE SPEC — MCP-003 · MCP OAuth/Secrets scaffold (auth surface) (MCP) | ✅ `SPEC_RECONSTRUCTED_FROM_SOURCE` |
+| `MCP-004.md` | CODE SPEC — MCP-004 · Sandbox Limits (policy guardrail) (MCP) | ✅ `SPEC_RECONSTRUCTED_FROM_SOURCE` |
 | `MCP-005.md` | CODE SPEC — MCP-005 · Error Taxonomy (MCP) | ✅ `SPEC_OK` (canonical — DO_NOT_TOUCH) |
-| `MCP-006.md` | CODE SPEC — MCP-006 · Retry & Backoff (MCP) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
-| `MCP-007.md` | CODE SPEC — MCP-007 · MCP Observability hooks (MCP) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
+| `MCP-006.md` | CODE SPEC — MCP-006 · Retry & Backoff (MCP) | ✅ `SPEC_RECONSTRUCTED_FROM_SOURCE` |
+| `MCP-007.md` | CODE SPEC — MCP-007 · MCP Observability hooks (MCP) | ✅ `SPEC_RECONSTRUCTED_FROM_SOURCE` |
 | `MCP-008.md` | MCP-008 · Domainless MCP Tool Allowlist Enforcement | ✅ `SPEC_OK` |
 | `MVP-CLOSEOUT-001.md` | MVP-CLOSEOUT-001 · MVP Tester Handoff and Readiness Packet | 🟡 `SPEC_NEEDS_OPERATOR_DECISION` |
 | `MVP-READINESS-CHECKPOINT-001.md` | MVP-READINESS-CHECKPOINT-001 · Operator-Test-Ready MVP Preview Checkpoint | 🟡 `SPEC_NEEDS_OPERATOR_DECISION` |
-| `NEW-009.md` | CODE SPEC — NEW-009 · Clarify Templates Pack (RES_02) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
-| `NEW-010.md` | CODE SPEC — NEW-010 · Section-Specific Prompt Decks (RES_01) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
-| `NEW-011.md` | CODE SPEC — NEW-011 · Weight-Tuning Harness (RES-03 scoring) (RES_03) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
-| `NEW-012.md` | CODE SPEC — NEW-012 · Budget CLI + CI Guard (RES_07) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
-| `NEW-013.md` | CODE SPEC — NEW-013 · Replay CLI + Trace Diff (text viewer) (RES_07) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
-| `NEW-014.md` | CODE SPEC — NEW-014 · Evidence Pack Store (catalog + retrieval) (RES_07) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
-| `NEW-015.md` | CODE SPEC — NEW-015 · Determinism Harness (exact replay & drift detector) (RES_07) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
-| `NEW-016.md` | CODE SPEC — NEW-016 · Grafana Dashboards Pack (metrics + sample boards) (RES_07) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
-| `NEW-017.md` | CODE SPEC — NEW-017 · Prompt Quality Pack (rubrics + evaluator) (RES_01) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
+| `NEW-009.md` | CODE SPEC — NEW-009 · Clarify Templates Pack (RES_02) | ✅ `SPEC_RECONSTRUCTED_FROM_SOURCE` |
+| `NEW-010.md` | CODE SPEC — NEW-010 · Section-Specific Prompt Decks (RES_01) | ✅ `SPEC_RECONSTRUCTED_FROM_SOURCE` |
+| `NEW-011.md` | CODE SPEC — NEW-011 · Weight-Tuning Harness (RES-03 scoring) (RES_03) | ✅ `SPEC_RECONSTRUCTED_FROM_SOURCE` |
+| `NEW-012.md` | CODE SPEC — NEW-012 · Budget CLI + CI Guard (RES_07) | ✅ `SPEC_RECONSTRUCTED_FROM_SOURCE` |
+| `NEW-013.md` | CODE SPEC — NEW-013 · Replay CLI + Trace Diff (text viewer) (RES_07) | ✅ `SPEC_RECONSTRUCTED_FROM_SOURCE` |
+| `NEW-014.md` | CODE SPEC — NEW-014 · Evidence Pack Store (catalog + retrieval) (RES_07) | ✅ `SPEC_RECONSTRUCTED_FROM_SOURCE` |
+| `NEW-015.md` | CODE SPEC — NEW-015 · Determinism Harness (exact replay & drift detector) (RES_07) | ✅ `SPEC_RECONSTRUCTED_FROM_SOURCE` |
+| `NEW-016.md` | CODE SPEC — NEW-016 · Grafana Dashboards Pack (metrics + sample boards) (RES_07) | ✅ `SPEC_RECONSTRUCTED_FROM_SOURCE` |
+| `NEW-017.md` | CODE SPEC — NEW-017 · Prompt Quality Pack (rubrics + evaluator) (RES_01) | ✅ `SPEC_RECONSTRUCTED_FROM_SOURCE` |
 | `NEW-024.md` | CODE SPEC — NEW-024 · JWT Service-to-Service Authentication (DR_TRACK_A) | ✅ `SPEC_OK` |
 | `NEW-045.md` | Spec: NEW-045 · Pilot Readiness & Release v0.1 | ✅ `SPEC_OK` |
 | `NEW-HEALTH-001.md` | NEW-HEALTH-001 · Health Check Endpoints | ✅ `SPEC_OK` |
@@ -68,12 +68,12 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `PROVIDER-EXPERT-PASS-001.md` | PROVIDER-EXPERT-PASS-001 · Opt-in Expert Provider Pass | ✅ `SPEC_OK` |
 | `PROVIDER-OPENAI-001.md` | PROVIDER-OPENAI-001 · Real OpenAI Provider Execution | ✅ `SPEC_OK` |
 | `PROVIDER-SAFEOUT-001.md` | PROVIDER-SAFEOUT-001 · Structured Provider SAFE-OUT Responses | ✅ `SPEC_OK` |
-| `RES-03.md` | CODE SPEC — RES-03 · Decision Rules & Scoring (RES) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
-| `RES-04.md` | CODE SPEC — RES-04 · Confidence & Budget Gates (RES) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
-| `RES-05.md` | CODE SPEC — RES-05 · Tool Adapters (Playwright, GSheets) — MVP stubs (RES) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
-| `RES-06.md` | CODE SPEC — RES-06 · Scenario Pack & Showcase (record/replay + rubric) (RES) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
-| `RES-07.md` | CODE SPEC — RES-07 · Observability (route_explain + JSONL replay) (RES) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
-| `RES-08.md` | CODE SPEC — RES-08 · Budget Simulator + Evidence Pack (RES) | ⚠️ `SPEC_CONTAMINATED` — non-authoritative; see audit |
+| `RES-03.md` | CODE SPEC — RES-03 · Decision Rules & Scoring (RES) | ✅ `SPEC_RECONSTRUCTED_FROM_SOURCE` |
+| `RES-04.md` | CODE SPEC — RES-04 · Confidence & Budget Gates (RES) | ✅ `SPEC_RECONSTRUCTED_FROM_SOURCE` |
+| `RES-05.md` | CODE SPEC — RES-05 · Tool Adapters (Playwright, GSheets) — MVP stubs (RES) | ✅ `SPEC_RECONSTRUCTED_FROM_SOURCE` |
+| `RES-06.md` | CODE SPEC — RES-06 · Scenario Pack & Showcase (record/replay + rubric) (RES) | ✅ `SPEC_RECONSTRUCTED_FROM_SOURCE` |
+| `RES-07.md` | CODE SPEC — RES-07 · Observability (route_explain + JSONL replay) (RES) | ✅ `SPEC_RECONSTRUCTED_FROM_SOURCE` |
+| `RES-08.md` | CODE SPEC — RES-08 · Budget Simulator + Evidence Pack (RES) | ✅ `SPEC_RECONSTRUCTED_FROM_SOURCE` |
 | `REVIEW-P0P1.md` | CODE SPEC — REVIEW-P0P1 · P0 + P1 Bulk Review (MVP Readiness) (RES_06) | ✅ `SPEC_OK` |
 | `SOLVE-EXPERT-EMPTY-ANSWER-GUARD-001.md` | SOLVE-EXPERT-EMPTY-ANSWER-GUARD-001 · Expert Route Empty Primary Answer Guard | ✅ `SPEC_OK` |
 | `SOLVE-PROVIDER-FINAL-ANSWER-EMPTY-GUARD-001.md` | SOLVE-PROVIDER-FINAL-ANSWER-EMPTY-GUARD-001 · Provider Final Answer Empty Output Guard | ✅ `SPEC_OK` |

--- a/.specs/MCP-001.md
+++ b/.specs/MCP-001.md
@@ -1,45 +1,41 @@
 # CODE SPEC — MCP-001 · MCP Registry Loader & Wiring (MCP)
 
-> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
-> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
-> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
-> titled feature or its own `## Code Targets`. The intended spec body for this feature is
-> therefore **missing**. The contaminated body is preserved **unchanged** below for
-> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
->
-> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
-> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
-> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
-> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+> Reconstructed by lane `ALPHA-SOLVER-SPEC-SOURCE-RECONSTRUCTION-001` from committed code and tests only. This file replaces a non-authoritative contaminated MCP-005 body. Do not infer implementation quality from this reconstruction.
 
 ## Goal
-Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
+
+Load JSON/YAML MCP registries, validate tool schema, apply defaults, resolve secrets from environment without exposing them in representations, and expose wiring summaries for routing.
 
 ## Acceptance Criteria
-- All taxonomy tests pass.
-- Deterministic mapping for timeouts, connectivity, auth, 429, schema validation, sandbox, cancelled, unknown.
-- `to_json()` serializes; `to_route_explain()` yields small dict; `is_retryable()` correct.
 
-## Code Targets
-registries/mcp/loader.py; service/mcp/wiring.py; tests/test_mcp_loader.py
+- Registry requires a top-level `tool` list and validates tool `name`, `type`, `entry`, retry, timeout, latency, enabled, and secrets fields.
+- Duplicate tool names and unsupported file suffixes fail validation/loading.
+- Defaults are applied for timeout, estimated latency, and enabled when omitted.
+- `list_tools` and `get_tool` return only enabled tools, with `get_tool` returning a defensive copy.
+- `init_mcp`, `tool_summary`, and `to_route_explain` expose registry version and enabled/disabled counts by tool type.
 
 ## Design
-- ErrorClass enum (TOOL_NOT_FOUND, SCHEMA_VALIDATION, AUTH, RATE_LIMIT, TIMEOUT, CANCELLED,
-  CONNECTIVITY, RETRYABLE, NON_RETRYABLE, SANDBOX_VIOLATION, SECURITY, UNKNOWN)
-- MCPError dataclass(cls, message, code|None, retryable:bool, root:str, meta:dict|None)
-- map_exception(exc) -> MCPError (rules as above); add meta["secondary"]="RETRYABLE" when applicable
-- Helpers: to_route_explain(mcp_error), is_retryable(mcp_error)
-- No external deps; tests use fake exceptions (no httpx import)
 
-## Tests (must add)
-tests/test_mcp_errors.py:
-- test_timeout_maps_retryable
-- test_connectivity_maps_retryable
-- test_rate_limit_429_retryable
-- test_auth_nonretryable
-- test_schema_validation_nonretryable
-- test_sandbox_violation_nonretryable
-- test_cancelled_nonretryable
-- test_unknown_default
-- test_to_route_explain_truncates_message
-- test_to_json_is_serializable
+- Source of truth for this reconstruction is limited to the committed implementation and test targets listed in `## Reconstruction Sources`.
+- Runtime behavior is represented by the implementation files in `## Code Targets`; expected observable behavior is represented by the listed tests.
+- No provider calls, tokens, external services, or runtime code changes are required by this spec reconstruction.
+- MCP-005 remains the canonical source for MCP error taxonomy names and semantics wherever error classes are referenced.
+- Unspecified behavior is not reconstructed; it remains unknown or requires an operator decision.
+
+## Tests
+
+Run the focused tests listed in `## Code Targets` for this spec. These tests define the reconstructed acceptance boundary and should be kept focused on the committed behavior summarized above.
+
+## Reconstruction Note
+
+This spec was reconstructed on 2026-06-14 by reading the contaminated spec's `## Code Targets` section and the committed source/test files named there. The prior MCP-005 Error Taxonomy body was treated as non-authoritative contamination and was not used to infer this feature's intent. Unknown: no source target defines production registry location or hot-reload behavior.
+
+## Reconstruction Sources
+
+- `registries/mcp/loader.py`
+- `service/mcp/wiring.py`
+- `tests/test_mcp_loader.py`
+
+## Code Targets
+
+registries/mcp/loader.py; service/mcp/wiring.py; tests/test_mcp_loader.py

--- a/.specs/MCP-002.md
+++ b/.specs/MCP-002.md
@@ -1,45 +1,40 @@
 # CODE SPEC — MCP-002 · Router decision rule (MCP)
 
-> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
-> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
-> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
-> titled feature or its own `## Code Targets`. The intended spec body for this feature is
-> therefore **missing**. The contaminated body is preserved **unchanged** below for
-> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
->
-> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
-> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
-> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
-> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+> Reconstructed by lane `ALPHA-SOLVER-SPEC-SOURCE-RECONSTRUCTION-001` from committed code and tests only. This file replaces a non-authoritative contaminated MCP-005 body. Do not infer implementation quality from this reconstruction.
 
 ## Goal
-Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
+
+Suggest an enabled MCP tool deterministically from request intent and policy flags using simple penalties and stable tie breaks.
 
 ## Acceptance Criteria
-- All taxonomy tests pass.
-- Deterministic mapping for timeouts, connectivity, auth, 429, schema validation, sandbox, cancelled, unknown.
-- `to_json()` serializes; `to_route_explain()` yields small dict; `is_retryable()` correct.
 
-## Code Targets
-registries/mcp/registry_lookup.py; tests/test_mcp_router_rule.py
+- A policy `block` flag returns a block decision with no tool and zero confidence.
+- No enabled tools returns clarify/no_tool.
+- Browse intent prefers HTTP tools; sheet intent prefers script tools.
+- Network need, latency SLA misses, and strict-sandbox script use apply penalties.
+- Results clamp confidence to [0,1], allow only positive scores, and tie-break by score descending, latency ascending, then tool name.
 
 ## Design
-- ErrorClass enum (TOOL_NOT_FOUND, SCHEMA_VALIDATION, AUTH, RATE_LIMIT, TIMEOUT, CANCELLED,
-  CONNECTIVITY, RETRYABLE, NON_RETRYABLE, SANDBOX_VIOLATION, SECURITY, UNKNOWN)
-- MCPError dataclass(cls, message, code|None, retryable:bool, root:str, meta:dict|None)
-- map_exception(exc) -> MCPError (rules as above); add meta["secondary"]="RETRYABLE" when applicable
-- Helpers: to_route_explain(mcp_error), is_retryable(mcp_error)
-- No external deps; tests use fake exceptions (no httpx import)
 
-## Tests (must add)
-tests/test_mcp_errors.py:
-- test_timeout_maps_retryable
-- test_connectivity_maps_retryable
-- test_rate_limit_429_retryable
-- test_auth_nonretryable
-- test_schema_validation_nonretryable
-- test_sandbox_violation_nonretryable
-- test_cancelled_nonretryable
-- test_unknown_default
-- test_to_route_explain_truncates_message
-- test_to_json_is_serializable
+- Source of truth for this reconstruction is limited to the committed implementation and test targets listed in `## Reconstruction Sources`.
+- Runtime behavior is represented by the implementation files in `## Code Targets`; expected observable behavior is represented by the listed tests.
+- No provider calls, tokens, external services, or runtime code changes are required by this spec reconstruction.
+- MCP-005 remains the canonical source for MCP error taxonomy names and semantics wherever error classes are referenced.
+- Unspecified behavior is not reconstructed; it remains unknown or requires an operator decision.
+
+## Tests
+
+Run the focused tests listed in `## Code Targets` for this spec. These tests define the reconstructed acceptance boundary and should be kept focused on the committed behavior summarized above.
+
+## Reconstruction Note
+
+This spec was reconstructed on 2026-06-14 by reading the contaminated spec's `## Code Targets` section and the committed source/test files named there. The prior MCP-005 Error Taxonomy body was treated as non-authoritative contamination and was not used to infer this feature's intent. Unknown: no source target defines additional intents beyond browse and sheet.
+
+## Reconstruction Sources
+
+- `registries/mcp/registry_lookup.py`
+- `tests/test_mcp_router_rule.py`
+
+## Code Targets
+
+registries/mcp/registry_lookup.py; tests/test_mcp_router_rule.py

--- a/.specs/MCP-003.md
+++ b/.specs/MCP-003.md
@@ -1,45 +1,40 @@
 # CODE SPEC — MCP-003 · MCP OAuth/Secrets scaffold (auth surface) (MCP)
 
-> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
-> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
-> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
-> titled feature or its own `## Code Targets`. The intended spec body for this feature is
-> therefore **missing**. The contaminated body is preserved **unchanged** below for
-> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
->
-> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
-> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
-> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
-> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+> Reconstructed by lane `ALPHA-SOLVER-SPEC-SOURCE-RECONSTRUCTION-001` from committed code and tests only. This file replaces a non-authoritative contaminated MCP-005 body. Do not infer implementation quality from this reconstruction.
 
 ## Goal
-Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
+
+Provide deterministic, no-network auth helpers for MCP policies and redacted route explanation metadata.
 
 ## Acceptance Criteria
-- All taxonomy tests pass.
-- Deterministic mapping for timeouts, connectivity, auth, 429, schema validation, sandbox, cancelled, unknown.
-- `to_json()` serializes; `to_route_explain()` yields small dict; `is_retryable()` correct.
 
-## Code Targets
-service/mcp/policy_auth.py; tests/test_mcp_auth.py
+- Missing required environment variables raise `AuthError`.
+- Static tokens attach `Token ...`; bearer and OAuth providers attach `Bearer ...`.
+- OAuth client-credentials refresh is simulated deterministically with expiring tokens and no provider call.
+- Allowlist checks are exact membership checks.
+- Token/secret/authorization-like keys are redacted in dictionaries and route explanation never includes secret values.
 
 ## Design
-- ErrorClass enum (TOOL_NOT_FOUND, SCHEMA_VALIDATION, AUTH, RATE_LIMIT, TIMEOUT, CANCELLED,
-  CONNECTIVITY, RETRYABLE, NON_RETRYABLE, SANDBOX_VIOLATION, SECURITY, UNKNOWN)
-- MCPError dataclass(cls, message, code|None, retryable:bool, root:str, meta:dict|None)
-- map_exception(exc) -> MCPError (rules as above); add meta["secondary"]="RETRYABLE" when applicable
-- Helpers: to_route_explain(mcp_error), is_retryable(mcp_error)
-- No external deps; tests use fake exceptions (no httpx import)
 
-## Tests (must add)
-tests/test_mcp_errors.py:
-- test_timeout_maps_retryable
-- test_connectivity_maps_retryable
-- test_rate_limit_429_retryable
-- test_auth_nonretryable
-- test_schema_validation_nonretryable
-- test_sandbox_violation_nonretryable
-- test_cancelled_nonretryable
-- test_unknown_default
-- test_to_route_explain_truncates_message
-- test_to_json_is_serializable
+- Source of truth for this reconstruction is limited to the committed implementation and test targets listed in `## Reconstruction Sources`.
+- Runtime behavior is represented by the implementation files in `## Code Targets`; expected observable behavior is represented by the listed tests.
+- No provider calls, tokens, external services, or runtime code changes are required by this spec reconstruction.
+- MCP-005 remains the canonical source for MCP error taxonomy names and semantics wherever error classes are referenced.
+- Unspecified behavior is not reconstructed; it remains unknown or requires an operator decision.
+
+## Tests
+
+Run the focused tests listed in `## Code Targets` for this spec. These tests define the reconstructed acceptance boundary and should be kept focused on the committed behavior summarized above.
+
+## Reconstruction Note
+
+This spec was reconstructed on 2026-06-14 by reading the contaminated spec's `## Code Targets` section and the committed source/test files named there. The prior MCP-005 Error Taxonomy body was treated as non-authoritative contamination and was not used to infer this feature's intent. Unknown: real OAuth wire protocol, token endpoint I/O, and secret store integration are out of scope in sources.
+
+## Reconstruction Sources
+
+- `service/mcp/policy_auth.py`
+- `tests/test_mcp_auth.py`
+
+## Code Targets
+
+service/mcp/policy_auth.py; tests/test_mcp_auth.py

--- a/.specs/MCP-004.md
+++ b/.specs/MCP-004.md
@@ -1,45 +1,40 @@
 # CODE SPEC — MCP-004 · Sandbox Limits (policy guardrail) (MCP)
 
-> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
-> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
-> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
-> titled feature or its own `## Code Targets`. The intended spec body for this feature is
-> therefore **missing**. The contaminated body is preserved **unchanged** below for
-> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
->
-> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
-> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
-> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
-> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+> Reconstructed by lane `ALPHA-SOLVER-SPEC-SOURCE-RECONSTRUCTION-001` from committed code and tests only. This file replaces a non-authoritative contaminated MCP-005 body. Do not infer implementation quality from this reconstruction.
 
 ## Goal
-Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
+
+Evaluate descriptors and execute callables under deterministic sandbox limits for network, scripts, timeout, output size, and route explanations.
 
 ## Acceptance Criteria
-- All taxonomy tests pass.
-- Deterministic mapping for timeouts, connectivity, auth, 429, schema validation, sandbox, cancelled, unknown.
-- `to_json()` serializes; `to_route_explain()` yields small dict; `is_retryable()` correct.
 
-## Code Targets
-service/mcp/sandbox_limits.py; tests/test_mcp_sandbox.py
+- Unknown descriptor keys produce policy violation.
+- Scripts are denied unless scripts are allowed.
+- Network is denied unless enabled and hostname is allowlisted; the guard simulates sockets without opening real connections.
+- Long-running calls return TIMEOUT; oversized output returns SIZE_LIMIT.
+- Route explain includes sandbox decision and configured budgets.
 
 ## Design
-- ErrorClass enum (TOOL_NOT_FOUND, SCHEMA_VALIDATION, AUTH, RATE_LIMIT, TIMEOUT, CANCELLED,
-  CONNECTIVITY, RETRYABLE, NON_RETRYABLE, SANDBOX_VIOLATION, SECURITY, UNKNOWN)
-- MCPError dataclass(cls, message, code|None, retryable:bool, root:str, meta:dict|None)
-- map_exception(exc) -> MCPError (rules as above); add meta["secondary"]="RETRYABLE" when applicable
-- Helpers: to_route_explain(mcp_error), is_retryable(mcp_error)
-- No external deps; tests use fake exceptions (no httpx import)
 
-## Tests (must add)
-tests/test_mcp_errors.py:
-- test_timeout_maps_retryable
-- test_connectivity_maps_retryable
-- test_rate_limit_429_retryable
-- test_auth_nonretryable
-- test_schema_validation_nonretryable
-- test_sandbox_violation_nonretryable
-- test_cancelled_nonretryable
-- test_unknown_default
-- test_to_route_explain_truncates_message
-- test_to_json_is_serializable
+- Source of truth for this reconstruction is limited to the committed implementation and test targets listed in `## Reconstruction Sources`.
+- Runtime behavior is represented by the implementation files in `## Code Targets`; expected observable behavior is represented by the listed tests.
+- No provider calls, tokens, external services, or runtime code changes are required by this spec reconstruction.
+- MCP-005 remains the canonical source for MCP error taxonomy names and semantics wherever error classes are referenced.
+- Unspecified behavior is not reconstructed; it remains unknown or requires an operator decision.
+
+## Tests
+
+Run the focused tests listed in `## Code Targets` for this spec. These tests define the reconstructed acceptance boundary and should be kept focused on the committed behavior summarized above.
+
+## Reconstruction Note
+
+This spec was reconstructed on 2026-06-14 by reading the contaminated spec's `## Code Targets` section and the committed source/test files named there. The prior MCP-005 Error Taxonomy body was treated as non-authoritative contamination and was not used to infer this feature's intent. Unknown: OS/container-level isolation is not implemented in source targets.
+
+## Reconstruction Sources
+
+- `service/mcp/sandbox_limits.py`
+- `tests/test_mcp_sandbox.py`
+
+## Code Targets
+
+service/mcp/sandbox_limits.py; tests/test_mcp_sandbox.py

--- a/.specs/MCP-006.md
+++ b/.specs/MCP-006.md
@@ -4,15 +4,15 @@
 
 ## Goal
 
-Retry idempotent MCP calls for retryable error classes using bounded exponential backoff metadata.
+Execute sync or async MCP callables with bounded retries for retryable error classes, deterministic backoff when seeded, timeout-budget enforcement, and retry metadata supported by the committed helper/tests.
 
 ## Acceptance Criteria
 
-- Retryable failures are retried up to configured limits; non-retryable failures are raised after one attempt.
-- Max retries and timeout budget are honored.
-- Backoff delays are deterministic when seeded and captured in metadata.
-- Metadata includes attempts, delays, last error class/code, idempotency, and retryability.
-- Idempotency guard permits retries only for idempotent operations or supplied idempotency keys.
+- Retryable failures are retried up to the configured `max_retries`; non-retryable failures are raised after the first attempt.
+- Timeout budget and max-retry limits are honored, with retry metadata attached to raised exceptions.
+- Backoff delays are deterministic when a seed is supplied and are captured in the metadata delay list.
+- Successful calls return `(result, metadata)` where metadata contains `attempts`, `delays`, `last_error_class`, and `last_error_code`.
+- When an `idempotency_key` argument is supplied, the helper forwards it to the callable; retries are not limited to idempotent-only calls by the committed helper/tests.
 
 ## Design
 

--- a/.specs/MCP-006.md
+++ b/.specs/MCP-006.md
@@ -1,45 +1,40 @@
 # CODE SPEC — MCP-006 · Retry & Backoff (MCP)
 
-> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
-> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
-> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
-> titled feature or its own `## Code Targets`. The intended spec body for this feature is
-> therefore **missing**. The contaminated body is preserved **unchanged** below for
-> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
->
-> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
-> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
-> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
-> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+> Reconstructed by lane `ALPHA-SOLVER-SPEC-SOURCE-RECONSTRUCTION-001` from committed code and tests only. This file replaces a non-authoritative contaminated MCP-005 body. Do not infer implementation quality from this reconstruction.
 
 ## Goal
-Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
+
+Retry idempotent MCP calls for retryable error classes using bounded exponential backoff metadata.
 
 ## Acceptance Criteria
-- All taxonomy tests pass.
-- Deterministic mapping for timeouts, connectivity, auth, 429, schema validation, sandbox, cancelled, unknown.
-- `to_json()` serializes; `to_route_explain()` yields small dict; `is_retryable()` correct.
 
-## Code Targets
-service/mcp/retry_backoff.py; tests/test_mcp_retry.py
+- Retryable failures are retried up to configured limits; non-retryable failures are raised after one attempt.
+- Max retries and timeout budget are honored.
+- Backoff delays are deterministic when seeded and captured in metadata.
+- Metadata includes attempts, delays, last error class/code, idempotency, and retryability.
+- Idempotency guard permits retries only for idempotent operations or supplied idempotency keys.
 
 ## Design
-- ErrorClass enum (TOOL_NOT_FOUND, SCHEMA_VALIDATION, AUTH, RATE_LIMIT, TIMEOUT, CANCELLED,
-  CONNECTIVITY, RETRYABLE, NON_RETRYABLE, SANDBOX_VIOLATION, SECURITY, UNKNOWN)
-- MCPError dataclass(cls, message, code|None, retryable:bool, root:str, meta:dict|None)
-- map_exception(exc) -> MCPError (rules as above); add meta["secondary"]="RETRYABLE" when applicable
-- Helpers: to_route_explain(mcp_error), is_retryable(mcp_error)
-- No external deps; tests use fake exceptions (no httpx import)
 
-## Tests (must add)
-tests/test_mcp_errors.py:
-- test_timeout_maps_retryable
-- test_connectivity_maps_retryable
-- test_rate_limit_429_retryable
-- test_auth_nonretryable
-- test_schema_validation_nonretryable
-- test_sandbox_violation_nonretryable
-- test_cancelled_nonretryable
-- test_unknown_default
-- test_to_route_explain_truncates_message
-- test_to_json_is_serializable
+- Source of truth for this reconstruction is limited to the committed implementation and test targets listed in `## Reconstruction Sources`.
+- Runtime behavior is represented by the implementation files in `## Code Targets`; expected observable behavior is represented by the listed tests.
+- No provider calls, tokens, external services, or runtime code changes are required by this spec reconstruction.
+- MCP-005 remains the canonical source for MCP error taxonomy names and semantics wherever error classes are referenced.
+- Unspecified behavior is not reconstructed; it remains unknown or requires an operator decision.
+
+## Tests
+
+Run the focused tests listed in `## Code Targets` for this spec. These tests define the reconstructed acceptance boundary and should be kept focused on the committed behavior summarized above.
+
+## Reconstruction Note
+
+This spec was reconstructed on 2026-06-14 by reading the contaminated spec's `## Code Targets` section and the committed source/test files named there. The prior MCP-005 Error Taxonomy body was treated as non-authoritative contamination and was not used to infer this feature's intent. Unknown: production sleep strategy and distributed idempotency store are not defined by source targets.
+
+## Reconstruction Sources
+
+- `service/mcp/retry_backoff.py`
+- `tests/test_mcp_retry.py`
+
+## Code Targets
+
+service/mcp/retry_backoff.py; tests/test_mcp_retry.py

--- a/.specs/MCP-007.md
+++ b/.specs/MCP-007.md
@@ -1,45 +1,40 @@
 # CODE SPEC — MCP-007 · MCP Observability hooks (MCP)
 
-> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
-> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
-> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
-> titled feature or its own `## Code Targets`. The intended spec body for this feature is
-> therefore **missing**. The contaminated body is preserved **unchanged** below for
-> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
->
-> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
-> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
-> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
-> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+> Reconstructed by lane `ALPHA-SOLVER-SPEC-SOURCE-RECONSTRUCTION-001` from committed code and tests only. This file replaces a non-authoritative contaminated MCP-005 body. Do not infer implementation quality from this reconstruction.
 
 ## Goal
-Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
+
+Capture MCP call events with redaction, latency metadata, error class metadata, JSONL roundtrip support, and low overhead.
 
 ## Acceptance Criteria
-- All taxonomy tests pass.
-- Deterministic mapping for timeouts, connectivity, auth, 429, schema validation, sandbox, cancelled, unknown.
-- `to_json()` serializes; `to_route_explain()` yields small dict; `is_retryable()` correct.
 
-## Code Targets
-service/mcp/observability.py; tests/test_mcp_observability.py
+- Success events contain name, payload, route_explain, and meta while redacting PII/token/secret-like values.
+- Error events include MCP error class and retryability metadata; MCP-005 remains canonical for error taxonomy values.
+- A context manager records latency.
+- JSONL serialization round-trips events deterministically.
+- Repeated identical events remain identical and p95 overhead remains below the tested threshold.
 
 ## Design
-- ErrorClass enum (TOOL_NOT_FOUND, SCHEMA_VALIDATION, AUTH, RATE_LIMIT, TIMEOUT, CANCELLED,
-  CONNECTIVITY, RETRYABLE, NON_RETRYABLE, SANDBOX_VIOLATION, SECURITY, UNKNOWN)
-- MCPError dataclass(cls, message, code|None, retryable:bool, root:str, meta:dict|None)
-- map_exception(exc) -> MCPError (rules as above); add meta["secondary"]="RETRYABLE" when applicable
-- Helpers: to_route_explain(mcp_error), is_retryable(mcp_error)
-- No external deps; tests use fake exceptions (no httpx import)
 
-## Tests (must add)
-tests/test_mcp_errors.py:
-- test_timeout_maps_retryable
-- test_connectivity_maps_retryable
-- test_rate_limit_429_retryable
-- test_auth_nonretryable
-- test_schema_validation_nonretryable
-- test_sandbox_violation_nonretryable
-- test_cancelled_nonretryable
-- test_unknown_default
-- test_to_route_explain_truncates_message
-- test_to_json_is_serializable
+- Source of truth for this reconstruction is limited to the committed implementation and test targets listed in `## Reconstruction Sources`.
+- Runtime behavior is represented by the implementation files in `## Code Targets`; expected observable behavior is represented by the listed tests.
+- No provider calls, tokens, external services, or runtime code changes are required by this spec reconstruction.
+- MCP-005 remains the canonical source for MCP error taxonomy names and semantics wherever error classes are referenced.
+- Unspecified behavior is not reconstructed; it remains unknown or requires an operator decision.
+
+## Tests
+
+Run the focused tests listed in `## Code Targets` for this spec. These tests define the reconstructed acceptance boundary and should be kept focused on the committed behavior summarized above.
+
+## Reconstruction Note
+
+This spec was reconstructed on 2026-06-14 by reading the contaminated spec's `## Code Targets` section and the committed source/test files named there. The prior MCP-005 Error Taxonomy body was treated as non-authoritative contamination and was not used to infer this feature's intent. Unknown: remote telemetry/export pipeline is not defined by source targets.
+
+## Reconstruction Sources
+
+- `service/mcp/observability.py`
+- `tests/test_mcp_observability.py`
+
+## Code Targets
+
+service/mcp/observability.py; tests/test_mcp_observability.py

--- a/.specs/NEW-009.md
+++ b/.specs/NEW-009.md
@@ -1,45 +1,42 @@
 # CODE SPEC — NEW-009 · Clarify Templates Pack (RES_02)
 
-> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
-> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
-> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
-> titled feature or its own `## Code Targets`. The intended spec body for this feature is
-> therefore **missing**. The contaminated body is preserved **unchanged** below for
-> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
->
-> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
-> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
-> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
-> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+> Reconstructed by lane `ALPHA-SOLVER-SPEC-SOURCE-RECONSTRUCTION-001` from committed code and tests only. This file replaces a non-authoritative contaminated MCP-005 body. Do not infer implementation quality from this reconstruction.
 
 ## Goal
-Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
+
+Trigger and render clarification prompts from deterministic templates for ambiguous or under-specified requests.
 
 ## Acceptance Criteria
-- All taxonomy tests pass.
-- Deterministic mapping for timeouts, connectivity, auth, 429, schema validation, sandbox, cancelled, unknown.
-- `to_json()` serializes; `to_route_explain()` yields small dict; `is_retryable()` correct.
 
-## Code Targets
-service/clarify/trigger.py; service/clarify/templates.yaml; service/clarify/render.py; tests/test_clarify.py
+- Clarification triggers on explicit decision flags and mid-confidence bands.
+- Template choice prioritizes missing fields, then low-budget scope reduction.
+- Renderer substitutes variables and joins list values.
+- Template deck SHA is stable and included in route explanation.
+- Tests require high trigger precision and large fail-rate reduction on the sample ambiguous set.
 
 ## Design
-- ErrorClass enum (TOOL_NOT_FOUND, SCHEMA_VALIDATION, AUTH, RATE_LIMIT, TIMEOUT, CANCELLED,
-  CONNECTIVITY, RETRYABLE, NON_RETRYABLE, SANDBOX_VIOLATION, SECURITY, UNKNOWN)
-- MCPError dataclass(cls, message, code|None, retryable:bool, root:str, meta:dict|None)
-- map_exception(exc) -> MCPError (rules as above); add meta["secondary"]="RETRYABLE" when applicable
-- Helpers: to_route_explain(mcp_error), is_retryable(mcp_error)
-- No external deps; tests use fake exceptions (no httpx import)
 
-## Tests (must add)
-tests/test_mcp_errors.py:
-- test_timeout_maps_retryable
-- test_connectivity_maps_retryable
-- test_rate_limit_429_retryable
-- test_auth_nonretryable
-- test_schema_validation_nonretryable
-- test_sandbox_violation_nonretryable
-- test_cancelled_nonretryable
-- test_unknown_default
-- test_to_route_explain_truncates_message
-- test_to_json_is_serializable
+- Source of truth for this reconstruction is limited to the committed implementation and test targets listed in `## Reconstruction Sources`.
+- Runtime behavior is represented by the implementation files in `## Code Targets`; expected observable behavior is represented by the listed tests.
+- No provider calls, tokens, external services, or runtime code changes are required by this spec reconstruction.
+- MCP-005 remains the canonical source for MCP error taxonomy names and semantics wherever error classes are referenced.
+- Unspecified behavior is not reconstructed; it remains unknown or requires an operator decision.
+
+## Tests
+
+Run the focused tests listed in `## Code Targets` for this spec. These tests define the reconstructed acceptance boundary and should be kept focused on the committed behavior summarized above.
+
+## Reconstruction Note
+
+This spec was reconstructed on 2026-06-14 by reading the contaminated spec's `## Code Targets` section and the committed source/test files named there. The prior MCP-005 Error Taxonomy body was treated as non-authoritative contamination and was not used to infer this feature's intent. Unknown: full product copy beyond committed templates is source-bound to current YAML only.
+
+## Reconstruction Sources
+
+- `service/clarify/trigger.py`
+- `service/clarify/templates.yaml`
+- `service/clarify/render.py`
+- `tests/test_clarify.py`
+
+## Code Targets
+
+service/clarify/trigger.py; service/clarify/templates.yaml; service/clarify/render.py; tests/test_clarify.py

--- a/.specs/NEW-010.md
+++ b/.specs/NEW-010.md
@@ -1,45 +1,42 @@
 # CODE SPEC — NEW-010 · Section-Specific Prompt Decks (RES_01)
 
-> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
-> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
-> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
-> titled feature or its own `## Code Targets`. The intended spec body for this feature is
-> therefore **missing**. The contaminated body is preserved **unchanged** below for
-> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
->
-> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
-> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
-> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
-> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+> Reconstructed by lane `ALPHA-SOLVER-SPEC-SOURCE-RECONSTRUCTION-001` from committed code and tests only. This file replaces a non-authoritative contaminated MCP-005 body. Do not infer implementation quality from this reconstruction.
 
 ## Goal
-Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
+
+Select and render prompt decks for generic, web extraction, sheet operations, and policy clarification contexts.
 
 ## Acceptance Criteria
-- All taxonomy tests pass.
-- Deterministic mapping for timeouts, connectivity, auth, 429, schema validation, sandbox, cancelled, unknown.
-- `to_json()` serializes; `to_route_explain()` yields small dict; `is_retryable()` correct.
 
-## Code Targets
-service/prompts/decks.yaml; service/prompts/selector.py; service/prompts/renderer.py; tests/test_prompt_decks.py
+- Deck selection is deterministic for supported intents.
+- Rendered prompts substitute variables and join field lists.
+- Deck SHA is stable and included with prompt_deck in route explanation.
+- Sample prompts demonstrate at least 20% token reduction versus baseline fixtures.
+- Render p95 latency stays below the tested 200ms bound.
 
 ## Design
-- ErrorClass enum (TOOL_NOT_FOUND, SCHEMA_VALIDATION, AUTH, RATE_LIMIT, TIMEOUT, CANCELLED,
-  CONNECTIVITY, RETRYABLE, NON_RETRYABLE, SANDBOX_VIOLATION, SECURITY, UNKNOWN)
-- MCPError dataclass(cls, message, code|None, retryable:bool, root:str, meta:dict|None)
-- map_exception(exc) -> MCPError (rules as above); add meta["secondary"]="RETRYABLE" when applicable
-- Helpers: to_route_explain(mcp_error), is_retryable(mcp_error)
-- No external deps; tests use fake exceptions (no httpx import)
 
-## Tests (must add)
-tests/test_mcp_errors.py:
-- test_timeout_maps_retryable
-- test_connectivity_maps_retryable
-- test_rate_limit_429_retryable
-- test_auth_nonretryable
-- test_schema_validation_nonretryable
-- test_sandbox_violation_nonretryable
-- test_cancelled_nonretryable
-- test_unknown_default
-- test_to_route_explain_truncates_message
-- test_to_json_is_serializable
+- Source of truth for this reconstruction is limited to the committed implementation and test targets listed in `## Reconstruction Sources`.
+- Runtime behavior is represented by the implementation files in `## Code Targets`; expected observable behavior is represented by the listed tests.
+- No provider calls, tokens, external services, or runtime code changes are required by this spec reconstruction.
+- MCP-005 remains the canonical source for MCP error taxonomy names and semantics wherever error classes are referenced.
+- Unspecified behavior is not reconstructed; it remains unknown or requires an operator decision.
+
+## Tests
+
+Run the focused tests listed in `## Code Targets` for this spec. These tests define the reconstructed acceptance boundary and should be kept focused on the committed behavior summarized above.
+
+## Reconstruction Note
+
+This spec was reconstructed on 2026-06-14 by reading the contaminated spec's `## Code Targets` section and the committed source/test files named there. The prior MCP-005 Error Taxonomy body was treated as non-authoritative contamination and was not used to infer this feature's intent. Unknown: additional decks/intents require operator decision or new source targets.
+
+## Reconstruction Sources
+
+- `service/prompts/decks.yaml`
+- `service/prompts/selector.py`
+- `service/prompts/renderer.py`
+- `tests/test_prompt_decks.py`
+
+## Code Targets
+
+service/prompts/decks.yaml; service/prompts/selector.py; service/prompts/renderer.py; tests/test_prompt_decks.py

--- a/.specs/NEW-011.md
+++ b/.specs/NEW-011.md
@@ -1,45 +1,41 @@
 # CODE SPEC — NEW-011 · Weight-Tuning Harness (RES-03 scoring) (RES_03)
 
-> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
-> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
-> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
-> titled feature or its own `## Code Targets`. The intended spec body for this feature is
-> therefore **missing**. The contaminated body is preserved **unchanged** below for
-> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
->
-> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
-> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
-> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
-> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+> Reconstructed by lane `ALPHA-SOLVER-SPEC-SOURCE-RECONSTRUCTION-001` from committed code and tests only. This file replaces a non-authoritative contaminated MCP-005 body. Do not infer implementation quality from this reconstruction.
 
 ## Goal
-Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
+
+Tune scoring weights deterministically from fixtures while preserving normalized, non-negative, sorted weights.
 
 ## Acceptance Criteria
-- All taxonomy tests pass.
-- Deterministic mapping for timeouts, connectivity, auth, 429, schema validation, sandbox, cancelled, unknown.
-- `to_json()` serializes; `to_route_explain()` yields small dict; `is_retryable()` correct.
 
-## Code Targets
-service/scoring/tuning.py; config/tuning.yaml; tests/test_weight_tuning.py
+- Tuning improves sample accuracy by at least 0.05 when a gain exists.
+- Weights normalize to sum 1.0, are non-negative, and have sorted keys.
+- Same seed yields identical results.
+- Frozen weights are represented as sorted tuples.
+- No-gain paths return a no_gain flag.
 
 ## Design
-- ErrorClass enum (TOOL_NOT_FOUND, SCHEMA_VALIDATION, AUTH, RATE_LIMIT, TIMEOUT, CANCELLED,
-  CONNECTIVITY, RETRYABLE, NON_RETRYABLE, SANDBOX_VIOLATION, SECURITY, UNKNOWN)
-- MCPError dataclass(cls, message, code|None, retryable:bool, root:str, meta:dict|None)
-- map_exception(exc) -> MCPError (rules as above); add meta["secondary"]="RETRYABLE" when applicable
-- Helpers: to_route_explain(mcp_error), is_retryable(mcp_error)
-- No external deps; tests use fake exceptions (no httpx import)
 
-## Tests (must add)
-tests/test_mcp_errors.py:
-- test_timeout_maps_retryable
-- test_connectivity_maps_retryable
-- test_rate_limit_429_retryable
-- test_auth_nonretryable
-- test_schema_validation_nonretryable
-- test_sandbox_violation_nonretryable
-- test_cancelled_nonretryable
-- test_unknown_default
-- test_to_route_explain_truncates_message
-- test_to_json_is_serializable
+- Source of truth for this reconstruction is limited to the committed implementation and test targets listed in `## Reconstruction Sources`.
+- Runtime behavior is represented by the implementation files in `## Code Targets`; expected observable behavior is represented by the listed tests.
+- No provider calls, tokens, external services, or runtime code changes are required by this spec reconstruction.
+- MCP-005 remains the canonical source for MCP error taxonomy names and semantics wherever error classes are referenced.
+- Unspecified behavior is not reconstructed; it remains unknown or requires an operator decision.
+
+## Tests
+
+Run the focused tests listed in `## Code Targets` for this spec. These tests define the reconstructed acceptance boundary and should be kept focused on the committed behavior summarized above.
+
+## Reconstruction Note
+
+This spec was reconstructed on 2026-06-14 by reading the contaminated spec's `## Code Targets` section and the committed source/test files named there. The prior MCP-005 Error Taxonomy body was treated as non-authoritative contamination and was not used to infer this feature's intent. Unknown: approval workflow for deploying tuned weights is not defined.
+
+## Reconstruction Sources
+
+- `service/scoring/tuning.py`
+- `config/tuning.yaml`
+- `tests/test_weight_tuning.py`
+
+## Code Targets
+
+service/scoring/tuning.py; config/tuning.yaml; tests/test_weight_tuning.py

--- a/.specs/NEW-011.md
+++ b/.specs/NEW-011.md
@@ -32,10 +32,10 @@ This spec was reconstructed on 2026-06-14 by reading the contaminated spec's `##
 
 ## Reconstruction Sources
 
-- `service/scoring/tuning.py`
-- `config/tuning.yaml`
+- `service/tuning/weight_harness.py`
+- `service/tuning/weights_normalize.py`
 - `tests/test_weight_tuning.py`
 
 ## Code Targets
 
-service/scoring/tuning.py; config/tuning.yaml; tests/test_weight_tuning.py
+service/tuning/weight_harness.py; service/tuning/weights_normalize.py; tests/test_weight_tuning.py

--- a/.specs/NEW-012.md
+++ b/.specs/NEW-012.md
@@ -1,45 +1,41 @@
 # CODE SPEC — NEW-012 · Budget CLI + CI Guard (RES_07)
 
-> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
-> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
-> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
-> titled feature or its own `## Code Targets`. The intended spec body for this feature is
-> therefore **missing**. The contaminated body is preserved **unchanged** below for
-> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
->
-> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
-> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
-> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
-> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+> Reconstructed by lane `ALPHA-SOLVER-SPEC-SOURCE-RECONSTRUCTION-001` from committed code and tests only. This file replaces a non-authoritative contaminated MCP-005 body. Do not infer implementation quality from this reconstruction.
 
 ## Goal
-Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
+
+Evaluate budget thresholds from JSON/JSONL inputs and provide CLI exit codes plus sanitized output.
 
 ## Acceptance Criteria
-- All taxonomy tests pass.
-- Deterministic mapping for timeouts, connectivity, auth, 429, schema validation, sandbox, cancelled, unknown.
-- `to_json()` serializes; `to_route_explain()` yields small dict; `is_retryable()` correct.
 
-## Code Targets
-service/budget/guard.py; service/budget/cli.py; tests/test_budget_cli_guard.py
+- Under-threshold usage returns ok/allow.
+- Over-cost and over-token usage block with matching budget verdicts.
+- CLI reads JSON and JSONL, exits 0 for ok and 2 for blocking verdicts.
+- CLI can write JSONL output with route_explain and without PII/token fields.
+- Performance and deterministic output bounds match tests.
 
 ## Design
-- ErrorClass enum (TOOL_NOT_FOUND, SCHEMA_VALIDATION, AUTH, RATE_LIMIT, TIMEOUT, CANCELLED,
-  CONNECTIVITY, RETRYABLE, NON_RETRYABLE, SANDBOX_VIOLATION, SECURITY, UNKNOWN)
-- MCPError dataclass(cls, message, code|None, retryable:bool, root:str, meta:dict|None)
-- map_exception(exc) -> MCPError (rules as above); add meta["secondary"]="RETRYABLE" when applicable
-- Helpers: to_route_explain(mcp_error), is_retryable(mcp_error)
-- No external deps; tests use fake exceptions (no httpx import)
 
-## Tests (must add)
-tests/test_mcp_errors.py:
-- test_timeout_maps_retryable
-- test_connectivity_maps_retryable
-- test_rate_limit_429_retryable
-- test_auth_nonretryable
-- test_schema_validation_nonretryable
-- test_sandbox_violation_nonretryable
-- test_cancelled_nonretryable
-- test_unknown_default
-- test_to_route_explain_truncates_message
-- test_to_json_is_serializable
+- Source of truth for this reconstruction is limited to the committed implementation and test targets listed in `## Reconstruction Sources`.
+- Runtime behavior is represented by the implementation files in `## Code Targets`; expected observable behavior is represented by the listed tests.
+- No provider calls, tokens, external services, or runtime code changes are required by this spec reconstruction.
+- MCP-005 remains the canonical source for MCP error taxonomy names and semantics wherever error classes are referenced.
+- Unspecified behavior is not reconstructed; it remains unknown or requires an operator decision.
+
+## Tests
+
+Run the focused tests listed in `## Code Targets` for this spec. These tests define the reconstructed acceptance boundary and should be kept focused on the committed behavior summarized above.
+
+## Reconstruction Note
+
+This spec was reconstructed on 2026-06-14 by reading the contaminated spec's `## Code Targets` section and the committed source/test files named there. The prior MCP-005 Error Taxonomy body was treated as non-authoritative contamination and was not used to infer this feature's intent. Unknown: CI wiring file is not in Code Targets; only CLI/guard behavior is reconstructed.
+
+## Reconstruction Sources
+
+- `service/budget/guard.py`
+- `service/budget/cli.py`
+- `tests/test_budget_cli_guard.py`
+
+## Code Targets
+
+service/budget/guard.py; service/budget/cli.py; tests/test_budget_cli_guard.py

--- a/.specs/NEW-013.md
+++ b/.specs/NEW-013.md
@@ -1,45 +1,41 @@
 # CODE SPEC — NEW-013 · Replay CLI + Trace Diff (text viewer) (RES_07)
 
-> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
-> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
-> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
-> titled feature or its own `## Code Targets`. The intended spec body for this feature is
-> therefore **missing**. The contaminated body is preserved **unchanged** below for
-> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
->
-> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
-> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
-> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
-> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+> Reconstructed by lane `ALPHA-SOLVER-SPEC-SOURCE-RECONSTRUCTION-001` from committed code and tests only. This file replaces a non-authoritative contaminated MCP-005 body. Do not infer implementation quality from this reconstruction.
 
 ## Goal
-Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
+
+Replay and compare JSONL traces with deterministic, bounded, sanitized text diffs.
 
 ## Acceptance Criteria
-- All taxonomy tests pass.
-- Deterministic mapping for timeouts, connectivity, auth, 429, schema validation, sandbox, cancelled, unknown.
-- `to_json()` serializes; `to_route_explain()` yields small dict; `is_retryable()` correct.
 
-## Code Targets
-service/observability/replay_cli.py; service/observability/diff.py; tests/test_replay_cli_diff.py
+- Identical replay of 10 events exits 0 with zero mismatches.
+- Comparison detects mismatches and exits 2.
+- Diff output is deterministic, sorted by id/key, and capped with truncation.
+- Event-name filtering and limits are honored.
+- Outputs/reports do not expose PII/token/secret-like fields.
 
 ## Design
-- ErrorClass enum (TOOL_NOT_FOUND, SCHEMA_VALIDATION, AUTH, RATE_LIMIT, TIMEOUT, CANCELLED,
-  CONNECTIVITY, RETRYABLE, NON_RETRYABLE, SANDBOX_VIOLATION, SECURITY, UNKNOWN)
-- MCPError dataclass(cls, message, code|None, retryable:bool, root:str, meta:dict|None)
-- map_exception(exc) -> MCPError (rules as above); add meta["secondary"]="RETRYABLE" when applicable
-- Helpers: to_route_explain(mcp_error), is_retryable(mcp_error)
-- No external deps; tests use fake exceptions (no httpx import)
 
-## Tests (must add)
-tests/test_mcp_errors.py:
-- test_timeout_maps_retryable
-- test_connectivity_maps_retryable
-- test_rate_limit_429_retryable
-- test_auth_nonretryable
-- test_schema_validation_nonretryable
-- test_sandbox_violation_nonretryable
-- test_cancelled_nonretryable
-- test_unknown_default
-- test_to_route_explain_truncates_message
-- test_to_json_is_serializable
+- Source of truth for this reconstruction is limited to the committed implementation and test targets listed in `## Reconstruction Sources`.
+- Runtime behavior is represented by the implementation files in `## Code Targets`; expected observable behavior is represented by the listed tests.
+- No provider calls, tokens, external services, or runtime code changes are required by this spec reconstruction.
+- MCP-005 remains the canonical source for MCP error taxonomy names and semantics wherever error classes are referenced.
+- Unspecified behavior is not reconstructed; it remains unknown or requires an operator decision.
+
+## Tests
+
+Run the focused tests listed in `## Code Targets` for this spec. These tests define the reconstructed acceptance boundary and should be kept focused on the committed behavior summarized above.
+
+## Reconstruction Note
+
+This spec was reconstructed on 2026-06-14 by reading the contaminated spec's `## Code Targets` section and the committed source/test files named there. The prior MCP-005 Error Taxonomy body was treated as non-authoritative contamination and was not used to infer this feature's intent. Unknown: graphical trace viewer is not represented in source targets.
+
+## Reconstruction Sources
+
+- `service/observability/replay_cli.py`
+- `service/observability/diff.py`
+- `tests/test_replay_cli_diff.py`
+
+## Code Targets
+
+service/observability/replay_cli.py; service/observability/diff.py; tests/test_replay_cli_diff.py

--- a/.specs/NEW-014.md
+++ b/.specs/NEW-014.md
@@ -1,45 +1,42 @@
 # CODE SPEC — NEW-014 · Evidence Pack Store (catalog + retrieval) (RES_07)
 
-> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
-> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
-> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
-> titled feature or its own `## Code Targets`. The intended spec body for this feature is
-> therefore **missing**. The contaminated body is preserved **unchanged** below for
-> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
->
-> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
-> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
-> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
-> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+> Reconstructed by lane `ALPHA-SOLVER-SPEC-SOURCE-RECONSTRUCTION-001` from committed code and tests only. This file replaces a non-authoritative contaminated MCP-005 body. Do not infer implementation quality from this reconstruction.
 
 ## Goal
-Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
+
+Store, catalog, list, retrieve, and explain evidence packs with integrity checks and sanitization.
 
 ## Acceptance Criteria
-- All taxonomy tests pass.
-- Deterministic mapping for timeouts, connectivity, auth, 429, schema validation, sandbox, cancelled, unknown.
-- `to_json()` serializes; `to_route_explain()` yields small dict; `is_retryable()` correct.
 
-## Code Targets
-service/evidence/store.py; service/evidence/index.jsonl; service/evidence/api.py; tests/test_evidence_store.py
+- Putting a pack writes manifest, simulation JSONL, metrics, zip, and one catalog entry.
+- Listing supports tag and date filters and sorts newest first.
+- Retrieval verifies hashes/size and raises on tampering.
+- Route explanation includes evidence-pack decision metadata.
+- Catalog and stored files omit PII/token/secret-like data and listing remains performant for 1k items.
 
 ## Design
-- ErrorClass enum (TOOL_NOT_FOUND, SCHEMA_VALIDATION, AUTH, RATE_LIMIT, TIMEOUT, CANCELLED,
-  CONNECTIVITY, RETRYABLE, NON_RETRYABLE, SANDBOX_VIOLATION, SECURITY, UNKNOWN)
-- MCPError dataclass(cls, message, code|None, retryable:bool, root:str, meta:dict|None)
-- map_exception(exc) -> MCPError (rules as above); add meta["secondary"]="RETRYABLE" when applicable
-- Helpers: to_route_explain(mcp_error), is_retryable(mcp_error)
-- No external deps; tests use fake exceptions (no httpx import)
 
-## Tests (must add)
-tests/test_mcp_errors.py:
-- test_timeout_maps_retryable
-- test_connectivity_maps_retryable
-- test_rate_limit_429_retryable
-- test_auth_nonretryable
-- test_schema_validation_nonretryable
-- test_sandbox_violation_nonretryable
-- test_cancelled_nonretryable
-- test_unknown_default
-- test_to_route_explain_truncates_message
-- test_to_json_is_serializable
+- Source of truth for this reconstruction is limited to the committed implementation and test targets listed in `## Reconstruction Sources`.
+- Runtime behavior is represented by the implementation files in `## Code Targets`; expected observable behavior is represented by the listed tests.
+- No provider calls, tokens, external services, or runtime code changes are required by this spec reconstruction.
+- MCP-005 remains the canonical source for MCP error taxonomy names and semantics wherever error classes are referenced.
+- Unspecified behavior is not reconstructed; it remains unknown or requires an operator decision.
+
+## Tests
+
+Run the focused tests listed in `## Code Targets` for this spec. These tests define the reconstructed acceptance boundary and should be kept focused on the committed behavior summarized above.
+
+## Reconstruction Note
+
+This spec was reconstructed on 2026-06-14 by reading the contaminated spec's `## Code Targets` section and the committed source/test files named there. The prior MCP-005 Error Taxonomy body was treated as non-authoritative contamination and was not used to infer this feature's intent. Unknown: remote/object-store backend is not defined.
+
+## Reconstruction Sources
+
+- `service/evidence/store.py`
+- `service/evidence/index.jsonl`
+- `service/evidence/api.py`
+- `tests/test_evidence_store.py`
+
+## Code Targets
+
+service/evidence/store.py; service/evidence/index.jsonl; service/evidence/api.py; tests/test_evidence_store.py

--- a/.specs/NEW-015.md
+++ b/.specs/NEW-015.md
@@ -1,45 +1,42 @@
 # CODE SPEC — NEW-015 · Determinism Harness (exact replay & drift detector) (RES_07)
 
-> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
-> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
-> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
-> titled feature or its own `## Code Targets`. The intended spec body for this feature is
-> therefore **missing**. The contaminated body is preserved **unchanged** below for
-> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
->
-> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
-> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
-> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
-> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+> Reconstructed by lane `ALPHA-SOLVER-SPEC-SOURCE-RECONSTRUCTION-001` from committed code and tests only. This file replaces a non-authoritative contaminated MCP-005 body. Do not infer implementation quality from this reconstruction.
 
 ## Goal
-Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
+
+Compare repeated outputs while ignoring configured non-semantic fields and report drift/flaps deterministically.
 
 ## Acceptance Criteria
-- All taxonomy tests pass.
-- Deterministic mapping for timeouts, connectivity, auth, 429, schema validation, sandbox, cancelled, unknown.
-- `to_json()` serializes; `to_route_explain()` yields small dict; `is_retryable()` correct.
 
-## Code Targets
-service/determinism/harness.py; service/determinism/report.py; config/determinism.yaml; tests/test_determinism.py
+- Exact replay of 10 cases has zero flaps.
+- Configured noise in non-semantic fields does not create flaps.
+- Decision changes create flaps with deterministic diffs.
+- Reports summarize flap rate, top diff keys, and p95 timing.
+- CI gate raises when any flap is detected.
 
 ## Design
-- ErrorClass enum (TOOL_NOT_FOUND, SCHEMA_VALIDATION, AUTH, RATE_LIMIT, TIMEOUT, CANCELLED,
-  CONNECTIVITY, RETRYABLE, NON_RETRYABLE, SANDBOX_VIOLATION, SECURITY, UNKNOWN)
-- MCPError dataclass(cls, message, code|None, retryable:bool, root:str, meta:dict|None)
-- map_exception(exc) -> MCPError (rules as above); add meta["secondary"]="RETRYABLE" when applicable
-- Helpers: to_route_explain(mcp_error), is_retryable(mcp_error)
-- No external deps; tests use fake exceptions (no httpx import)
 
-## Tests (must add)
-tests/test_mcp_errors.py:
-- test_timeout_maps_retryable
-- test_connectivity_maps_retryable
-- test_rate_limit_429_retryable
-- test_auth_nonretryable
-- test_schema_validation_nonretryable
-- test_sandbox_violation_nonretryable
-- test_cancelled_nonretryable
-- test_unknown_default
-- test_to_route_explain_truncates_message
-- test_to_json_is_serializable
+- Source of truth for this reconstruction is limited to the committed implementation and test targets listed in `## Reconstruction Sources`.
+- Runtime behavior is represented by the implementation files in `## Code Targets`; expected observable behavior is represented by the listed tests.
+- No provider calls, tokens, external services, or runtime code changes are required by this spec reconstruction.
+- MCP-005 remains the canonical source for MCP error taxonomy names and semantics wherever error classes are referenced.
+- Unspecified behavior is not reconstructed; it remains unknown or requires an operator decision.
+
+## Tests
+
+Run the focused tests listed in `## Code Targets` for this spec. These tests define the reconstructed acceptance boundary and should be kept focused on the committed behavior summarized above.
+
+## Reconstruction Note
+
+This spec was reconstructed on 2026-06-14 by reading the contaminated spec's `## Code Targets` section and the committed source/test files named there. The prior MCP-005 Error Taxonomy body was treated as non-authoritative contamination and was not used to infer this feature's intent. Unknown: semantic equivalence beyond configured ignored fields is not defined.
+
+## Reconstruction Sources
+
+- `service/determinism/harness.py`
+- `service/determinism/report.py`
+- `config/determinism.yaml`
+- `tests/test_determinism.py`
+
+## Code Targets
+
+service/determinism/harness.py; service/determinism/report.py; config/determinism.yaml; tests/test_determinism.py

--- a/.specs/NEW-016.md
+++ b/.specs/NEW-016.md
@@ -8,8 +8,9 @@ Export sanitized Prometheus metrics and maintain Grafana dashboard JSON for obse
 
 ## Acceptance Criteria
 
-- Exporter emits route decision, budget verdict, latency bucket, errors, tokens, and cost metrics.
-- Metric output redacts PII/token/secret-like fields and meets performance bound.
+- `MetricsExporter.record_event` emits route decision, budget verdict, latency bucket, token, and cost metrics.
+- Metric output redacts PII/token/secret-like fields and meets the committed performance bound.
+- `tests/test_metrics_dashboards.py` manually creates `alpha_solver_errors_total` before scraping; dashboards reference error metrics, but the committed exporter is not reconstructed as the owner/emitter of that error series.
 - Dashboard JSON contains required panels and PromQL expressions for route, budget, latency p95, tokens, cost, confidence, errors, throughput, gates, and adapters.
 - Latency panels link to trace context.
 

--- a/.specs/NEW-016.md
+++ b/.specs/NEW-016.md
@@ -1,45 +1,41 @@
 # CODE SPEC — NEW-016 · Grafana Dashboards Pack (metrics + sample boards) (RES_07)
 
-> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
-> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
-> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
-> titled feature or its own `## Code Targets`. The intended spec body for this feature is
-> therefore **missing**. The contaminated body is preserved **unchanged** below for
-> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
->
-> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
-> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
-> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
-> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+> Reconstructed by lane `ALPHA-SOLVER-SPEC-SOURCE-RECONSTRUCTION-001` from committed code and tests only. This file replaces a non-authoritative contaminated MCP-005 body. Do not infer implementation quality from this reconstruction.
 
 ## Goal
-Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
+
+Export sanitized Prometheus metrics and maintain Grafana dashboard JSON for observability and cost/budget views.
 
 ## Acceptance Criteria
-- All taxonomy tests pass.
-- Deterministic mapping for timeouts, connectivity, auth, 429, schema validation, sandbox, cancelled, unknown.
-- `to_json()` serializes; `to_route_explain()` yields small dict; `is_retryable()` correct.
 
-## Code Targets
-service/metrics/exporter.py; dashboards/alpha_observability.json; dashboards/cost_budget.json; tests/test_metrics_dashboards.py
+- Exporter emits route decision, budget verdict, latency bucket, errors, tokens, and cost metrics.
+- Metric output redacts PII/token/secret-like fields and meets performance bound.
+- Dashboard JSON contains required panels and PromQL expressions for route, budget, latency p95, tokens, cost, confidence, errors, throughput, gates, and adapters.
+- Latency panels link to trace context.
 
 ## Design
-- ErrorClass enum (TOOL_NOT_FOUND, SCHEMA_VALIDATION, AUTH, RATE_LIMIT, TIMEOUT, CANCELLED,
-  CONNECTIVITY, RETRYABLE, NON_RETRYABLE, SANDBOX_VIOLATION, SECURITY, UNKNOWN)
-- MCPError dataclass(cls, message, code|None, retryable:bool, root:str, meta:dict|None)
-- map_exception(exc) -> MCPError (rules as above); add meta["secondary"]="RETRYABLE" when applicable
-- Helpers: to_route_explain(mcp_error), is_retryable(mcp_error)
-- No external deps; tests use fake exceptions (no httpx import)
 
-## Tests (must add)
-tests/test_mcp_errors.py:
-- test_timeout_maps_retryable
-- test_connectivity_maps_retryable
-- test_rate_limit_429_retryable
-- test_auth_nonretryable
-- test_schema_validation_nonretryable
-- test_sandbox_violation_nonretryable
-- test_cancelled_nonretryable
-- test_unknown_default
-- test_to_route_explain_truncates_message
-- test_to_json_is_serializable
+- Source of truth for this reconstruction is limited to the committed implementation and test targets listed in `## Reconstruction Sources`.
+- Runtime behavior is represented by the implementation files in `## Code Targets`; expected observable behavior is represented by the listed tests.
+- No provider calls, tokens, external services, or runtime code changes are required by this spec reconstruction.
+- MCP-005 remains the canonical source for MCP error taxonomy names and semantics wherever error classes are referenced.
+- Unspecified behavior is not reconstructed; it remains unknown or requires an operator decision.
+
+## Tests
+
+Run the focused tests listed in `## Code Targets` for this spec. These tests define the reconstructed acceptance boundary and should be kept focused on the committed behavior summarized above.
+
+## Reconstruction Note
+
+This spec was reconstructed on 2026-06-14 by reading the contaminated spec's `## Code Targets` section and the committed source/test files named there. The prior MCP-005 Error Taxonomy body was treated as non-authoritative contamination and was not used to infer this feature's intent. Unknown: deployment of dashboards to Grafana is not defined.
+
+## Reconstruction Sources
+
+- `service/metrics/exporter.py`
+- `dashboards/alpha_observability.json`
+- `dashboards/cost_budget.json`
+- `tests/test_metrics_dashboards.py`
+
+## Code Targets
+
+service/metrics/exporter.py; dashboards/alpha_observability.json; dashboards/cost_budget.json; tests/test_metrics_dashboards.py

--- a/.specs/NEW-017.md
+++ b/.specs/NEW-017.md
@@ -1,45 +1,42 @@
 # CODE SPEC — NEW-017 · Prompt Quality Pack (rubrics + evaluator) (RES_01)
 
-> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
-> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
-> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
-> titled feature or its own `## Code Targets`. The intended spec body for this feature is
-> therefore **missing**. The contaminated body is preserved **unchanged** below for
-> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
->
-> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
-> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
-> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
-> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+> Reconstructed by lane `ALPHA-SOLVER-SPEC-SOURCE-RECONSTRUCTION-001` from committed code and tests only. This file replaces a non-authoritative contaminated MCP-005 body. Do not infer implementation quality from this reconstruction.
 
 ## Goal
-Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
+
+Evaluate prompt/answer quality with rubric hashes, deterministic scoring, comparison, batch reports, and sanitized outputs.
 
 ## Acceptance Criteria
-- All taxonomy tests pass.
-- Deterministic mapping for timeouts, connectivity, auth, 429, schema validation, sandbox, cancelled, unknown.
-- `to_json()` serializes; `to_route_explain()` yields small dict; `is_retryable()` correct.
 
-## Code Targets
-service/prompts/quality/rubrics.yaml; service/prompts/quality/evaluator.py; service/prompts/quality/report.py; tests/test_prompt_quality.py
+- Rubrics SHA is stable.
+- Evaluator scores keyword coverage, brevity, structure, and safety as tests assert.
+- Comparison selects a winner and includes prompt deck and rubric SHAs in route explanation.
+- Batch comparison reports total, wins, win_rate, and meets sample lift threshold.
+- Outputs omit PII/token/secret-like content and performance remains below tested bound.
 
 ## Design
-- ErrorClass enum (TOOL_NOT_FOUND, SCHEMA_VALIDATION, AUTH, RATE_LIMIT, TIMEOUT, CANCELLED,
-  CONNECTIVITY, RETRYABLE, NON_RETRYABLE, SANDBOX_VIOLATION, SECURITY, UNKNOWN)
-- MCPError dataclass(cls, message, code|None, retryable:bool, root:str, meta:dict|None)
-- map_exception(exc) -> MCPError (rules as above); add meta["secondary"]="RETRYABLE" when applicable
-- Helpers: to_route_explain(mcp_error), is_retryable(mcp_error)
-- No external deps; tests use fake exceptions (no httpx import)
 
-## Tests (must add)
-tests/test_mcp_errors.py:
-- test_timeout_maps_retryable
-- test_connectivity_maps_retryable
-- test_rate_limit_429_retryable
-- test_auth_nonretryable
-- test_schema_validation_nonretryable
-- test_sandbox_violation_nonretryable
-- test_cancelled_nonretryable
-- test_unknown_default
-- test_to_route_explain_truncates_message
-- test_to_json_is_serializable
+- Source of truth for this reconstruction is limited to the committed implementation and test targets listed in `## Reconstruction Sources`.
+- Runtime behavior is represented by the implementation files in `## Code Targets`; expected observable behavior is represented by the listed tests.
+- No provider calls, tokens, external services, or runtime code changes are required by this spec reconstruction.
+- MCP-005 remains the canonical source for MCP error taxonomy names and semantics wherever error classes are referenced.
+- Unspecified behavior is not reconstructed; it remains unknown or requires an operator decision.
+
+## Tests
+
+Run the focused tests listed in `## Code Targets` for this spec. These tests define the reconstructed acceptance boundary and should be kept focused on the committed behavior summarized above.
+
+## Reconstruction Note
+
+This spec was reconstructed on 2026-06-14 by reading the contaminated spec's `## Code Targets` section and the committed source/test files named there. The prior MCP-005 Error Taxonomy body was treated as non-authoritative contamination and was not used to infer this feature's intent. Unknown: human review rubric governance is not defined.
+
+## Reconstruction Sources
+
+- `service/prompts/quality/rubrics.yaml`
+- `service/prompts/quality/evaluator.py`
+- `service/prompts/quality/report.py`
+- `tests/test_prompt_quality.py`
+
+## Code Targets
+
+service/prompts/quality/rubrics.yaml; service/prompts/quality/evaluator.py; service/prompts/quality/report.py; tests/test_prompt_quality.py

--- a/.specs/RES-03.md
+++ b/.specs/RES-03.md
@@ -1,45 +1,41 @@
 # CODE SPEC — RES-03 · Decision Rules & Scoring (RES)
 
-> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
-> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
-> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
-> titled feature or its own `## Code Targets`. The intended spec body for this feature is
-> therefore **missing**. The contaminated body is preserved **unchanged** below for
-> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
->
-> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
-> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
-> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
-> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+> Reconstructed by lane `ALPHA-SOLVER-SPEC-SOURCE-RECONSTRUCTION-001` from committed code and tests only. This file replaces a non-authoritative contaminated MCP-005 body. Do not infer implementation quality from this reconstruction.
 
 ## Goal
-Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
+
+Load/validate scoring weights, score/rank candidate plans deterministically, and explain score components.
 
 ## Acceptance Criteria
-- All taxonomy tests pass.
-- Deterministic mapping for timeouts, connectivity, auth, 429, schema validation, sandbox, cancelled, unknown.
-- `to_json()` serializes; `to_route_explain()` yields small dict; `is_retryable()` correct.
 
-## Code Targets
-service/scoring/decision_rules.py; config/decision_rules.yaml; tests/test_decision_rules.py
+- Weights load and invalid shapes raise errors.
+- Scoring is deterministic.
+- Ranking chooses expected top plan in sample fixtures.
+- Ties break deterministically by confidence, latency_ms, cost_tokens, then id.
+- Explain includes score, configured components, and tiebreak chain.
 
 ## Design
-- ErrorClass enum (TOOL_NOT_FOUND, SCHEMA_VALIDATION, AUTH, RATE_LIMIT, TIMEOUT, CANCELLED,
-  CONNECTIVITY, RETRYABLE, NON_RETRYABLE, SANDBOX_VIOLATION, SECURITY, UNKNOWN)
-- MCPError dataclass(cls, message, code|None, retryable:bool, root:str, meta:dict|None)
-- map_exception(exc) -> MCPError (rules as above); add meta["secondary"]="RETRYABLE" when applicable
-- Helpers: to_route_explain(mcp_error), is_retryable(mcp_error)
-- No external deps; tests use fake exceptions (no httpx import)
 
-## Tests (must add)
-tests/test_mcp_errors.py:
-- test_timeout_maps_retryable
-- test_connectivity_maps_retryable
-- test_rate_limit_429_retryable
-- test_auth_nonretryable
-- test_schema_validation_nonretryable
-- test_sandbox_violation_nonretryable
-- test_cancelled_nonretryable
-- test_unknown_default
-- test_to_route_explain_truncates_message
-- test_to_json_is_serializable
+- Source of truth for this reconstruction is limited to the committed implementation and test targets listed in `## Reconstruction Sources`.
+- Runtime behavior is represented by the implementation files in `## Code Targets`; expected observable behavior is represented by the listed tests.
+- No provider calls, tokens, external services, or runtime code changes are required by this spec reconstruction.
+- MCP-005 remains the canonical source for MCP error taxonomy names and semantics wherever error classes are referenced.
+- Unspecified behavior is not reconstructed; it remains unknown or requires an operator decision.
+
+## Tests
+
+Run the focused tests listed in `## Code Targets` for this spec. These tests define the reconstructed acceptance boundary and should be kept focused on the committed behavior summarized above.
+
+## Reconstruction Note
+
+This spec was reconstructed on 2026-06-14 by reading the contaminated spec's `## Code Targets` section and the committed source/test files named there. The prior MCP-005 Error Taxonomy body was treated as non-authoritative contamination and was not used to infer this feature's intent. Unknown: business-approved weight values beyond config fixture are not inferred.
+
+## Reconstruction Sources
+
+- `service/scoring/decision_rules.py`
+- `config/decision_rules.yaml`
+- `tests/test_decision_rules.py`
+
+## Code Targets
+
+service/scoring/decision_rules.py; config/decision_rules.yaml; tests/test_decision_rules.py

--- a/.specs/RES-04.md
+++ b/.specs/RES-04.md
@@ -1,45 +1,41 @@
 # CODE SPEC — RES-04 · Confidence & Budget Gates (RES)
 
-> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
-> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
-> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
-> titled feature or its own `## Code Targets`. The intended spec body for this feature is
-> therefore **missing**. The contaminated body is preserved **unchanged** below for
-> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
->
-> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
-> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
-> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
-> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+> Reconstructed by lane `ALPHA-SOLVER-SPEC-SOURCE-RECONSTRUCTION-001` from committed code and tests only. This file replaces a non-authoritative contaminated MCP-005 body. Do not infer implementation quality from this reconstruction.
 
 ## Goal
-Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
+
+Gate solver actions using confidence thresholds, budget minimums, and policy block flags.
 
 ## Acceptance Criteria
-- All taxonomy tests pass.
-- Deterministic mapping for timeouts, connectivity, auth, 429, schema validation, sandbox, cancelled, unknown.
-- `to_json()` serializes; `to_route_explain()` yields small dict; `is_retryable()` correct.
 
-## Code Targets
-service/gating/gates.py; alpha_solver_cli.py; tests/test_gates.py
+- Confident requests with adequate budget allow.
+- Low confidence or low budget clarifies with budget_verdict.
+- Policy block returns block and gate_rules policy_block.
+- Route explain always includes budget_verdict.
+- CLI overrides pass threshold values into the gate function; latency and determinism match tests.
 
 ## Design
-- ErrorClass enum (TOOL_NOT_FOUND, SCHEMA_VALIDATION, AUTH, RATE_LIMIT, TIMEOUT, CANCELLED,
-  CONNECTIVITY, RETRYABLE, NON_RETRYABLE, SANDBOX_VIOLATION, SECURITY, UNKNOWN)
-- MCPError dataclass(cls, message, code|None, retryable:bool, root:str, meta:dict|None)
-- map_exception(exc) -> MCPError (rules as above); add meta["secondary"]="RETRYABLE" when applicable
-- Helpers: to_route_explain(mcp_error), is_retryable(mcp_error)
-- No external deps; tests use fake exceptions (no httpx import)
 
-## Tests (must add)
-tests/test_mcp_errors.py:
-- test_timeout_maps_retryable
-- test_connectivity_maps_retryable
-- test_rate_limit_429_retryable
-- test_auth_nonretryable
-- test_schema_validation_nonretryable
-- test_sandbox_violation_nonretryable
-- test_cancelled_nonretryable
-- test_unknown_default
-- test_to_route_explain_truncates_message
-- test_to_json_is_serializable
+- Source of truth for this reconstruction is limited to the committed implementation and test targets listed in `## Reconstruction Sources`.
+- Runtime behavior is represented by the implementation files in `## Code Targets`; expected observable behavior is represented by the listed tests.
+- No provider calls, tokens, external services, or runtime code changes are required by this spec reconstruction.
+- MCP-005 remains the canonical source for MCP error taxonomy names and semantics wherever error classes are referenced.
+- Unspecified behavior is not reconstructed; it remains unknown or requires an operator decision.
+
+## Tests
+
+Run the focused tests listed in `## Code Targets` for this spec. These tests define the reconstructed acceptance boundary and should be kept focused on the committed behavior summarized above.
+
+## Reconstruction Note
+
+This spec was reconstructed on 2026-06-14 by reading the contaminated spec's `## Code Targets` section and the committed source/test files named there. The prior MCP-005 Error Taxonomy body was treated as non-authoritative contamination and was not used to infer this feature's intent. Unknown: end-user wording for clarify/block messages is not defined.
+
+## Reconstruction Sources
+
+- `service/gating/gates.py`
+- `alpha_solver_cli.py`
+- `tests/test_gates.py`
+
+## Code Targets
+
+service/gating/gates.py; alpha_solver_cli.py; tests/test_gates.py

--- a/.specs/RES-05.md
+++ b/.specs/RES-05.md
@@ -1,45 +1,43 @@
 # CODE SPEC — RES-05 · Tool Adapters (Playwright, GSheets) — MVP stubs (RES)
 
-> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
-> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
-> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
-> titled feature or its own `## Code Targets`. The intended spec body for this feature is
-> therefore **missing**. The contaminated body is preserved **unchanged** below for
-> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
->
-> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
-> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
-> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
-> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+> Reconstructed by lane `ALPHA-SOLVER-SPEC-SOURCE-RECONSTRUCTION-001` from committed code and tests only. This file replaces a non-authoritative contaminated MCP-005 body. Do not infer implementation quality from this reconstruction.
 
 ## Goal
-Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
+
+Provide deterministic Playwright and GSheets adapter stubs with schema errors, retry metadata, idempotent sheet append, and route explanations.
 
 ## Acceptance Criteria
-- All taxonomy tests pass.
-- Deterministic mapping for timeouts, connectivity, auth, 429, schema validation, sandbox, cancelled, unknown.
-- `to_json()` serializes; `to_route_explain()` yields small dict; `is_retryable()` correct.
 
-## Code Targets
-service/adapters/base.py; service/adapters/playwright_adapter.py; service/adapters/gsheets_adapter.py; tests/test_adapters_playwright.py; tests/test_adapters_gsheets.py
+- Playwright get_text returns fixture text and schema/timeout errors map to AdapterError codes/retryability.
+- GSheets append is idempotent for repeated keys and read returns rows.
+- Invalid schemas raise non-retryable schema errors.
+- Route explanations include adapter, latency, attempts, and retriable/idempotent fields.
+- Sample adapter success rate is at least 95%.
 
 ## Design
-- ErrorClass enum (TOOL_NOT_FOUND, SCHEMA_VALIDATION, AUTH, RATE_LIMIT, TIMEOUT, CANCELLED,
-  CONNECTIVITY, RETRYABLE, NON_RETRYABLE, SANDBOX_VIOLATION, SECURITY, UNKNOWN)
-- MCPError dataclass(cls, message, code|None, retryable:bool, root:str, meta:dict|None)
-- map_exception(exc) -> MCPError (rules as above); add meta["secondary"]="RETRYABLE" when applicable
-- Helpers: to_route_explain(mcp_error), is_retryable(mcp_error)
-- No external deps; tests use fake exceptions (no httpx import)
 
-## Tests (must add)
-tests/test_mcp_errors.py:
-- test_timeout_maps_retryable
-- test_connectivity_maps_retryable
-- test_rate_limit_429_retryable
-- test_auth_nonretryable
-- test_schema_validation_nonretryable
-- test_sandbox_violation_nonretryable
-- test_cancelled_nonretryable
-- test_unknown_default
-- test_to_route_explain_truncates_message
-- test_to_json_is_serializable
+- Source of truth for this reconstruction is limited to the committed implementation and test targets listed in `## Reconstruction Sources`.
+- Runtime behavior is represented by the implementation files in `## Code Targets`; expected observable behavior is represented by the listed tests.
+- No provider calls, tokens, external services, or runtime code changes are required by this spec reconstruction.
+- MCP-005 remains the canonical source for MCP error taxonomy names and semantics wherever error classes are referenced.
+- Unspecified behavior is not reconstructed; it remains unknown or requires an operator decision.
+
+## Tests
+
+Run the focused tests listed in `## Code Targets` for this spec. These tests define the reconstructed acceptance boundary and should be kept focused on the committed behavior summarized above.
+
+## Reconstruction Note
+
+This spec was reconstructed on 2026-06-14 by reading the contaminated spec's `## Code Targets` section and the committed source/test files named there. The prior MCP-005 Error Taxonomy body was treated as non-authoritative contamination and was not used to infer this feature's intent. Unknown: real browser/API integration is not in MVP stub sources.
+
+## Reconstruction Sources
+
+- `service/adapters/base.py`
+- `service/adapters/playwright_adapter.py`
+- `service/adapters/gsheets_adapter.py`
+- `tests/test_adapters_playwright.py`
+- `tests/test_adapters_gsheets.py`
+
+## Code Targets
+
+service/adapters/base.py; service/adapters/playwright_adapter.py; service/adapters/gsheets_adapter.py; tests/test_adapters_playwright.py; tests/test_adapters_gsheets.py

--- a/.specs/RES-06.md
+++ b/.specs/RES-06.md
@@ -1,45 +1,42 @@
 # CODE SPEC — RES-06 · Scenario Pack & Showcase (record/replay + rubric) (RES)
 
-> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
-> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
-> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
-> titled feature or its own `## Code Targets`. The intended spec body for this feature is
-> therefore **missing**. The contaminated body is preserved **unchanged** below for
-> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
->
-> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
-> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
-> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
-> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+> Reconstructed by lane `ALPHA-SOLVER-SPEC-SOURCE-RECONSTRUCTION-001` from committed code and tests only. This file replaces a non-authoritative contaminated MCP-005 body. Do not infer implementation quality from this reconstruction.
 
 ## Goal
-Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
+
+Load scenario packs, execute steps through adapters, judge with rubric, summarize pass rates, and replay recorded events.
 
 ## Acceptance Criteria
-- All taxonomy tests pass.
-- Deterministic mapping for timeouts, connectivity, auth, 429, schema validation, sandbox, cancelled, unknown.
-- `to_json()` serializes; `to_route_explain()` yields small dict; `is_retryable()` correct.
 
-## Code Targets
-service/scenarios/runner.py; service/scenarios/rubric.py; scenarios/pack.yaml; tests/test_scenarios.py
+- Pack contains at least 30 scenarios.
+- Single scenario runs pass expected steps with adapter values.
+- Rubric supports equals, contains, regex, type, and approximate expectations.
+- Record/replay preserves verdicts for 10 events.
+- Summaries include total, passed, pass_rate, and route_explain fields.
 
 ## Design
-- ErrorClass enum (TOOL_NOT_FOUND, SCHEMA_VALIDATION, AUTH, RATE_LIMIT, TIMEOUT, CANCELLED,
-  CONNECTIVITY, RETRYABLE, NON_RETRYABLE, SANDBOX_VIOLATION, SECURITY, UNKNOWN)
-- MCPError dataclass(cls, message, code|None, retryable:bool, root:str, meta:dict|None)
-- map_exception(exc) -> MCPError (rules as above); add meta["secondary"]="RETRYABLE" when applicable
-- Helpers: to_route_explain(mcp_error), is_retryable(mcp_error)
-- No external deps; tests use fake exceptions (no httpx import)
 
-## Tests (must add)
-tests/test_mcp_errors.py:
-- test_timeout_maps_retryable
-- test_connectivity_maps_retryable
-- test_rate_limit_429_retryable
-- test_auth_nonretryable
-- test_schema_validation_nonretryable
-- test_sandbox_violation_nonretryable
-- test_cancelled_nonretryable
-- test_unknown_default
-- test_to_route_explain_truncates_message
-- test_to_json_is_serializable
+- Source of truth for this reconstruction is limited to the committed implementation and test targets listed in `## Reconstruction Sources`.
+- Runtime behavior is represented by the implementation files in `## Code Targets`; expected observable behavior is represented by the listed tests.
+- No provider calls, tokens, external services, or runtime code changes are required by this spec reconstruction.
+- MCP-005 remains the canonical source for MCP error taxonomy names and semantics wherever error classes are referenced.
+- Unspecified behavior is not reconstructed; it remains unknown or requires an operator decision.
+
+## Tests
+
+Run the focused tests listed in `## Code Targets` for this spec. These tests define the reconstructed acceptance boundary and should be kept focused on the committed behavior summarized above.
+
+## Reconstruction Note
+
+This spec was reconstructed on 2026-06-14 by reading the contaminated spec's `## Code Targets` section and the committed source/test files named there. The prior MCP-005 Error Taxonomy body was treated as non-authoritative contamination and was not used to infer this feature's intent. Unknown: showcase UI or demo script outside pack/runner is not defined.
+
+## Reconstruction Sources
+
+- `service/scenarios/runner.py`
+- `service/scenarios/rubric.py`
+- `scenarios/pack.yaml`
+- `tests/test_scenarios.py`
+
+## Code Targets
+
+service/scenarios/runner.py; service/scenarios/rubric.py; scenarios/pack.yaml; tests/test_scenarios.py

--- a/.specs/RES-07.md
+++ b/.specs/RES-07.md
@@ -1,45 +1,41 @@
 # CODE SPEC — RES-07 · Observability (route_explain + JSONL replay) (RES)
 
-> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
-> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
-> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
-> titled feature or its own `## Code Targets`. The intended spec body for this feature is
-> therefore **missing**. The contaminated body is preserved **unchanged** below for
-> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
->
-> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
-> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
-> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
-> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+> Reconstructed by lane `ALPHA-SOLVER-SPEC-SOURCE-RECONSTRUCTION-001` from committed code and tests only. This file replaces a non-authoritative contaminated MCP-005 body. Do not infer implementation quality from this reconstruction.
 
 ## Goal
-Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
+
+Write structured JSONL events with required route_explain fields, rotate logs, filter/replay events, and reconstruct requests.
 
 ## Acceptance Criteria
-- All taxonomy tests pass.
-- Deterministic mapping for timeouts, connectivity, auth, 429, schema validation, sandbox, cancelled, unknown.
-- `to_json()` serializes; `to_route_explain()` yields small dict; `is_retryable()` correct.
 
-## Code Targets
-service/observability/logger.py; service/observability/replay.py; tests/test_observability.py
+- Logger writes JSONL and rotates by size.
+- Event envelope contains timestamp, pid, name, route_explain, payload, and meta.
+- route_explain requires decision, confidence, and budget_verdict; only allowed optional policy/redaction fields pass through.
+- Payload drops pii_raw.
+- Replay iterates rotated files, filters nested fields, and reconstructs requests 10/10.
 
 ## Design
-- ErrorClass enum (TOOL_NOT_FOUND, SCHEMA_VALIDATION, AUTH, RATE_LIMIT, TIMEOUT, CANCELLED,
-  CONNECTIVITY, RETRYABLE, NON_RETRYABLE, SANDBOX_VIOLATION, SECURITY, UNKNOWN)
-- MCPError dataclass(cls, message, code|None, retryable:bool, root:str, meta:dict|None)
-- map_exception(exc) -> MCPError (rules as above); add meta["secondary"]="RETRYABLE" when applicable
-- Helpers: to_route_explain(mcp_error), is_retryable(mcp_error)
-- No external deps; tests use fake exceptions (no httpx import)
 
-## Tests (must add)
-tests/test_mcp_errors.py:
-- test_timeout_maps_retryable
-- test_connectivity_maps_retryable
-- test_rate_limit_429_retryable
-- test_auth_nonretryable
-- test_schema_validation_nonretryable
-- test_sandbox_violation_nonretryable
-- test_cancelled_nonretryable
-- test_unknown_default
-- test_to_route_explain_truncates_message
-- test_to_json_is_serializable
+- Source of truth for this reconstruction is limited to the committed implementation and test targets listed in `## Reconstruction Sources`.
+- Runtime behavior is represented by the implementation files in `## Code Targets`; expected observable behavior is represented by the listed tests.
+- No provider calls, tokens, external services, or runtime code changes are required by this spec reconstruction.
+- MCP-005 remains the canonical source for MCP error taxonomy names and semantics wherever error classes are referenced.
+- Unspecified behavior is not reconstructed; it remains unknown or requires an operator decision.
+
+## Tests
+
+Run the focused tests listed in `## Code Targets` for this spec. These tests define the reconstructed acceptance boundary and should be kept focused on the committed behavior summarized above.
+
+## Reconstruction Note
+
+This spec was reconstructed on 2026-06-14 by reading the contaminated spec's `## Code Targets` section and the committed source/test files named there. The prior MCP-005 Error Taxonomy body was treated as non-authoritative contamination and was not used to infer this feature's intent. Unknown: central log aggregation is not defined.
+
+## Reconstruction Sources
+
+- `service/observability/logger.py`
+- `service/observability/replay.py`
+- `tests/test_observability.py`
+
+## Code Targets
+
+service/observability/logger.py; service/observability/replay.py; tests/test_observability.py

--- a/.specs/RES-08.md
+++ b/.specs/RES-08.md
@@ -1,45 +1,43 @@
 # CODE SPEC — RES-08 · Budget Simulator + Evidence Pack (RES)
 
-> **⚠️ NON-AUTHORITATIVE — CONTAMINATED SPEC (do not implement from this).**
-> The `## Goal`, `## Acceptance Criteria`, `## Design`, and `## Tests` sections below are a
-> verbatim copy of **`MCP-005 · Error Taxonomy (MCP)`** and do **not** describe this spec's
-> titled feature or its own `## Code Targets`. The intended spec body for this feature is
-> therefore **missing**. The contaminated body is preserved **unchanged** below for
-> forensic / source-reconstruction purposes; it must **not** be used as implementation scope.
->
-> Classification: `SPEC_CONTAMINATED` + `SPEC_NEEDS_SOURCE_RECONSTRUCTION`.
-> Tracked by lane `ALPHA-SOLVER-SPEC-CONTAMINATION-RECONCILIATION-001` — see
-> [`docs/SPECS_HEALTH_AUDIT.md`](../docs/SPECS_HEALTH_AUDIT.md) and
-> [`docs/SPECS_RECONCILIATION_PLAN.md`](../docs/SPECS_RECONCILIATION_PLAN.md).
+> Reconstructed by lane `ALPHA-SOLVER-SPEC-SOURCE-RECONSTRUCTION-001` from committed code and tests only. This file replaces a non-authoritative contaminated MCP-005 body. Do not infer implementation quality from this reconstruction.
 
 ## Goal
-Create a stable MCP error taxonomy with enum, mapper, helpers, and tests. Normalize arbitrary exceptions to deterministic classes.
+
+Simulate token costs and package sanitized evidence artifacts with hashes, metrics, and zipped files.
 
 ## Acceptance Criteria
-- All taxonomy tests pass.
-- Deterministic mapping for timeouts, connectivity, auth, 429, schema validation, sandbox, cancelled, unknown.
-- `to_json()` serializes; `to_route_explain()` yields small dict; `is_retryable()` correct.
 
-## Code Targets
-service/budget/simulator.py; service/evidence/collector.py; config/cost_models.yaml; tests/test_budget_simulator.py; tests/test_evidence_pack.py
+- Cost simulation computes per-item tokens/cost/latency and totals from configured provider/model pricing.
+- Budget simulator parity/caps/what-if CLI behavior follows tests.
+- Evidence pack writes manifest, metrics, simulation JSONL, and evidence.zip.
+- Manifest contains counts and SHA-256 hashes; JSONL rows are sorted and sanitized.
+- Simulation is deterministic and performance meets tested bounds.
 
 ## Design
-- ErrorClass enum (TOOL_NOT_FOUND, SCHEMA_VALIDATION, AUTH, RATE_LIMIT, TIMEOUT, CANCELLED,
-  CONNECTIVITY, RETRYABLE, NON_RETRYABLE, SANDBOX_VIOLATION, SECURITY, UNKNOWN)
-- MCPError dataclass(cls, message, code|None, retryable:bool, root:str, meta:dict|None)
-- map_exception(exc) -> MCPError (rules as above); add meta["secondary"]="RETRYABLE" when applicable
-- Helpers: to_route_explain(mcp_error), is_retryable(mcp_error)
-- No external deps; tests use fake exceptions (no httpx import)
 
-## Tests (must add)
-tests/test_mcp_errors.py:
-- test_timeout_maps_retryable
-- test_connectivity_maps_retryable
-- test_rate_limit_429_retryable
-- test_auth_nonretryable
-- test_schema_validation_nonretryable
-- test_sandbox_violation_nonretryable
-- test_cancelled_nonretryable
-- test_unknown_default
-- test_to_route_explain_truncates_message
-- test_to_json_is_serializable
+- Source of truth for this reconstruction is limited to the committed implementation and test targets listed in `## Reconstruction Sources`.
+- Runtime behavior is represented by the implementation files in `## Code Targets`; expected observable behavior is represented by the listed tests.
+- No provider calls, tokens, external services, or runtime code changes are required by this spec reconstruction.
+- MCP-005 remains the canonical source for MCP error taxonomy names and semantics wherever error classes are referenced.
+- Unspecified behavior is not reconstructed; it remains unknown or requires an operator decision.
+
+## Tests
+
+Run the focused tests listed in `## Code Targets` for this spec. These tests define the reconstructed acceptance boundary and should be kept focused on the committed behavior summarized above.
+
+## Reconstruction Note
+
+This spec was reconstructed on 2026-06-14 by reading the contaminated spec's `## Code Targets` section and the committed source/test files named there. The prior MCP-005 Error Taxonomy body was treated as non-authoritative contamination and was not used to infer this feature's intent. Unknown: authoritative external pricing source is not defined; committed config is the source.
+
+## Reconstruction Sources
+
+- `service/budget/simulator.py`
+- `service/evidence/collector.py`
+- `config/cost_models.yaml`
+- `tests/test_budget_simulator.py`
+- `tests/test_evidence_pack.py`
+
+## Code Targets
+
+service/budget/simulator.py; service/evidence/collector.py; config/cost_models.yaml; tests/test_budget_simulator.py; tests/test_evidence_pack.py

--- a/.specs/RES-08.md
+++ b/.specs/RES-08.md
@@ -33,6 +33,8 @@ This spec was reconstructed on 2026-06-14 by reading the contaminated spec's `##
 ## Reconstruction Sources
 
 - `service/budget/simulator.py`
+- `service/finops/simulator.py`
+- `cli/budget_sim.py`
 - `service/evidence/collector.py`
 - `config/cost_models.yaml`
 - `tests/test_budget_simulator.py`
@@ -40,4 +42,4 @@ This spec was reconstructed on 2026-06-14 by reading the contaminated spec's `##
 
 ## Code Targets
 
-service/budget/simulator.py; service/evidence/collector.py; config/cost_models.yaml; tests/test_budget_simulator.py; tests/test_evidence_pack.py
+service/budget/simulator.py; service/finops/simulator.py; cli/budget_sim.py; service/evidence/collector.py; config/cost_models.yaml; tests/test_budget_simulator.py; tests/test_evidence_pack.py

--- a/docs/evals/runs/alpha-solver-spec-source-reconstruction-001/README.md
+++ b/docs/evals/runs/alpha-solver-spec-source-reconstruction-001/README.md
@@ -1,0 +1,15 @@
+# Alpha Solver Spec Source Reconstruction 001
+
+Verdict: `SPEC_SOURCE_RECONSTRUCTION_CAPTURED`
+
+This packet records the reconstruction of 22 formerly contaminated specs from committed code and tests only. The lane replaced the MCP-005 copied bodies in place, preserved per-spec reconstruction notes/source lists, updated `.specs/INDEX.md`, and made no runtime code changes.
+
+## Files in this packet
+
+- `reconstruction-method.md`
+- `per-spec-source-map.md`
+- `unknowns-and-operator-decisions.md`
+- `changed-specs-index.md`
+- `selected-next-lane.md`
+- `evidence-boundary.md`
+- `non-actions.md`

--- a/docs/evals/runs/alpha-solver-spec-source-reconstruction-001/changed-specs-index.md
+++ b/docs/evals/runs/alpha-solver-spec-source-reconstruction-001/changed-specs-index.md
@@ -1,0 +1,5 @@
+# Changed Specs Index
+
+The following specs were reconstructed and `.specs/INDEX.md` now marks them `SPEC_RECONSTRUCTED_FROM_SOURCE`:
+
+`AS-145`, `MCP-001`, `MCP-002`, `MCP-003`, `MCP-004`, `MCP-006`, `MCP-007`, `NEW-009`, `NEW-010`, `NEW-011`, `NEW-012`, `NEW-013`, `NEW-014`, `NEW-015`, `NEW-016`, `NEW-017`, `RES-03`, `RES-04`, `RES-05`, `RES-06`, `RES-07`, `RES-08`.

--- a/docs/evals/runs/alpha-solver-spec-source-reconstruction-001/evidence-boundary.md
+++ b/docs/evals/runs/alpha-solver-spec-source-reconstruction-001/evidence-boundary.md
@@ -1,0 +1,15 @@
+# Evidence Boundary
+
+Included evidence:
+
+- Committed implementation files listed in each contaminated spec's `## Code Targets`.
+- Committed test files listed in each contaminated spec's `## Code Targets`.
+- Existing audit and reconciliation documents.
+
+Excluded evidence:
+
+- Memory or inferred original intent.
+- Provider calls, live tokens, external services, or runtime executions beyond local checks.
+- The contaminated MCP-005 copied body, except as contamination history.
+
+Allowed verdict emitted by this packet: `SPEC_SOURCE_RECONSTRUCTION_CAPTURED`.

--- a/docs/evals/runs/alpha-solver-spec-source-reconstruction-001/non-actions.md
+++ b/docs/evals/runs/alpha-solver-spec-source-reconstruction-001/non-actions.md
@@ -1,0 +1,7 @@
+# Non-Actions
+
+- Did not delete, rename, or move specs.
+- Did not modify runtime code, tests, CI, configs, dashboards, or data artifacts.
+- Did not call providers or use live tokens.
+- Did not modify MCP-005.
+- Did not claim specs prove implementation quality, MVP readiness, or production completeness.

--- a/docs/evals/runs/alpha-solver-spec-source-reconstruction-001/per-spec-source-map.md
+++ b/docs/evals/runs/alpha-solver-spec-source-reconstruction-001/per-spec-source-map.md
@@ -10,7 +10,7 @@
 | `MCP-007` | `service/mcp/observability.py`; `tests/test_mcp_observability.py` |
 | `NEW-009` | `service/clarify/trigger.py`; `service/clarify/templates.yaml`; `service/clarify/render.py`; `tests/test_clarify.py` |
 | `NEW-010` | `service/prompts/decks.yaml`; `service/prompts/selector.py`; `service/prompts/renderer.py`; `tests/test_prompt_decks.py` |
-| `NEW-011` | `service/scoring/tuning.py`; `config/tuning.yaml`; `tests/test_weight_tuning.py` |
+| `NEW-011` | `service/tuning/weight_harness.py`; `service/tuning/weights_normalize.py`; `tests/test_weight_tuning.py` |
 | `NEW-012` | `service/budget/guard.py`; `service/budget/cli.py`; `tests/test_budget_cli_guard.py` |
 | `NEW-013` | `service/observability/replay_cli.py`; `service/observability/diff.py`; `tests/test_replay_cli_diff.py` |
 | `NEW-014` | `service/evidence/store.py`; `service/evidence/index.jsonl`; `service/evidence/api.py`; `tests/test_evidence_store.py` |
@@ -22,5 +22,5 @@
 | `RES-05` | `service/adapters/base.py`; `service/adapters/playwright_adapter.py`; `service/adapters/gsheets_adapter.py`; `tests/test_adapters_playwright.py`; `tests/test_adapters_gsheets.py` |
 | `RES-06` | `service/scenarios/runner.py`; `service/scenarios/rubric.py`; `scenarios/pack.yaml`; `tests/test_scenarios.py` |
 | `RES-07` | `service/observability/logger.py`; `service/observability/replay.py`; `tests/test_observability.py` |
-| `RES-08` | `service/budget/simulator.py`; `service/evidence/collector.py`; `config/cost_models.yaml`; `tests/test_budget_simulator.py`; `tests/test_evidence_pack.py` |
+| `RES-08` | `service/budget/simulator.py`; `service/finops/simulator.py`; `cli/budget_sim.py`; `service/evidence/collector.py`; `config/cost_models.yaml`; `tests/test_budget_simulator.py`; `tests/test_evidence_pack.py` |
 | `AS-145` | `service/adapters/base.py`; `service/adapters/playwright_adapter.py`; `service/adapters/gsheets_adapter.py`; `tests/test_adapters_playwright_hardened.py`; `tests/test_adapters_gsheets_hardened.py` |

--- a/docs/evals/runs/alpha-solver-spec-source-reconstruction-001/per-spec-source-map.md
+++ b/docs/evals/runs/alpha-solver-spec-source-reconstruction-001/per-spec-source-map.md
@@ -1,0 +1,26 @@
+# Per-Spec Source Map
+
+| Spec | Sources |
+| --- | --- |
+| `MCP-001` | `registries/mcp/loader.py`; `service/mcp/wiring.py`; `tests/test_mcp_loader.py` |
+| `MCP-002` | `registries/mcp/registry_lookup.py`; `tests/test_mcp_router_rule.py` |
+| `MCP-003` | `service/mcp/policy_auth.py`; `tests/test_mcp_auth.py` |
+| `MCP-004` | `service/mcp/sandbox_limits.py`; `tests/test_mcp_sandbox.py` |
+| `MCP-006` | `service/mcp/retry_backoff.py`; `tests/test_mcp_retry.py` |
+| `MCP-007` | `service/mcp/observability.py`; `tests/test_mcp_observability.py` |
+| `NEW-009` | `service/clarify/trigger.py`; `service/clarify/templates.yaml`; `service/clarify/render.py`; `tests/test_clarify.py` |
+| `NEW-010` | `service/prompts/decks.yaml`; `service/prompts/selector.py`; `service/prompts/renderer.py`; `tests/test_prompt_decks.py` |
+| `NEW-011` | `service/scoring/tuning.py`; `config/tuning.yaml`; `tests/test_weight_tuning.py` |
+| `NEW-012` | `service/budget/guard.py`; `service/budget/cli.py`; `tests/test_budget_cli_guard.py` |
+| `NEW-013` | `service/observability/replay_cli.py`; `service/observability/diff.py`; `tests/test_replay_cli_diff.py` |
+| `NEW-014` | `service/evidence/store.py`; `service/evidence/index.jsonl`; `service/evidence/api.py`; `tests/test_evidence_store.py` |
+| `NEW-015` | `service/determinism/harness.py`; `service/determinism/report.py`; `config/determinism.yaml`; `tests/test_determinism.py` |
+| `NEW-016` | `service/metrics/exporter.py`; `dashboards/alpha_observability.json`; `dashboards/cost_budget.json`; `tests/test_metrics_dashboards.py` |
+| `NEW-017` | `service/prompts/quality/rubrics.yaml`; `service/prompts/quality/evaluator.py`; `service/prompts/quality/report.py`; `tests/test_prompt_quality.py` |
+| `RES-03` | `service/scoring/decision_rules.py`; `config/decision_rules.yaml`; `tests/test_decision_rules.py` |
+| `RES-04` | `service/gating/gates.py`; `alpha_solver_cli.py`; `tests/test_gates.py` |
+| `RES-05` | `service/adapters/base.py`; `service/adapters/playwright_adapter.py`; `service/adapters/gsheets_adapter.py`; `tests/test_adapters_playwright.py`; `tests/test_adapters_gsheets.py` |
+| `RES-06` | `service/scenarios/runner.py`; `service/scenarios/rubric.py`; `scenarios/pack.yaml`; `tests/test_scenarios.py` |
+| `RES-07` | `service/observability/logger.py`; `service/observability/replay.py`; `tests/test_observability.py` |
+| `RES-08` | `service/budget/simulator.py`; `service/evidence/collector.py`; `config/cost_models.yaml`; `tests/test_budget_simulator.py`; `tests/test_evidence_pack.py` |
+| `AS-145` | `service/adapters/base.py`; `service/adapters/playwright_adapter.py`; `service/adapters/gsheets_adapter.py`; `tests/test_adapters_playwright_hardened.py`; `tests/test_adapters_gsheets_hardened.py` |

--- a/docs/evals/runs/alpha-solver-spec-source-reconstruction-001/reconstruction-method.md
+++ b/docs/evals/runs/alpha-solver-spec-source-reconstruction-001/reconstruction-method.md
@@ -1,0 +1,10 @@
+# Reconstruction Method
+
+1. Read the prior audit and reconciliation plan.
+2. For each of the 22 contaminated specs, read the spec `## Code Targets` section.
+3. Read the committed implementation and test files named by those targets.
+4. Draft replacement `Goal`, `Acceptance Criteria`, `Design`, and `Tests` sections from those sources only.
+5. Add a `Reconstruction Note` and `Reconstruction Sources` list to each spec.
+6. Mark behavior not represented in code/tests as unknown or operator-decision-required.
+
+The contaminated MCP-005 body was not used as source evidence for the reconstructed features. MCP-005 remains canonical for Error Taxonomy.

--- a/docs/evals/runs/alpha-solver-spec-source-reconstruction-001/selected-next-lane.md
+++ b/docs/evals/runs/alpha-solver-spec-source-reconstruction-001/selected-next-lane.md
@@ -1,0 +1,5 @@
+# Selected Next Lane
+
+Selected next lane: operator review of reconstructed specs.
+
+Recommended next action: review the 22 reconstructed specs against product intent and either approve them as source-reconstructed contracts or open narrow follow-up specs for unknown/operator-decision items.

--- a/docs/evals/runs/alpha-solver-spec-source-reconstruction-001/unknowns-and-operator-decisions.md
+++ b/docs/evals/runs/alpha-solver-spec-source-reconstruction-001/unknowns-and-operator-decisions.md
@@ -1,0 +1,10 @@
+# Unknowns and Operator Decisions
+
+Each reconstructed spec contains a per-spec unknown note. Common unknowns:
+
+- Live provider/service integration is unknown unless represented by committed tests.
+- Deployment, CI wiring, remote storage, Grafana import, central telemetry, and external pricing authority are unknown unless represented by source targets.
+- Additional intents, prompt decks, scenarios, and production credentials require operator decision or new specs.
+- Reconstruction does not assert implementation quality, completeness, or readiness.
+
+Uncertain specs: all 22 have at least one bounded unknown because code/tests do not define every possible production behavior.


### PR DESCRIPTION
### Motivation

- Recover the real per-feature spec text for 22 `.specs` files that were contaminated by a copied `MCP-005` body by reconstructing each spec strictly from committed code and tests per `ALPHA-SOLVER-SPEC-SOURCE-RECONSTRUCTION-001`. 
- Replace the non-authoritative duplicated MCP-005 bodies under the wrong titles with source-derived `Goal`/`Acceptance Criteria`/`Design`/`Tests` material so each spec reflects the committed implementation and test expectations. 
- Preserve contamination history and bounded unknowns (marking operator decisions where code/tests do not define production behavior) and keep `MCP-005` untouched as the canonical error-taxonomy source. 

### Description

- Rewrote the bodies of the 22 contaminated spec files in `.specs/` (examples: `MCP-001`, `MCP-002`, `AS-145`, `NEW-009` … `RES-08`) to include `Goal`, `Acceptance Criteria`, `Design`, `Tests`, `Reconstruction Note`, `Reconstruction Sources`, and `Code Targets` derived only from the referenced implementation and test files. 
- Updated `.specs/INDEX.md` to mark those specs as `SPEC_RECONSTRUCTED_FROM_SOURCE` and added a per-spec source map and evidence packet under `docs/evals/runs/alpha-solver-spec-source-reconstruction-001/`. 
- Added the evidence packet files (`README.md`, `reconstruction-method.md`, `per-spec-source-map.md`, `unknowns-and-operator-decisions.md`, `changed-specs-index.md`, `selected-next-lane.md`, `evidence-boundary.md`, `non-actions.md`) documenting method, sources, unknowns, and non-actions. 
- No runtime/product code, tests, CI, provider calls, or tokens were changed; this is a docs/specs-only reconstruction from committed sources. 

### Testing

- Ran a focused test run for the impacted subsystems with `python -m pytest -q tests/test_mcp_loader.py tests/test_mcp_router_rule.py tests/test_mcp_auth.py tests/test_mcp_sandbox.py tests/test_mcp_retry.py tests/test_mcp_observability.py tests/test_clarify.py tests/test_prompt_decks.py tests/test_weight_tuning.py tests/test_budget_cli_guard.py tests/test_replay_cli_diff.py tests/test_evidence_store.py tests/test_determinism.py tests/test_metrics_dashboards.py tests/test_prompt_quality.py tests/test_decision_rules.py tests/test_gates.py tests/test_adapters_playwright.py tests/test_adapters_gsheets.py tests/test_scenarios.py tests/test_observability.py tests/test_budget_simulator.py tests/test_evidence_pack.py tests/test_adapters_playwright_hardened.py tests/test_adapters_gsheets_hardened.py`, and the focused subset passed. 
- Ran the full test suite with `python -m pytest -q` and observed unrelated/full-suite failures in provider-sensitive tests: three parameterized failures in `tests/test_api_endpoints.py::test_solve_openai_provider_errors_return_safe_responses` (model mismatch: expected `gpt-5` but observed `gpt-5-mini`), `tests/test_cost_tracking.py::test_cost_tracking` (missing `artifacts/costs.csv`), and `tests/test_security.py::test_a3_1_prompt_subset_passes_solve_input_validation` (response content mismatch); these failures are outside the reconstruction scope and reflect pre-existing/live-provider-sensitive expectations. 
- Performed spec smoke checks and static checks: ran the spec markdown smoke script (found 83 markdown files and flagged three files with missing titles: `EPIC_RAG_001.md`, `NEW-HEALTH-001.md`, `NEW-RATE-001.md`) and ran `python -m compileall -q registries service alpha_solver_cli.py` which succeeded, and `git diff --check` showed no whitespace errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2df5805fc083299dfafb425e6d0bf4)