### PR TITLE
docs(mvp): add readiness scorecard packet

### DIFF
--- a/docs/evals/runs/alpha-solver-mvp-readiness-scorecard-001/README.md
+++ b/docs/evals/runs/alpha-solver-mvp-readiness-scorecard-001/README.md
@@ -1,0 +1,36 @@
+# ALPHA-SOLVER-MVP-READINESS-SCORECARD-001
+
+Verdict: `MVP_SCORECARD_CAPTURED_OPERATOR_DECISION_REQUIRED`
+
+This packet is an internal MVP readiness evidence and non-claims scorecard. It is not an MVP readiness claim, public-readiness claim, production-readiness claim, provider-validation claim, value-evidence claim, or Alpha-superiority claim.
+
+## Purpose
+
+Create a brutally honest scorecard showing what is ready, what is blocked, what is only local evidence, and what must not be claimed before any MVP, public, production, demo, investor, or incubator narrative is used externally.
+
+## Source context inspected
+
+- `docs/CURRENT_STATE.md`
+- `docs/EVIDENCE_INDEX.md`
+- `docs/LANE_REGISTRY.md`
+- `docs/DEFERRAL_REGISTER.md`
+- `docs/ISSUE_REGISTER.md`
+- Recent packet chain including PR #512 project/billing attestation, PR #527 blocked smoke retry 002, DEF-002 security/privacy review and follow-on hardening packets, runtime-entrypoint map, public-exposure gate, and value-experiment protocol/pilot packets.
+
+## Required outputs
+
+| File | Purpose |
+| --- | --- |
+| `scorecard.md` | MVP readiness and discrimination-value signal scorecard. |
+| `blocker-register.md` | Top blockers and unblock evidence required. |
+| `claim-boundary.md` | Allowed internal statements and forbidden claims. |
+| `operator-decision.md` | Operator decision points and allowed verdict rationale. |
+| `selected-next-lane.md` | Selected next lane from this scorecard. |
+| `evidence-boundary.md` | Evidence inspected and evidence limits. |
+| `non-actions.md` | Actions explicitly not performed. |
+
+## Decision summary
+
+The current evidence supports an internal scorecard, not a readiness declaration. The selected next lane is `LOCAL-OPENAI-TOKEN-SMOKE-CAPTURE-RETRY-002-AUTHORIZATION-REFRESH`, because the live-token smoke path remains blocked on explicit operator authorization and no value/no-echo evidence exists.
+
+The discrimination-value addendum is captured as a future evidence question. Current signal is within noise because the value experiment is protocol-only/not executed and no provider smoke/no-echo output exists. Therefore this packet does not open productization lanes and does not claim the wedge is ready, superior, or proven.

--- a/docs/evals/runs/alpha-solver-mvp-readiness-scorecard-001/blocker-register.md
+++ b/docs/evals/runs/alpha-solver-mvp-readiness-scorecard-001/blocker-register.md
@@ -1,0 +1,17 @@
+# Blocker register
+
+## Top blockers
+
+| Rank | Blocker | Current evidence | Unblock evidence required | Blocks |
+| --- | --- | --- | --- | --- |
+| 1 | Provider smoke authorization missing | `LOCAL-OPENAI-TOKEN-SMOKE-CAPTURE-RETRY-002` blocked before any call because explicit operator authorization fields were missing. | Authorization-refresh packet with explicit model, project boundary, cost cap, token cap, max run count, and exact synthetic fixture; then a successful tiny synthetic smoke if authorized. | Provider smoke, no-echo gate, value experiment execution. |
+| 2 | No substantive/no-echo output | No provider response and no generated answer evidence exists in the current chain. | Controlled output artifact showing Alpha produces substantive non-echo content under approved constraints. | Value evidence, demo narrative, operator preference scoring. |
+| 3 | Value experiment not executed | `ALPHA-SOLVER-VALUE-EXPERIMENT-PROTOCOL-001` is protocol-only and not a result. | Frozen task bank, paired Alpha/plain-baseline generations, scoring rubric, blinded or disciplined review, cost/latency capture. | Core product value claim and discrimination-value signal. |
+| 4 | DEF-002 security/privacy not claimably closed | Security/privacy review captured open gaps and follow-on decisions, but public/security completion is not claimable from the current central state. | Gap closure or explicit operator risk acceptance with exposure-specific controls documented. | Public exposure, production readiness, external demo with live surface. |
+| 5 | Public exposure gate blocked | Runtime/public maps identify product-shaped surfaces and unsafe-to-expose conditions. | Auth/CORS/secrets/provider disclosure/tenancy/operator controls resolved for the exact surface to expose. | Public MVP, dashboard readiness, `/v1/solve` readiness. |
+| 6 | Runtime entrypoints not canonicalized for exposure | Entrypoint map shows overlapping service, dashboard, provider, portable, and legacy/reference surfaces. | Operator-selected canonical path and docs/code alignment before any external surface. | Public or production narrative clarity. |
+| 7 | Test/CI health not globally clean | Local Self Operator evidence exists; full-suite health has known ambient failures in prior packet evidence. | Controlled focused/full test run with failures resolved or explicitly registered. | Release readiness and broad confidence claims. |
+
+## Blocker interpretation
+
+The blockers do not mean the project has no useful work. They mean the current evidence supports internal governance and local/offline discipline, not MVP readiness. The highest-leverage next step remains removing the narrow smoke authorization blocker before attempting value evidence.

--- a/docs/evals/runs/alpha-solver-mvp-readiness-scorecard-001/claim-boundary.md
+++ b/docs/evals/runs/alpha-solver-mvp-readiness-scorecard-001/claim-boundary.md
@@ -1,0 +1,38 @@
+# Claim boundary
+
+## Allowed internal statements
+
+- Alpha Solver has a committed evidence chain for local/offline Self Operator execution and governance packets.
+- PR #512 records a redacted operator project/billing/cost/data-sharing boundary attestation for one tiny synthetic OpenAI smoke retry.
+- PR #527 records that the selected smoke retry was blocked before provider execution because explicit operator authorization fields were missing.
+- Provider calls, tokens, and provider cost for PR #527 were all `0`.
+- DEF-002 security/privacy review work has identified and routed gaps, but the current scorecard does not claim closure.
+- Runtime entrypoints and public-exposure risks have been mapped at documentation level.
+- The value experiment protocol exists, but has not been executed and contains no value evidence.
+- The discrimination-value wedge is worth preserving as a future candidate only after prerequisite evidence exists; current signal is within noise.
+
+## Forbidden claims
+
+Do not claim:
+
+- MVP readiness.
+- Public readiness.
+- Production readiness.
+- Alpha superiority.
+- OpenAI/provider validation.
+- API smoke success.
+- Token usage evidence.
+- Benchmark validation.
+- Core product value proof.
+- No-echo substantive generation success.
+- Operator preference versus a plain baseline.
+- Security/privacy completion or DEF-002 closure.
+- `/v1/solve` readiness.
+- Dashboard readiness.
+- Broad-user, customer-pilot, autonomous, investor-traction, or incubator-readiness status.
+
+## Narrative-safe wording
+
+Use: "internal readiness scorecard captured; not ready; operator decision required."
+
+Do not use: "MVP ready," "production ready," "validated by OpenAI," "superior to baseline," or "ready for users."

--- a/docs/evals/runs/alpha-solver-mvp-readiness-scorecard-001/evidence-boundary.md
+++ b/docs/evals/runs/alpha-solver-mvp-readiness-scorecard-001/evidence-boundary.md
@@ -1,0 +1,32 @@
+# Evidence boundary
+
+## Evidence inspected
+
+This packet used committed repository evidence only, including:
+
+- Current-state and lane-control docs: `docs/CURRENT_STATE.md`, `docs/EVIDENCE_INDEX.md`, `docs/LANE_REGISTRY.md`, `docs/DEFERRAL_REGISTER.md`, `docs/ISSUE_REGISTER.md`.
+- Provider/billing/smoke chain: `docs/evals/runs/openai-project-billing-boundary-attestation-retry-001/` and `docs/evals/runs/local-openai-token-smoke-capture-retry-002/`.
+- Value protocol context: `docs/evals/runs/alpha-solver-value-experiment-protocol-001/` and related value pilot evidence where present.
+- DEF-002/security context: DEF-002 review and follow-on hardening/gap packets under `docs/evals/runs/alpha-solver-def-002-*`.
+- Runtime/public context: `docs/evals/runs/alpha-solver-runtime-entrypoint-map-001/` and `docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/`.
+
+## What this packet proves
+
+- The MVP scorecard has been captured as an internal decision aid.
+- Current evidence does not support MVP/public/production readiness claims.
+- The top blockers and non-claims have been recorded.
+- The discrimination-value signal is currently within noise because no paired outputs or scored value experiment results exist.
+
+## What this packet does not prove
+
+- It does not prove MVP readiness.
+- It does not prove public readiness.
+- It does not prove production readiness.
+- It does not prove provider validation or smoke success.
+- It does not prove security/privacy closure.
+- It does not prove value, benchmark performance, no-echo success, operator preference, or Alpha superiority.
+- It does not prove test/CI health.
+
+## Evidence method limit
+
+This was a docs-only review. No provider, runtime, dashboard, or test execution is converted into readiness evidence by this packet.

--- a/docs/evals/runs/alpha-solver-mvp-readiness-scorecard-001/non-actions.md
+++ b/docs/evals/runs/alpha-solver-mvp-readiness-scorecard-001/non-actions.md
@@ -1,0 +1,21 @@
+# Non-actions
+
+This packet did not:
+
+- Claim MVP readiness.
+- Claim public readiness.
+- Claim production readiness.
+- Claim Alpha superiority.
+- Call OpenAI or any other provider.
+- Use tokens.
+- Incur provider cost.
+- Access credentials, billing pages, private project settings, environment secrets, or private files.
+- Edit runtime code.
+- Edit provider, model, dashboard, auth, tenancy, SAFE-OUT, budget, determinism, observability, replay, or SolverEnvelope code.
+- Run broad evals.
+- Execute the value experiment.
+- Expose `/v1/solve`.
+- Expose dashboards.
+- Update Google Sheets or backlog workbooks.
+- Resolve DEF-002 or DEF-003.
+- Open a productization lane.

--- a/docs/evals/runs/alpha-solver-mvp-readiness-scorecard-001/operator-decision.md
+++ b/docs/evals/runs/alpha-solver-mvp-readiness-scorecard-001/operator-decision.md
@@ -1,0 +1,30 @@
+# Operator decision
+
+## Verdict
+
+`MVP_SCORECARD_CAPTURED_OPERATOR_DECISION_REQUIRED`
+
+## Why this verdict
+
+The scorecard can be captured from committed repository evidence, but the result is not a go decision. The operator must decide whether to:
+
+1. complete the authorization-refresh lane for the blocked tiny smoke;
+2. continue DEF-002 closure / risk-acceptance work before any exposure;
+3. refine the value task bank and scoring contract without claiming value; or
+4. reconsider the wedge if future evidence remains within noise.
+
+## Allowed verdicts considered
+
+| Verdict | Selected? | Rationale |
+| --- | --- | --- |
+| `MVP_SCORECARD_CAPTURED_NOT_READY` | Not selected | Accurate on readiness, but insufficient because the packet also needs an operator next-lane decision. |
+| `MVP_SCORECARD_CAPTURED_OPERATOR_DECISION_REQUIRED` | **Selected** | Captures the scorecard and highlights that the next executable path depends on operator authorization and sequencing. |
+| `STOP_INCONCLUSIVE` | Not selected | Evidence is sufficient to score the state conservatively; it is not sufficient to claim readiness. |
+
+## Decision constraints
+
+- No provider calls are authorized by this packet.
+- No runtime code changes are authorized by this packet.
+- No Google Sheets update is authorized by this packet.
+- Productization lanes must not open while the value read is within noise.
+- If future output evidence still cannot discriminate Alpha from a plain baseline, select task-bank refinement, contract refinement, or wedge reconsideration rather than public/product lanes.

--- a/docs/evals/runs/alpha-solver-mvp-readiness-scorecard-001/scorecard.md
+++ b/docs/evals/runs/alpha-solver-mvp-readiness-scorecard-001/scorecard.md
@@ -1,0 +1,43 @@
+# MVP readiness scorecard
+
+Verdict: `MVP_SCORECARD_CAPTURED_OPERATOR_DECISION_REQUIRED`
+
+Scale used here:
+
+- **Captured / local-only**: committed local or docs evidence exists, but does not prove runtime/provider/public readiness.
+- **Blocked**: explicit prerequisite missing.
+- **Protocol-only**: a future test plan exists, but no result exists.
+- **Not claimable**: evidence does not support an external claim.
+
+## Required scorecard categories
+
+| Category | Current read | Evidence basis | Blocked by | Non-claim |
+| --- | --- | --- | --- | --- |
+| 1. Core product value evidence | **Blocked / protocol-only** | Value experiment protocol exists and asks a useful A/B question, but is not executed and contains no results. | Successful provider/smoke boundary, no-echo substantive generation evidence, frozen task bank, scored paired outputs. | No value proof, superiority, benchmark validation, or MVP readiness. |
+| 2. Provider smoke and billing boundary | **Billing boundary attested; smoke blocked** | PR #512 records redacted project/billing/cost/data-sharing attestation for one tiny synthetic smoke retry. PR #527 consumed retry 002 as blocked with provider calls `0`, tokens `0`, cost `$0.00`. | Explicit model, project boundary, cost cap, token cap, max run count, and exact synthetic fixture authorization. | No OpenAI/provider validation and no API smoke success. |
+| 3. No-echo substantive generation gate | **Blocked / absent** | PR #527 produced no smoke output and no provider response. Value protocol requires substantive Alpha-generation/no-echo evidence before execution. | A successful tiny smoke and later controlled value task outputs showing non-echo behavior. | No substantive-generation or no-echo claim. |
+| 4. Security and privacy closure | **Review captured; closure not claimable** | DEF-002 review captured open gaps; follow-on hardening packets exist, but central current-state/deferral register still does not support public/security completion claims. | Operator-recognized closure or accepted residual-risk packet after all required gap dispositions, especially exposure-relevant controls. | No DEF-002 resolved, security/privacy completion, or public-safe claim. |
+| 5. Runtime entrypoint clarity | **Mapped, not consolidated** | Runtime entrypoint map identifies `/v1/solve`, dashboard, provider, portable, modular/reference, auth, tenancy, and evidence surfaces. | Operator decision on canonical runtime/public surface and security model before exposure. | No `/v1/solve`, dashboard, or consolidated runtime readiness. |
+| 6. Public exposure gate | **Blocked** | Public-exposure and runtime-map packets classify product-shaped surfaces as unsafe-to-expose until security, CORS, secrets, provider disclosure, tenancy, and operations are resolved. | DEF-002 closure/acceptance, provider/data-sharing boundary, auth/CORS/secret posture, operator go/no-go. | No public MVP readiness or production readiness. |
+| 7. Test and CI health | **Local evidence exists; full health not proven** | Self Operator local evidence chain passed focused local/offline checks; dependency packet recorded full-suite failures in the ambient environment; current lane is docs-only. | Clean focused/full suite under controlled non-provider environment, or explicit issue register for failures. | No CI green, release readiness, or complete test health claim. |
+| 8. Documentation and backlog hygiene | **Improved but not finished** | Current-state, evidence index, lane registry, deferral register, issue register, and packets now constrain the evidence narrative. | Ongoing drift control, spec contamination reconciliation, and backlog updates outside repo as operator work. | No claim that all specs/backlog entries are clean or synchronized. |
+| 9. Demo readiness | **Internal dry-run only; external demo blocked** | Operator demo/run packets and local Self Operator evidence support local narration of boundaries. | Smoke/no-echo evidence, claim-safe script, security/public-exposure gates if demo touches live/public surfaces. | No external demo readiness, live demo safety, or customer pilot readiness. |
+| 10. Investor/incubator narrative readiness | **Narrative must be boundary-heavy** | Evidence supports saying the project has disciplined governance, local execution evidence, and explicit blockers. | Actual value evidence, provider smoke, security/privacy disposition, and claim-approved narrative. | No investor-grade MVP traction, superiority, production, or readiness claim. |
+
+## Opportunity signal scorecard addendum: discrimination-value signal
+
+This addendum asks whether the latest evidence suggests the wedge is worth further investment. It does **not** ask whether Alpha Solver is ready, superior, or productized.
+
+| Signal dimension | Current read | Evidence / missing evidence | Allowed conclusion |
+| --- | --- | --- | --- |
+| Confidence-envelope usefulness | **Plausible but unmeasured** | Protocol plans calibration and confidence-bound comparisons, but no scored outputs exist. | preserve as Phase G candidate |
+| False-premise catch rate | **Unmeasured** | Protocol includes hallucination-bait / false-premise tasks; no run exists. | preserve as Phase G candidate |
+| Hidden-constraint catch rate | **Unmeasured** | Protocol can include underspecified/constraint-heavy tasks, but no frozen task bank or results exist. | preserve as Phase G candidate |
+| Needs-human escalation usefulness | **Plausible locally; unmeasured in value setting** | Self Operator gates show local approval/stop behavior, but not user-visible escalation quality. | preserve as Phase G candidate |
+| Unsupported-claim avoidance | **Governance evidence strong; answer-quality evidence absent** | Packets consistently enforce forbidden claims; no generated-answer comparison exists. | add as immediate follow-up only as rubric/contract refinement, not productization |
+| Operator preference versus plain baseline | **Absent** | No paired plain-baseline vs Alpha outputs and no blinded operator preference scores. | defer until more evidence |
+| Signal strong enough to justify a future focused lane | **Not yet for productization; yes for protocol/rubric refinement** | Current value read is within noise because no outputs exist. | select task-bank refinement, contract refinement, or wedge-reconsideration; do not open productization lanes |
+
+## Decision rule application
+
+The value read is within noise. Therefore this packet does **not** open productization lanes. The only value-related follow-up that fits the evidence is refinement work: task-bank refinement, contract/rubric refinement, or wedge reconsideration after the provider smoke/no-echo prerequisites are satisfied.

--- a/docs/evals/runs/alpha-solver-mvp-readiness-scorecard-001/selected-next-lane.md
+++ b/docs/evals/runs/alpha-solver-mvp-readiness-scorecard-001/selected-next-lane.md
@@ -1,0 +1,18 @@
+# Selected next lane
+
+Selected next lane: `LOCAL-OPENAI-TOKEN-SMOKE-CAPTURE-RETRY-002-AUTHORIZATION-REFRESH`
+
+## Rationale
+
+The current controlling blocker is explicit operator authorization for the already-selected tiny synthetic OpenAI smoke retry. Without this authorization, there is no provider response, no token/cost record, no no-echo artifact, and no basis to execute the value experiment.
+
+## Not selected
+
+- `ALPHA-SOLVER-VALUE-EXPERIMENT-PROTOCOL-001` execution — not selected because smoke/no-echo prerequisites are missing.
+- Productization lane — not selected because the value read is within noise.
+- Public exposure lane — not selected because DEF-002/public-exposure gates are not claimably closed.
+- Runtime consolidation lane — not selected because entrypoint overlap is mapped but not safe to refactor or expose without operator decisions.
+
+## Future candidate after prerequisites
+
+After a successful tiny smoke and no-echo substantive output evidence, the operator may choose a narrow task-bank/contract-refinement lane for the discrimination-value scorecard before any broad value experiment or productization lane.


### PR DESCRIPTION
### Motivation

- Capture a conservative, evidence-bound internal MVP readiness scorecard that distinguishes what is ready, blocked, local-only, and explicitly not claimable. 
- Record the discrimination-value opportunity addendum so the team can decide whether to invest further in the wedge without making any readiness or superiority claims. 
- Surface the single actionable next step (operator authorization refresh for the blocked tiny smoke) and keep productization lanes closed while the value signal is within noise.

### Description

- Add a new packet at `docs/evals/runs/alpha-solver-mvp-readiness-scorecard-001/` containing `README.md`, `scorecard.md`, `blocker-register.md`, `claim-boundary.md`, `operator-decision.md`, `selected-next-lane.md`, `evidence-boundary.md`, and `non-actions.md`. 
- The packet records verdict `MVP_SCORECARD_CAPTURED_OPERATOR_DECISION_REQUIRED`, documents top blockers (leading with `BLOCKED_OPERATOR_AUTHORIZATION_MISSING`), and selects `LOCAL-OPENAI-TOKEN-SMOKE-CAPTURE-RETRY-002-AUTHORIZATION-REFRESH` as the next lane. 
- Includes the required discrimination-value scorecard addendum (confidence envelope, false-premise catch rate, hidden-constraint catch rate, escalation usefulness, unsupported-claim avoidance, operator preference vs baseline, and whether to open a future lane) and applies the decision rule to avoid opening productization lanes while signal is within noise. 
- This is a docs-only change that does not modify runtime code, tests, CI, provider calls, or any secret/billing data.

### Testing

- Ran a packet file and trailing-whitespace check (`python` one-liner) and confirmed all required files exist and have no trailing whitespace (passed). 
- Ran the local packet validation scripts `python scripts/check_local_llm_packet_consistency.py`, `python scripts/check_local_llm_doc_paths.py`, and `python scripts/check_local_llm_evidence_boundaries.py` against the new packet (all passed). 
- Ran `git diff --check` to verify no whitespace errors (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e4995b82c8329a7099115bfb2a1e8)