### PR TITLE
Add local multi-model smoke harness for Ollama adapter

### DIFF
--- a/alpha/local_llm/multi_model_smoke_harness.py
+++ b/alpha/local_llm/multi_model_smoke_harness.py
@@ -47,6 +47,7 @@ _REASON_STATUS_MAP = {
     "system_echo_non_evidence": "prompt_echo",
     "model_not_installed_non_evidence": "not_installed",
 }
+_URLLIB_CONNECTION_EXCEPTION_CLASSES = frozenset({"URLError"})
 
 SMOKE_EVIDENCE_LABEL = "local_multi_model_smoke_only_no_behavior_evidence"
 DEFAULT_SMOKE_PROMPT = (
@@ -99,7 +100,47 @@ def _safe_preview(text: str, limit: int = 160) -> str:
     return text[:limit]
 
 
-def _status_from_reason(reason: str) -> str:
+def _is_default_loopback_urllib_connection_failure(
+    *,
+    reason: str,
+    metadata: Mapping[str, Any],
+    default_transport_used: bool,
+) -> bool:
+    """Detect only default local urllib connection failures.
+
+    This intentionally does not map every ``backend_error_non_evidence`` to
+    ``connection_failed``. The mapping applies only when the operator/default
+    transport path was used, the adapter metadata still identifies a loopback
+    Ollama backend, and the preserved exception/cause class is urllib's
+    connection-oriented ``URLError``.
+    """
+
+    if reason != "backend_error_non_evidence" or not default_transport_used:
+        return False
+    if metadata.get("endpoint_is_loopback") is not True:
+        return False
+    if metadata.get("local_backend") != "ollama_chat":
+        return False
+    exception_class = str(metadata.get("adapter_exception_class", ""))
+    cause_class = str(metadata.get("adapter_exception_cause_class", ""))
+    return (
+        exception_class in _URLLIB_CONNECTION_EXCEPTION_CLASSES
+        or cause_class in _URLLIB_CONNECTION_EXCEPTION_CLASSES
+    )
+
+
+def _status_from_adapter_result(
+    *,
+    reason: str,
+    metadata: Mapping[str, Any],
+    default_transport_used: bool,
+) -> str:
+    if _is_default_loopback_urllib_connection_failure(
+        reason=reason,
+        metadata=metadata,
+        default_transport_used=default_transport_used,
+    ):
+        return "connection_failed"
     return _REASON_STATUS_MAP.get(reason, "blocked")
 
 
@@ -158,10 +199,16 @@ def run_multi_model_smoke_harness(
         result = run_configured_local_llm_runtime(
             prompt, config=config, transport=transport, env={}
         )
+        result_metadata = dict(result.metadata)
+        default_transport_used = transport is None
         if result.status == "non_evidence":
             status = "substantive_looking_output"
         else:
-            status = _status_from_reason(result.reason)
+            status = _status_from_adapter_result(
+                reason=result.reason,
+                metadata=result_metadata,
+                default_transport_used=default_transport_used,
+            )
         records.append(
             ModelSmokeResult(
                 model=model,
@@ -169,7 +216,9 @@ def run_multi_model_smoke_harness(
                 reason=result.reason,
                 output_preview=_safe_preview(result.output_text),
                 metadata={
+                    **result_metadata,
                     "adapter_status": result.status,
+                    "default_transport_used": default_transport_used,
                     "no_hosted_fallback": True,
                     "no_provider_keys_accepted": True,
                     "strict_no_behavior_evidence_labeling": True,

--- a/alpha/local_llm/multi_model_smoke_harness.py
+++ b/alpha/local_llm/multi_model_smoke_harness.py
@@ -1,0 +1,222 @@
+"""Local-only multi-model smoke harness for Ollama adapter checks.
+
+This module iterates operator-supplied local Ollama model names through the
+existing Alpha Solver local LLM provider adapter. It is smoke evidence only:
+results are not behavior evidence, not quality evidence, and not routing or
+production readiness evidence. Tests should inject fake transports.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import asdict, dataclass, field
+from typing import Any, Mapping, Sequence, TextIO
+
+from .provider_adapter import (
+    LocalLLMProviderAdapterError,
+    LocalLLMRuntimeConfig,
+    OllamaJSONTransport,
+    run_configured_local_llm_runtime,
+    validate_ollama_local_endpoint,
+)
+
+_ALLOWED_STATUSES = frozenset({
+    "not_installed",
+    "connection_failed",
+    "timeout",
+    "empty_output",
+    "prompt_echo",
+    "substantive_looking_output",
+    "blocked",
+})
+_FORBIDDEN_PROVIDER_KEY_ENVS = (
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GOOGLE_API_KEY",
+    "GEMINI_API_KEY",
+    "DEEPSEEK_API_KEY",
+)
+_REASON_STATUS_MAP = {
+    "connection_failure_non_evidence": "connection_failed",
+    "timeout_non_evidence": "timeout",
+    "empty_model_output_non_evidence": "empty_output",
+    "prompt_echo_non_evidence": "prompt_echo",
+    "system_echo_non_evidence": "prompt_echo",
+    "model_not_installed_non_evidence": "not_installed",
+}
+
+SMOKE_EVIDENCE_LABEL = "local_multi_model_smoke_only_no_behavior_evidence"
+DEFAULT_SMOKE_PROMPT = (
+    "Local smoke check only. Reply with one short sentence about a safe test object. "
+    "Do not echo this prompt."
+)
+
+
+@dataclass(frozen=True)
+class ModelSmokeResult:
+    """Single model smoke record with no behavior-evidence claims."""
+
+    model: str
+    status: str
+    reason: str
+    behavior_evidence: bool = False
+    evidence_label: str = SMOKE_EVIDENCE_LABEL
+    output_preview: str = ""
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.status not in _ALLOWED_STATUSES:
+            raise ValueError(f"unsupported smoke status: {self.status}")
+        if self.behavior_evidence is not False:
+            raise ValueError("multi-model smoke results cannot claim behavior evidence")
+
+
+def parse_model_names(value: str | Sequence[str]) -> tuple[str, ...]:
+    """Parse comma/newline/sequence model input into exact non-empty names."""
+
+    raw_items: list[str] = []
+    if isinstance(value, str):
+        raw_items.extend(part for chunk in value.splitlines() for part in chunk.split(","))
+    else:
+        raw_items.extend(str(item) for item in value)
+    models = tuple(item.strip() for item in raw_items if item.strip())
+    if not models:
+        raise LocalLLMProviderAdapterError("missing_model_non_evidence")
+    if any(model != model.strip() for model in models):
+        raise LocalLLMProviderAdapterError("invalid_model_non_evidence")
+    return models
+
+
+def _present_provider_keys(env: Mapping[str, str]) -> tuple[str, ...]:
+    return tuple(key for key in _FORBIDDEN_PROVIDER_KEY_ENVS if str(env.get(key, "")).strip())
+
+
+def _safe_preview(text: str, limit: int = 160) -> str:
+    text = " ".join(text.strip().split())
+    return text[:limit]
+
+
+def _status_from_reason(reason: str) -> str:
+    return _REASON_STATUS_MAP.get(reason, "blocked")
+
+
+def run_multi_model_smoke_harness(
+    *,
+    models: Sequence[str] | str,
+    endpoint_url: str,
+    prompt: str = DEFAULT_SMOKE_PROMPT,
+    timeout_seconds: float = 10.0,
+    env: Mapping[str, str] | None = None,
+    transport: OllamaJSONTransport | None = None,
+) -> tuple[ModelSmokeResult, ...]:
+    """Run local-only adapter smoke checks for each model name.
+
+    The function validates loopback endpoint and hosted-provider-key absence
+    before any transport can be invoked. It never falls back to hosted
+    providers; callers must pass fake transports in tests.
+    """
+
+    source_env = os.environ if env is None else env
+    present_keys = _present_provider_keys(source_env)
+    parsed_models = parse_model_names(models)
+    if not isinstance(prompt, str) or not prompt.strip():
+        raise LocalLLMProviderAdapterError("missing_prompt_non_evidence")
+    if present_keys:
+        return tuple(
+            ModelSmokeResult(
+                model=model,
+                status="blocked",
+                reason="provider_keys_forbidden_non_evidence",
+                metadata={"blocked_provider_key_names": present_keys, "no_hosted_fallback": True},
+            )
+            for model in parsed_models
+        )
+    try:
+        endpoint_url = validate_ollama_local_endpoint(endpoint_url)
+    except LocalLLMProviderAdapterError as exc:
+        return tuple(
+            ModelSmokeResult(
+                model=model,
+                status="blocked",
+                reason=exc.reason_code,
+                metadata={"endpoint_is_loopback": False, "no_hosted_fallback": True},
+            )
+            for model in parsed_models
+        )
+
+    records: list[ModelSmokeResult] = []
+    for model in parsed_models:
+        config = LocalLLMRuntimeConfig(
+            endpoint_url=endpoint_url,
+            model=model,
+            timeout_seconds=timeout_seconds,
+            enabled=True,
+        )
+        result = run_configured_local_llm_runtime(
+            prompt, config=config, transport=transport, env={}
+        )
+        if result.status == "non_evidence":
+            status = "substantive_looking_output"
+        else:
+            status = _status_from_reason(result.reason)
+        records.append(
+            ModelSmokeResult(
+                model=model,
+                status=status,
+                reason=result.reason,
+                output_preview=_safe_preview(result.output_text),
+                metadata={
+                    "adapter_status": result.status,
+                    "no_hosted_fallback": True,
+                    "no_provider_keys_accepted": True,
+                    "strict_no_behavior_evidence_labeling": True,
+                },
+            )
+        )
+    return tuple(records)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m alpha.local_llm.multi_model_smoke_harness",
+        description="Local-only multi-model Ollama adapter smoke harness; no behavior evidence.",
+    )
+    parser.add_argument("--local-only", action="store_true", required=True)
+    parser.add_argument("--models", required=True, help="Comma-separated local Ollama model names.")
+    parser.add_argument("--endpoint-url", required=True)
+    parser.add_argument("--timeout-seconds", type=float, default=10.0)
+    parser.add_argument("--prompt", default=DEFAULT_SMOKE_PROMPT)
+    return parser
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    stdout: TextIO | None = None,
+    stderr: TextIO | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    out = sys.stdout if stdout is None else stdout
+    err = sys.stderr if stderr is None else stderr
+    try:
+        results = run_multi_model_smoke_harness(
+            models=args.models,
+            endpoint_url=args.endpoint_url,
+            prompt=args.prompt,
+            timeout_seconds=args.timeout_seconds,
+            env=os.environ if environ is None else environ,
+        )
+    except LocalLLMProviderAdapterError as exc:
+        print(f"blocked: {exc.reason_code}", file=err)
+        return 2
+    print(json.dumps([asdict(record) for record in results], indent=2, sort_keys=True), file=out)
+    return 0 if all(record.status in {"substantive_looking_output"} for record in results) else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/alpha/local_llm/provider_adapter.py
+++ b/alpha/local_llm/provider_adapter.py
@@ -460,12 +460,28 @@ def run_local_llm_provider_adapter(
         output_text = backend.generate(request)
     except Exception as exc:  # injected-backend-only failure normalization
         reason = getattr(exc, "reason_code", f"adapter_error:{exc.__class__.__name__}")
+        cause = exc.__cause__
+        failure_metadata = {
+            "adapter_exception_class": exc.__class__.__name__,
+            "adapter_exception_module": exc.__class__.__module__,
+        }
+        if cause is not None:
+            failure_metadata.update(
+                {
+                    "adapter_exception_cause_class": cause.__class__.__name__,
+                    "adapter_exception_cause_module": cause.__class__.__module__,
+                }
+            )
         return LocalLLMAdapterResult(
             request=request,
             output_text="",
             status="failed_closed",
             reason=reason,
-            metadata={**result_metadata, "failure_label": "failed_closed_result"},
+            metadata={
+                **result_metadata,
+                **failure_metadata,
+                "failure_label": "failed_closed_result",
+            },
         )
 
     if not output_text.strip():

--- a/alpha/local_llm/provider_adapter.py
+++ b/alpha/local_llm/provider_adapter.py
@@ -16,7 +16,7 @@ from math import isfinite
 import os
 from typing import Any, Mapping, Protocol
 from urllib.parse import urlsplit
-from urllib.error import HTTPError
+from urllib.error import HTTPError, URLError
 from urllib.request import HTTPRedirectHandler, Request as URLRequest, build_opener
 
 from .portable_contract import PortableContract, PortableContractError, load_portable_contract
@@ -271,6 +271,10 @@ class OllamaLocalHTTPBackend:
         except TimeoutError as exc:
             raise LocalLLMProviderAdapterError("timeout_non_evidence", str(exc)) from exc
         except ConnectionError as exc:
+            raise LocalLLMProviderAdapterError(
+                "connection_failure_non_evidence", str(exc)
+            ) from exc
+        except URLError as exc:
             raise LocalLLMProviderAdapterError(
                 "connection_failure_non_evidence", str(exc)
             ) from exc

--- a/docs/evals/runs/alpha-solver-local-multi-model-smoke-harness-001/README.md
+++ b/docs/evals/runs/alpha-solver-local-multi-model-smoke-harness-001/README.md
@@ -1,0 +1,17 @@
+# ALPHA-SOLVER-LOCAL-MULTI-MODEL-SMOKE-HARNESS-001
+
+Verdict: `LOCAL_MULTI_MODEL_SMOKE_HARNESS_CAPTURED_FAKE_TRANSPORT_ONLY`
+
+This packet records implementation of a local-only, multi-model smoke harness for Alpha Solver's local LLM provider adapter. The harness iterates operator-supplied Ollama model names against a loopback-only endpoint and records per-model smoke status only.
+
+This is not behavior evidence, not model quality evidence, not benchmark evidence, not routing evidence, not production readiness evidence, and not Alpha superiority evidence.
+
+## Files
+
+- [implementation-summary.md](implementation-summary.md)
+- [fake-transport-test-evidence.md](fake-transport-test-evidence.md)
+- [operator-local-run-template.md](operator-local-run-template.md)
+- [model-smoke-result-template.md](model-smoke-result-template.md)
+- [evidence-boundary.md](evidence-boundary.md)
+- [selected-next-lane.md](selected-next-lane.md)
+- [non-actions.md](non-actions.md)

--- a/docs/evals/runs/alpha-solver-local-multi-model-smoke-harness-001/evidence-boundary.md
+++ b/docs/evals/runs/alpha-solver-local-multi-model-smoke-harness-001/evidence-boundary.md
@@ -2,6 +2,10 @@
 
 This lane may be cited only as evidence that a local-only multi-model smoke harness exists and that fake-transport tests exercised its safety boundaries.
 
+`connection_failed` means the local loopback adapter path could not connect to
+local Ollama or a test fixture simulated that condition. It is not behavior
+evidence, not model quality evidence, and not a provider-readiness claim.
+
 It may not be cited as evidence of:
 
 - model quality;

--- a/docs/evals/runs/alpha-solver-local-multi-model-smoke-harness-001/evidence-boundary.md
+++ b/docs/evals/runs/alpha-solver-local-multi-model-smoke-harness-001/evidence-boundary.md
@@ -1,0 +1,20 @@
+# Evidence Boundary
+
+This lane may be cited only as evidence that a local-only multi-model smoke harness exists and that fake-transport tests exercised its safety boundaries.
+
+It may not be cited as evidence of:
+
+- model quality;
+- answer correctness;
+- behavioral scoring;
+- benchmark validation;
+- local routing success;
+- production readiness;
+- MVP readiness;
+- hosted provider integration;
+- value evidence;
+- Alpha superiority;
+- dashboard readiness;
+- `/v1/solve` readiness.
+
+The strict evidence label is `local_multi_model_smoke_only_no_behavior_evidence`. Every per-model record must keep `behavior_evidence` set to `false` unless a later approved lane explicitly changes the evidence model.

--- a/docs/evals/runs/alpha-solver-local-multi-model-smoke-harness-001/fake-transport-test-evidence.md
+++ b/docs/evals/runs/alpha-solver-local-multi-model-smoke-harness-001/fake-transport-test-evidence.md
@@ -1,0 +1,21 @@
+# Fake Transport Test Evidence
+
+CI tests use fake transports only and do not require Ollama.
+
+Targeted test command:
+
+```bash
+python -m pytest -q tests/test_local_llm_multi_model_smoke_harness.py tests/test_local_llm_provider_adapter.py
+```
+
+Coverage assertions:
+
+1. Multiple model names are iterated safely.
+2. Hosted provider keys in env fail closed before transport.
+3. Non-loopback endpoints fail closed before transport.
+4. Empty output fails closed.
+5. Prompt echo is detected.
+6. Per-model result records do not claim behavior evidence.
+7. No hosted fallback exists on local connection failure.
+
+Verdict: `LOCAL_MULTI_MODEL_SMOKE_HARNESS_CAPTURED_FAKE_TRANSPORT_ONLY`.

--- a/docs/evals/runs/alpha-solver-local-multi-model-smoke-harness-001/fake-transport-test-evidence.md
+++ b/docs/evals/runs/alpha-solver-local-multi-model-smoke-harness-001/fake-transport-test-evidence.md
@@ -17,5 +17,9 @@ Coverage assertions:
 5. Prompt echo is detected.
 6. Per-model result records do not claim behavior evidence.
 7. No hosted fallback exists on local connection failure.
+8. Default/operator-path urllib loopback unavailability is preserved as
+   `connection_failed` without requiring real Ollama.
+9. Generic backend errors remain `blocked` so unrelated backend failures are
+   not hidden as connection failures.
 
 Verdict: `LOCAL_MULTI_MODEL_SMOKE_HARNESS_CAPTURED_FAKE_TRANSPORT_ONLY`.

--- a/docs/evals/runs/alpha-solver-local-multi-model-smoke-harness-001/fake-transport-test-evidence.md
+++ b/docs/evals/runs/alpha-solver-local-multi-model-smoke-harness-001/fake-transport-test-evidence.md
@@ -19,7 +19,10 @@ Coverage assertions:
 7. No hosted fallback exists on local connection failure.
 8. Default/operator-path urllib loopback unavailability is preserved as
    `connection_failed` without requiring real Ollama.
-9. Generic backend errors remain `blocked` so unrelated backend failures are
+9. Adapter-normalized `backend_error_non_evidence` with default loopback
+   Ollama context and a preserved urllib `URLError` cause maps to
+   `connection_failed`.
+10. Generic backend errors remain `blocked` so unrelated backend failures are
    not hidden as connection failures.
 
 Verdict: `LOCAL_MULTI_MODEL_SMOKE_HARNESS_CAPTURED_FAKE_TRANSPORT_ONLY`.

--- a/docs/evals/runs/alpha-solver-local-multi-model-smoke-harness-001/implementation-summary.md
+++ b/docs/evals/runs/alpha-solver-local-multi-model-smoke-harness-001/implementation-summary.md
@@ -10,6 +10,9 @@ Implemented `alpha.local_llm.multi_model_smoke_harness` as a narrow, local-only 
 - preserves local loopback connection failures, including default urllib
   operator-path failures when Ollama is unavailable, as `connection_failed`
   rather than collapsing them into generic `blocked`;
+- narrowly maps adapter-normalized `backend_error_non_evidence` to
+  `connection_failed` only when the default loopback Ollama transport context
+  preserves a urllib `URLError` exception/cause class;
 - records per-model statuses only: `not_installed`, `connection_failed`, `timeout`, `empty_output`, `prompt_echo`, `substantive_looking_output`, or `blocked`;
 - labels every result with `local_multi_model_smoke_only_no_behavior_evidence` and `behavior_evidence: false`;
 - contains no hosted-provider fallback path.

--- a/docs/evals/runs/alpha-solver-local-multi-model-smoke-harness-001/implementation-summary.md
+++ b/docs/evals/runs/alpha-solver-local-multi-model-smoke-harness-001/implementation-summary.md
@@ -7,6 +7,9 @@ Implemented `alpha.local_llm.multi_model_smoke_harness` as a narrow, local-only 
 - rejects hosted provider keys by failing closed before transport invocation;
 - uses the existing `run_configured_local_llm_runtime` local adapter path;
 - supports fake injected transports for CI tests;
+- preserves local loopback connection failures, including default urllib
+  operator-path failures when Ollama is unavailable, as `connection_failed`
+  rather than collapsing them into generic `blocked`;
 - records per-model statuses only: `not_installed`, `connection_failed`, `timeout`, `empty_output`, `prompt_echo`, `substantive_looking_output`, or `blocked`;
 - labels every result with `local_multi_model_smoke_only_no_behavior_evidence` and `behavior_evidence: false`;
 - contains no hosted-provider fallback path.
@@ -22,3 +25,8 @@ python -m alpha.local_llm.multi_model_smoke_harness \
 ```
 
 Do not run this against real Ollama unless the operator explicitly confirms local Ollama is running and no private data will be sent.
+
+Compatibility note: if the local-model packet guardrail discovery update from
+PR #540 is present on the target base, this `alpha-solver-local-*` packet should
+be included in the static guardrail scans. If #540 is not yet present, recheck
+this PR after #540 lands rather than duplicating broad checker changes here.

--- a/docs/evals/runs/alpha-solver-local-multi-model-smoke-harness-001/implementation-summary.md
+++ b/docs/evals/runs/alpha-solver-local-multi-model-smoke-harness-001/implementation-summary.md
@@ -1,0 +1,24 @@
+# Implementation Summary
+
+Implemented `alpha.local_llm.multi_model_smoke_harness` as a narrow, local-only harness that:
+
+- accepts a comma-separated or sequence list of model names;
+- validates the Ollama endpoint as HTTP loopback or localhost before transport invocation;
+- rejects hosted provider keys by failing closed before transport invocation;
+- uses the existing `run_configured_local_llm_runtime` local adapter path;
+- supports fake injected transports for CI tests;
+- records per-model statuses only: `not_installed`, `connection_failed`, `timeout`, `empty_output`, `prompt_echo`, `substantive_looking_output`, or `blocked`;
+- labels every result with `local_multi_model_smoke_only_no_behavior_evidence` and `behavior_evidence: false`;
+- contains no hosted-provider fallback path.
+
+The CLI is intentionally operator-only:
+
+```bash
+python -m alpha.local_llm.multi_model_smoke_harness \
+  --local-only \
+  --models "llama3.2:1b,qwen2.5:0.5b" \
+  --endpoint-url http://127.0.0.1:11434/api/chat \
+  --timeout-seconds 10
+```
+
+Do not run this against real Ollama unless the operator explicitly confirms local Ollama is running and no private data will be sent.

--- a/docs/evals/runs/alpha-solver-local-multi-model-smoke-harness-001/model-smoke-result-template.md
+++ b/docs/evals/runs/alpha-solver-local-multi-model-smoke-harness-001/model-smoke-result-template.md
@@ -1,0 +1,21 @@
+# Model Smoke Result Template
+
+Use one record per model name.
+
+```json
+{
+  "model": "<local-ollama-model-name>",
+  "status": "not_installed | connection_failed | timeout | empty_output | prompt_echo | substantive_looking_output | blocked",
+  "reason": "<non_evidence_reason_code>",
+  "behavior_evidence": false,
+  "evidence_label": "local_multi_model_smoke_only_no_behavior_evidence",
+  "output_preview": "<short redacted preview if safe>",
+  "metadata": {
+    "no_hosted_fallback": true,
+    "no_provider_keys_accepted": true,
+    "strict_no_behavior_evidence_labeling": true
+  }
+}
+```
+
+`substantive_looking_output` means only that the adapter received non-empty text that was not exact prompt/system echo. It is not a claim of correctness, quality, utility, benchmark performance, routing success, production readiness, value evidence, or Alpha superiority.

--- a/docs/evals/runs/alpha-solver-local-multi-model-smoke-harness-001/non-actions.md
+++ b/docs/evals/runs/alpha-solver-local-multi-model-smoke-harness-001/non-actions.md
@@ -1,0 +1,12 @@
+# Non-Actions
+
+This lane did not:
+
+- call hosted providers;
+- use OpenAI, Anthropic, Gemini, DeepSeek, or other hosted API tokens;
+- send private repo files or secrets to any model;
+- expose dashboard routes, API routes, or `/v1/solve`;
+- run broad evals;
+- run real Ollama in CI;
+- claim model quality, routing success, value evidence, benchmark validation, production readiness, or Alpha superiority;
+- update Google Sheets or backlog workbooks.

--- a/docs/evals/runs/alpha-solver-local-multi-model-smoke-harness-001/operator-local-run-template.md
+++ b/docs/evals/runs/alpha-solver-local-multi-model-smoke-harness-001/operator-local-run-template.md
@@ -1,0 +1,29 @@
+# Operator Local Run Template
+
+Only run on an operator machine after confirming all of the following:
+
+- Ollama is installed and listening on a loopback endpoint.
+- The named models are local Ollama model names.
+- No private repo files, secrets, customer data, or credentials are included in the prompt.
+- No hosted provider keys are present in the environment.
+- The output will be treated as smoke evidence only.
+
+Template:
+
+```bash
+unset OPENAI_API_KEY ANTHROPIC_API_KEY GOOGLE_API_KEY GEMINI_API_KEY DEEPSEEK_API_KEY
+python -m alpha.local_llm.multi_model_smoke_harness \
+  --local-only \
+  --models "llama3.2:1b,qwen2.5:0.5b" \
+  --endpoint-url "http://127.0.0.1:11434/api/chat" \
+  --timeout-seconds 10 \
+  --prompt "Local smoke check only. Reply with one short sentence about a safe test object. Do not echo this prompt."
+```
+
+Allowed operator-run verdicts:
+
+- `LOCAL_MULTI_MODEL_SMOKE_CAPTURED_OPERATOR_LOCAL_OLLAMA`
+- `LOCAL_MULTI_MODEL_SMOKE_BLOCKED_LOCAL_OLLAMA_UNAVAILABLE`
+- `STOP_INCONCLUSIVE`
+
+Do not convert an operator local run into quality, benchmark, routing, production, or value evidence.

--- a/docs/evals/runs/alpha-solver-local-multi-model-smoke-harness-001/operator-local-run-template.md
+++ b/docs/evals/runs/alpha-solver-local-multi-model-smoke-harness-001/operator-local-run-template.md
@@ -7,6 +7,9 @@ Only run on an operator machine after confirming all of the following:
 - No private repo files, secrets, customer data, or credentials are included in the prompt.
 - No hosted provider keys are present in the environment.
 - The output will be treated as smoke evidence only.
+- If local Ollama is unavailable, preserve that result as
+  `connection_failed` / `LOCAL_MULTI_MODEL_SMOKE_BLOCKED_LOCAL_OLLAMA_UNAVAILABLE`
+  and do not retry through hosted providers.
 
 Template:
 

--- a/docs/evals/runs/alpha-solver-local-multi-model-smoke-harness-001/selected-next-lane.md
+++ b/docs/evals/runs/alpha-solver-local-multi-model-smoke-harness-001/selected-next-lane.md
@@ -1,0 +1,5 @@
+# Selected Next Lane
+
+Likely selected next lane: `ALPHA-SOLVER-LOCAL-ROUTING-MATRIX-001`.
+
+Rationale: after safe local multi-model smoke capture exists, the next narrow lane can define a local routing matrix without making quality, benchmark, value, production-readiness, or superiority claims.

--- a/tests/test_local_llm_multi_model_smoke_harness.py
+++ b/tests/test_local_llm_multi_model_smoke_harness.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
 from urllib.error import URLError
 
 from alpha.local_llm.multi_model_smoke_harness import (
@@ -157,6 +158,41 @@ def test_default_operator_path_urllib_unavailable_maps_to_connection_failed(monk
     assert results[0].behavior_evidence is False
     assert results[0].metadata["no_hosted_fallback"] is True
     assert results[0].metadata["no_provider_keys_accepted"] is True
+
+
+def test_adapter_normalized_urllib_backend_error_with_local_context_maps_to_connection_failed(
+    monkeypatch,
+):
+    def adapter_normalized_backend_error(prompt, *, config, transport, env):
+        assert transport is None
+        return SimpleNamespace(
+            status="failed_closed",
+            reason="backend_error_non_evidence",
+            output_text="",
+            metadata={
+                "endpoint_is_loopback": True,
+                "local_backend": "ollama_chat",
+                "adapter_exception_cause_class": "URLError",
+                "behavior_evidence": False,
+            },
+        )
+
+    monkeypatch.setattr(
+        "alpha.local_llm.multi_model_smoke_harness.run_configured_local_llm_runtime",
+        adapter_normalized_backend_error,
+    )
+
+    results = run_multi_model_smoke_harness(
+        models="operator-local-model",
+        endpoint_url="http://127.0.0.1:11434/api/chat",
+        env={},
+    )
+
+    assert results[0].status == "connection_failed"
+    assert results[0].reason == "backend_error_non_evidence"
+    assert results[0].behavior_evidence is False
+    assert results[0].metadata["default_transport_used"] is True
+    assert results[0].metadata["no_hosted_fallback"] is True
 
 
 def test_default_operator_path_keeps_generic_backend_errors_blocked(monkeypatch):

--- a/tests/test_local_llm_multi_model_smoke_harness.py
+++ b/tests/test_local_llm_multi_model_smoke_harness.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from alpha.local_llm.multi_model_smoke_harness import (
+    run_multi_model_smoke_harness,
+)
+
+
+def _content_transport(content: str):
+    def transport(*, endpoint_url, payload, timeout_seconds):
+        return {"message": {"role": "assistant", "content": content}}
+
+    return transport
+
+
+def test_multiple_model_names_are_iterated_safely_with_fake_transport():
+    seen_models = []
+
+    def fake_transport(*, endpoint_url, payload, timeout_seconds):
+        seen_models.append(payload["model"])
+        return {"message": {"role": "assistant", "content": f"fixture for {payload['model']}"}}
+
+    results = run_multi_model_smoke_harness(
+        models="llama3.2:1b, qwen2.5:0.5b",
+        endpoint_url="http://127.0.0.1:11434/api/chat",
+        env={},
+        transport=fake_transport,
+    )
+
+    assert seen_models == ["llama3.2:1b", "qwen2.5:0.5b"]
+    assert [record.model for record in results] == ["llama3.2:1b", "qwen2.5:0.5b"]
+    assert all(record.status == "substantive_looking_output" for record in results)
+    assert all(record.behavior_evidence is False for record in results)
+
+
+def test_hosted_provider_keys_in_env_fail_closed_before_transport():
+    observed = {"called": False}
+
+    def fake_transport(*, endpoint_url, payload, timeout_seconds):
+        observed["called"] = True
+        return {"message": {"role": "assistant", "content": "must not run"}}
+
+    results = run_multi_model_smoke_harness(
+        models=["local-a", "local-b"],
+        endpoint_url="http://127.0.0.1:11434/api/chat",
+        env={"OPENAI_API_KEY": "sk-test"},
+        transport=fake_transport,
+    )
+
+    assert observed["called"] is False
+    assert [record.status for record in results] == ["blocked", "blocked"]
+    assert all(record.reason == "provider_keys_forbidden_non_evidence" for record in results)
+
+
+def test_non_loopback_endpoint_fails_closed_before_transport():
+    observed = {"called": False}
+
+    def fake_transport(*, endpoint_url, payload, timeout_seconds):
+        observed["called"] = True
+        return {"message": {"role": "assistant", "content": "must not run"}}
+
+    results = run_multi_model_smoke_harness(
+        models="local-a,local-b",
+        endpoint_url="https://api.openai.com/v1/chat/completions",
+        env={},
+        transport=fake_transport,
+    )
+
+    assert observed["called"] is False
+    assert all(record.status == "blocked" for record in results)
+    assert all(record.reason == "endpoint_not_local_non_evidence" for record in results)
+
+
+def test_empty_output_fails_closed():
+    results = run_multi_model_smoke_harness(
+        models="local-empty",
+        endpoint_url="http://localhost:11434/api/chat",
+        env={},
+        transport=_content_transport("   "),
+    )
+
+    assert results[0].status == "empty_output"
+    assert results[0].reason == "empty_model_output_non_evidence"
+    assert results[0].behavior_evidence is False
+
+
+def test_prompt_echo_is_detected():
+    prompt = "Do not echo this local smoke prompt."
+
+    results = run_multi_model_smoke_harness(
+        models="local-echo",
+        endpoint_url="http://localhost:11434/api/chat",
+        prompt=prompt,
+        env={},
+        transport=_content_transport(prompt),
+    )
+
+    assert results[0].status == "prompt_echo"
+    assert results[0].reason == "prompt_echo_non_evidence"
+    assert results[0].behavior_evidence is False
+
+
+def test_per_model_records_do_not_claim_behavior_evidence():
+    results = run_multi_model_smoke_harness(
+        models=["local-a"],
+        endpoint_url="http://[::1]:11434/api/chat",
+        env={},
+        transport=_content_transport("A small safe fixture response."),
+    )
+
+    record = results[0]
+    assert record.status == "substantive_looking_output"
+    assert record.behavior_evidence is False
+    assert record.evidence_label == "local_multi_model_smoke_only_no_behavior_evidence"
+    assert record.metadata["strict_no_behavior_evidence_labeling"] is True
+
+
+def test_no_hosted_fallback_exists_on_connection_failure():
+    def connection_transport(*, endpoint_url, payload, timeout_seconds):
+        raise ConnectionError("local ollama unavailable")
+
+    results = run_multi_model_smoke_harness(
+        models="missing-local-model",
+        endpoint_url="http://127.0.0.1:11434/api/chat",
+        env={},
+        transport=connection_transport,
+    )
+
+    assert results[0].status == "connection_failed"
+    assert results[0].reason == "connection_failure_non_evidence"
+    assert results[0].metadata["no_hosted_fallback"] is True
+    assert results[0].metadata["no_provider_keys_accepted"] is True

--- a/tests/test_local_llm_multi_model_smoke_harness.py
+++ b/tests/test_local_llm_multi_model_smoke_harness.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from urllib.error import URLError
+
 from alpha.local_llm.multi_model_smoke_harness import (
     run_multi_model_smoke_harness,
 )
@@ -129,3 +131,50 @@ def test_no_hosted_fallback_exists_on_connection_failure():
     assert results[0].reason == "connection_failure_non_evidence"
     assert results[0].metadata["no_hosted_fallback"] is True
     assert results[0].metadata["no_provider_keys_accepted"] is True
+
+
+def test_default_operator_path_urllib_unavailable_maps_to_connection_failed(monkeypatch):
+    observed = {"called": False}
+
+    def unavailable_default_transport(*, endpoint_url, payload, timeout_seconds):
+        observed["called"] = True
+        raise URLError("connection refused by local loopback ollama fixture")
+
+    monkeypatch.setattr(
+        "alpha.local_llm.provider_adapter.urllib_ollama_json_transport",
+        unavailable_default_transport,
+    )
+
+    results = run_multi_model_smoke_harness(
+        models="operator-local-model",
+        endpoint_url="http://127.0.0.1:11434/api/chat",
+        env={},
+    )
+
+    assert observed["called"] is True
+    assert results[0].status == "connection_failed"
+    assert results[0].reason == "connection_failure_non_evidence"
+    assert results[0].behavior_evidence is False
+    assert results[0].metadata["no_hosted_fallback"] is True
+    assert results[0].metadata["no_provider_keys_accepted"] is True
+
+
+def test_default_operator_path_keeps_generic_backend_errors_blocked(monkeypatch):
+    def malformed_default_transport(*, endpoint_url, payload, timeout_seconds):
+        raise RuntimeError("generic local backend fixture")
+
+    monkeypatch.setattr(
+        "alpha.local_llm.provider_adapter.urllib_ollama_json_transport",
+        malformed_default_transport,
+    )
+
+    results = run_multi_model_smoke_harness(
+        models="operator-local-model",
+        endpoint_url="http://127.0.0.1:11434/api/chat",
+        env={},
+    )
+
+    assert results[0].status == "blocked"
+    assert results[0].reason == "backend_error_non_evidence"
+    assert results[0].behavior_evidence is False
+    assert results[0].metadata["no_hosted_fallback"] is True

--- a/tests/test_local_llm_provider_adapter.py
+++ b/tests/test_local_llm_provider_adapter.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sys
 from hashlib import sha256
 from pathlib import Path
+from urllib.error import URLError
 
 import pytest
 
@@ -312,6 +313,26 @@ def test_ollama_backend_fails_closed_on_connection_failure_from_injected_transpo
 
     result = run_local_llm_provider_adapter(
         "Connection failure should fail closed.", backend=backend
+    )
+
+    assert result.status == "failed_closed"
+    assert result.reason == "connection_failure_non_evidence"
+    assert result.metadata["failure_label"] == "failed_closed_result"
+    assert result.behavior_evidence is False
+
+
+def test_ollama_backend_fails_closed_on_urllib_connection_failure():
+    from alpha.local_llm.provider_adapter import OllamaLocalHTTPBackend
+
+    def urllib_connection_transport(*, endpoint_url, payload, timeout_seconds):
+        raise URLError("connection refused by local loopback ollama fixture")
+
+    backend = OllamaLocalHTTPBackend(
+        model="offline-fixture-model", transport=urllib_connection_transport
+    )
+
+    result = run_local_llm_provider_adapter(
+        "Default urllib connection failure should fail closed.", backend=backend
     )
 
     assert result.status == "failed_closed"


### PR DESCRIPTION
### Motivation

- Provide a safe, local-only harness to iterate multiple Ollama model names through the existing Alpha Solver local LLM adapter for smoke evidence only. 
- Enforce loopback-only endpoint validation and fail-closed behavior when hosted-provider keys are present or endpoints are non-local. 
- Support CI-friendly fake transports and an optional operator-only command for real local Ollama runs while preventing any hosted-provider fallback or behavior-evidence claims.

### Description

- Add `alpha/local_llm/multi_model_smoke_harness.py`, a narrow harness that parses model lists, validates loopback endpoints, rejects hosted-provider keys, invokes `run_configured_local_llm_runtime` with an injected transport, and emits per-model `ModelSmokeResult` records with `behavior_evidence: false` and the label `local_multi_model_smoke_only_no_behavior_evidence`.
- Add CLI entrypoint `python -m alpha.local_llm.multi_model_smoke_harness` that is operator-only (`--local-only`) and requires `--models` and `--endpoint-url`.
- Add CI-only test suite `tests/test_local_llm_multi_model_smoke_harness.py` covering multi-model iteration, provider-key fail-closed, non-loopback rejection, empty output, prompt echo detection, per-model non-evidence labeling, and no hosted fallback on connection failure.
- Add evidence packet docs under `docs/evals/runs/alpha-solver-local-multi-model-smoke-harness-001/` (README, implementation summary, fake-transport test evidence, operator-run template, model result template, evidence boundary, selected next lane, non-actions).

### Testing

- Ran `pytest -q tests/test_local_llm_multi_model_smoke_harness.py tests/test_local_llm_provider_adapter.py` and all tests passed. 
- Ran the static doc checks `python scripts/check_local_llm_doc_paths.py`, `python scripts/check_local_llm_evidence_boundaries.py`, and `python scripts/check_local_llm_packet_consistency.py`, and all checks passed. 
- Verified `python -m alpha.local_llm.multi_model_smoke_harness --help` and reran the harness tests; the CLI/help and targeted tests succeeded. 
- CI uses fake transports only and the evidence packet documents the fake-transport-only verdict and strict non-evidence boundaries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e678461448329a371aca54ae1b1fd)