### PR TITLE
Add operator UI sidecar feasibility packet

### DIFF
--- a/docs/evals/runs/alpha-solver-operator-ui-sidecar-feasibility-001/README.md
+++ b/docs/evals/runs/alpha-solver-operator-ui-sidecar-feasibility-001/README.md
@@ -1,0 +1,28 @@
+# ALPHA-SOLVER-OPERATOR-UI-SIDECAR-FEASIBILITY-001
+
+## TLDR
+
+Verdict: **UI_SIDECAR_FEASIBILITY_CAPTURED**.
+
+Alpha Solver can plausibly improve operator usability by sitting behind an existing chat/operator UI, but the only acceptable early pattern is:
+
+```text
+UI sidecar -> Alpha Solver controlled endpoint -> Alpha Solver router/policy/evidence layer -> local or hosted model backend
+```
+
+The UI must not talk directly to Ollama, OpenAI, or any other model backend for Alpha Solver workflows. This packet is docs-only and records feasibility, boundary requirements, and the next security decision lane. No UI was deployed, no endpoint was exposed, no credentials were connected, and no repo data was uploaded to RAG or external services.
+
+## Packet files
+
+- [candidate-ui-comparison.md](candidate-ui-comparison.md)
+- [sidecar-architecture-options.md](sidecar-architecture-options.md)
+- [alpha-boundary-preservation.md](alpha-boundary-preservation.md)
+- [risks-and-non-goals.md](risks-and-non-goals.md)
+- [recommendation.md](recommendation.md)
+- [selected-next-lane.md](selected-next-lane.md)
+- [evidence-boundary.md](evidence-boundary.md)
+- [non-actions.md](non-actions.md)
+
+## Primary recommendation
+
+Use a **minimal local console first**, then evaluate **Open WebUI in endpoint-only sidecar mode** after security gates define endpoint exposure, auth, data retention, upload/RAG disablement, and routing-bypass controls.

--- a/docs/evals/runs/alpha-solver-operator-ui-sidecar-feasibility-001/alpha-boundary-preservation.md
+++ b/docs/evals/runs/alpha-solver-operator-ui-sidecar-feasibility-001/alpha-boundary-preservation.md
@@ -1,0 +1,29 @@
+# Alpha boundary preservation
+
+## Must preserve
+
+- Alpha Solver controls routing and model selection.
+- Alpha Solver emits and stores the authoritative SolverEnvelope.
+- Evidence and citations are Alpha Solver artifacts, not UI-inferred artifacts.
+- SAFE-OUT, policy, determinism, budget, replay, and observability gates remain upstream of any model backend.
+- UI conversation history cannot become an alternate source of truth for eval or production claims.
+
+## Required controls before any UI trial
+
+1. **Endpoint allowlist:** the sidecar may call only the Alpha Solver controlled endpoint.
+2. **Provider lockdown:** users cannot add direct Ollama/OpenAI/OpenRouter/Anthropic/etc. endpoints for Alpha Solver workflows.
+3. **Upload/RAG off by default:** document upload, embedding, knowledge bases, workspace sync, and file injection remain disabled unless a separate evidence-ingestion lane approves them.
+4. **Tooling off by default:** plugins, code execution, terminal access, web search, MCP, OpenAPI tools, auto-approved tools, and pipelines remain disabled.
+5. **Envelope-first display:** UI renders Alpha Solver answer, route, safety state, evidence references, and stop conditions without rewriting them as free-form chat metadata.
+6. **Retention decision:** conversation storage, deletion, export, and audit retention must be explicitly specified before shared use.
+7. **Auth decision:** local-only usage can defer multi-user auth; shared usage requires authn/authz and per-user audit identity.
+
+## Boundary test questions for any future implementation
+
+- Can a user make the UI call a model directly without Alpha Solver?
+- Can a user upload a private repo file into UI RAG or memory?
+- Can the UI summarize or transform evidence in a way that looks authoritative but is not in the SolverEnvelope?
+- Can a plugin/tool/pipeline invoke external services with prompt or repo data?
+- Can a conversation be replayed from Alpha Solver artifacts alone, without trusting sidecar state?
+
+If any answer is unsafe or unknown, the lane remains blocked.

--- a/docs/evals/runs/alpha-solver-operator-ui-sidecar-feasibility-001/candidate-ui-comparison.md
+++ b/docs/evals/runs/alpha-solver-operator-ui-sidecar-feasibility-001/candidate-ui-comparison.md
@@ -1,0 +1,42 @@
+# Candidate UI comparison
+
+## Evidence consulted
+
+- Open WebUI feature docs state support for Ollama, OpenAI-compatible providers, model switching, file upload, RAG/knowledge bases, tools, pipelines, MCP, RBAC, SSO/OIDC/LDAP, API keys, Docker/Kubernetes/pip deployment, and observability-style deployment options.
+- LibreChat docs describe custom OpenAI-compatible endpoints, Ollama via Ollama OpenAI compatibility, Docker-mounted configuration, `.env` API-key storage, and many AI endpoint integrations.
+- AnythingLLM docs describe local and cloud LLM provider setup including Ollama and generic OpenAI, chat logs, document attachment, embedding/RAG, workspace-scoped document sharing, native tool-calling settings, and automatic tool approval controls.
+- Ollama documents OpenAI Chat Completions compatibility, making UI tools that can target OpenAI-compatible endpoints technically relevant to local model backends.
+
+## Comparison matrix
+
+| Criterion | Open WebUI | LibreChat | AnythingLLM | Custom minimal console |
+|---|---|---|---|---|
+| Local Ollama support | Strong native fit; commonly Ollama-first and supports Ollama from UI. | Supported through custom endpoint using Ollama OpenAI compatibility. | Supported as local LLM and embedding provider. | Only if Alpha Solver endpoint exposes a safe abstraction; console should not call Ollama directly. |
+| OpenAI-compatible endpoint support | Strong; can connect to OpenAI-compatible providers. | Strong; custom endpoints support OpenAI-compatible services. | Present through OpenAI generic provider. | Alpha Solver can define exactly one controlled endpoint contract. |
+| Multi-model switching | Strong UI-level switching and side-by-side model use. | Strong multi-endpoint/multi-model potential. | Has provider/model/router concepts, but RAG/workspace focus may dominate. | Deliberately limited; model choice should remain Alpha Solver policy/router output. |
+| Conversation history | Strong built-in history and organization. | Strong ChatGPT-like conversation history. | Strong chat logs/workspaces. | Minimal durable logs only if explicitly designed for SolverEnvelope/audit needs. |
+| RAG/document upload risk | High by default because upload, knowledge, web search, code execution, and agentic retrieval are feature-rich. | Medium/high where file upload, RAG API, tools, and plugins are enabled. | High because document chat, embedding, workspace sharing, and RAG are core features. | Low if uploads are absent and transcript retention is explicit. |
+| Auth and user management | Strong RBAC/SSO/OIDC/LDAP/user groups, but adds admin surface. | Configurable auth/social login/user controls; requires app stack. | Supports security/access settings and multi-user/workspace behavior. | Initially local-only; auth must be added before any shared use. |
+| Plugins/tools/pipelines | Very high; tools, functions, pipelines, MCP, OpenAPI servers. | High; tools/MCP/toolkit ecosystem. | High; agents, skills, native tool calling, automatic approvals. | None until Alpha Solver explicitly exposes safe operations. |
+| Deployment complexity | Medium/high: full web app, storage, users, optional vector stores. | High: Docker stack/config/env/database concerns. | Medium/high: self-hosted app with documents/vector storage/workspaces. | Low: repo-owned docs/CLI or local web shell, no external app stack. |
+| Preserve SolverEnvelope/evidence boundaries | Possible only if configured as UI-to-Alpha endpoint with RAG/tools disabled. | Possible only if every endpoint points at Alpha Solver and direct providers are removed. | Difficult because workspace/RAG semantics can blur evidence provenance. | Strongest because UI can be shaped around envelopes and citations. |
+| Risk of bypassing Alpha Solver routing | High if direct Ollama/OpenAI connections remain available. | High if users can add alternate endpoints or direct providers. | High if users select direct providers, agents, or workspace RAG. | Low if no direct backend configuration exists. |
+| Early MVP suitability | Best off-the-shelf candidate after security gates, but too capable to enable casually. | Viable later for ChatGPT-like operator UX, but heavier configuration and provider sprawl. | Not preferred for early MVP because document/RAG-first UX conflicts with evidence-boundary discipline. | Best early MVP pattern for boundary preservation and scope control. |
+
+## Candidate notes
+
+### Open WebUI
+
+Open WebUI is the most attractive existing UI candidate because it combines local Ollama, OpenAI-compatible providers, conversation management, auth, and extensibility. That strength is also the primary risk: RAG, file upload, web search, code execution, tools, pipelines, MCP, OpenAPI tools, and model switching can all create paths that bypass Alpha Solver evidence and routing if not locked down.
+
+### LibreChat
+
+LibreChat is a plausible chat-operator UI when the desired experience is closer to ChatGPT with configurable providers. Its custom endpoint support is useful for pointing at Alpha Solver, but its provider configuration and plugin/tool ecosystem need strong administrative lockdown before use.
+
+### AnythingLLM
+
+AnythingLLM is strongest when the product goal is document-centric RAG and workspace knowledge. That is not the Alpha Solver sidecar objective for this lane. Its upload/embed/workspace behavior creates avoidable ambiguity about evidence provenance and access boundaries.
+
+### Custom minimal console
+
+A minimal console has fewer conveniences, but it best preserves Alpha Solver envelopes, SAFE-OUT behavior, routing decisions, evidence boundaries, and audit trail requirements. It is the safest early MVP lane because it can be limited to prompt submission, envelope display, route trace display, evidence/citation display, and stop-state surfacing.

--- a/docs/evals/runs/alpha-solver-operator-ui-sidecar-feasibility-001/evidence-boundary.md
+++ b/docs/evals/runs/alpha-solver-operator-ui-sidecar-feasibility-001/evidence-boundary.md
@@ -1,0 +1,26 @@
+# Evidence boundary
+
+## Evidence used
+
+This packet used public documentation for Open WebUI, LibreChat, AnythingLLM, and Ollama to compare sidecar feasibility. It also used the repository's existing agent instructions and docs-only lane constraints.
+
+Public documentation references:
+
+- Open WebUI features: https://docs.openwebui.com/features/
+- LibreChat Ollama endpoint configuration: https://www.librechat.ai/docs/configuration/librechat_yaml/ai_endpoints/ollama
+- LibreChat custom endpoints: https://www.librechat.ai/docs/quick_start/custom_endpoints
+- AnythingLLM document chat/RAG behavior: https://docs.anythingllm.com/chatting-with-documents/introduction
+- AnythingLLM configuration index: https://docs.anythingllm.com/configuration
+- Ollama OpenAI compatibility: https://ollama.com/blog/openai-compatibility
+
+## Evidence not used
+
+- No private Alpha Solver repo content was uploaded to any external UI, RAG system, or provider.
+- No live UI instance was installed or tested.
+- No credentials, API keys, or external provider accounts were used.
+- No endpoint was exposed.
+- No production or public readiness assessment was performed.
+
+## Interpretation caveat
+
+The candidate comparison is a feasibility snapshot, not a security certification. All third-party UI capabilities and defaults must be re-verified against pinned versions before implementation.

--- a/docs/evals/runs/alpha-solver-operator-ui-sidecar-feasibility-001/non-actions.md
+++ b/docs/evals/runs/alpha-solver-operator-ui-sidecar-feasibility-001/non-actions.md
@@ -1,0 +1,12 @@
+# Non-actions
+
+The following actions were intentionally not taken:
+
+- Did not deploy Open WebUI, LibreChat, AnythingLLM, or a custom UI.
+- Did not expose an Alpha Solver endpoint.
+- Did not connect real credentials.
+- Did not configure Ollama, OpenAI, or any hosted model backend.
+- Did not upload private repo data to RAG, document stores, memory, or external services.
+- Did not modify runtime code.
+- Did not alter routing, policy, evidence, SAFE-OUT, determinism, replay, observability, budget, or SolverEnvelope behavior.
+- Did not claim product readiness, production readiness, or public readiness.

--- a/docs/evals/runs/alpha-solver-operator-ui-sidecar-feasibility-001/recommendation.md
+++ b/docs/evals/runs/alpha-solver-operator-ui-sidecar-feasibility-001/recommendation.md
@@ -1,0 +1,26 @@
+# Recommendation
+
+## Verdict
+
+**UI_SIDECAR_FEASIBILITY_CAPTURED**
+
+## Recommended sidecar pattern
+
+Start with a **minimal local Alpha Solver operator console**. Use it to prove the envelope-first UX before introducing a full external UI.
+
+A later Open WebUI experiment can be considered only as an **endpoint-only sidecar** after security/exposure gates decide how to lock down direct providers, upload/RAG, tools, memory, web search, code execution, auth, and retention.
+
+## Ranking for early MVP
+
+1. **Custom minimal console** — best boundary preservation and lowest bypass risk.
+2. **Open WebUI endpoint-only sidecar** — best off-the-shelf candidate after lockdown decisions.
+3. **LibreChat endpoint-only sidecar** — plausible fallback if ChatGPT-like UX is favored and provider sprawl is controlled.
+4. **AnythingLLM** — defer; document/RAG/workspace orientation is not aligned with this safety-first lane.
+
+## Do-not-integrate-yet warnings
+
+- Do not connect any UI directly to Ollama, OpenAI, or other model backends for Alpha Solver workflows.
+- Do not enable document upload, RAG, memory, knowledge bases, workspace sync, web search, tools, code execution, MCP, OpenAPI tools, pipelines, or auto-approved agents.
+- Do not expose Alpha Solver endpoints to a browser or network until auth, CORS, CSRF, rate limiting, audit identity, and retention are specified.
+- Do not treat UI chat history as authoritative evidence.
+- Do not claim public, product, or production readiness.

--- a/docs/evals/runs/alpha-solver-operator-ui-sidecar-feasibility-001/risks-and-non-goals.md
+++ b/docs/evals/runs/alpha-solver-operator-ui-sidecar-feasibility-001/risks-and-non-goals.md
@@ -1,0 +1,22 @@
+# Risks and non-goals
+
+## Main risks
+
+- **Routing bypass:** UI connects directly to local or hosted models.
+- **Evidence confusion:** UI RAG, memory, or notes become untracked evidence sources.
+- **Credential exposure:** UI stores provider keys or permits users to add providers.
+- **Tool overreach:** plugins, code execution, web search, MCP, OpenAPI tools, or auto-approved agents send data outside Alpha Solver controls.
+- **Data retention drift:** conversation history persists sensitive prompts outside approved artifact storage.
+- **False readiness:** a polished UI can imply product readiness despite unapproved security and exposure gates.
+- **Admin surface expansion:** full web UIs add auth, user, database, file-storage, and deployment obligations.
+
+## Non-goals
+
+- No runtime implementation.
+- No UI deployment.
+- No endpoint exposure.
+- No credentials or provider keys.
+- No production mounting of an external UI.
+- No RAG ingestion of private repo data.
+- No product-readiness or public-readiness claim.
+- No replacement of Alpha Solver routing, policy, evidence, SAFE-OUT, determinism, replay, observability, or SolverEnvelope semantics.

--- a/docs/evals/runs/alpha-solver-operator-ui-sidecar-feasibility-001/selected-next-lane.md
+++ b/docs/evals/runs/alpha-solver-operator-ui-sidecar-feasibility-001/selected-next-lane.md
@@ -1,0 +1,24 @@
+# Selected next lane
+
+## Selected lane
+
+**ALPHA-SOLVER-OPERATOR-UI-SIDECAR-SECURITY-GATES-001**
+
+## Purpose
+
+Decide the security and exposure gates required before any UI sidecar can be connected to an Alpha Solver controlled endpoint.
+
+## Required decisions
+
+- Endpoint exposure model: local-only, loopback, LAN, or authenticated shared deployment.
+- Authn/authz model and per-user audit identity.
+- CORS/CSRF/session constraints for browser-based sidecars.
+- Provider lockdown requirements and verification method.
+- Upload/RAG/memory/tooling disablement requirements.
+- Conversation retention, deletion, export, and replay policy.
+- Evidence-envelope rendering contract.
+- Configuration test plan proving the UI cannot bypass Alpha Solver routing.
+
+## Initial implementation lane after security gates
+
+If gates pass, implement a **minimal local operator console prototype** rather than integrating a full third-party UI first.

--- a/docs/evals/runs/alpha-solver-operator-ui-sidecar-feasibility-001/sidecar-architecture-options.md
+++ b/docs/evals/runs/alpha-solver-operator-ui-sidecar-feasibility-001/sidecar-architecture-options.md
@@ -1,0 +1,48 @@
+# Sidecar architecture options
+
+## Preferred architecture
+
+```text
+UI sidecar
+  -> Alpha Solver controlled endpoint
+    -> Alpha Solver router / policy / evidence layer
+      -> local or hosted model backend
+```
+
+This keeps model selection, policy enforcement, evidence handling, budget/determinism controls, and SolverEnvelope rendering in Alpha Solver rather than the UI.
+
+## Disallowed architecture
+
+```text
+UI sidecar
+  -> Ollama / OpenAI / hosted model directly
+```
+
+This bypasses Alpha Solver routing and can produce responses with no Alpha Solver envelope, route trace, safety boundary, or evidence provenance.
+
+## Options reviewed
+
+### Option A: Minimal local console first
+
+- Implement later as a local-only operator shell against an already-approved Alpha Solver endpoint or CLI bridge.
+- No document upload, RAG, external tools, model-provider settings, or direct backend credentials.
+- Displays Alpha Solver response fields as first-class UI components.
+- Recommended as the next implementation shape after security review.
+
+### Option B: Open WebUI endpoint-only sidecar later
+
+- Configure one provider: Alpha Solver controlled endpoint only.
+- Disable or hide direct model endpoints, uploads, knowledge bases, web search, tools, code execution, pipelines, MCP, OpenAPI tool import, memory, and autonomous agents until individually approved.
+- Treat Open WebUI as a shell, not as a policy or evidence engine.
+- Candidate for later MVP if security gates prove configuration lockdown is reliable.
+
+### Option C: LibreChat endpoint-only sidecar later
+
+- Configure custom endpoint to Alpha Solver only.
+- Lock down provider addition, credentials, plugins/tools, file upload/RAG, and user-level endpoint overrides.
+- Consider only if Open WebUI is too broad or if LibreChat's ChatGPT-like UX is preferred.
+
+### Option D: AnythingLLM document workspace sidecar
+
+- Not recommended for early MVP.
+- Document and workspace abstractions are useful for RAG products, but they add provenance, sharing, and embedding risks that conflict with this lane's boundary-preservation goal.


### PR DESCRIPTION
### Motivation

- Evaluate whether Alpha Solver should sit behind or integrate with existing chat/operator UIs while preserving routing, evidence, and safety boundaries. 
- Capture a docs-only feasibility analysis to compare candidate UIs (Open WebUI, LibreChat, AnythingLLM, and a custom console) against Alpha Solver preservation requirements. 
- Record clear non-actions and hard boundary constraints to prevent accidental exposure, deployment, or bypass of Alpha Solver controls.

### Description

- Add a new evidence packet at `docs/evals/runs/alpha-solver-operator-ui-sidecar-feasibility-001/` containing `README.md`, `candidate-ui-comparison.md`, `sidecar-architecture-options.md`, `alpha-boundary-preservation.md`, `risks-and-non-goals.md`, `recommendation.md`, `selected-next-lane.md`, `evidence-boundary.md`, and `non-actions.md`. 
- Capture the preferred architecture as `UI sidecar -> Alpha Solver controlled endpoint -> Alpha Solver router/policy/evidence layer -> local or hosted model backend` and explicitly disallow direct UI-to-model routing. 
- Recommend starting with a minimal local operator console as the early MVP and select `ALPHA-SOLVER-OPERATOR-UI-SIDECAR-SECURITY-GATES-001` as the next decision lane. 
- Document public references, do-not-integrate-yet warnings, preserved evidence/envelope requirements, and an explicit list of non-actions taken.

### Testing

- Ran a focused validation script (`python` snippet) that asserts all required packet files exist and that the verdict and preferred architecture strings are present, and the script passed. 
- Ran the full test suite with `python -m pytest -q`, which completed successfully (some tests were skipped and the run emitted warnings), indicating the docs-only changes did not break automated checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e74def4f08329968e3891f1097553)