### PR TITLE
Add DEF-002 data-classification registry reconciliation packet and tests

### DIFF
--- a/docs/evals/runs/alpha-solver-def-002-data-classification-registry-reconciliation-001/README.md
+++ b/docs/evals/runs/alpha-solver-def-002-data-classification-registry-reconciliation-001/README.md
@@ -1,0 +1,44 @@
+# DEF-002 data classification registry reconciliation
+
+Lane: `ALPHA-SOLVER-DEF-002-DATA-CLASSIFICATION-REGISTRY-RECONCILIATION-001`
+
+## Verdict
+
+`DEF_002_DATA_CLASSIFICATION_PARTIAL`
+
+## Scope
+
+This packet reconciles repository policy sources that describe data classification,
+provider routing, tool/vendor policy metadata, logging, replay, evidence packets,
+and dashboard data. It is a documentation and policy-precedence lane only.
+
+## Precedence decision
+
+1. `registries/data_classification.yaml` is the canonical classification-policy
+   registry for registry-loaded policy decisions.
+2. `config/data_classification.yaml` remains a runtime governance input for the
+   existing `DataClassifier` downgrade behavior until a later enforcement lane
+   migrates or rewires runtime classification.
+3. Runtime allowlists and local redaction modules govern their own emission
+   boundaries where code already enforces them.
+4. Evidence-packet policy text constrains claims and operator decisions, but does
+   not override committed runtime code.
+
+## Files in this packet
+
+- `registry-inventory.md`
+- `precedence-map.md`
+- `enforcement-boundary.md`
+- `residual-risks.md`
+- `selected-next-lane.md`
+- `evidence-boundary.md`
+- `non-actions.md`
+
+## Non-claims
+
+This packet does not claim DEF-002 security/privacy completion, public-exposure
+readiness, provider-safety validation, dashboard readiness, or full runtime
+enforcement of every policy-only registry field. The policy precedence decision is
+reconciled, but the lane verdict is partial because an attempted broad test run
+encountered environment-coupled provider-path failures and one live-provider
+request despite the intended no-provider boundary.

--- a/docs/evals/runs/alpha-solver-def-002-data-classification-registry-reconciliation-001/README.md
+++ b/docs/evals/runs/alpha-solver-def-002-data-classification-registry-reconciliation-001/README.md
@@ -41,4 +41,7 @@ readiness, provider-safety validation, dashboard readiness, or full runtime
 enforcement of every policy-only registry field. The policy precedence decision is
 reconciled, but the lane verdict is partial because an attempted broad test run
 encountered environment-coupled provider-path failures and one live-provider
-request despite the intended no-provider boundary.
+request despite the intended no-provider boundary. Targeted lane validation was
+rerun with `MODEL_PROVIDER=local` controls; the broad-suite provider incident is
+retained only as a boundary violation / failed validation-boundary signal and is
+not provider-readiness evidence.

--- a/docs/evals/runs/alpha-solver-def-002-data-classification-registry-reconciliation-001/enforcement-boundary.md
+++ b/docs/evals/runs/alpha-solver-def-002-data-classification-registry-reconciliation-001/enforcement-boundary.md
@@ -1,0 +1,34 @@
+# Enforcement boundary
+
+## Runtime-enforced today
+
+- `alpha.core.policy.PolicyEngine.classify()` enforces exact-tag `deny` and
+  `mask` decisions from the registry-loaded `data_classification` rules supplied
+  to the engine.
+- `alpha.core.governance.DataClassifier.enforce()` applies the legacy
+  `config/data_classification.yaml` regex rules by downgrading matching plan
+  steps to `instructions_only` when that classifier is used.
+- `alpha.providers.telemetry` emits only explicit allowlisted metadata fields and
+  has no prompt or completion content field.
+- `alpha.self_operator.redaction` performs deterministic local redaction of
+  secret-like fields and strings before Self Operator artifact emission when used
+  by callers.
+
+## Policy-only today
+
+- Treating `registries/data_classification.yaml` as canonical for all prompts,
+  traces, provider requests, logs, replay artifacts, evidence packets, and
+  dashboard data is a precedence decision, not universal runtime enforcement.
+- `registries/tools.json` `data_handling`, `audit_level`, `risk_flags`, and
+  `compliance_scope` fields are policy metadata unless an explicit caller
+  interprets them.
+- `registries/policy.routes.yaml` is route metadata and does not itself enforce
+  classification, auth, consent, budget, redaction, or provider-call controls.
+- Evidence packet non-claims and exposure gates are operator/reviewer constraints,
+  not runtime gates.
+
+## Narrow runtime change decision
+
+No runtime enforcement was changed in this lane. The conflict was reconciled by
+source-of-truth documentation because changing runtime classification behavior
+would alter provider/log/replay semantics beyond this lane's approved boundary.

--- a/docs/evals/runs/alpha-solver-def-002-data-classification-registry-reconciliation-001/evidence-boundary.md
+++ b/docs/evals/runs/alpha-solver-def-002-data-classification-registry-reconciliation-001/evidence-boundary.md
@@ -1,0 +1,29 @@
+# Evidence boundary
+
+This packet is based on committed repository files and offline static checks. It
+reviewed registry contents, existing DEF-002 and public-exposure evidence
+packets, and local code paths for policy loading, telemetry, replay, logging,
+registry snapshots, and redaction. During validation, a broad `python -m pytest
+-q` run was attempted in an environment that exercised an OpenAI provider path;
+that incident is recorded as a boundary violation and is not used as provider
+safety evidence.
+
+## Included evidence
+
+- Registry and config files under `registries/` and `config/`.
+- Existing DEF-002 security/privacy review packet and public-exposure readiness
+  gate packet.
+- Local source modules for registry loading, policy classification, governance
+  classification, provider telemetry, JSONL logging, replay, registry snapshots,
+  and Self Operator redaction.
+- Offline tests and static docs checks run from the repository checkout.
+
+## Excluded evidence
+
+- Live provider behavior, except for the recorded validation incident, which is
+  treated only as a boundary violation and failed validation signal.
+- Token billing or model usage.
+- Public API or dashboard exposure.
+- External vendor policy review.
+- Runtime proof that every prompt, trace, replay event, evidence packet, log, and
+  dashboard datum is classification-enforced.

--- a/docs/evals/runs/alpha-solver-def-002-data-classification-registry-reconciliation-001/evidence-boundary.md
+++ b/docs/evals/runs/alpha-solver-def-002-data-classification-registry-reconciliation-001/evidence-boundary.md
@@ -16,13 +16,14 @@ safety evidence.
 - Local source modules for registry loading, policy classification, governance
   classification, provider telemetry, JSONL logging, replay, registry snapshots,
   and Self Operator redaction.
-- Offline tests and static docs checks run from the repository checkout.
+- Targeted local-only tests and static docs checks run from the repository checkout with `MODEL_PROVIDER=local` controls.
 
 ## Excluded evidence
 
-- Live provider behavior, except for the recorded validation incident, which is
-  treated only as a boundary violation and failed validation signal.
-- Token billing or model usage.
+- Live provider behavior, except for the recorded broad-suite validation incident,
+  which is treated only as a boundary violation and failed validation signal.
+- Provider-readiness evidence, provider-safety validation, token billing, or model
+  usage evidence.
 - Public API or dashboard exposure.
 - External vendor policy review.
 - Runtime proof that every prompt, trace, replay event, evidence packet, log, and

--- a/docs/evals/runs/alpha-solver-def-002-data-classification-registry-reconciliation-001/non-actions.md
+++ b/docs/evals/runs/alpha-solver-def-002-data-classification-registry-reconciliation-001/non-actions.md
@@ -1,0 +1,15 @@
+# Non-actions
+
+- Did not intentionally call providers as part of the lane design. A broad
+  `python -m pytest -q` validation attempt nevertheless exercised an OpenAI
+  provider path in the ambient environment; this is recorded as a validation
+  boundary violation, not evidence for provider readiness.
+- Did not intentionally use model/provider tokens.
+- Did not expose API routes or dashboard routes.
+- Did not change runtime provider, logging, replay, dashboard, or SAFE-OUT
+  enforcement.
+- Did not edit backlog workbooks or planning ledgers.
+- Did not mark DEF-002 security/privacy complete.
+- Did not claim public-exposure readiness.
+- Did not populate nullable `tools.json` governance fields.
+- Did not delete, rename, or move legacy classification files.

--- a/docs/evals/runs/alpha-solver-def-002-data-classification-registry-reconciliation-001/non-actions.md
+++ b/docs/evals/runs/alpha-solver-def-002-data-classification-registry-reconciliation-001/non-actions.md
@@ -2,9 +2,11 @@
 
 - Did not intentionally call providers as part of the lane design. A broad
   `python -m pytest -q` validation attempt nevertheless exercised an OpenAI
-  provider path in the ambient environment; this is recorded as a validation
-  boundary violation, not evidence for provider readiness.
-- Did not intentionally use model/provider tokens.
+  provider path in the ambient environment; this remains recorded as a validation
+  boundary violation / failed validation-boundary signal, not evidence for
+  provider readiness.
+- Did not intentionally use model/provider tokens, and this packet does not
+  authorize provider calls.
 - Did not expose API routes or dashboard routes.
 - Did not change runtime provider, logging, replay, dashboard, or SAFE-OUT
   enforcement.

--- a/docs/evals/runs/alpha-solver-def-002-data-classification-registry-reconciliation-001/precedence-map.md
+++ b/docs/evals/runs/alpha-solver-def-002-data-classification-registry-reconciliation-001/precedence-map.md
@@ -30,7 +30,7 @@
 | --- | --- | --- |
 | Prompts and user context | Runtime `/v1/solve` provider gate first; canonical classification registry for policy; config classifier only where explicitly invoked. | Default local path does not call providers; current classification enforcement is not proven on every prompt/provider path in this lane. |
 | Reasoning traces / session traces | Runtime trace writers first; evidence-boundary docs for claims. | Not proven classification-filtered here. |
-| Provider calls | Provider opt-in/config gate, provider client code, provider telemetry allowlist, then canonical classification policy for future gating. | Provider calls were not exercised; no new provider enforcement was added. |
+| Provider calls | Provider opt-in/config gate, provider client code, provider telemetry allowlist, then canonical classification policy for future gating. | No intentional provider validation was performed by this lane and no new provider enforcement was added. A broad-suite validation attempt nevertheless exercised one OpenAI provider path; that incident remains recorded as a failed validation-boundary signal, is not used as provider-readiness evidence, and does not authorize provider calls. |
 | Request logs and provider telemetry | Logging code and telemetry allowlist first; canonical policy registry for allowed future fields. | Provider telemetry is allowlist-only; generic loggers require caller hygiene. |
 | Replay artifacts | Replay harness behavior first; canonical policy registry for future capture decisions. | Replay can persist supplied events; classification/redaction is not automatically enforced by the harness. |
 | Evidence packets | Evidence-boundary docs and packet-specific non-actions first. | Policy-only; no runtime effect. |

--- a/docs/evals/runs/alpha-solver-def-002-data-classification-registry-reconciliation-001/precedence-map.md
+++ b/docs/evals/runs/alpha-solver-def-002-data-classification-registry-reconciliation-001/precedence-map.md
@@ -1,0 +1,44 @@
+# Precedence map
+
+## Source-of-truth order
+
+1. **Runtime code controls first for actual emissions.** Allowlist telemetry,
+   SAFE-OUT construction, request logging, redaction, replay writing, and
+   dashboard/API handlers determine what can be emitted at runtime.
+2. **`registries/data_classification.yaml` is the canonical policy registry for
+   data-classification decisions loaded from `registries/`.** It supersedes
+   duplicate registry-like classification statements for policy review and future
+   provider/tool governance work.
+3. **`config/data_classification.yaml` is a compatibility runtime input only.** It
+   remains authoritative for the current `DataClassifier.load()` default path and
+   its `instructions_only` downgrade behavior, but it is not the source of truth
+   for new policy-registry work.
+4. **`registries/tools.json` can annotate tools/vendors but cannot override the
+   classification registry.** A populated `data_handling`, `risk_flags`, or
+   `compliance_scope` field may add constraints; null/empty fields do not grant
+   permission.
+5. **`registries/policy.routes.yaml` can identify route endpoints but cannot
+   authorize provider calls or relax data classification.** Route metadata is
+   subordinate to provider opt-in, budget, auth, classification, and redaction
+   controls.
+6. **Evidence packets and docs constrain claims and operator decisions.** They do
+   not change runtime behavior unless a later lane implements code/config changes.
+
+## Prompt, trace, provider, log, replay, evidence, and dashboard mapping
+
+| Data surface | Governing precedence | Current runtime enforcement |
+| --- | --- | --- |
+| Prompts and user context | Runtime `/v1/solve` provider gate first; canonical classification registry for policy; config classifier only where explicitly invoked. | Default local path does not call providers; current classification enforcement is not proven on every prompt/provider path in this lane. |
+| Reasoning traces / session traces | Runtime trace writers first; evidence-boundary docs for claims. | Not proven classification-filtered here. |
+| Provider calls | Provider opt-in/config gate, provider client code, provider telemetry allowlist, then canonical classification policy for future gating. | Provider calls were not exercised; no new provider enforcement was added. |
+| Request logs and provider telemetry | Logging code and telemetry allowlist first; canonical policy registry for allowed future fields. | Provider telemetry is allowlist-only; generic loggers require caller hygiene. |
+| Replay artifacts | Replay harness behavior first; canonical policy registry for future capture decisions. | Replay can persist supplied events; classification/redaction is not automatically enforced by the harness. |
+| Evidence packets | Evidence-boundary docs and packet-specific non-actions first. | Policy-only; no runtime effect. |
+| Dashboard/API data | Mounted route code, auth/CORS/tenancy controls, exposure-gate docs, then canonical classification policy. | Public-exposure packet still blocks readiness; dashboard data classification was not proven complete. |
+
+## Decision
+
+RR-05 is reconciled at the policy-registry level: new policy work should read
+`registries/data_classification.yaml` as canonical and treat
+`config/data_classification.yaml` as a legacy runtime compatibility input until a
+specific enforcement migration closes the implementation gap.

--- a/docs/evals/runs/alpha-solver-def-002-data-classification-registry-reconciliation-001/registry-inventory.md
+++ b/docs/evals/runs/alpha-solver-def-002-data-classification-registry-reconciliation-001/registry-inventory.md
@@ -1,0 +1,40 @@
+# Registry inventory
+
+## Data classification registries
+
+| File | Role | Current content | Runtime reader | Reconciliation status |
+| --- | --- | --- | --- | --- |
+| `registries/data_classification.yaml` | Canonical registry-loaded data-classification policy. | Versioned registry with `phi -> mask` and `pii -> deny`. | `alpha.core.loader.FILES` maps `data_classification` to this file under the `registries/` root; `alpha.core.policy.PolicyEngine.classify()` consumes loaded `rules`. | Authoritative for registry-loaded policy decisions. |
+| `config/data_classification.yaml` | Legacy/runtime governance downgrade input. | Unversioned config with `pii|secret|token -> instructions_only`. | `alpha.core.governance.DataClassifier.load()` defaults to this path and `enforce()` downgrades matching plan steps to `instructions_only`. | Not canonical policy registry; retained as runtime enforcement input until migration. |
+
+## Policy and provider/tool registries
+
+| File | Role | Current content | Runtime reader | Reconciliation status |
+| --- | --- | --- | --- | --- |
+| `registries/policy.routes.yaml` | Vendor route registry. | JSON-shaped YAML with a `signs365` order endpoint. | Loaded by `alpha.core.loader` as `policy_routes`; no data-classification actions are present. | Not a classification source; route metadata only. |
+| `registries/tools.json` | Canonical tool/vendor registry enrichment. | Tool records with nullable `data_handling`, `audit_level`, `risk_flags`, and `compliance_scope` fields. | `alpha.core.registry_provider.RegistryProvider.load()` enriches seed rows from this file and gives canonical rows precedence. | Policy metadata source only unless downstream code explicitly interprets a populated field. |
+
+## Runtime boundary registries and modules reviewed
+
+| Area | Source | Boundary observed |
+| --- | --- | --- |
+| Provider telemetry | `alpha/providers/telemetry.py` | Allowlist-based event fields; prompt/response content fields are absent. |
+| JSONL logs | `alpha/core/jsonl_logger.py` | Generic logger persists caller-provided events; classification depends on caller hygiene. |
+| Replay | `alpha/core/replay.py` | Generic event capture/replay; no registry classification or redaction is applied in the harness. |
+| Registry snapshots | `alpha/core/registry_provider.py` | Shortlist snapshots include `query`, region, scores, and explanations; no classification policy is applied before writing. |
+| Self Operator redaction | `alpha/self_operator/redaction.py` | Deterministic local redaction for secret-like keys and strings; pattern-based limitation remains. |
+| Evidence packets | `docs/evals/runs/...` | Evidence docs state boundaries and non-claims; they are policy/evidence constraints, not runtime controls. |
+
+## Conflicts and stale entries
+
+1. `pii` conflicts: `registries/data_classification.yaml` denies it, while
+   `config/data_classification.yaml` downgrades matching prompts to
+   `instructions_only`.
+2. `secret` and `token` exist in `config/data_classification.yaml` but not in the
+   canonical registry-loaded policy.
+3. `phi` exists in `registries/data_classification.yaml` but not in the runtime
+   governance config.
+4. `registries/tools.json` contains many nullable data-governance fields. Nulls
+   are not policy decisions and must not be treated as allow/deny evidence.
+5. `registries/policy.routes.yaml` is route metadata and should not be used to
+   infer classification or provider-data-sharing consent.

--- a/docs/evals/runs/alpha-solver-def-002-data-classification-registry-reconciliation-001/residual-risks.md
+++ b/docs/evals/runs/alpha-solver-def-002-data-classification-registry-reconciliation-001/residual-risks.md
@@ -8,4 +8,4 @@
 | DCR-04 | Tool registry governance fields are mostly null and not enforcement-backed. | Open. | Populate audited values and wire enforcement only after policy approval. |
 | DCR-05 | Public-exposure data-sharing/telemetry gate remains not ready. | Open. | Continue exposure-readiness gap closure; do not expose dashboard/API based on this packet. |
 | DCR-06 | Pattern-based redaction can miss novel secrets. | Open residual candidate. | Expand tests/formats or require operator acceptance with compensating controls. |
-| DCR-07 | Broad test execution can exercise provider paths when ambient provider environment variables or credentials are present. | Open validation risk. | Add/require no-provider validation profiles for DEF/security lanes before running broad suites. |
+| DCR-07 | Broad test execution can exercise provider paths when ambient provider environment variables or credentials are present. | Open validation risk; occurred once during this lane and is not provider-readiness evidence. | Add/require no-provider validation profiles for DEF/security lanes before running broad suites. |

--- a/docs/evals/runs/alpha-solver-def-002-data-classification-registry-reconciliation-001/residual-risks.md
+++ b/docs/evals/runs/alpha-solver-def-002-data-classification-registry-reconciliation-001/residual-risks.md
@@ -1,0 +1,11 @@
+# Residual risks
+
+| ID | Risk | Status | Required follow-up |
+| --- | --- | --- | --- |
+| DCR-01 | Runtime still has two classification inputs with different actions. | Reconciled for precedence, not migrated. | Implement a dedicated migration lane to make runtime use the canonical registry or generate compatibility config from it. |
+| DCR-02 | Replay and generic JSONL logging can persist caller-supplied event content without automatic classification or redaction. | Open. | Add capture-time classification/redaction or document approved event schemas. |
+| DCR-03 | Registry shortlist snapshots include raw `query` text. | Open. | Decide whether shortlist snapshots require redaction, hashing, opt-in, or retention limits. |
+| DCR-04 | Tool registry governance fields are mostly null and not enforcement-backed. | Open. | Populate audited values and wire enforcement only after policy approval. |
+| DCR-05 | Public-exposure data-sharing/telemetry gate remains not ready. | Open. | Continue exposure-readiness gap closure; do not expose dashboard/API based on this packet. |
+| DCR-06 | Pattern-based redaction can miss novel secrets. | Open residual candidate. | Expand tests/formats or require operator acceptance with compensating controls. |
+| DCR-07 | Broad test execution can exercise provider paths when ambient provider environment variables or credentials are present. | Open validation risk. | Add/require no-provider validation profiles for DEF/security lanes before running broad suites. |

--- a/docs/evals/runs/alpha-solver-def-002-data-classification-registry-reconciliation-001/selected-next-lane.md
+++ b/docs/evals/runs/alpha-solver-def-002-data-classification-registry-reconciliation-001/selected-next-lane.md
@@ -14,6 +14,8 @@ registry with explicit tests.
 - Expected handling for `pii`, `phi`, `secret`, and `token` is explicitly stated.
 - Replay, shortlist snapshot, JSONL logging, provider-call, and dashboard data
   surfaces have approved event/data schemas or redaction requirements.
+- Validation commands for the lane have an explicit no-provider profile before any
+  broad suite is attempted.
 
 ## Non-goals
 

--- a/docs/evals/runs/alpha-solver-def-002-data-classification-registry-reconciliation-001/selected-next-lane.md
+++ b/docs/evals/runs/alpha-solver-def-002-data-classification-registry-reconciliation-001/selected-next-lane.md
@@ -1,0 +1,23 @@
+# Selected next lane
+
+`ALPHA-SOLVER-DEF-002-DATA-CLASSIFICATION-RUNTIME-MIGRATION-001`
+
+## Purpose
+
+Migrate runtime classification enforcement to the canonical registry decision
+made in this packet, or generate runtime compatibility rules from the canonical
+registry with explicit tests.
+
+## Entry criteria
+
+- Operator approves changing runtime classification behavior.
+- Expected handling for `pii`, `phi`, `secret`, and `token` is explicitly stated.
+- Replay, shortlist snapshot, JSONL logging, provider-call, and dashboard data
+  surfaces have approved event/data schemas or redaction requirements.
+
+## Non-goals
+
+- Do not call live providers.
+- Do not expose `/v1/solve` or dashboard publicly.
+- Do not claim DEF-002 closure unless all remaining DEF-002 gates are separately
+  closed or accepted.

--- a/tests/test_data_classification_registry_reconciliation.py
+++ b/tests/test_data_classification_registry_reconciliation.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+from alpha.core.loader import load_all, parse_yaml_lite
+from alpha.core.policy import PolicyEngine
+
+
+def test_canonical_registry_classification_policy_loads_and_enforces_expected_tags():
+    registries = load_all("registries")
+    policy = registries.get("data_classification")
+
+    assert policy["version"] == "0.1.0"
+    assert {rule["match"]: rule["action"] for rule in policy["rules"]} == {
+        "phi": "mask",
+        "pii": "deny",
+    }
+
+    engine = PolicyEngine(registries)
+    assert engine.classify(["pii"])["allow"] is False
+    phi = engine.classify(["phi"])
+    assert phi["allow"] is True
+    assert phi["masked"] is True
+
+
+def test_legacy_runtime_config_remains_distinct_from_canonical_registry():
+    canonical = load_all("registries")["data_classification"]
+    legacy = parse_yaml_lite(Path("config/data_classification.yaml").read_text())
+
+    canonical_actions = {rule["match"]: rule["action"] for rule in canonical["rules"]}
+    legacy_actions = {rule["match"]: rule["action"] for rule in legacy["rules"]}
+
+    assert canonical_actions["pii"] == "deny"
+    assert legacy_actions["pii|secret|token"] == "instructions_only"
+
+
+def test_reconciliation_packet_records_precedence_and_enforcement_boundary():
+    packet = Path(
+        "docs/evals/runs/"
+        "alpha-solver-def-002-data-classification-registry-reconciliation-001"
+    )
+    precedence = (packet / "precedence-map.md").read_text(encoding="utf-8")
+    boundary = (packet / "enforcement-boundary.md").read_text(encoding="utf-8")
+
+    assert "registries/data_classification.yaml` is the canonical policy registry" in precedence
+    assert "config/data_classification.yaml` is a compatibility runtime input only" in precedence
+    assert "No runtime enforcement was changed in this lane" in boundary


### PR DESCRIPTION
### Motivation

- Reconcile divergent data-classification sources in the repo and clarify which files govern prompts, traces, provider calls, logs, replay, evidence packets, and dashboard data. 
- Preserve the existing runtime behavior while documenting a clear precedence decision to avoid ambiguity for reviewers and future enforcement work. 
- Capture residual risks and next-lane work to migrate runtime enforcement later without changing provider/log/replay semantics in this lane.

### Description

- Add a DEF-002 evidence packet under `docs/evals/runs/alpha-solver-def-002-data-classification-registry-reconciliation-001/` including `README.md`, `registry-inventory.md`, `precedence-map.md`, `enforcement-boundary.md`, `residual-risks.md`, `selected-next-lane.md`, `evidence-boundary.md`, and `non-actions.md`. 
- Record the precedence decision that `registries/data_classification.yaml` is the canonical registry-loaded policy and that `config/data_classification.yaml` remains a legacy runtime compatibility input until a migration lane rewires enforcement. 
- Add `tests/test_data_classification_registry_reconciliation.py` with focused tests that assert canonical registry parsing/enforcement and the distinction from the legacy runtime config, and explicitly document that no runtime enforcement was changed in this lane.

### Testing

- Ran the focused test suite with `MODEL_PROVIDER=local python -m pytest -q tests/test_data_classification_registry_reconciliation.py`, which passed. 
- Ran the three offline repo validators with `MODEL_PROVIDER=local python scripts/check_local_llm_doc_paths.py && MODEL_PROVIDER=local python scripts/check_local_llm_evidence_boundaries.py && MODEL_PROVIDER=local python scripts/check_local_llm_packet_consistency.py`, which all passed. 
- A full `python -m pytest -q` run in the ambient environment failed because it exercised provider-coupled paths (several parameterized provider-error tests plus unrelated integration tests), producing a live provider request; that incident is recorded in the packet as a validation boundary violation and is not used as provider-readiness evidence.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e4d2434d0832987692a7617436111)