### PR TITLE
Add local Ollama model catalog packet (ALPHA-SOLVER-LOCAL-MODEL-CATALOG-001)

### DIFF
--- a/docs/evals/runs/alpha-solver-local-model-catalog-001/README.md
+++ b/docs/evals/runs/alpha-solver-local-model-catalog-001/README.md
@@ -1,0 +1,30 @@
+# Alpha Solver Local Model Catalog 001
+
+Lane ID: `ALPHA-SOLVER-LOCAL-MODEL-CATALOG-001`
+
+Verdict: `LOCAL_MODEL_CATALOG_CAPTURED`
+
+## TLDR
+
+This packet inventories Ollama-hosted local model families that operators may consider for free local testing before any paid-provider testing. It is documentation only: no models were installed, no Ollama endpoint was called, no hosted providers were called, and no routing behavior was exercised.
+
+## Source context inspected
+
+- `alpha/local_llm/provider_adapter.py`
+- `alpha/local_llm/operator_cli.py`
+- `alpha/local_llm/orchestration_runner.py`
+- `docs/local_llm_solver_orchestration_operator_guide/`
+- `docs/local_llm_solver_orchestration_guardrails/`
+- `docs/evals/runs/20260604-alpha-local-llm-preview-readiness/`
+- `docs/evals/runs/20260604-alpha-local-llm-provider-adapter/`
+
+## Packet files
+
+- `current-local-llm-adapter-map.md`
+- `ollama-model-candidates.md`
+- `model-role-matrix.md`
+- `local-resource-notes.md`
+- `routing-opportunity-map.md`
+- `evidence-boundary.md`
+- `selected-next-lane.md`
+- `non-actions.md`

--- a/docs/evals/runs/alpha-solver-local-model-catalog-001/README.md
+++ b/docs/evals/runs/alpha-solver-local-model-catalog-001/README.md
@@ -6,7 +6,7 @@ Verdict: `LOCAL_MODEL_CATALOG_CAPTURED`
 
 ## TLDR
 
-This packet inventories Ollama-hosted local model families that operators may consider for free local testing before any paid-provider testing. It is documentation only: no models were installed, no Ollama endpoint was called, no hosted providers were called, and no routing behavior was exercised.
+This packet inventories Ollama-hosted local model families that operators may consider for free local testing before any paid-provider testing. It is documentation only: no models were installed, no Ollama endpoint was called, no default urllib loopback transport was exercised, no hosted providers were called, and no routing behavior was exercised.
 
 ## Source context inspected
 

--- a/docs/evals/runs/alpha-solver-local-model-catalog-001/README.md
+++ b/docs/evals/runs/alpha-solver-local-model-catalog-001/README.md
@@ -18,6 +18,10 @@ This packet inventories Ollama-hosted local model families that operators may co
 - `docs/evals/runs/20260604-alpha-local-llm-preview-readiness/`
 - `docs/evals/runs/20260604-alpha-local-llm-provider-adapter/`
 
+## Guardrail coverage
+
+This packet lives under `docs/evals/runs/alpha-solver-local-model-catalog-001/`. The local LLM evidence-boundary checker and packet-consistency checker must discover the general `docs/evals/runs/alpha-solver-local-*` namespace so this packet is scanned instead of skipped.
+
 ## Packet files
 
 - `current-local-llm-adapter-map.md`

--- a/docs/evals/runs/alpha-solver-local-model-catalog-001/current-local-llm-adapter-map.md
+++ b/docs/evals/runs/alpha-solver-local-model-catalog-001/current-local-llm-adapter-map.md
@@ -14,14 +14,15 @@ The repository already contains a default-off local LLM adapter and operator-onl
 | `ALPHA_LOCAL_LLM_TIMEOUT_SECONDS` | Present in runtime config and operator CLI environment builder. | Must be finite and positive. |
 | Local loopback endpoint validation | Present via `validate_ollama_local_endpoint`. | Allows HTTP loopback such as localhost or loopback IP; rejects non-local hosts, credentials, and non-HTTP schemes. |
 | Default-off local model behavior | Present. | Runtime config requires explicit enablement and fails closed otherwise. |
-| Fake or injected transport tests support | Present by design through injected backend and `OllamaJSONTransport`. | No default network call happens without explicit transport. |
+| Fake or injected transport tests support | Present by design through injected backend and `OllamaJSONTransport`. | Tests and CI should use injected fake transports; the public/operator runtime path may use the default urllib loopback transport when explicitly enabled and valid config is supplied. |
 
 ## Current adapter shape
 
 - The provider adapter builds messages with a portable-contract system message and a separate user message.
 - The Ollama backend maps requests to an `/api/chat`-style JSON payload.
-- The backend records calls and payloads, validates endpoint/model/timeout, and fails closed if no injected transport is provided.
-- The operator CLI is explicitly local-only and default-off through a required `--enable-local-llm` flag plus endpoint, model, and timeout arguments.
+- The backend records calls and payloads and validates endpoint/model/timeout before transport use.
+- Direct backend construction without a transport fails closed, while `run_configured_local_llm_runtime` supplies the default urllib loopback Ollama transport when local LLM is explicitly enabled and valid endpoint/model/timeout config is provided.
+- The operator CLI is explicitly local-only and default-off through a required `--enable-local-llm` flag plus endpoint, model, and timeout arguments, so operator-run local mode may make a real loopback Ollama call after opt-in.
 - The orchestration runner is non-production, local-only, and bounded to a two-pass local expert flow.
 
 ## Current unsupported states
@@ -29,3 +30,4 @@ The repository already contains a default-off local LLM adapter and operator-onl
 - No claim is made that any cataloged Ollama model is installed.
 - No claim is made that local routing works.
 - No claim is made that model output quality, benchmark behavior, or provider readiness has been established.
+- This docs-only catalog did not exercise the default urllib loopback transport or any injected fake transport.

--- a/docs/evals/runs/alpha-solver-local-model-catalog-001/current-local-llm-adapter-map.md
+++ b/docs/evals/runs/alpha-solver-local-model-catalog-001/current-local-llm-adapter-map.md
@@ -1,0 +1,31 @@
+# Current Local LLM Adapter Map
+
+## Inventory result
+
+The repository already contains a default-off local LLM adapter and operator-only path. The current state supports documentation-level inventory for model cataloging, not live model evaluation.
+
+## Configuration support
+
+| Item | Observed state | Boundary |
+| --- | --- | --- |
+| `ALPHA_LOCAL_LLM_ENABLED` | Present in runtime config and operator CLI environment builder. | Required opt-in; disabled by default when absent or false-like. |
+| `ALPHA_LOCAL_LLM_ENDPOINT` | Present in runtime config and operator CLI environment builder. | Must pass local loopback validation. |
+| `ALPHA_LOCAL_LLM_MODEL` | Present in runtime config and operator CLI environment builder. | Exact non-empty model string required; catalog names are examples only. |
+| `ALPHA_LOCAL_LLM_TIMEOUT_SECONDS` | Present in runtime config and operator CLI environment builder. | Must be finite and positive. |
+| Local loopback endpoint validation | Present via `validate_ollama_local_endpoint`. | Allows HTTP loopback such as localhost or loopback IP; rejects non-local hosts, credentials, and non-HTTP schemes. |
+| Default-off local model behavior | Present. | Runtime config requires explicit enablement and fails closed otherwise. |
+| Fake or injected transport tests support | Present by design through injected backend and `OllamaJSONTransport`. | No default network call happens without explicit transport. |
+
+## Current adapter shape
+
+- The provider adapter builds messages with a portable-contract system message and a separate user message.
+- The Ollama backend maps requests to an `/api/chat`-style JSON payload.
+- The backend records calls and payloads, validates endpoint/model/timeout, and fails closed if no injected transport is provided.
+- The operator CLI is explicitly local-only and default-off through a required `--enable-local-llm` flag plus endpoint, model, and timeout arguments.
+- The orchestration runner is non-production, local-only, and bounded to a two-pass local expert flow.
+
+## Current unsupported states
+
+- No claim is made that any cataloged Ollama model is installed.
+- No claim is made that local routing works.
+- No claim is made that model output quality, benchmark behavior, or provider readiness has been established.

--- a/docs/evals/runs/alpha-solver-local-model-catalog-001/evidence-boundary.md
+++ b/docs/evals/runs/alpha-solver-local-model-catalog-001/evidence-boundary.md
@@ -4,6 +4,10 @@
 
 This lane may be cited only as evidence that a documentation catalog of local Ollama model family candidates was captured against the existing default-off local LLM adapter context. It is not evidence that the default urllib loopback transport or an injected fake transport was exercised.
 
+## Guardrail expectation
+
+The repository guardrail checks must include this packet path: `docs/evals/runs/alpha-solver-local-model-catalog-001/`. Passing checks are meaningful for this lane only when this packet is included in evidence-boundary and packet-consistency discovery.
+
 ## Required evidence before behavior use
 
 Before any model family can be used as behavior evidence, a future lane must capture at minimum:

--- a/docs/evals/runs/alpha-solver-local-model-catalog-001/evidence-boundary.md
+++ b/docs/evals/runs/alpha-solver-local-model-catalog-001/evidence-boundary.md
@@ -2,7 +2,7 @@
 
 ## Allowed evidence
 
-This lane may be cited only as evidence that a documentation catalog of local Ollama model family candidates was captured against the existing default-off local LLM adapter context.
+This lane may be cited only as evidence that a documentation catalog of local Ollama model family candidates was captured against the existing default-off local LLM adapter context. It is not evidence that the default urllib loopback transport or an injected fake transport was exercised.
 
 ## Required evidence before behavior use
 

--- a/docs/evals/runs/alpha-solver-local-model-catalog-001/evidence-boundary.md
+++ b/docs/evals/runs/alpha-solver-local-model-catalog-001/evidence-boundary.md
@@ -1,0 +1,27 @@
+# Evidence Boundary
+
+## Allowed evidence
+
+This lane may be cited only as evidence that a documentation catalog of local Ollama model family candidates was captured against the existing default-off local LLM adapter context.
+
+## Required evidence before behavior use
+
+Before any model family can be used as behavior evidence, a future lane must capture at minimum:
+
+1. exact model identifier and, when available, model digest;
+2. local endpoint URL after loopback validation;
+3. timeout and host resource class;
+4. prompt set and expected non-secret input boundaries;
+5. raw response artifact or normalized response artifact;
+6. fail-closed reason codes for blocked or failed calls;
+7. statement that no hosted-provider token or fallback was used;
+8. repeatability notes and operator environment constraints;
+9. review criteria for each role such as coder, critic, judge, router, summarizer, or boundary checker.
+
+## Non-claims
+
+This lane does not claim local model behavior, local routing works, production readiness, provider readiness, benchmark validation, value evidence, Alpha superiority, paid-provider parity, hosted-provider fallback, dashboard readiness, `/v1/solve` readiness, or safety validation.
+
+## Allowed verdict
+
+`LOCAL_MODEL_CATALOG_CAPTURED`

--- a/docs/evals/runs/alpha-solver-local-model-catalog-001/local-resource-notes.md
+++ b/docs/evals/runs/alpha-solver-local-model-catalog-001/local-resource-notes.md
@@ -1,0 +1,15 @@
+# Local Resource Notes
+
+## Resource classes
+
+- Small laptop: likely appropriate for smaller quantized chat or embedding models, subject to operator hardware and current Ollama packaging.
+- Stronger laptop: likely appropriate for mid-size quantized models, especially coder or stronger generalist variants.
+- Desktop/GPU: likely needed for larger variants or multiple-model iteration where latency matters.
+- Unknown: use when model size, quantization, memory pressure, or local availability is not yet confirmed.
+
+## Practical notes
+
+- Exact RAM, VRAM, CPU, and latency needs are not measured in this lane.
+- Install commands in this packet are not execution logs.
+- The next harness should record model name, model digest when available, host class, endpoint URL shape, timeout, prompt count, and fail-closed reason codes.
+- Multi-model local testing should start serially before any parallel execution, to avoid confounding resource failures with model behavior.

--- a/docs/evals/runs/alpha-solver-local-model-catalog-001/model-role-matrix.md
+++ b/docs/evals/runs/alpha-solver-local-model-catalog-001/model-role-matrix.md
@@ -1,0 +1,14 @@
+# Model Role Matrix
+
+| Family | Generalist | Coder | Critic | Safety/boundary checker | Summarizer | Judge candidate | Router candidate | Embedding/retrieval |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Llama | Candidate | Possible | Candidate | Possible | Candidate | Possible | Candidate | No |
+| Qwen | Candidate | Possible | Candidate | Possible | Candidate | Possible | Candidate | No |
+| Qwen Coder | Possible | Candidate | Candidate | Possible | Possible | Possible | Possible | No |
+| DeepSeek-R1 related | Possible | Possible | Candidate | Possible | Possible | Candidate | Possible | No |
+| Gemma | Candidate | Possible | Possible | Candidate | Candidate | Possible | Possible | No |
+| Mistral / Nemo | Candidate | Possible | Possible | Possible | Candidate | Possible | Candidate | No |
+| Hermes | Candidate | Possible | Candidate | Possible | Possible | Candidate | Possible | No |
+| Embedding models | No | No | No | No | No | No | Possible support | Candidate |
+
+`Candidate` means worth considering in a future smoke harness. It does not mean proven, validated, recommended for production, or behaviorally superior.

--- a/docs/evals/runs/alpha-solver-local-model-catalog-001/non-actions.md
+++ b/docs/evals/runs/alpha-solver-local-model-catalog-001/non-actions.md
@@ -12,4 +12,5 @@ This lane intentionally did not:
 - implement routing or retrieval;
 - claim model performance;
 - claim local routing works;
-- claim production readiness, provider readiness, benchmark validation, value evidence, Alpha superiority, or safety validation.
+- claim production readiness, provider readiness, benchmark validation, value evidence, Alpha superiority, or safety validation;
+- bypass or intentionally exclude this packet from local LLM guardrail discovery.

--- a/docs/evals/runs/alpha-solver-local-model-catalog-001/non-actions.md
+++ b/docs/evals/runs/alpha-solver-local-model-catalog-001/non-actions.md
@@ -1,0 +1,15 @@
+# Non-Actions
+
+This lane intentionally did not:
+
+- call Ollama;
+- install or pull models;
+- call hosted providers;
+- use OpenAI, Anthropic, Gemini, DeepSeek hosted, or other API tokens;
+- run paid providers;
+- update Google Sheets or external backlog ledgers;
+- expose API routes, dashboard surfaces, or `/v1/solve`;
+- implement routing or retrieval;
+- claim model performance;
+- claim local routing works;
+- claim production readiness, provider readiness, benchmark validation, value evidence, Alpha superiority, or safety validation.

--- a/docs/evals/runs/alpha-solver-local-model-catalog-001/ollama-model-candidates.md
+++ b/docs/evals/runs/alpha-solver-local-model-catalog-001/ollama-model-candidates.md
@@ -1,0 +1,14 @@
+# Ollama Model Candidates
+
+These entries are operator guidance examples for future local testing. Install commands are examples only and are not evidence that the model exists in the local environment, has been pulled, can run on the operator machine, or performs well. Operators should check the current Ollama library and local hardware before use.
+
+| Family | Example Ollama names or pulls | Likely role candidates | Resource class | Notes |
+| --- | --- | --- | --- | --- |
+| Llama | `ollama pull llama3.2`, `ollama pull llama3.1`, `ollama pull llama3` | generalist, summarizer, critic, router candidate | small laptop to desktop/GPU depending on size | Useful baseline family for broad instruction following; behavior evidence requires controlled prompts and logged outputs. |
+| Qwen | `ollama pull qwen2.5`, `ollama pull qwen3` | generalist, summarizer, critic, router candidate | small laptop to desktop/GPU depending on size | Candidate for multilingual/general reasoning trials; no performance claim in this packet. |
+| Qwen Coder | `ollama pull qwen2.5-coder`, `ollama pull qwen3-coder` | coder, code critic, implementation reviewer | stronger laptop to desktop/GPU depending on size | Candidate for code-focused local smoke tasks; evidence requires scoped code prompts and deterministic logs. |
+| DeepSeek-R1 related | `ollama pull deepseek-r1` | reasoning candidate, critic, judge candidate | stronger laptop to desktop/GPU; unknown for larger variants | Candidate for reasoning-style local comparison; outputs may require special parsing boundaries. |
+| Gemma | `ollama pull gemma3`, `ollama pull gemma2` | generalist, summarizer, safety/boundary checker candidate | small laptop to desktop/GPU depending on size | Candidate for lightweight local checks; must not be treated as safety validation without test evidence. |
+| Mistral / Nemo | `ollama pull mistral`, `ollama pull mistral-nemo` | generalist, summarizer, router candidate | stronger laptop to desktop/GPU depending on size | Candidate for concise local instruction following; availability varies by operator environment. |
+| Hermes | `ollama pull hermes3`, `ollama pull nous-hermes2` | generalist, critic, judge candidate | stronger laptop to desktop/GPU depending on size | Candidate for instruction-tuned local review roles; no judge reliability is claimed. |
+| Embedding models | `ollama pull nomic-embed-text`, `ollama pull mxbai-embed-large` | embedding/retrieval support | small laptop to stronger laptop depending on model | Future retrieval/routing support only; current adapter is chat-shaped and does not provide retrieval routing evidence. |

--- a/docs/evals/runs/alpha-solver-local-model-catalog-001/routing-opportunity-map.md
+++ b/docs/evals/runs/alpha-solver-local-model-catalog-001/routing-opportunity-map.md
@@ -1,0 +1,18 @@
+# Routing Opportunity Map
+
+## Opportunities
+
+| Opportunity | Candidate families | What a future harness should test | Evidence needed before use |
+| --- | --- | --- | --- |
+| General answer path | Llama, Qwen, Gemma, Mistral/Nemo, Hermes | Single prompt, normalized output, failure handling. | Prompt transcript, model identifier, endpoint validation, timeout, output capture, non-echo checks. |
+| Code-focused path | Qwen Coder, Llama, DeepSeek-R1 related | Code explanation or patch-planning prompts only. | Reproducible local logs and reviewer assessment criteria. |
+| Critic/reviewer path | DeepSeek-R1 related, Hermes, Qwen Coder, Llama | Second-pass critique of another local output. | Paired input/output logs and documented disagreement handling. |
+| Boundary-check path | Gemma, Llama, Qwen | Classify blocked claims or unsafe requests. | Gold prompts and expected labels; model output alone is not safety validation. |
+| Summarizer path | Llama, Qwen, Gemma, Mistral/Nemo | Compress operator artifacts without changing claims. | Diffable summaries and boundary-preservation checks. |
+| Judge candidate path | DeepSeek-R1 related, Hermes, Qwen | Rank or label outputs for local-only experiments. | Calibration set, blind labels, tie handling, and audit logs. |
+| Router candidate path | Llama, Qwen, Mistral/Nemo | Choose a model family based on prompt type. | Ground-truth routing set and explicit misroute handling. |
+| Retrieval support | nomic-embed-text, mxbai-embed-large | Local embedding generation and retrieval lookup. | Separate embedding endpoint support, corpus version, retrieval metrics, and privacy boundary review. |
+
+## Not yet implemented
+
+This packet recommends a future local multi-model smoke harness. It does not implement routing, retrieval, model selection, dashboard exposure, or `/v1/solve` exposure.

--- a/docs/evals/runs/alpha-solver-local-model-catalog-001/selected-next-lane.md
+++ b/docs/evals/runs/alpha-solver-local-model-catalog-001/selected-next-lane.md
@@ -1,0 +1,25 @@
+# Selected Next Lane
+
+Selected next lane: `ALPHA-SOLVER-LOCAL-MULTI-MODEL-SMOKE-HARNESS-001`
+
+## Purpose
+
+Build a local-only, default-off, multi-model smoke harness that can iterate over operator-specified Ollama model names through the existing loopback-only adapter path.
+
+## Recommended scope
+
+- Accept an explicit list of local model names.
+- Require `ALPHA_LOCAL_LLM_ENABLED=true` or an equivalent operator-only flag.
+- Reuse loopback endpoint validation and finite timeout validation.
+- Use no hosted-provider keys and no hosted fallback.
+- Run a tiny fixed prompt set with serial execution first.
+- Store normalized non-promotional artifacts with model identifiers, statuses, reasons, and boundary labels.
+- Preserve `behavior_evidence=False` unless a later approved evidence lane defines stronger criteria.
+
+## Out of scope for next lane
+
+- Production routing.
+- Dashboard or `/v1/solve` exposure.
+- Paid-provider calls.
+- Benchmark claims.
+- Model superiority claims.

--- a/scripts/check_local_llm_evidence_boundaries.py
+++ b/scripts/check_local_llm_evidence_boundaries.py
@@ -34,6 +34,7 @@ OPENAI_PACKET_DIR_PREFIXES = (
     "docs/evals/runs/local-openai-",
     "docs/evals/runs/alpha-solver-openai-",
 )
+LOCAL_MODEL_PACKET_DIR_PREFIX = "docs/evals/runs/alpha-solver-local-"
 COUNCIL_AUDIT_EVIDENCE_BUNDLE_DIR = Path(
     "docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-council-audit-evidence-bundle"
 )
@@ -183,6 +184,8 @@ def is_relevant_doc(path: Path) -> bool:
     if rel.startswith(DEF_PACKET_DIR_PREFIX):
         return True
     if rel.startswith(OPENAI_PACKET_DIR_PREFIXES):
+        return True
+    if rel.startswith(LOCAL_MODEL_PACKET_DIR_PREFIX):
         return True
     return rel.startswith(RUNS_DIR.as_posix()) and LOCAL_ORCHESTRATION_DIR_MARKER in rel
 

--- a/scripts/check_local_llm_packet_consistency.py
+++ b/scripts/check_local_llm_packet_consistency.py
@@ -37,6 +37,7 @@ PACKET_DIR_MARKERS = (
     "alpha-solver-post-level-3-",
     "alpha-solver-post-level-7-",
     "alpha-solver-def-",
+    "alpha-solver-local-",
     "openai-",
     "local-openai-",
     "alpha-solver-openai-",

--- a/tests/test_local_llm_evidence_boundaries.py
+++ b/tests/test_local_llm_evidence_boundaries.py
@@ -5,6 +5,8 @@ Ollama, hosted providers, benchmarks, dashboard routes, or /v1/solve.
 """
 from pathlib import Path
 
+LOCAL_MODEL_CATALOG_PACKET_DIR = Path("docs/evals/runs/alpha-solver-local-model-catalog-001")
+
 from scripts.check_local_llm_evidence_boundaries import (
     AUTHORITATIVE_FINAL_PACKET_FILES,
     FINAL_PACKET_DIR,
@@ -32,13 +34,25 @@ def test_relevant_docs_include_closeout_and_skip_source_artifacts():
     assert is_relevant_doc(Path("docs/evals/runs/local-openai-fixture/README.md"))
     assert is_relevant_doc(Path("docs/evals/runs/alpha-solver-openai-fixture/README.md"))
     assert is_relevant_doc(
-        Path("docs/evals/runs/alpha-solver-local-model-catalog-001/README.md")
+        LOCAL_MODEL_CATALOG_PACKET_DIR / "README.md"
     )
     assert is_relevant_doc(
         Path("docs/evals/runs/alpha-solver-local-multi-model-smoke-harness-001/README.md")
     )
     assert not is_relevant_doc(Path("docs/RUNTIME_READINESS.md"))
 
+
+
+def test_current_local_model_catalog_packet_files_are_discovered():
+    docs = set(iter_relevant_docs())
+    catalog_files = {
+        path
+        for path in LOCAL_MODEL_CATALOG_PACKET_DIR.glob("*.md")
+        if path.is_file()
+    }
+
+    assert catalog_files, "expected local model catalog packet markdown files"
+    assert catalog_files <= docs
 
 def test_promotional_claim_without_boundary_language_is_flagged():
     findings = find_promotional_claim_findings(
@@ -120,6 +134,6 @@ def test_current_relevant_docs_pass_static_check():
 
     assert docs, "expected local LLM solver orchestration docs to be discovered"
     assert (
-        Path("docs/evals/runs/alpha-solver-local-model-catalog-001/README.md") in docs
+        LOCAL_MODEL_CATALOG_PACKET_DIR / "README.md" in docs
     )
     assert check_paths(docs) == []

--- a/tests/test_local_llm_evidence_boundaries.py
+++ b/tests/test_local_llm_evidence_boundaries.py
@@ -31,6 +31,12 @@ def test_relevant_docs_include_closeout_and_skip_source_artifacts():
     assert is_relevant_doc(Path("docs/evals/runs/openai-fixture/README.md"))
     assert is_relevant_doc(Path("docs/evals/runs/local-openai-fixture/README.md"))
     assert is_relevant_doc(Path("docs/evals/runs/alpha-solver-openai-fixture/README.md"))
+    assert is_relevant_doc(
+        Path("docs/evals/runs/alpha-solver-local-model-catalog-001/README.md")
+    )
+    assert is_relevant_doc(
+        Path("docs/evals/runs/alpha-solver-local-multi-model-smoke-harness-001/README.md")
+    )
     assert not is_relevant_doc(Path("docs/RUNTIME_READINESS.md"))
 
 
@@ -113,4 +119,7 @@ def test_current_relevant_docs_pass_static_check():
     docs = iter_relevant_docs()
 
     assert docs, "expected local LLM solver orchestration docs to be discovered"
+    assert (
+        Path("docs/evals/runs/alpha-solver-local-model-catalog-001/README.md") in docs
+    )
     assert check_paths(docs) == []

--- a/tests/test_local_llm_packet_consistency.py
+++ b/tests/test_local_llm_packet_consistency.py
@@ -5,6 +5,8 @@ Ollama, hosted providers, benchmarks, dashboard routes, or /v1/solve.
 """
 from pathlib import Path
 
+LOCAL_MODEL_CATALOG_PACKET_DIR = Path("docs/evals/runs/alpha-solver-local-model-catalog-001")
+
 from scripts.check_local_llm_packet_consistency import (
     CONTROLLED_USAGE_ACCEPTED,
     LEVEL_3_ACCEPTED,
@@ -88,7 +90,7 @@ def test_current_repo_local_llm_packets_pass_packet_consistency_check():
 
 def test_default_discovery_includes_local_model_packet_families(tmp_path):
     packet_dirs = [
-        Path("docs/evals/runs/alpha-solver-local-model-catalog-001"),
+        LOCAL_MODEL_CATALOG_PACKET_DIR,
         Path("docs/evals/runs/alpha-solver-local-multi-model-smoke-harness-001"),
     ]
     for packet_dir in packet_dirs:
@@ -107,8 +109,7 @@ def test_default_discovery_includes_local_model_packet_families(tmp_path):
 
 def test_default_discovery_includes_current_local_model_catalog_packet():
     assert (
-        Path("docs/evals/runs/alpha-solver-local-model-catalog-001")
-        in iter_packet_dirs()
+        LOCAL_MODEL_CATALOG_PACKET_DIR in iter_packet_dirs()
     )
 
 

--- a/tests/test_local_llm_packet_consistency.py
+++ b/tests/test_local_llm_packet_consistency.py
@@ -86,6 +86,32 @@ def test_current_repo_local_llm_packets_pass_packet_consistency_check():
     assert check_packet_consistency(packet_dirs) == []
 
 
+def test_default_discovery_includes_local_model_packet_families(tmp_path):
+    packet_dirs = [
+        Path("docs/evals/runs/alpha-solver-local-model-catalog-001"),
+        Path("docs/evals/runs/alpha-solver-local-multi-model-smoke-harness-001"),
+    ]
+    for packet_dir in packet_dirs:
+        _write_packet(
+            tmp_path,
+            packet_dir,
+            selected_text="`ALPHA-SOLVER-LOCAL-FIXTURE-NEXT-001`\n",
+            boundary_name="non-actions.md",
+        )
+
+    discovered = iter_packet_dirs(tmp_path)
+
+    for packet_dir in packet_dirs:
+        assert packet_dir in discovered
+
+
+def test_default_discovery_includes_current_local_model_catalog_packet():
+    assert (
+        Path("docs/evals/runs/alpha-solver-local-model-catalog-001")
+        in iter_packet_dirs()
+    )
+
+
 def test_default_discovery_includes_openai_packet_families(tmp_path):
     packet_dirs = [
         Path("docs/evals/runs/openai-fixture"),


### PR DESCRIPTION
### Motivation

- Capture an operator-facing, docs-only catalog of Ollama-hosted local model families to guide safe, default-off local testing and later multi-model smoke harness work. 
- Record model-family role candidates, high-level local resource guidance, routing opportunities, and required evidence boundaries without installing or calling any models or providers. 
- Preserve existing default-off adapter semantics and loopback-only validation already present in the local adapter codepath. 

### Description

- Add a new evidence packet `docs/evals/runs/alpha-solver-local-model-catalog-001/` containing `README.md`, `current-local-llm-adapter-map.md`, `ollama-model-candidates.md`, `model-role-matrix.md`, `local-resource-notes.md`, `routing-opportunity-map.md`, `evidence-boundary.md`, `selected-next-lane.md`, and `non-actions.md`. 
- The packet inventories the adapter support visible in `alpha/local_llm/provider_adapter.py` and `operator_cli.py`, lists example Ollama pull names for families (Llama, Qwen, Qwen Coder, DeepSeek-R1 related, Gemma, Mistral/Nemo, Hermes, and embedding models), and classifies likely roles and coarse resource classes. 
- The packet defines strict evidence requirements before any local model output may be treated as behavior evidence, selects `ALPHA-SOLVER-LOCAL-MULTI-MODEL-SMOKE-HARNESS-001` as the recommended next lane, and documents explicit non-actions (no model pulls, no Ollama calls, no hosted providers, no routing implementation, no claims). 

### Testing

- Ran `python scripts/check_local_llm_doc_paths.py` which passed. 
- Ran `python scripts/check_local_llm_evidence_boundaries.py` which passed. 
- Ran `python scripts/check_local_llm_packet_consistency.py` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e677aacf88329a37c23b1517d2674)