### PR TITLE
docs: add deferred opportunity addendum

### DIFF
--- a/docs/OPPORTUNITY_REGISTER.md
+++ b/docs/OPPORTUNITY_REGISTER.md
@@ -33,3 +33,57 @@
   (see [`VALUE_EXPERIMENT_DIRECTION.md`](VALUE_EXPERIMENT_DIRECTION.md)).
 - `DO_NOT_DO_YET` items are deferred specifically to avoid implying readiness
   the evidence does not support.
+
+## Deferred Addendum — 2026-06-14
+
+These ideas were independently reviewed but are **not** folded into active lanes now.
+Preserve them as later candidates, not current execution. No executable prompts are
+provided for these items by design.
+
+### Later Candidates
+
+Add later only if the value-read signal supports them:
+
+| candidate | deferred activation condition |
+|-----------|-------------------------------|
+| Decision Provenance Ledger | Convert evidence packets into a buyer-facing decision trail only after value-read signal supports buyer-facing governance demand. |
+| Stop Engine | Add a pre-generation answerability verdict before any model answer only after value-read or near-term failure evidence supports it. |
+| Discrimination Task Bank Asset | Build a reusable false-premise, hidden-constraint, should-stop task bank only after it materially improves value reads or operator decisions. |
+| Prompt-Contract Simulation Methodology | Package as a reusable kit only if the current value-read method proves useful. |
+| Overclaim Auditor | Use Alpha to audit external AI claims and readiness language only after value-read supports the lane. |
+| Second-Opinion Widget | Critique AI answers for missing assumptions and unsupported claims only after value-read supports the lane. |
+| OpenAI-Compatible Discrimination Pipe | Consider endpoint contract only after security and value proof. |
+| Air-Gapped Local-First Governance | Treat as a business-strategy lane only after local smoke proves viability. |
+| Local Model Refusal/Instruction Registry | Consider after local multi-model smoke. |
+| Evidence-Bound Investor Proof Harness | Consider after value-read and MVP Scorecard. |
+| Compliance-Pack Generator | Consider after Decision Provenance Ledger validates governance demand. |
+
+### Reject for Now
+
+- generic chat UI
+- direct Pi integration
+- broad RAG
+- consensus-only model jury
+- broad observability dashboard
+- commercial launch material
+
+### Activation Rule
+
+Do not add a candidate as an execution lane unless it either follows a positive
+value-read signal, prevents a concrete near-term failure, or materially improves
+operator decision quality without weakening evidence boundaries.
+
+### Explicitly Deferred or Forbidden Exposure/Claim Lanes
+
+These remain deferred even after the expanded prompt set. Do not run them until
+the required evidence gates pass.
+
+| item | executor | status | reason |
+|------|----------|--------|--------|
+| Actual external exposure | none | deferred | Requires public exposure readiness gate to pass, DEF-002 closure, smoke evidence, operator approval, auth/rate-limit/tenant/CORS closure, cost controls, and incident-response minimums. |
+| Production readiness claims | none | forbidden | No evidence supports production readiness. Do not create a prompt for this until value, runtime, security, provider, and exposure gates all pass. |
+| Benchmark superiority claims | none | forbidden | Requires an executed value experiment or stronger benchmark protocol that passes predefined criteria. Protocol-only evidence is not enough. |
+| Deleting evidence packets | none | forbidden | Evidence packets should be archived, indexed, or superseded, not deleted. Deletion would damage traceability. |
+| Broad runtime architecture rewrite | none | deferred | Runtime entrypoint map may recommend future consolidation, but no broad rewrite should start before value proof and specific low-risk consolidation lanes exist. |
+| Large broad eval run | none | deferred | Use smoke, no-echo gate, preregistration, and value pilot first. Do not run large evals until protocol preconditions are satisfied. |
+| Commercial launch | none | deferred | Needs value proof, security closure, product UX, support plan, legal/privacy review, and pricing/billing model. |


### PR DESCRIPTION
### Motivation

- Preserve a set of reviewed but non-executing ideas so they remain visible as later candidates rather than being promoted into active lanes. 
- Make explicit which opportunity items are intentionally rejected, deferred, or forbidden to prevent accidental escalation or public-facing readiness claims. 
- Provide a clear activation rule to gate future additions on concrete value-read, failure-prevention, or operator-decision-quality signals. 

### Description

- Add a `Deferred Addendum — 2026-06-14` section to `docs/OPPORTUNITY_REGISTER.md` containing the preserved candidate list and activation conditions. 
- Record a concise "Reject for Now" list and a single-line activation rule that must be satisfied before any candidate is promoted. 
- Document explicitly deferred/forbidden exposure or claim lanes (e.g., production readiness claims, benchmark superiority claims, evidence deletion, broad runtime rewrites, large eval runs, commercial launch). 

### Testing

- Ran `git diff --check` to validate whitespace and diff sanity, which passed. 
- Executed a Python smoke assertion that verified the addendum strings exist in `docs/OPPORTUNITY_REGISTER.md`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e677057908329aa525450a20545dc)