### PR TITLE
Rebuild /v1/solve auth/tenancy evidence lane (local-only DEF-002)

### DIFF
--- a/.specs/ALPHA-SOLVER-DEF-002-V1-SOLVE-AUTH-TENANCY-CLOSURE-001.md
+++ b/.specs/ALPHA-SOLVER-DEF-002-V1-SOLVE-AUTH-TENANCY-CLOSURE-001.md
@@ -1,0 +1,24 @@
+# ALPHA-SOLVER-DEF-002-V1-SOLVE-AUTH-TENANCY-CLOSURE-001
+
+Lane ID: `ALPHA-SOLVER-DEF-002-V1-SOLVE-AUTH-TENANCY-CLOSURE-001`
+
+Verdict: `DEF_002_V1_SOLVE_PARTIAL_REMEDIATION`
+
+## Purpose
+
+Capture local-only evidence for the bundled `/v1/solve` auth, rate-limit, CORS-inherited, logging, and SAFE-OUT boundaries without exposing `/v1/solve`, without calling hosted providers, and without claiming runtime, public, provider, production, or DEF-002 readiness.
+
+## Requirements
+
+- `/v1/solve` remains bundled/local and unexposed as a public runtime surface by this lane.
+- Evidence must be local-only and must not call providers, consume tokens, access credentials, deploy, or run provider-backed tests.
+- Unauthorized `/v1/solve` requests must fail before solver execution.
+- Authorized synthetic local requests with `MODEL_PROVIDER=local` must not construct provider clients or make provider calls.
+- Rate limiting evidence must be scoped by API key.
+- CORS preflight behavior must inherit the already-merged CORS configuration from `main`; this lane must not modify CORS implementation.
+- The packet must state that JWT/key-to-tenant binding, `TenantMiddleware` mounting on `/v1/solve`, and `JWTAuthMiddleware` mounting on `/v1/solve` remain unresolved.
+- `/v1/solve` must remain unexposed until an operator/security decision resolves the identity and tenancy model.
+
+## Evidence
+
+See `docs/evals/runs/alpha-solver-def-002-v1-solve-auth-tenancy-closure-001/`.

--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -15,6 +15,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `ALPHA-PRIMARY-ANSWER-EMPTY-001.md` | ALPHA-PRIMARY-ANSWER-EMPTY-001 · Ensure Answer-with-Assumptions Returns a Primary Deliverable | ✅ `SPEC_OK` |
 | `ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001.md` | ALPHA-SIDE-BY-SIDE-EVIDENCE-PACKET-001 - Side-by-Side Evidence Packet Contract | ✅ `SPEC_OK` |
 | `ALPHA-SOLVER-DEF-002-PROVIDER-COST-CAPS-STOP-CONTROL-001.md` | ALPHA-SOLVER-DEF-002-PROVIDER-COST-CAPS-STOP-CONTROL-001 | ✅ `SPEC_OK` |
+| `ALPHA-SOLVER-DEF-002-V1-SOLVE-AUTH-TENANCY-CLOSURE-001.md` | ALPHA-SOLVER-DEF-002-V1-SOLVE-AUTH-TENANCY-CLOSURE-001 | ✅ `SPEC_OK` |
 | `AS-145.md` | CODE SPEC — AS-145 · Tool Adapters: Playwright + GSheets (MVP hardening) (RES_05) | ✅ `SPEC_RECONSTRUCTED_FROM_SOURCE` |
 | `AS-148.md` | CODE SPEC — AS-148 · Policy & PII Gateway (DR_TRACK_A) | ✅ `SPEC_OK` |
 | `AUTH-SESSION-001.md` | AUTH-SESSION-001 · Dashboard Login + Session | ✅ `SPEC_OK` |

--- a/docs/evals/runs/alpha-solver-def-002-v1-solve-auth-tenancy-closure-001/README.md
+++ b/docs/evals/runs/alpha-solver-def-002-v1-solve-auth-tenancy-closure-001/README.md
@@ -1,0 +1,9 @@
+# DEF-002 `/v1/solve` Auth/Tenancy Closure Evidence Packet
+
+Lane ID: `ALPHA-SOLVER-DEF-002-V1-SOLVE-AUTH-TENANCY-CLOSURE-001`
+
+Verdict: `DEF_002_V1_SOLVE_PARTIAL_REMEDIATION`
+
+This packet records local-only evidence for the bundled `/v1/solve` auth, rate-limit, CORS-inherited, logging, and SAFE-OUT boundaries. `/v1/solve` remains unexposed as a public/runtime/provider-ready surface. The lane made no provider calls, used no tokens, accessed no credentials, and claims no runtime readiness, public readiness, provider readiness, production readiness, benchmark validation, Alpha superiority, security/privacy completion, or DEF-002 closure.
+
+The identity and tenancy model is intentionally not closed. JWT/key-to-tenant binding remains unresolved. Whether `TenantMiddleware` should mount on `/v1/solve` remains unresolved. Whether `JWTAuthMiddleware` should mount on `/v1/solve` remains unresolved. `/v1/solve` should remain unexposed until an operator/security decision resolves that model.

--- a/docs/evals/runs/alpha-solver-def-002-v1-solve-auth-tenancy-closure-001/evidence-boundary.md
+++ b/docs/evals/runs/alpha-solver-def-002-v1-solve-auth-tenancy-closure-001/evidence-boundary.md
@@ -1,0 +1,15 @@
+# Evidence Boundary
+
+Accepted evidence is limited to deterministic local tests and static packet checks for the bundled `/v1/solve` auth, rate-limit, inherited CORS preflight, logging, and SAFE-OUT boundaries.
+
+Non-claims and denied promotions:
+
+- No provider calls were made.
+- No tokens were used.
+- No credentials were accessed.
+- No deployment was performed.
+- No runtime/public/provider readiness is claimed.
+- No production readiness is claimed.
+- No benchmark validation or Alpha superiority is claimed.
+- No security/privacy completion or DEF-002 closure is claimed.
+- `/v1/solve` remains unexposed until an operator/security decision resolves JWT/key-to-tenant binding and middleware mounting.

--- a/docs/evals/runs/alpha-solver-def-002-v1-solve-auth-tenancy-closure-001/implementation-summary.md
+++ b/docs/evals/runs/alpha-solver-def-002-v1-solve-auth-tenancy-closure-001/implementation-summary.md
@@ -1,0 +1,5 @@
+# Implementation Summary
+
+This lane adds a scoped spec, packet documentation, and focused local tests only. It does not change runtime exposure policy, CORS implementation, provider-cost controls, telemetry/redaction behavior, or data-classification registry artifacts.
+
+The focused test file verifies that unauthorized `/v1/solve` traffic fails before solver execution, synthetic authorized local traffic does not construct provider clients when `MODEL_PROVIDER=local`, rate limiting is API-key scoped, inherited CORS preflight behavior remains available for configured local origins, and no provider call is made.

--- a/docs/evals/runs/alpha-solver-def-002-v1-solve-auth-tenancy-closure-001/non-actions.md
+++ b/docs/evals/runs/alpha-solver-def-002-v1-solve-auth-tenancy-closure-001/non-actions.md
@@ -1,0 +1,5 @@
+# Non-Actions
+
+This lane did not expose `/v1/solve`, did not deploy, did not call providers, did not use tokens, did not access credentials, did not broaden auth bypasses, did not weaken CORS behavior, and did not include provider-cost, telemetry/redaction, CORS packet, or data-classification registry work.
+
+It does not claim `/v1/solve` readiness, production readiness, public readiness, provider readiness, DEF-002 closure, security/privacy completion, benchmark validation, or Alpha superiority.

--- a/docs/evals/runs/alpha-solver-def-002-v1-solve-auth-tenancy-closure-001/residual-risks.md
+++ b/docs/evals/runs/alpha-solver-def-002-v1-solve-auth-tenancy-closure-001/residual-risks.md
@@ -1,0 +1,7 @@
+# Residual Risks
+
+- JWT/key-to-tenant binding remains unresolved.
+- Whether `TenantMiddleware` should mount on `/v1/solve` remains unresolved.
+- Whether `JWTAuthMiddleware` should mount on `/v1/solve` remains unresolved.
+- `/v1/solve` should remain unexposed until an operator/security decision resolves the identity and tenancy model.
+- Local-only tests are not provider-readiness, public-readiness, production-readiness, or security/privacy-completion evidence.

--- a/docs/evals/runs/alpha-solver-def-002-v1-solve-auth-tenancy-closure-001/selected-next-lane.md
+++ b/docs/evals/runs/alpha-solver-def-002-v1-solve-auth-tenancy-closure-001/selected-next-lane.md
@@ -1,0 +1,5 @@
+# Selected Next Lane
+
+Selected next lane: `NO_FURTHER_DEF_002_V1_SOLVE_AUTH_TENANCY_CLOSURE_LANES_SELECTED`
+
+Any future work to expose `/v1/solve` must start from a new operator/security-approved lane that resolves identity, tenant binding, and middleware mounting. This packet closes only the local-evidence lane and does not select exposure or readiness work.

--- a/docs/evals/runs/alpha-solver-def-002-v1-solve-auth-tenancy-closure-001/test-evidence.md
+++ b/docs/evals/runs/alpha-solver-def-002-v1-solve-auth-tenancy-closure-001/test-evidence.md
@@ -1,0 +1,14 @@
+# Test Evidence
+
+Required focused tests are in `tests/test_v1_solve_auth_tenancy_boundary.py`.
+
+The intended validation set is local-only:
+
+- `python -m pytest -q tests/test_v1_solve_auth_tenancy_boundary.py tests/test_api_auth_ratelimit.py tests/test_default_credentials_hardening.py`
+- `python -m py_compile alpha/core/config.py service/app.py`
+- `python scripts/check_local_llm_doc_paths.py`
+- `python scripts/check_local_llm_evidence_boundaries.py`
+- `python scripts/check_local_llm_packet_consistency.py`
+- `git diff --check`
+
+These checks do not require real credentials, live provider access, provider-backed tests, tokens, or deployment.

--- a/docs/evals/runs/alpha-solver-def-002-v1-solve-auth-tenancy-closure-001/v1-solve-boundary-evidence.md
+++ b/docs/evals/runs/alpha-solver-def-002-v1-solve-auth-tenancy-closure-001/v1-solve-boundary-evidence.md
@@ -1,0 +1,14 @@
+# `/v1/solve` Boundary Evidence
+
+Verdict: `DEF_002_V1_SOLVE_PARTIAL_REMEDIATION`
+
+Observed local-only boundary evidence:
+
+1. Unauthorized `/v1/solve` requests fail with SAFE-OUT before solver execution.
+2. Authorized synthetic requests with `MODEL_PROVIDER=local` execute local solver seams without constructing provider clients.
+3. Rate limiting is scoped by API key, so one synthetic key exhausting its quota does not consume another key's quota.
+4. CORS preflight behavior is inherited from the already-merged CORS configuration on `main`; this lane does not modify CORS implementation.
+5. No provider call is made.
+6. Tests require no real credentials and no live provider access.
+
+This is not `/v1/solve` readiness evidence. `/v1/solve` remains local/unexposed and partial-remediation only.

--- a/tests/test_v1_solve_auth_tenancy_boundary.py
+++ b/tests/test_v1_solve_auth_tenancy_boundary.py
@@ -1,0 +1,125 @@
+import uuid
+
+from fastapi.testclient import TestClient
+
+from service.app import _REQUESTS, app, time as service_time
+
+
+def _configure_boundary(max_requests=10):
+    key = f"test-{uuid.uuid4()}"
+    app.state.config.auth.enabled = True
+    app.state.config.auth.header = "X-API-Key"
+    app.state.config.auth.keys = [key]
+    app.state.config.ratelimit.enabled = True
+    app.state.config.ratelimit.window_seconds = 60
+    app.state.config.ratelimit.max_requests = max_requests
+    _REQUESTS.clear()
+    return TestClient(app), key
+
+
+def test_unauthorized_v1_solve_fails_before_solver_execution(monkeypatch):
+    client, _key = _configure_boundary()
+    solver_called = False
+
+    def fail_solver(*args, **kwargs):
+        nonlocal solver_called
+        solver_called = True
+        raise AssertionError("solver must not run for unauthorized requests")
+
+    monkeypatch.setattr("service.app._tree_of_thought", fail_solver)
+
+    resp = client.post("/v1/solve", json={"query": "local boundary"})
+
+    assert resp.status_code == 401
+    assert resp.json()["final_answer"].startswith("SAFE-OUT")
+    assert solver_called is False
+
+
+def test_authorized_local_request_does_not_construct_provider_client(monkeypatch):
+    client, key = _configure_boundary()
+    monkeypatch.setenv("MODEL_PROVIDER", "local")
+    monkeypatch.setattr(
+        "service.app._tree_of_thought",
+        lambda query, **kwargs: {"final_answer": f"local:{query}"},
+    )
+
+    def fail_provider_factory(*args, **kwargs):
+        raise AssertionError("provider client must not be constructed for local provider")
+
+    app.state.provider_client_factory = fail_provider_factory
+    try:
+        resp = client.post(
+            "/v1/solve",
+            json={"query": "local only"},
+            headers={"X-API-Key": key},
+        )
+    finally:
+        if hasattr(app.state, "provider_client_factory"):
+            delattr(app.state, "provider_client_factory")
+
+    assert resp.status_code == 200
+    assert resp.json()["final_answer"] == "local:local only"
+
+
+def test_rate_limit_is_api_key_scoped(monkeypatch):
+    client, key_one = _configure_boundary(max_requests=1)
+    key_two = f"test-{uuid.uuid4()}"
+    app.state.config.auth.keys = [key_one, key_two]
+    monkeypatch.setattr(
+        "service.app._tree_of_thought",
+        lambda query, **kwargs: {"final_answer": query},
+    )
+    now = [100.0]
+    monkeypatch.setattr(service_time, "time", lambda: now[0])
+
+    first = client.post("/v1/solve", json={"query": "one"}, headers={"X-API-Key": key_one})
+    limited = client.post("/v1/solve", json={"query": "one again"}, headers={"X-API-Key": key_one})
+    other_key = client.post("/v1/solve", json={"query": "two"}, headers={"X-API-Key": key_two})
+
+    assert first.status_code == 200
+    assert limited.status_code == 429
+    assert other_key.status_code == 200
+
+
+def test_cors_preflight_inherits_main_cors_configuration():
+    client, _key = _configure_boundary()
+
+    resp = client.options(
+        "/v1/solve",
+        headers={
+            "Origin": "http://localhost:3000",
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "X-API-Key,Content-Type",
+        },
+    )
+
+    assert resp.status_code == 200
+    assert resp.headers["access-control-allow-origin"] == "http://localhost:3000"
+    assert "POST" in resp.headers["access-control-allow-methods"]
+
+
+def test_local_boundary_makes_no_provider_call(monkeypatch):
+    client, key = _configure_boundary()
+    monkeypatch.setenv("MODEL_PROVIDER", "local")
+    provider_called = False
+
+    def fake_execute_provider_call(*args, **kwargs):
+        nonlocal provider_called
+        provider_called = True
+        raise AssertionError("provider call must not run in local boundary test")
+
+    monkeypatch.setattr("service.app._execute_provider_call", fake_execute_provider_call)
+    monkeypatch.setattr(
+        "service.app._tree_of_thought",
+        lambda query, **kwargs: {"final_answer": "local evidence"},
+    )
+
+    resp = client.post(
+        "/v1/solve",
+        json={"query": "no provider"},
+        headers={"X-API-Key": key},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["final_answer"] == "local evidence"
+    assert provider_called is False


### PR DESCRIPTION
### Motivation

- Provide a clean, narrow reconstruction of the DEF-002 `/v1/solve` auth/tenancy local-evidence lane built from latest `main` and avoid carrying contaminated/unrelated DEF-002 work into this packet. 
- Capture and document local-only boundary evidence for `/v1/solve` without exposing the route, calling providers, using tokens, or claiming any readiness. 

### Description

- Add a scoped spec file ` .specs/ALPHA-SOLVER-DEF-002-V1-SOLVE-AUTH-TENANCY-CLOSURE-001.md` declaring the verdict `DEF_002_V1_SOLVE_PARTIAL_REMEDIATION` and enumerating requirements and constraints for the lane. 
- Update `.specs/INDEX.md` to preserve existing entries and add only the new `/v1/solve` spec entry. 
- Add the evidence packet under `docs/evals/runs/alpha-solver-def-002-v1-solve-auth-tenancy-closure-001/` with `README.md`, `evidence-boundary.md`, `implementation-summary.md`, `non-actions.md`, `residual-risks.md`, `selected-next-lane.md`, `test-evidence.md`, and `v1-solve-boundary-evidence.md` documenting that `/v1/solve` remains unexposed and that no providers/tokens/credentials were used. 
- Add focused tests in `tests/test_v1_solve_auth_tenancy_boundary.py` validating unauthorized SAFE-OUT behavior, that local-authorized requests do not construct provider clients or call providers when `MODEL_PROVIDER=local`, API-key-scoped rate limiting, and inherited CORS preflight responses. 

### Testing

- Ran `pytest` for the focused test set (`tests/test_v1_solve_auth_tenancy_boundary.py`, `tests/test_api_auth_ratelimit.py`, `tests/test_default_credentials_hardening.py`) and all tests passed. 
- Performed static/CI checks: `python -m py_compile alpha/core/config.py service/app.py` and the repository's local LLM doc/evidence/packet check scripts (`scripts/check_local_llm_doc_paths.py`, `scripts/check_local_llm_evidence_boundaries.py`, `scripts/check_local_llm_packet_consistency.py`) and `git diff --check`, all of which succeeded. 
- The final change set is scoped to the allowed files only and contains no CORS, provider-cost, telemetry/redaction, or data-classification registry lane files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e633f346883298a5cdcdcf5462523)