### PR TITLE
Add local council model-jury design packet (ALPHA-SOLVER-LOCAL-COUNCIL-MODEL-JURY-001)

### DIFF
--- a/docs/evals/runs/alpha-solver-local-council-model-jury-001/README.md
+++ b/docs/evals/runs/alpha-solver-local-council-model-jury-001/README.md
@@ -1,0 +1,44 @@
+# ALPHA-SOLVER-LOCAL-COUNCIL-MODEL-JURY-001
+
+## TLDR
+
+Verdict: `LOCAL_COUNCIL_MODEL_JURY_DESIGNED_NOT_EXECUTED`.
+
+This packet designs a local-only council/model-jury lane for Alpha Solver routing and disagreement logic. It begins with fake-model templates and capture rules only. It does not call local models, Ollama, hosted providers, `/v1/solve`, dashboard routes, tokens, Google Sheets, or broad evals.
+
+## Purpose
+
+The lane defines how multiple local roles can produce first-pass, critique, safety/boundary, evidence-audit, and final synthesis outputs while treating disagreement as an uncertainty signal rather than a consensus vote.
+
+## Source context reviewed
+
+- `alpha_solver_portable.py` portable SolverEnvelope, SAFE-OUT, routing, and claim-boundary contract.
+- `alpha/local_llm/` adapter, orchestration runner, operator CLI, portable contract, and multi-model smoke harness surfaces.
+- `service/models/modelset_registry.py` and `service/models/modelset_resolver.py` model-set metadata surfaces.
+- Local LLM guardrail/operator packets under `docs/local_llm_solver_orchestration_*`.
+- Level 3 local LLM validation design and execution evidence packets under `docs/evals/runs/20260607-local-llm-solver-orchestration-level-3-validation-*`.
+- Value experiment protocol and manual discrimination packets under `docs/evals/runs/alpha-solver-value-experiment-protocol-001/` and `docs/evals/runs/alpha-solver-manual-discrimination-value-read-001/`.
+- Existing council audit evidence packets under `docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-council-*`.
+
+## Packet files
+
+- `council-role-map.md` — local council roles and required role outputs.
+- `model-assignment-policy.md` — local/fake model assignment policy and family diversity strategy.
+- `disagreement-and-synthesis-rules.md` — disagreement taxonomy, escalation triggers, and finalizer limits.
+- `fake-model-test-evidence.md` — fake-model templates and non-executed test evidence plan.
+- `operator-local-run-template.md` — operator-only local capture template for a future execution lane.
+- `residual-risks.md` — risks that remain after design-only work.
+- `selected-next-lane.md` — proposed next lane.
+- `evidence-boundary.md` — evidence and claim boundaries.
+- `non-actions.md` — explicit non-actions.
+
+## Allowed verdicts for this lane
+
+- `LOCAL_COUNCIL_MODEL_JURY_DESIGNED_NOT_EXECUTED`
+- `LOCAL_COUNCIL_FAKE_MODEL_HARNESS_CAPTURED`
+- `LOCAL_COUNCIL_BLOCKED_LOCAL_MODEL_EVIDENCE_MISSING`
+- `STOP_INCONCLUSIVE`
+
+## Current verdict rationale
+
+The packet defines roles, assignment policy, disagreement capture, safe stop conditions, fake-model templates, and operator-local run template. No executable fake harness was added and no local model run was performed, so the strongest supported verdict is design-only.

--- a/docs/evals/runs/alpha-solver-local-council-model-jury-001/council-role-map.md
+++ b/docs/evals/runs/alpha-solver-local-council-model-jury-001/council-role-map.md
@@ -1,0 +1,41 @@
+# Council Role Map
+
+## Required local council roles
+
+| Role | Purpose | Required output fields | Must not do |
+| --- | --- | --- | --- |
+| Router | Classifies the prompt route and decides whether the council should proceed, ask for clarification, or stop. | `route`, `route_rationale`, `required_roles`, `missing_context`, `initial_risk_flags` | Must not solve the task or hide ambiguity behind a route label. |
+| Solver | Produces the first-pass task answer or work product within the router boundary. | `answer`, `assumptions`, `confidence`, `evidence_used`, `known_gaps` | Must not claim evidence it did not receive or use hosted-provider knowledge. |
+| Critic | Reviews the solver output for logical gaps, false premises, weak assumptions, and alternate interpretations. | `agreement_points`, `disagreement_points`, `ambiguity_flags`, `suggested_revision` | Must not rewrite disagreement as a winner-take-all vote. |
+| Safety / Boundary Reviewer | Checks user boundary, SAFE-OUT needs, privacy, security, regulated-domain risk, and forbidden surfaces. | `boundary_status`, `safety_flags`, `stop_reasons`, `allowed_response_shape` | Must not relax hard boundaries to make a result easier to finalize. |
+| Evidence Auditor | Checks whether claims are supported by provided artifacts, cited files, or permitted local context. | `supported_claims`, `unsupported_claims`, `missing_evidence`, `citation_or_artifact_gaps` | Must not infer proof from role agreement alone. |
+| Finalizer | Synthesizes only what the prior roles support and preserves disagreement as uncertainty. | `final_answer`, `agreement_summary`, `disagreement_summary`, `escalation_status`, `must_not_claim` | Must not claim council quality, model superiority, benchmark value, production readiness, or validation. |
+
+## Required council/jury outputs
+
+Every captured council run must include:
+
+1. Where roles agree.
+2. Where roles disagree.
+3. Whether each disagreement indicates ambiguity, missing evidence, route mismatch, safety concern, or weak prompt design.
+4. Whether disagreement should trigger human escalation.
+5. What the finalizer is allowed to synthesize.
+6. What the finalizer must not claim.
+
+## Role sequencing
+
+1. Router decides route and whether the prompt is eligible for council handling.
+2. Solver produces first-pass output only within router constraints.
+3. Critic reviews solver output and route fit.
+4. Safety / Boundary Reviewer checks stop conditions independently of answer quality.
+5. Evidence Auditor maps claims to artifacts and marks gaps.
+6. Finalizer creates a bounded synthesis or stops inconclusive.
+
+## Human escalation triggers by role
+
+- Router: task is underspecified, route is contested, or local-only constraints conflict with the request.
+- Solver: answer depends on missing private data, current external facts, or non-local execution.
+- Critic: major alternative interpretations remain unresolved.
+- Safety / Boundary Reviewer: unsafe request, privacy risk, regulated-domain risk, or boundary violation appears.
+- Evidence Auditor: material claims lack evidence.
+- Finalizer: disagreement remains strong enough that a stable answer would overstate support.

--- a/docs/evals/runs/alpha-solver-local-council-model-jury-001/disagreement-and-synthesis-rules.md
+++ b/docs/evals/runs/alpha-solver-local-council-model-jury-001/disagreement-and-synthesis-rules.md
@@ -1,0 +1,74 @@
+# Disagreement and Synthesis Rules
+
+## Principle
+
+Disagreement is an uncertainty signal. The council must not optimize for consensus voting, majority selection, or winner-picking.
+
+## Disagreement taxonomy
+
+| Category | Meaning | Required handling |
+| --- | --- | --- |
+| Ambiguity | Multiple reasonable interpretations of the prompt remain. | Ask for clarification or preserve alternatives. |
+| Missing evidence | A material claim lacks supplied artifact support. | Remove the claim, mark it unsupported, or stop. |
+| Route mismatch | Roles disagree about basic, structured, constrained, or SAFE-OUT route. | Escalate to router review; finalizer may not ignore route conflict. |
+| Safety concern | A role flags privacy, security, regulated-domain, or boundary risk. | Safety review controls; stop or constrain output. |
+| Weak prompt design | The prompt causes role echoing, instruction collision, or vague criteria. | Mark harness/prompt unstable and revise template before rerun. |
+
+## Capture matrix
+
+Every run must include a disagreement matrix:
+
+| Claim or decision | Agreeing roles | Disagreeing roles | Disagreement category | Evidence state | Escalation? | Finalizer permission |
+| --- | --- | --- | --- | --- | --- | --- |
+| Example: route is constrained | Router, Safety | Solver | Route mismatch / safety concern | Supported by prompt boundary | Yes | May state route conflict; must not provide unrestricted answer. |
+
+## What the finalizer is allowed to synthesize
+
+This section defines what the finalizer is allowed to synthesize.
+
+
+The finalizer may:
+
+- summarize agreements and disagreements;
+- produce a bounded answer supported by the evidence auditor and safety reviewer;
+- include explicit uncertainty and unresolved alternatives;
+- recommend human escalation when stop conditions or strong disagreement appear;
+- return one of the allowed lane verdicts.
+
+## What the finalizer must not claim
+
+This section defines what the finalizer must not claim.
+
+
+The finalizer must not claim:
+
+- council quality, model superiority, or benchmark value;
+- Alpha superiority or production readiness;
+- broad local model readiness;
+- provider orchestration readiness;
+- hidden evidence, unstated citations, or private-data review;
+- that majority agreement proves correctness;
+- that fake-model evidence proves real-model behavior.
+
+## Escalation thresholds
+
+Human escalation is required when any of these occur:
+
+1. Safety / Boundary Reviewer returns a stop reason.
+2. Evidence Auditor marks a material final-answer claim unsupported.
+3. Router and Safety disagree on whether a constrained route is required.
+4. Solver output depends on private data, live external facts, or hosted providers.
+5. Two or more roles identify the prompt as underspecified or instruction-conflicted.
+6. Echo/hallucination checks fail for any role whose output would affect final synthesis.
+
+## Safe stop conditions
+
+Stop with `STOP_INCONCLUSIVE` or a blocked verdict when local or fake outputs:
+
+- echo the task prompt instead of performing the role;
+- hallucinate files, commands, metrics, citations, model names, or run results;
+- ignore local-only, no-token, or no-hosted-provider boundaries;
+- produce mutually incompatible safety decisions;
+- produce strong disagreement on a material claim without enough evidence to resolve it;
+- omit required role fields;
+- include private data or request private data that is not necessary for the local test.

--- a/docs/evals/runs/alpha-solver-local-council-model-jury-001/evidence-boundary.md
+++ b/docs/evals/runs/alpha-solver-local-council-model-jury-001/evidence-boundary.md
@@ -1,0 +1,22 @@
+# Evidence Boundary
+
+## Evidence this packet supports
+
+- A local council/model-jury lane has been designed.
+- Required roles, outputs, assignment strategy, disagreement taxonomy, synthesis rules, stop conditions, fake-model templates, and operator run template are documented.
+- The current verdict is design-only: `LOCAL_COUNCIL_MODEL_JURY_DESIGNED_NOT_EXECUTED`.
+
+## Evidence this packet does not support
+
+- Real local model behavior.
+- Fake harness execution.
+- Answer quality or council quality.
+- Model superiority or model-family rankings.
+- Benchmark value.
+- Production readiness, MVP readiness, broad runtime readiness, provider orchestration readiness, or `/v1/solve` readiness.
+- Hosted provider behavior.
+- Google Sheets updates or backlog state.
+
+## Source boundary
+
+Do not call hosted providers. This packet relies on repository-local context and static documentation inspection. It does not introduce runtime behavior and does not mutate source artifacts from prior local LLM or value experiment lanes.

--- a/docs/evals/runs/alpha-solver-local-council-model-jury-001/fake-model-test-evidence.md
+++ b/docs/evals/runs/alpha-solver-local-council-model-jury-001/fake-model-test-evidence.md
@@ -1,0 +1,100 @@
+# Fake-Model Test Evidence
+
+## Verdict
+
+`LOCAL_COUNCIL_MODEL_JURY_DESIGNED_NOT_EXECUTED`
+
+## What was captured
+
+This packet captures fake-model test templates, expected role fields, disagreement matrix requirements, and stop conditions. It does not add executable harness code and does not run model inference.
+
+## Fake role fixture templates
+
+### Fake router output
+
+```json
+{
+  "role": "router",
+  "route": "constrained",
+  "route_rationale": "The prompt has missing evidence and local-only constraints.",
+  "required_roles": ["solver", "critic", "safety_boundary_reviewer", "evidence_auditor", "finalizer"],
+  "missing_context": ["source artifact for claimed result"],
+  "initial_risk_flags": ["missing_evidence"]
+}
+```
+
+### Fake solver output
+
+```json
+{
+  "role": "solver",
+  "answer": "Draft a bounded response that states evidence is missing.",
+  "assumptions": ["No hosted providers are available."],
+  "confidence": "low",
+  "evidence_used": ["operator prompt only"],
+  "known_gaps": ["no local model output artifact"]
+}
+```
+
+### Fake critic output
+
+```json
+{
+  "role": "critic",
+  "agreement_points": ["local-only boundary is required"],
+  "disagreement_points": ["solver confidence may be overstated"],
+  "ambiguity_flags": ["execution versus design scope could be confused"],
+  "suggested_revision": "Use a design-only verdict and avoid execution claims."
+}
+```
+
+### Fake safety / boundary reviewer output
+
+```json
+{
+  "role": "safety_boundary_reviewer",
+  "boundary_status": "constrained",
+  "safety_flags": ["no hosted providers", "no private data", "no /v1/solve"],
+  "stop_reasons": [],
+  "allowed_response_shape": "design packet with non-claims"
+}
+```
+
+### Fake evidence auditor output
+
+```json
+{
+  "role": "evidence_auditor",
+  "supported_claims": ["roles were defined", "rules were documented"],
+  "unsupported_claims": ["real local model behavior was tested"],
+  "missing_evidence": ["executable harness output", "local model transcripts"],
+  "citation_or_artifact_gaps": ["no model stdout artifact"]
+}
+```
+
+### Fake finalizer output
+
+```json
+{
+  "role": "finalizer",
+  "final_answer": "Local council model-jury design is captured, but not executed.",
+  "agreement_summary": ["all roles preserve local-only boundary"],
+  "disagreement_summary": ["confidence in behavior remains unresolved without execution"],
+  "escalation_status": "no escalation for design; escalation required before real-model claims",
+  "must_not_claim": ["benchmark value", "model superiority", "production readiness"]
+}
+```
+
+## Expected fake test assertions for a future harness
+
+- All six roles are present.
+- Every role emits its required fields.
+- The disagreement matrix contains at least one explicit agreement and one explicit disagreement or `none_observed` marker.
+- Strong disagreement maps to a taxonomy category.
+- Unsupported material claims are excluded from the final answer.
+- Finalizer `must_not_claim` includes council quality, model superiority, benchmark value, and production readiness.
+- Any missing role, echo output, or boundary violation returns `STOP_INCONCLUSIVE`.
+
+## Evidence limitation
+
+Fake fixtures can test schema and stop-state mechanics only. They do not test answer quality, local model reliability, benchmark value, or production readiness.

--- a/docs/evals/runs/alpha-solver-local-council-model-jury-001/fake-model-test-evidence.md
+++ b/docs/evals/runs/alpha-solver-local-council-model-jury-001/fake-model-test-evidence.md
@@ -81,7 +81,7 @@ This packet captures fake-model test templates, expected role fields, disagreeme
   "agreement_summary": ["all roles preserve local-only boundary"],
   "disagreement_summary": ["confidence in behavior remains unresolved without execution"],
   "escalation_status": "no escalation for design; escalation required before real-model claims",
-  "must_not_claim": ["benchmark value", "model superiority", "production readiness"]
+  "must_not_claim": ["no benchmark-value claim is supported", "no model-superiority claim is supported", "no production-readiness claim is supported"]
 }
 ```
 
@@ -92,9 +92,10 @@ This packet captures fake-model test templates, expected role fields, disagreeme
 - The disagreement matrix contains at least one explicit agreement and one explicit disagreement or `none_observed` marker.
 - Strong disagreement maps to a taxonomy category.
 - Unsupported material claims are excluded from the final answer.
-- Finalizer `must_not_claim` includes council quality, model superiority, benchmark value, and production readiness.
+- Finalizer `must_not_claim` records forbidden non-claims with immediate boundary wording: no council-quality claim is supported, no model-superiority claim is supported, no benchmark-value claim is supported, and no production-readiness claim is supported.
+- These are forbidden non-claims from a docs-only, fake-fixture packet, not observed evidence.
 - Any missing role, echo output, or boundary violation returns `STOP_INCONCLUSIVE`.
 
 ## Evidence limitation
 
-Fake fixtures can test schema and stop-state mechanics only. They do not test answer quality, local model reliability, benchmark value, or production readiness.
+Fake fixtures can test schema and stop-state mechanics only. They are not observed evidence for answer quality, local model reliability, benchmark value, model superiority, production readiness, provider readiness, or local model behavior.

--- a/docs/evals/runs/alpha-solver-local-council-model-jury-001/model-assignment-policy.md
+++ b/docs/evals/runs/alpha-solver-local-council-model-jury-001/model-assignment-policy.md
@@ -1,0 +1,55 @@
+# Model Assignment Policy
+
+## Policy summary
+
+The lane starts with fake-model roles before any local model execution. Future local execution may assign local model families from the operator catalog, but the harness must stay local-only, default-off, and without hosted fallback.
+
+## Assignment phases
+
+### Phase 0: fake-model templates
+
+Use deterministic fixtures or hand-authored role stubs to exercise the capture schema. This phase is suitable for checking disagreement formatting, stop-state handling, and finalizer boundaries without model inference.
+
+### Phase 1: single local family, multiple roles
+
+If a later execution lane is authorized, one local model family may be reused across roles to test orchestration plumbing. This may expose prompt-role fragility but must not be treated as model-family diversity evidence.
+
+### Phase 2: local family diversity
+
+If multiple local model families are available in the operator catalog, assign roles across families to surface route mismatch and role sensitivity. Example family categories for catalog mapping:
+
+- small instruction-tuned model family for router and boundary checks;
+- code/reasoning-oriented family for solver on technical prompts;
+- general instruction family for critic;
+- safety- or policy-prompted local role for boundary review;
+- compact deterministic fake/auditor role for evidence checking.
+
+These are assignment categories, not quality rankings.
+
+## Assignment constraints
+
+- No hosted provider may be called.
+- No provider token, API key, dashboard credential, or private user data may be sent to a model.
+- Local model names must be operator-supplied or read from a local catalog; the harness must not download or install models automatically.
+- Missing local model evidence must produce `LOCAL_COUNCIL_BLOCKED_LOCAL_MODEL_EVIDENCE_MISSING` or `STOP_INCONCLUSIVE` rather than a quality claim.
+- Role diversity may be described only as a test-design choice, not as proof of better answers.
+
+## Assignment record template
+
+```yaml
+run_id: LOCAL-COUNCIL-YYYYMMDD-NN
+execution_mode: fake_model | local_model
+models:
+  router: fake-router-v0
+  solver: fake-solver-v0
+  critic: fake-critic-v0
+  safety_boundary_reviewer: fake-safety-v0
+  evidence_auditor: fake-auditor-v0
+  finalizer: fake-finalizer-v0
+assignment_rationale:
+  - local-only
+  - no hosted fallback
+  - role-diverse prompts
+catalog_source: operator supplied | local config path | fake fixture
+missing_models: []
+```

--- a/docs/evals/runs/alpha-solver-local-council-model-jury-001/non-actions.md
+++ b/docs/evals/runs/alpha-solver-local-council-model-jury-001/non-actions.md
@@ -1,0 +1,16 @@
+# Non-Actions
+
+This lane did not:
+
+- call hosted providers;
+- use provider tokens or API keys;
+- run local model inference;
+- call Ollama;
+- expose, modify, or call `/v1/solve`;
+- expose, modify, or call dashboard routes;
+- add hosted fallback;
+- send private data to local models;
+- run broad evals or benchmarks;
+- update Google Sheets;
+- modify backlog workbooks;
+- claim council quality, model superiority, benchmark value, Alpha superiority, production readiness, or provider orchestration readiness.

--- a/docs/evals/runs/alpha-solver-local-council-model-jury-001/operator-local-run-template.md
+++ b/docs/evals/runs/alpha-solver-local-council-model-jury-001/operator-local-run-template.md
@@ -1,0 +1,66 @@
+# Operator Local Run Template
+
+Use this template only in a future authorized execution lane. Do not use it to call hosted providers or expose `/v1/solve`.
+
+## Preflight
+
+- [ ] Confirm execution mode is `fake_model` or `local_model` only.
+- [ ] Confirm no provider API keys or tokens are loaded into prompts.
+- [ ] Confirm no private data is included.
+- [ ] Confirm no dashboard, API route, or `/v1/solve` surface is invoked.
+- [ ] Confirm local model names are operator supplied.
+- [ ] Confirm capture directory is under `docs/evals/runs/`.
+
+## Run metadata
+
+```yaml
+run_id:
+date_utc:
+operator:
+execution_mode: fake_model | local_model
+local_endpoint: loopback only | none for fake
+model_catalog_source:
+models:
+  router:
+  solver:
+  critic:
+  safety_boundary_reviewer:
+  evidence_auditor:
+  finalizer:
+forbidden_surfaces_confirmed:
+  hosted_providers: not_called
+  tokens: not_used
+  v1_solve: not_called
+  dashboard: not_called
+  google_sheets: not_updated
+```
+
+## Role capture
+
+Paste sanitized role outputs in this order:
+
+1. Router
+2. Solver
+3. Critic
+4. Safety / Boundary Reviewer
+5. Evidence Auditor
+6. Finalizer
+
+## Disagreement matrix
+
+| Claim or decision | Agreeing roles | Disagreeing roles | Category | Evidence state | Escalation? | Finalizer permission |
+| --- | --- | --- | --- | --- | --- | --- |
+|  |  |  | ambiguity / missing evidence / route mismatch / safety concern / weak prompt design | supported / unsupported / missing | yes / no | synthesize / constrain / stop |
+
+## Verdict
+
+Choose one:
+
+- `LOCAL_COUNCIL_MODEL_JURY_DESIGNED_NOT_EXECUTED`
+- `LOCAL_COUNCIL_FAKE_MODEL_HARNESS_CAPTURED`
+- `LOCAL_COUNCIL_BLOCKED_LOCAL_MODEL_EVIDENCE_MISSING`
+- `STOP_INCONCLUSIVE`
+
+## Required non-claims
+
+The run record must state that it does not prove council quality, model superiority, benchmark value, Alpha superiority, production readiness, broad local model readiness, provider orchestration, or `/v1/solve` readiness.

--- a/docs/evals/runs/alpha-solver-local-council-model-jury-001/residual-risks.md
+++ b/docs/evals/runs/alpha-solver-local-council-model-jury-001/residual-risks.md
@@ -1,0 +1,10 @@
+# Residual Risks
+
+- Fake fixtures may pass schema checks while real local models echo prompts or ignore role boundaries.
+- Local model family assignment may create apparent diversity without independent reasoning behavior.
+- Finalizer prompts may accidentally smooth over disagreement unless the disagreement matrix is mandatory.
+- Evidence auditor behavior is fragile if artifacts are missing, malformed, or uncited.
+- Safety reviewer outputs may conflict with router outputs; this must escalate instead of being majority-voted away.
+- Operator-supplied model catalogs may be stale, unavailable, or inconsistent across machines.
+- Local model transcripts may contain private data if operators ignore the preflight checklist.
+- A later implementation could accidentally add hosted fallback unless local-only flags and tests explicitly forbid it.

--- a/docs/evals/runs/alpha-solver-local-council-model-jury-001/selected-next-lane.md
+++ b/docs/evals/runs/alpha-solver-local-council-model-jury-001/selected-next-lane.md
@@ -1,0 +1,17 @@
+# Selected Next Lane
+
+Recommended next lane: `ALPHA-SOLVER-LOCAL-COUNCIL-FAKE-HARNESS-002`.
+
+## Objective
+
+Implement a minimal fake-model-only council harness that consumes deterministic role fixtures, emits the disagreement matrix, enforces finalizer non-claims, and returns a blocked or inconclusive verdict when required role fields are missing.
+
+## Boundaries
+
+The next lane should not run local model inference, call Ollama, call hosted providers, use tokens, expose or call `/v1/solve`, touch dashboards, run broad evals, update Google Sheets, or claim validation.
+
+## Acceptance evidence
+
+- Focused tests for missing role, echo output, unsupported finalizer claim, and strong disagreement escalation.
+- Static docs check for non-claims and local-only boundaries.
+- Evidence packet with fake harness output only.


### PR DESCRIPTION
### Motivation

- Define a local-only council/model-jury lane to capture role-based disagreement as an uncertainty signal rather than forcing consensus. 
- Provide a safe, design-first scaffold for routing, disagreement taxonomy, escalation rules, and finalizer limits without running local models or hosted providers. 
- Preserve strict evidence and non-claim boundaries so future execution lanes remain operator-controlled and local-only. 

### Description

- Add a docs-only evidence packet `docs/evals/runs/alpha-solver-local-council-model-jury-001/` containing `README.md`, `council-role-map.md`, `model-assignment-policy.md`, `disagreement-and-synthesis-rules.md`, `fake-model-test-evidence.md`, `operator-local-run-template.md`, `residual-risks.md`, `selected-next-lane.md`, `evidence-boundary.md`, and `non-actions.md`. 
- Define the council roles (router, solver, critic, safety/boundary reviewer, evidence auditor, finalizer), role sequencing, the disagreement taxonomy (ambiguity, missing evidence, route mismatch, safety concern, weak prompt design), safe-stop conditions, and explicit finalizer prohibitions (no council-quality, model-superiority, benchmark, or production-readiness claims). 
- Provide fake-model fixture templates, an operator run metadata template, a disagreement capture matrix, allowed lane verdicts (`LOCAL_COUNCIL_MODEL_JURY_DESIGNED_NOT_EXECUTED`, `LOCAL_COUNCIL_FAKE_MODEL_HARNESS_CAPTURED`, `LOCAL_COUNCIL_BLOCKED_LOCAL_MODEL_EVIDENCE_MISSING`, `STOP_INCONCLUSIVE`), and a recommended next lane `ALPHA-SOLVER-LOCAL-COUNCIL-FAKE-HARNESS-002` for implementing a fake-model harness. 

### Testing

- Ran file and markdown sanity checks using the repository-local Python scripts that verify required files exist, each file starts with a heading and ends with a final newline via `python - <<'PY' ...` and the checks passed. 
- Ran a forbidden-phrase scan with `rg` to ensure non-claim boundaries (no hosted-provider/token/production/benchmark/model-superiority claims) and found no violations. 
- Ran a lightweight whitespace/final-newline validation and `git status --short` to confirm the working tree after the docs-only changes; all automated checks succeeded and no model inference or hosted-provider calls were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e74c58b48832986ffc379fbcdd72b)