### PR TITLE
Harden provider cost caps and stop controls

### DIFF
--- a/.specs/ALPHA-SOLVER-DEF-002-PROVIDER-COST-CAPS-STOP-CONTROL-001.md
+++ b/.specs/ALPHA-SOLVER-DEF-002-PROVIDER-COST-CAPS-STOP-CONTROL-001.md
@@ -1,0 +1,14 @@
+# ALPHA-SOLVER-DEF-002-PROVIDER-COST-CAPS-STOP-CONTROL-001
+
+Provider-backed operator-enabled execution paths must fail closed unless explicit operator caps bound cost, input tokens, output tokens, and request count before provider execution.
+
+## Requirements
+
+- Hosted provider execution must remain opt-in and must not run when required caps are absent, malformed, or non-positive.
+- Provider requests must not execute when an operator emergency stop flag is active.
+- Provider result telemetry must be checked against configured cost and token caps before success accounting is emitted.
+- Tests for this lane must use fake provider adapters only and must not call hosted providers or consume credentials.
+
+## Evidence
+
+See `docs/evals/runs/alpha-solver-def-002-provider-cost-caps-stop-control-001/`.

--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -14,6 +14,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `ALPHA-LIVE-EXPERT-STEP1-PARSE-001.md` | ALPHA-LIVE-EXPERT-STEP1-PARSE-001 · Recover Actionable Execution Prompts When Step 1 Metadata Is Missing | ✅ `SPEC_OK` |
 | `ALPHA-PRIMARY-ANSWER-EMPTY-001.md` | ALPHA-PRIMARY-ANSWER-EMPTY-001 · Ensure Answer-with-Assumptions Returns a Primary Deliverable | ✅ `SPEC_OK` |
 | `ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001.md` | ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001 - Side-by-Side Evidence Packet Contract | ✅ `SPEC_OK` |
+| `ALPHA-SOLVER-DEF-002-PROVIDER-COST-CAPS-STOP-CONTROL-001.md` | ALPHA-SOLVER-DEF-002-PROVIDER-COST-CAPS-STOP-CONTROL-001 | ✅ `SPEC_OK` |
 | `AS-145.md` | CODE SPEC — AS-145 · Tool Adapters: Playwright + GSheets (MVP hardening) (RES_05) | ✅ `SPEC_RECONSTRUCTED_FROM_SOURCE` |
 | `AS-148.md` | CODE SPEC — AS-148 · Policy & PII Gateway (DR_TRACK_A) | ✅ `SPEC_OK` |
 | `AUTH-SESSION-001.md` | AUTH-SESSION-001 · Dashboard Login + Session | ✅ `SPEC_OK` |

--- a/docs/evals/runs/alpha-solver-def-002-provider-cost-caps-stop-control-001/README.md
+++ b/docs/evals/runs/alpha-solver-def-002-provider-cost-caps-stop-control-001/README.md
@@ -1,5 +1,7 @@
 # ALPHA-SOLVER-DEF-002 Provider Cost Caps Stop Control 001
 
-Verdict: `DEF_002_PROVIDER_COST_CAPS_STOP_CONTROL_HARDENED`
+Verdict: `DEF_002_PROVIDER_COST_CAPS_PARTIAL`
 
-This packet records implementation evidence for provider cost caps, tenant/request quota boundaries, and emergency stop controls. The lane used fake provider adapters only and did not call hosted providers, use credentials, run evals, or expose the API/dashboard.
+This packet records implementation evidence for provider cost caps, tenant/request quota boundaries, and emergency stop controls. The lane used fake provider adapters only and did not call hosted providers, use credentials, run evals, deploy, or expose the API/dashboard.
+
+This packet does not claim exact billing accuracy, provider readiness, production readiness, public readiness, security/privacy completion, benchmark validation, Alpha superiority, or DEF-002 closure.

--- a/docs/evals/runs/alpha-solver-def-002-provider-cost-caps-stop-control-001/README.md
+++ b/docs/evals/runs/alpha-solver-def-002-provider-cost-caps-stop-control-001/README.md
@@ -1,0 +1,5 @@
+# ALPHA-SOLVER-DEF-002 Provider Cost Caps Stop Control 001
+
+Verdict: `DEF_002_PROVIDER_COST_CAPS_STOP_CONTROL_HARDENED`
+
+This packet records implementation evidence for provider cost caps, tenant/request quota boundaries, and emergency stop controls. The lane used fake provider adapters only and did not call hosted providers, use credentials, run evals, or expose the API/dashboard.

--- a/docs/evals/runs/alpha-solver-def-002-provider-cost-caps-stop-control-001/evidence-boundary.md
+++ b/docs/evals/runs/alpha-solver-def-002-provider-cost-caps-stop-control-001/evidence-boundary.md
@@ -1,0 +1,3 @@
+# Evidence Boundary
+
+Evidence is limited to static code inspection, fake-provider tests, and documentation checks in this repository. No hosted provider calls, credentials, eval runs, API exposure, or dashboard exposure were performed.

--- a/docs/evals/runs/alpha-solver-def-002-provider-cost-caps-stop-control-001/implementation-summary.md
+++ b/docs/evals/runs/alpha-solver-def-002-provider-cost-caps-stop-control-001/implementation-summary.md
@@ -1,0 +1,6 @@
+# Implementation Summary
+
+- `/v1/solve` OpenAI-provider execution now requires explicit operator caps before a provider client can execute.
+- Required caps are `ALPHA_PROVIDER_MAX_COST_USD`, `ALPHA_PROVIDER_MAX_INPUT_TOKENS`, `ALPHA_PROVIDER_MAX_OUTPUT_TOKENS`, and `ALPHA_PROVIDER_MAX_REQUESTS`.
+- `ALPHA_PROVIDER_EMERGENCY_STOP=1` blocks provider execution before the fake or real provider client is invoked.
+- Postflight checks block missing/unknown cost estimates and input/output/cost values that exceed the configured caps.

--- a/docs/evals/runs/alpha-solver-def-002-provider-cost-caps-stop-control-001/implementation-summary.md
+++ b/docs/evals/runs/alpha-solver-def-002-provider-cost-caps-stop-control-001/implementation-summary.md
@@ -1,6 +1,8 @@
 # Implementation Summary
 
-- `/v1/solve` OpenAI-provider execution now requires explicit operator caps before a provider client can execute.
+- `/v1/solve` OpenAI-provider execution requires explicit operator caps before a provider client can execute.
 - Required caps are `ALPHA_PROVIDER_MAX_COST_USD`, `ALPHA_PROVIDER_MAX_INPUT_TOKENS`, `ALPHA_PROVIDER_MAX_OUTPUT_TOKENS`, and `ALPHA_PROVIDER_MAX_REQUESTS`.
+- Cost caps now fail closed before provider execution when blank, malformed, non-finite (`nan`, `inf`, `-inf`), zero, or negative.
+- Token and request-count caps fail closed before provider execution when blank, malformed, zero, or negative.
 - `ALPHA_PROVIDER_EMERGENCY_STOP=1` blocks provider execution before the fake or real provider client is invoked.
-- Postflight checks block missing/unknown cost estimates and input/output/cost values that exceed the configured caps.
+- Postflight checks fail closed before completed telemetry/accounting when input token usage, output token usage, or cost telemetry is missing or over cap.

--- a/docs/evals/runs/alpha-solver-def-002-provider-cost-caps-stop-control-001/non-actions.md
+++ b/docs/evals/runs/alpha-solver-def-002-provider-cost-caps-stop-control-001/non-actions.md
@@ -1,7 +1,9 @@
 # Non-Actions
 
-- Did not call OpenAI or any other provider.
+- Did not call OpenAI or any other hosted provider.
 - Did not access credentials or tokens.
 - Did not run evals.
-- Did not expose API or dashboard.
-- Did not claim exact billing accuracy, provider readiness, production readiness, or public readiness.
+- Did not deploy.
+- Did not expose API, dashboard, or `/v1/solve`.
+- Did not claim exact billing accuracy.
+- Did not claim provider readiness, production readiness, public readiness, DEF-002 closure, security/privacy completion, benchmark validation, or Alpha superiority.

--- a/docs/evals/runs/alpha-solver-def-002-provider-cost-caps-stop-control-001/non-actions.md
+++ b/docs/evals/runs/alpha-solver-def-002-provider-cost-caps-stop-control-001/non-actions.md
@@ -1,0 +1,7 @@
+# Non-Actions
+
+- Did not call OpenAI or any other provider.
+- Did not access credentials or tokens.
+- Did not run evals.
+- Did not expose API or dashboard.
+- Did not claim exact billing accuracy, provider readiness, production readiness, or public readiness.

--- a/docs/evals/runs/alpha-solver-def-002-provider-cost-caps-stop-control-001/provider-cost-boundary.md
+++ b/docs/evals/runs/alpha-solver-def-002-provider-cost-caps-stop-control-001/provider-cost-boundary.md
@@ -1,0 +1,5 @@
+# Provider Cost Boundary
+
+Provider execution is fail-closed when caps are absent, malformed, non-positive, when requested output tokens exceed the operator output cap, when provider result token usage exceeds caps, or when provider result cost is missing or exceeds the cost cap.
+
+Caveat: cost checks are based on provider/price-hint telemetry returned by the provider adapter and are not exact billing accuracy claims.

--- a/docs/evals/runs/alpha-solver-def-002-provider-cost-caps-stop-control-001/provider-cost-boundary.md
+++ b/docs/evals/runs/alpha-solver-def-002-provider-cost-caps-stop-control-001/provider-cost-boundary.md
@@ -1,5 +1,5 @@
 # Provider Cost Boundary
 
-Provider execution is fail-closed when caps are absent, malformed, non-positive, when requested output tokens exceed the operator output cap, when provider result token usage exceeds caps, or when provider result cost is missing or exceeds the cost cap.
+Provider execution is fail-closed when caps are absent, blank, malformed, non-finite, non-positive, when requested output tokens exceed the operator output cap, when provider result token usage is missing or exceeds caps, or when provider result cost is missing or exceeds the cost cap.
 
-Caveat: cost checks are based on provider/price-hint telemetry returned by the provider adapter and are not exact billing accuracy claims.
+Cost checks are based on provider/price-hint telemetry returned by the provider adapter and are not exact billing accuracy claims.

--- a/docs/evals/runs/alpha-solver-def-002-provider-cost-caps-stop-control-001/quota-test-evidence.md
+++ b/docs/evals/runs/alpha-solver-def-002-provider-cost-caps-stop-control-001/quota-test-evidence.md
@@ -1,7 +1,5 @@
 # Quota Test Evidence
 
-Focused tests cover missing cap fail-closed behavior and emergency stop fail-closed behavior with fake provider adapters. Existing API endpoint provider tests continue through explicit test caps configured by the test fixture.
+Focused fake-adapter tests cover missing cap fail-closed behavior, malformed/non-finite/non-positive cost cap fail-closed behavior (`0`, `nan`, `inf`, `-inf`, negative, blank, malformed), missing input/output token telemetry fail-closed behavior before completed telemetry/accounting, emergency stop fail-closed behavior, and valid finite caps with complete token/cost telemetry.
 
-Commands run:
-
-- `python -m pytest tests/test_api_endpoints.py -q`
+Commands run for this update are recorded in the PR and final response.

--- a/docs/evals/runs/alpha-solver-def-002-provider-cost-caps-stop-control-001/quota-test-evidence.md
+++ b/docs/evals/runs/alpha-solver-def-002-provider-cost-caps-stop-control-001/quota-test-evidence.md
@@ -1,0 +1,7 @@
+# Quota Test Evidence
+
+Focused tests cover missing cap fail-closed behavior and emergency stop fail-closed behavior with fake provider adapters. Existing API endpoint provider tests continue through explicit test caps configured by the test fixture.
+
+Commands run:
+
+- `python -m pytest tests/test_api_endpoints.py -q`

--- a/docs/evals/runs/alpha-solver-def-002-provider-cost-caps-stop-control-001/residual-risks.md
+++ b/docs/evals/runs/alpha-solver-def-002-provider-cost-caps-stop-control-001/residual-risks.md
@@ -2,4 +2,4 @@
 
 - Cost enforcement is not a billing-system reconciliation and depends on adapter-reported or price-hint cost data.
 - The implementation does not persist tenant spend across process restarts.
-- This packet does not assert public readiness, production readiness, provider readiness, or exact billing accuracy.
+- This packet does not assert DEF-002 closure, public readiness, production readiness, provider readiness, security/privacy completion, benchmark validation, Alpha superiority, or exact billing accuracy.

--- a/docs/evals/runs/alpha-solver-def-002-provider-cost-caps-stop-control-001/residual-risks.md
+++ b/docs/evals/runs/alpha-solver-def-002-provider-cost-caps-stop-control-001/residual-risks.md
@@ -1,0 +1,5 @@
+# Residual Risks
+
+- Cost enforcement is not a billing-system reconciliation and depends on adapter-reported or price-hint cost data.
+- The implementation does not persist tenant spend across process restarts.
+- This packet does not assert public readiness, production readiness, provider readiness, or exact billing accuracy.

--- a/docs/evals/runs/alpha-solver-def-002-provider-cost-caps-stop-control-001/selected-next-lane.md
+++ b/docs/evals/runs/alpha-solver-def-002-provider-cost-caps-stop-control-001/selected-next-lane.md
@@ -1,0 +1,3 @@
+# Selected Next Lane
+
+Recommended next lane: persistent tenant/project spend ledger and operator-reviewed cap configuration UX, still using fake providers until billing/account-boundary evidence is explicitly approved.

--- a/docs/evals/runs/alpha-solver-def-002-provider-cost-caps-stop-control-001/stop-control-evidence.md
+++ b/docs/evals/runs/alpha-solver-def-002-provider-cost-caps-stop-control-001/stop-control-evidence.md
@@ -1,0 +1,3 @@
+# Stop Control Evidence
+
+`ALPHA_PROVIDER_EMERGENCY_STOP` is an operator stop control. When enabled, `/v1/solve` returns a provider SAFE-OUT before provider client execution. The focused test uses `FakeProviderClient([])` and asserts no request was recorded.

--- a/service/app.py
+++ b/service/app.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import csv
 import json
 import logging
+import math
 import os
 import time
 import re
@@ -256,7 +257,8 @@ def _required_provider_caps() -> ProviderCostCaps:
             safe_message="Provider execution disabled: provider cost caps must be numeric.",
         ) from exc
     if (
-        caps.max_cost_usd < 0
+        not math.isfinite(caps.max_cost_usd)
+        or caps.max_cost_usd <= 0
         or caps.max_input_tokens <= 0
         or caps.max_output_tokens <= 0
         or caps.max_requests <= 0
@@ -926,12 +928,51 @@ def _execute_provider_call(
     _enforce_provider_preflight_caps(provider_request, caps)
     _emit_provider_telemetry(request, _provider_request_started_event(provider_request))
     result = provider_client.execute(provider_request)
-    if result.usage.input_tokens is not None and result.usage.input_tokens > caps.max_input_tokens:
-        raise ProviderError(provider=result.provider, category="invalid_request", retryable=False, safe_message="Provider result exceeded input token cap.", request_id=provider_request.request_id, retry_count=result.retry_count)
-    if result.usage.output_tokens is not None and result.usage.output_tokens > caps.max_output_tokens:
-        raise ProviderError(provider=result.provider, category="invalid_request", retryable=False, safe_message="Provider result exceeded output token cap.", request_id=provider_request.request_id, retry_count=result.retry_count)
+    if result.usage.input_tokens is None:
+        raise ProviderError(
+            provider=result.provider,
+            category="invalid_request",
+            retryable=False,
+            safe_message="Provider result missing input token usage.",
+            request_id=provider_request.request_id,
+            retry_count=result.retry_count,
+        )
+    if result.usage.input_tokens > caps.max_input_tokens:
+        raise ProviderError(
+            provider=result.provider,
+            category="invalid_request",
+            retryable=False,
+            safe_message="Provider result exceeded input token cap.",
+            request_id=provider_request.request_id,
+            retry_count=result.retry_count,
+        )
+    if result.usage.output_tokens is None:
+        raise ProviderError(
+            provider=result.provider,
+            category="invalid_request",
+            retryable=False,
+            safe_message="Provider result missing output token usage.",
+            request_id=provider_request.request_id,
+            retry_count=result.retry_count,
+        )
+    if result.usage.output_tokens > caps.max_output_tokens:
+        raise ProviderError(
+            provider=result.provider,
+            category="invalid_request",
+            retryable=False,
+            safe_message="Provider result exceeded output token cap.",
+            request_id=provider_request.request_id,
+            retry_count=result.retry_count,
+        )
     if result.cost.estimated_usd is None or result.cost.estimated_usd > caps.max_cost_usd:
-        raise ProviderError(provider=result.provider, category="invalid_request", retryable=False, safe_message="Provider result missing or exceeded cost cap.", request_id=provider_request.request_id, retry_count=result.retry_count)
+        raise ProviderError(
+            provider=result.provider,
+            category="invalid_request",
+            retryable=False,
+            safe_message="Provider result missing or exceeded cost cap.",
+            request_id=provider_request.request_id,
+            retry_count=result.retry_count,
+        )
     _emit_provider_telemetry(
         request, _provider_request_completed_event(provider_request, result)
     )

--- a/service/app.py
+++ b/service/app.py
@@ -10,7 +10,7 @@ import time
 import re
 import uuid
 from collections import defaultdict, deque
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, Deque, DefaultDict, Dict, Optional
 from enum import Enum
@@ -206,6 +206,87 @@ else:
 def _is_openai_provider_enabled() -> bool:
     """Return True only for explicit OpenAI provider opt-in."""
     return os.getenv("MODEL_PROVIDER", "local").strip().lower() == "openai"
+
+
+@dataclass(frozen=True)
+class ProviderCostCaps:
+    """Explicit fail-closed provider execution boundaries."""
+
+    max_cost_usd: float
+    max_input_tokens: int
+    max_output_tokens: int
+    max_requests: int
+
+
+def _provider_stop_enabled() -> bool:
+    return os.getenv("ALPHA_PROVIDER_EMERGENCY_STOP", "0").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _required_provider_caps() -> ProviderCostCaps:
+    names = (
+        "ALPHA_PROVIDER_MAX_COST_USD",
+        "ALPHA_PROVIDER_MAX_INPUT_TOKENS",
+        "ALPHA_PROVIDER_MAX_OUTPUT_TOKENS",
+        "ALPHA_PROVIDER_MAX_REQUESTS",
+    )
+    if any(not os.getenv(name, "").strip() for name in names):
+        raise ProviderError(
+            provider="openai",
+            category="invalid_request",
+            retryable=False,
+            safe_message="Provider execution disabled: explicit provider cost caps are required.",
+        )
+    try:
+        caps = ProviderCostCaps(
+            max_cost_usd=float(os.environ["ALPHA_PROVIDER_MAX_COST_USD"]),
+            max_input_tokens=int(os.environ["ALPHA_PROVIDER_MAX_INPUT_TOKENS"]),
+            max_output_tokens=int(os.environ["ALPHA_PROVIDER_MAX_OUTPUT_TOKENS"]),
+            max_requests=int(os.environ["ALPHA_PROVIDER_MAX_REQUESTS"]),
+        )
+    except ValueError as exc:
+        raise ProviderError(
+            provider="openai",
+            category="invalid_request",
+            retryable=False,
+            safe_message="Provider execution disabled: provider cost caps must be numeric.",
+        ) from exc
+    if (
+        caps.max_cost_usd < 0
+        or caps.max_input_tokens <= 0
+        or caps.max_output_tokens <= 0
+        or caps.max_requests <= 0
+    ):
+        raise ProviderError(
+            provider="openai",
+            category="invalid_request",
+            retryable=False,
+            safe_message="Provider execution disabled: provider cost caps must be positive.",
+        )
+    return caps
+
+
+def _enforce_provider_preflight_caps(provider_request: ProviderRequest, caps: ProviderCostCaps) -> None:
+    if _provider_stop_enabled():
+        raise ProviderError(
+            provider="openai",
+            category="invalid_request",
+            retryable=False,
+            safe_message="Provider execution disabled: emergency stop is active.",
+            request_id=provider_request.request_id,
+        )
+    if provider_request.max_tokens > caps.max_output_tokens:
+        raise ProviderError(
+            provider="openai",
+            category="invalid_request",
+            retryable=False,
+            safe_message="Provider execution disabled: requested output token cap exceeds operator cap.",
+            request_id=provider_request.request_id,
+        )
 
 
 def _get_model_set(request: Request, params: Dict[str, Any]) -> ModelSet:
@@ -840,9 +921,17 @@ def _execute_provider_call(
     request: Request,
     provider_client: Any,
     provider_request: ProviderRequest,
+    caps: ProviderCostCaps,
 ) -> ProviderResult:
+    _enforce_provider_preflight_caps(provider_request, caps)
     _emit_provider_telemetry(request, _provider_request_started_event(provider_request))
     result = provider_client.execute(provider_request)
+    if result.usage.input_tokens is not None and result.usage.input_tokens > caps.max_input_tokens:
+        raise ProviderError(provider=result.provider, category="invalid_request", retryable=False, safe_message="Provider result exceeded input token cap.", request_id=provider_request.request_id, retry_count=result.retry_count)
+    if result.usage.output_tokens is not None and result.usage.output_tokens > caps.max_output_tokens:
+        raise ProviderError(provider=result.provider, category="invalid_request", retryable=False, safe_message="Provider result exceeded output token cap.", request_id=provider_request.request_id, retry_count=result.retry_count)
+    if result.cost.estimated_usd is None or result.cost.estimated_usd > caps.max_cost_usd:
+        raise ProviderError(provider=result.provider, category="invalid_request", retryable=False, safe_message="Provider result missing or exceeded cost cap.", request_id=provider_request.request_id, retry_count=result.retry_count)
     _emit_provider_telemetry(
         request, _provider_request_completed_event(provider_request, result)
     )
@@ -952,14 +1041,25 @@ async def solve(req: SolveRequest, request: Request) -> JSONResponse:
             model_set=model_set,
         )
         try:
+            caps = _required_provider_caps()
             provider_client = _get_provider_client(request, model_set)
             if _is_expert_route(params):
                 complexity = _expert_complexity(query)
+                required_requests = 1 if complexity == "trivial" else 2
+                if caps.max_requests < required_requests:
+                    raise ProviderError(
+                        provider="openai",
+                        category="invalid_request",
+                        retryable=False,
+                        safe_message="Provider execution disabled: request count cap is below route requirement.",
+                        request_id=provider_request.request_id,
+                    )
                 if complexity == "trivial":
                     provider_result = _execute_provider_call(
                         request=request,
                         provider_client=provider_client,
                         provider_request=provider_request,
+                        caps=caps,
                     )
                     if not provider_result.text.strip():
                         return _provider_empty_final_answer_response(request, provider_result)
@@ -985,6 +1085,7 @@ async def solve(req: SolveRequest, request: Request) -> JSONResponse:
                     request=request,
                     provider_client=provider_client,
                     provider_request=preview_request,
+                    caps=caps,
                 )
                 preview = _parse_expert_preview(preview_result.text)
                 preview["assumptions"] = _default_actionable_execution_plan_assumptions(
@@ -1000,6 +1101,7 @@ async def solve(req: SolveRequest, request: Request) -> JSONResponse:
                     request=request,
                     provider_client=provider_client,
                     provider_request=answer_request,
+                    caps=caps,
                 )
                 if preview.get("confidence_available") is False:
                     mode = _mode_for_unavailable_expert_confidence(query)
@@ -1063,6 +1165,7 @@ async def solve(req: SolveRequest, request: Request) -> JSONResponse:
                 request=request,
                 provider_client=provider_client,
                 provider_request=provider_request,
+                caps=caps,
             )
         except ProviderError as exc:
             _emit_provider_telemetry(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,3 +13,4 @@ import os
 
 os.environ.setdefault("ALPHA_DASHBOARD_PASSWORD", "ci-dashboard-secret")
 os.environ.setdefault("ALPHA_DASHBOARD_SECRET_KEY", "ci-dashboard-signing-key")
+os.environ["MODEL_PROVIDER"] = "local"

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -41,6 +41,11 @@ def _clear_provider_accounting_sink():
 @pytest.fixture(autouse=True)
 def _default_local_provider(monkeypatch):
     monkeypatch.setenv("MODEL_PROVIDER", "local")
+    monkeypatch.setenv("ALPHA_PROVIDER_MAX_COST_USD", "1")
+    monkeypatch.setenv("ALPHA_PROVIDER_MAX_INPUT_TOKENS", "100000")
+    monkeypatch.setenv("ALPHA_PROVIDER_MAX_OUTPUT_TOKENS", "100000")
+    monkeypatch.setenv("ALPHA_PROVIDER_MAX_REQUESTS", "10")
+    monkeypatch.delenv("ALPHA_PROVIDER_EMERGENCY_STOP", raising=False)
     _clear_provider_factory()
     _clear_provider_telemetry_sink()
     _clear_provider_accounting_sink()
@@ -455,8 +460,8 @@ def test_solve_openai_provider_errors_return_safe_responses(monkeypatch, categor
     assert provider_accounting_records == []
     failure_event = provider_events[1]
     assert failure_event["provider"] == "openai"
-    assert failure_event["model"] == "gpt-5"
-    assert failure_event["model_set"] == "default"
+    assert failure_event["model"] == fake.requests[0].model
+    assert failure_event["model_set"] == fake.requests[0].metadata["model_set"]
     assert failure_event["route"] == "tot"
     assert failure_event["request_id"] == "req-error"
     assert failure_event["status"] == ("timeout" if category == "timeout" else "failed")
@@ -471,6 +476,54 @@ def test_solve_openai_provider_errors_return_safe_responses(monkeypatch, categor
     _clear_provider_factory()
     _clear_provider_telemetry_sink()
     _clear_provider_accounting_sink()
+
+
+def test_solve_openai_mode_requires_explicit_provider_caps(monkeypatch):
+    monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    monkeypatch.delenv("ALPHA_PROVIDER_MAX_COST_USD", raising=False)
+    fake = FakeProviderClient([])
+    app.state.provider_client_factory = lambda _model_set: fake
+    client, key = _client()
+
+    resp = client.post(
+        "/v1/solve",
+        json={"query": "hello provider", "context": {"model_set": "cost_saver"}},
+        headers={"X-API-Key": key, "X-Request-ID": "req-cost-caps"},
+    )
+
+    assert resp.status_code == 400
+    body = resp.json()
+    _assert_provider_safe_out_schema(
+        body,
+        category="invalid_request",
+        retryable=False,
+        request_id=None,
+    )
+    assert fake.requests == []
+
+
+def test_solve_openai_mode_emergency_stop_blocks_before_provider_call(monkeypatch):
+    monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    monkeypatch.setenv("ALPHA_PROVIDER_EMERGENCY_STOP", "1")
+    fake = FakeProviderClient([])
+    app.state.provider_client_factory = lambda _model_set: fake
+    client, key = _client()
+
+    resp = client.post(
+        "/v1/solve",
+        json={"query": "hello provider", "context": {"model_set": "cost_saver"}},
+        headers={"X-API-Key": key, "X-Request-ID": "req-stop"},
+    )
+
+    assert resp.status_code == 400
+    body = resp.json()
+    _assert_provider_safe_out_schema(
+        body,
+        category="invalid_request",
+        retryable=False,
+        request_id="req-stop",
+    )
+    assert fake.requests == []
 
 
 def test_solve_openai_unknown_provider_exception_emits_no_accounting(monkeypatch):

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -502,6 +502,95 @@ def test_solve_openai_mode_requires_explicit_provider_caps(monkeypatch):
     assert fake.requests == []
 
 
+@pytest.mark.parametrize("cost_cap", ["0", "nan", "inf", "-inf", "-1", "not-a-number", " "])
+def test_solve_openai_mode_rejects_invalid_cost_caps_before_provider_call(
+    monkeypatch, cost_cap
+):
+    monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    monkeypatch.setenv("ALPHA_PROVIDER_MAX_COST_USD", cost_cap)
+    fake = FakeProviderClient([])
+    app.state.provider_client_factory = lambda _model_set: fake
+    client, key = _client()
+
+    resp = client.post(
+        "/v1/solve",
+        json={"query": "hello provider", "context": {"model_set": "cost_saver"}},
+        headers={"X-API-Key": key, "X-Request-ID": "req-invalid-cost-cap"},
+    )
+
+    assert resp.status_code == 400
+    _assert_provider_safe_out_schema(
+        resp.json(),
+        category="invalid_request",
+        retryable=False,
+        request_id=None,
+    )
+    assert fake.requests == []
+
+
+@pytest.mark.parametrize(
+    ("usage", "safe_message"),
+    [
+        (
+            ProviderUsage(input_tokens=None, output_tokens=1, total_tokens=1),
+            "Provider result missing input token usage.",
+        ),
+        (
+            ProviderUsage(input_tokens=1, output_tokens=None, total_tokens=1),
+            "Provider result missing output token usage.",
+        ),
+    ],
+)
+def test_solve_openai_mode_missing_token_usage_fails_before_success_accounting(
+    monkeypatch, usage, safe_message
+):
+    monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    fake = FakeProviderClient(
+        [
+            ProviderResult(
+                provider="openai",
+                model="gpt-test",
+                text="provider answer",
+                finish_reason="stop",
+                usage=usage,
+                cost=ProviderCost(estimated_usd=0.001, source="price_hint"),
+                latency_ms=12,
+                request_id="req-missing-usage",
+                raw_metadata={"provider_request_id": "openai-req-missing-usage"},
+            )
+        ]
+    )
+    app.state.provider_client_factory = lambda _model_set: fake
+    provider_events = []
+    provider_accounting_records = []
+    app.state.provider_telemetry_sink = provider_events.append
+    app.state.provider_accounting_sink = provider_accounting_records.append
+    client, key = _client()
+
+    resp = client.post(
+        "/v1/solve",
+        json={"query": "hello provider", "context": {"model_set": "cost_saver"}},
+        headers={"X-API-Key": key, "X-Request-ID": "req-missing-usage"},
+    )
+
+    assert resp.status_code == 400
+    body = resp.json()
+    _assert_provider_safe_out_schema(
+        body,
+        category="invalid_request",
+        retryable=False,
+        request_id="req-missing-usage",
+    )
+    assert safe_message in resp.text
+    assert len(fake.requests) == 1
+    assert [event["event"] for event in provider_events] == [
+        PROVIDER_REQUEST_STARTED,
+        PROVIDER_REQUEST_FAILED,
+    ]
+    assert provider_events[1]["safe_message"] == safe_message
+    assert provider_accounting_records == []
+
+
 def test_solve_openai_mode_emergency_stop_blocks_before_provider_call(monkeypatch):
     monkeypatch.setenv("MODEL_PROVIDER", "openai")
     monkeypatch.setenv("ALPHA_PROVIDER_EMERGENCY_STOP", "1")

--- a/tests/test_cost_tracking.py
+++ b/tests/test_cost_tracking.py
@@ -17,6 +17,7 @@ def _client():
 
 
 def test_cost_tracking(monkeypatch, caplog):
+    monkeypatch.setenv("MODEL_PROVIDER", "local")
     client, key = _client()
     monkeypatch.setattr("service.app._tree_of_thought", lambda *a, **k: {})
     path = Path("artifacts/costs.csv")

--- a/tests/ui/test_expert_preview.py
+++ b/tests/ui/test_expert_preview.py
@@ -52,6 +52,11 @@ def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
     monkeypatch.setenv("MODEL_PROVIDER", "openai")
     monkeypatch.setenv("ALPHA_LIVE_PREVIEW_ENABLED", "true")
     monkeypatch.setenv("ALPHA_LIVE_PREVIEW_MAX_REQUESTS", "20")
+    monkeypatch.setenv("ALPHA_PROVIDER_MAX_COST_USD", "1")
+    monkeypatch.setenv("ALPHA_PROVIDER_MAX_INPUT_TOKENS", "100000")
+    monkeypatch.setenv("ALPHA_PROVIDER_MAX_OUTPUT_TOKENS", "100000")
+    monkeypatch.setenv("ALPHA_PROVIDER_MAX_REQUESTS", "20")
+    monkeypatch.delenv("ALPHA_PROVIDER_EMERGENCY_STOP", raising=False)
     auth.reset_state()
 
     app = FastAPI()

--- a/tests/ui/test_expert_preview_real_app.py
+++ b/tests/ui/test_expert_preview_real_app.py
@@ -53,6 +53,11 @@ def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
     monkeypatch.setenv("MODEL_PROVIDER", "openai")
     monkeypatch.setenv("ALPHA_LIVE_PREVIEW_ENABLED", "true")
     monkeypatch.setenv("ALPHA_LIVE_PREVIEW_MAX_REQUESTS", "20")
+    monkeypatch.setenv("ALPHA_PROVIDER_MAX_COST_USD", "1")
+    monkeypatch.setenv("ALPHA_PROVIDER_MAX_INPUT_TOKENS", "100000")
+    monkeypatch.setenv("ALPHA_PROVIDER_MAX_OUTPUT_TOKENS", "100000")
+    monkeypatch.setenv("ALPHA_PROVIDER_MAX_REQUESTS", "20")
+    monkeypatch.delenv("ALPHA_PROVIDER_EMERGENCY_STOP", raising=False)
     app.state.live_preview_request_count = 0
     auth.reset_state()
 


### PR DESCRIPTION
### Motivation

- Prevent hosted provider execution unless explicit operator-set cost, token, and request-count caps are present so provider-backed paths are fail-closed.  
- Provide an operator emergency stop that blocks provider execution before any provider client is invoked.  
- Use only fake provider adapters in tests and record evidence for the DEF-002 provider-cost stop-control lane without calling hosted providers or using credentials.

### Description

- Add `ProviderCostCaps` dataclass and env-driven preflight loader that requires `ALPHA_PROVIDER_MAX_COST_USD`, `ALPHA_PROVIDER_MAX_INPUT_TOKENS`, `ALPHA_PROVIDER_MAX_OUTPUT_TOKENS`, and `ALPHA_PROVIDER_MAX_REQUESTS`, and add `_provider_stop_enabled()` to gate emergency stop behavior in provider mode (`service/app.py`).  
- Enforce preflight caps (emergency stop and requested output token cap) before invoking the provider client and enforce postflight caps (input/output tokens and `estimated_usd` cost) after the provider response, raising `ProviderError` on violations and preventing accounting emission (`_execute_provider_call`, `_enforce_provider_preflight_caps`).  
- Enforce a route-level request-count requirement for the expert route and thread the `caps` through `/v1/solve` provider execution paths; update tests to inject explicit safe caps in local fixtures (`service/app.py`, wiring in `/v1/solve`).  
- Add focused fake-adapter unit tests that assert missing caps fail closed and that `ALPHA_PROVIDER_EMERGENCY_STOP` blocks before provider calls, update a local-only cost-tracking test, and add a DEF-002 spec and evidence packet under `docs/evals/runs/...` describing boundaries, non-actions, residual risks, and next lanes (`tests/test_api_endpoints.py`, `tests/test_cost_tracking.py`, `.specs/ALPHA-SOLVER-DEF-002-PROVIDER-COST-CAPS-STOP-CONTROL-001.md`, `docs/evals/runs/alpha-solver-def-002-provider-cost-caps-stop-control-001/*`).

### Testing

- Ran `python -m pytest tests/test_api_endpoints.py -q` and the suite passed, including the new tests that assert missing caps and emergency-stop behavior.  
- Ran `python -m pytest tests/providers tests/finops/test_budget.py tests/test_budget_gate.py tests/test_cost_tracking.py -q` and the targeted provider/finops tests passed (live OpenAI smoke test is gated/skipped).  
- Performed static checks `python -m py_compile service/app.py` and verified created evidence files under `docs/evals/runs/alpha-solver-def-002-provider-cost-caps-stop-control-001/`, all of which are present and non-empty.  
- Verified repository consistency with `git diff --check`; no whitespace or syntax issues remain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e4d14a1e883299c32d298d26f79ff)