### PR TITLE
Add Pi-like agent UX feasibility packet

### DIFF
--- a/docs/evals/runs/alpha-solver-pi-like-agent-ux-feasibility-001/README.md
+++ b/docs/evals/runs/alpha-solver-pi-like-agent-ux-feasibility-001/README.md
@@ -1,0 +1,42 @@
+# Pi-Like Agent UX Feasibility Packet
+
+Lane: `ALPHA-SOLVER-PI-LIKE-AGENT-UX-FEASIBILITY-001`
+
+Verdict: `PI_LIKE_AGENT_UX_FEASIBILITY_CAPTURED`
+
+## TLDR
+
+Alpha Solver may benefit from a more personal, conversational, operator-friendly UX pattern, but only as a local-first operator-assistant layer that keeps evidence boundaries explicit. This packet recommends capturing Pi-like interaction patterns as design inspiration, not integrating Inflection Pi or any closed external assistant product.
+
+## Recommendation
+
+Proceed with a narrow design lane for an Alpha-native operator assistant pattern:
+
+- warmer but still precise guidance;
+- concise project-memory summaries derived only from explicit repo artifacts or operator-approved notes;
+- interruption, stop-condition, and uncertainty reminders;
+- next-action coaching that reduces operator workload;
+- no therapy, companion, emotional-dependency, or product-readiness claims.
+
+## Integration / no-integration decision
+
+Decision: no direct Pi integration.
+
+This packet does not assume Pi has an embeddable API, license, SDK, or product surface appropriate for Alpha Solver. If the operator intends a specific Pi Agent product, library, or API, the next action is to stop and request the exact operator-approved link before any technical integration analysis.
+
+## Selected next lane
+
+`ALPHA-SOLVER-OPERATOR-ASSISTANT-UX-PATTERN-SPEC-001`
+
+The selected next lane should create an implementation-neutral UX pattern spec for an Alpha-native operator assistant. It should not modify runtime code, call external services, or route private operator chats outside Alpha Solver.
+
+## Files in this packet
+
+- `ux-pattern-analysis.md` evaluates Pi-like UX patterns that may or may not transfer to Alpha Solver.
+- `operator-assistant-design.md` proposes Alpha-native operator-assistant behavior.
+- `risks-and-boundaries.md` maps risks and required mitigations.
+- `integration-options.md` records integration and non-integration options.
+- `recommendation.md` records the lane recommendation and decision.
+- `selected-next-lane.md` records the selected next lane.
+- `evidence-boundary.md` records evidence limits and non-claims.
+- `non-actions.md` records actions explicitly not taken.

--- a/docs/evals/runs/alpha-solver-pi-like-agent-ux-feasibility-001/evidence-boundary.md
+++ b/docs/evals/runs/alpha-solver-pi-like-agent-ux-feasibility-001/evidence-boundary.md
@@ -1,0 +1,22 @@
+# Evidence Boundary
+
+## What this packet establishes
+
+This packet establishes that Pi-like personal-agent UX patterns are feasible to study as design inspiration for Alpha Solver. It captures a recommendation to pursue an Alpha-native operator-assistant UX pattern with strict evidence boundaries.
+
+## What this packet does not establish
+
+This packet does not establish:
+
+- that Inflection Pi has an available API;
+- that Inflection Pi can be embedded in Alpha Solver;
+- that any external product is licensed for Alpha Solver use;
+- that Alpha Solver has implemented a personal assistant;
+- that Alpha Solver is product-ready, MVP-ready, production-ready, or voice-ready;
+- that any runtime behavior changed;
+- that any private user data was used;
+- that Alpha Solver provides therapy, companionship, emotional support, or mental-health services.
+
+## Evidence sources
+
+The packet is based on the operator-provided lane request and repository-local operating instructions. No external service was called for product integration research.

--- a/docs/evals/runs/alpha-solver-pi-like-agent-ux-feasibility-001/integration-options.md
+++ b/docs/evals/runs/alpha-solver-pi-like-agent-ux-feasibility-001/integration-options.md
@@ -1,0 +1,29 @@
+# Integration Options
+
+## Option A: No integration; capture UX principles only
+
+Status: recommended.
+
+Alpha Solver can adopt selected UX principles: warmer guidance, artifact-grounded memory summaries, stop-condition reminders, next-action coaching, and local-first operator assistance. This option does not require external product dependencies.
+
+## Option B: Alpha-native local operator assistant
+
+Status: plausible future lane, not implemented here.
+
+A future spec could define a local assistant surface backed by Alpha Solver artifacts. It would need strict memory provenance, privacy policy, operator controls, and evidence-boundary rendering.
+
+## Option C: Voice/conversational mode
+
+Status: defer.
+
+Voice may be useful later for low-risk status review. It should wait until transcript handling, consent, redaction, storage, and citation behavior are specified.
+
+## Option D: Direct Pi or third-party assistant integration
+
+Status: blocked unless operator provides an exact source link and explicit approval.
+
+This lane does not assume an API, license, embedding right, or technical feasibility. Direct integration would require a separate source-linked technical and legal review.
+
+## Decision
+
+Choose Option A now and select Option B as the future design direction. Do not choose Option D in this lane.

--- a/docs/evals/runs/alpha-solver-pi-like-agent-ux-feasibility-001/non-actions.md
+++ b/docs/evals/runs/alpha-solver-pi-like-agent-ux-feasibility-001/non-actions.md
@@ -1,0 +1,16 @@
+# Non-Actions
+
+This packet did not:
+
+- integrate Pi directly;
+- call external services;
+- use private user data;
+- change runtime code;
+- create emotional-dependency, therapy, companion, or mental-health claims;
+- weaken evidence-boundary language;
+- claim product readiness;
+- assume Pi has an API, SDK, embedding path, or compatible license;
+- implement voice mode;
+- create persistent memory storage;
+- modify backlog workbooks;
+- change specs or entrypoints.

--- a/docs/evals/runs/alpha-solver-pi-like-agent-ux-feasibility-001/operator-assistant-design.md
+++ b/docs/evals/runs/alpha-solver-pi-like-agent-ux-feasibility-001/operator-assistant-design.md
@@ -1,0 +1,73 @@
+# Operator Assistant Design
+
+## Design goal
+
+Create an Alpha-native operator-assistant UX that makes the system easier to operate without weakening technical rigor, safety boundaries, or evidence requirements.
+
+## Proposed interaction pattern
+
+The assistant should respond with:
+
+1. a brief human-readable status summary;
+2. the relevant evidence boundary;
+3. the recommended next action;
+4. the stop condition or approval gate, if any;
+5. a short fallback if the operator disagrees or the lane is blocked.
+
+## Memory behavior
+
+Allowed memory sources:
+
+- committed specs;
+- committed docs packets;
+- current branch diffs;
+- command outputs from the current session;
+- explicit operator-provided lane instructions;
+- operator-approved notes if a future lane creates a storage policy.
+
+Disallowed memory behavior:
+
+- claiming to remember private user facts that are not in the current context or approved artifacts;
+- silently storing personal data;
+- summarizing external chats routed outside Alpha Solver;
+- using private data to personalize tone.
+
+## Tone rules
+
+The assistant may be warm, clear, and encouraging. It must also remain explicit about uncertainty, source boundaries, and non-readiness claims.
+
+Recommended phrasing pattern:
+
+- "Here is the safest next step based on the packet."
+- "This is a design recommendation, not runtime evidence."
+- "I do not have an approved source link for that external product, so integration analysis should stop here."
+
+Avoided phrasing pattern:
+
+- "I know you need this emotionally."
+- "Trust me."
+- "I remember your preference" unless grounded in an approved artifact.
+- "This is production-ready" unless established by accepted readiness evidence.
+
+## Stop-condition reminders
+
+The assistant should proactively surface stop conditions when:
+
+- a lane requires operator approval;
+- an external service, API, license, or private data source is implied;
+- evidence is insufficient;
+- further work would change runtime code outside authorized scope;
+- an answer risks overstating readiness or quality.
+
+## Workload-reduction features for later lanes
+
+Potential later features:
+
+- lane status digest;
+- selected-next-lane explainer;
+- blocked-claims reminder;
+- evidence packet map;
+- operator decision checklist;
+- safe handoff summary between agents.
+
+These are design candidates only and require later specs before implementation.

--- a/docs/evals/runs/alpha-solver-pi-like-agent-ux-feasibility-001/recommendation.md
+++ b/docs/evals/runs/alpha-solver-pi-like-agent-ux-feasibility-001/recommendation.md
@@ -1,0 +1,28 @@
+# Recommendation
+
+## Verdict
+
+`PI_LIKE_AGENT_UX_FEASIBILITY_CAPTURED`
+
+## Recommendation
+
+Adopt Pi-like UX patterns only as inspiration for an Alpha-native operator-assistant design. The valuable pattern is not external product integration; it is conversational operator support that reduces workload while making evidence, uncertainty, and stop conditions easier to see.
+
+## Integration decision
+
+No integration. Do not integrate Pi directly and do not call external services.
+
+## Rationale
+
+Alpha Solver's core trust model depends on explicit evidence boundaries. A warmer personal-agent layer can help operators navigate complex lane packets, but only if it reinforces rather than masks those boundaries.
+
+## Required next design constraints
+
+The next lane should define:
+
+- allowable tone range;
+- artifact-grounded memory rules;
+- stop-condition reminder behavior;
+- source citation and uncertainty display requirements;
+- private local-first defaults;
+- forbidden claims and forbidden companion/therapy framing.

--- a/docs/evals/runs/alpha-solver-pi-like-agent-ux-feasibility-001/risks-and-boundaries.md
+++ b/docs/evals/runs/alpha-solver-pi-like-agent-ux-feasibility-001/risks-and-boundaries.md
@@ -1,0 +1,49 @@
+# Risks and Boundaries
+
+## Risk map
+
+### Overfriendly tone weakening evidence boundaries
+
+Risk: a friend-like tone could make uncertainty, blocked claims, or stop states feel optional.
+
+Boundary: warmth must be subordinate to evidence. Responses should preserve citations, explicit uncertainty, and lane scope.
+
+### Implied therapist or companion claims
+
+Risk: Pi-like language can drift into emotional-support, therapy, or companion framing.
+
+Boundary: Alpha Solver must not claim to provide therapy, mental-health support, companionship, emotional dependency, or personal relationship behavior.
+
+### Hallucinated memory
+
+Risk: conversational agents can imply continuity or memory not grounded in artifacts.
+
+Boundary: memory summaries must be derived from explicit repository artifacts, current context, command output, or approved notes.
+
+### Dependency on closed external products
+
+Risk: direct reliance on a closed assistant product could create licensing, availability, privacy, and reproducibility risks.
+
+Boundary: do not integrate Inflection Pi or similar services without exact operator-approved source links, API/license review, and a dedicated integration spec.
+
+### Privacy issues if chats route outside Alpha Solver
+
+Risk: operator chats may contain sensitive project, credential, planning, or private context.
+
+Boundary: private local-first behavior is preferred. External routing requires explicit operator approval, data classification, redaction policy, and logging rules.
+
+### Operator trust erosion if UX hides uncertainty
+
+Risk: a polished conversational UX can make weak evidence appear stronger.
+
+Boundary: the assistant must expose uncertainty, blocked evidence, and non-claims prominently.
+
+## Hard boundaries preserved
+
+- No direct Pi integration.
+- No external service calls.
+- No private user data use.
+- No runtime code changes.
+- No emotional-dependency or therapy claims.
+- No weakened evidence-boundary language.
+- No product-readiness claim.

--- a/docs/evals/runs/alpha-solver-pi-like-agent-ux-feasibility-001/selected-next-lane.md
+++ b/docs/evals/runs/alpha-solver-pi-like-agent-ux-feasibility-001/selected-next-lane.md
@@ -1,0 +1,25 @@
+# Selected Next Lane
+
+Selected next lane:
+
+`ALPHA-SOLVER-OPERATOR-ASSISTANT-UX-PATTERN-SPEC-001`
+
+## Purpose
+
+Create an implementation-neutral spec for an Alpha-native operator assistant UX pattern.
+
+## Required scope
+
+The lane should specify:
+
+- tone and interaction guidelines;
+- project-memory provenance rules;
+- stop-condition and approval-gate reminders;
+- next-action coaching format;
+- evidence-boundary rendering;
+- privacy and local-first requirements;
+- non-claims and forbidden language.
+
+## Exclusions
+
+The lane should not integrate Pi, use external services, use private user data, implement voice, or modify runtime behavior unless separately authorized.

--- a/docs/evals/runs/alpha-solver-pi-like-agent-ux-feasibility-001/ux-pattern-analysis.md
+++ b/docs/evals/runs/alpha-solver-pi-like-agent-ux-feasibility-001/ux-pattern-analysis.md
@@ -1,0 +1,39 @@
+# UX Pattern Analysis
+
+## Scope
+
+This analysis studies whether Alpha Solver should adopt a more personal, conversational, operator-friendly interaction pattern inspired by Pi-like assistants. It evaluates UX pattern transfer only. It does not evaluate or integrate Inflection Pi as a product.
+
+## Potential benefits
+
+### Warmer operator guidance
+
+A warmer tone may reduce operator fatigue when the system asks for review, confirmation, or triage. The tone should be calm, concise, and supportive without implying friendship, companionship, therapy, or certainty beyond available evidence.
+
+### Context-aware project memory summaries
+
+Alpha Solver could provide short summaries of active lanes, accepted boundaries, selected next actions, and unresolved blockers. Memory must be artifact-grounded: summaries should cite repo docs, specs, command logs, or operator-approved notes rather than inferred private memory.
+
+### Interruption and stop-condition reminders
+
+A personal-agent style can make stop states more usable by reminding the operator when a lane is blocked, when an approval gate is reached, when a safety boundary applies, or when further action would exceed scope.
+
+### Next-action coaching
+
+The assistant can reduce decision overhead by offering one recommended next action, one fallback, and the reason for each. This is useful when Alpha Solver has many packets, lanes, and guardrails.
+
+### Operator workload reduction
+
+A conversational layer can compress status, highlight what changed, identify what still needs operator judgment, and avoid requiring the operator to re-read long evidence packets for every decision.
+
+### Voice or conversational mode later
+
+Voice may be useful later for low-risk status review and task triage, but should remain downstream. Voice adds privacy, transcript, consent, and evidence-citation challenges and should not be part of this feasibility lane.
+
+### Private local-first personal assistant behavior
+
+The best-fit pattern is a local-first operator assistant that helps navigate Alpha Solver context while preserving evidence boundaries. Local-first behavior reduces privacy risk and avoids dependency on closed external products.
+
+## Friend-like UX vs evidence-bound technical agent
+
+Alpha Solver should not become a friend-like companion. The transferable pattern is conversational helpfulness, not emotional bonding. The agent should remain evidence-bound, cite sources when answering repository questions, expose uncertainty, and clearly separate product guidance from personal support.


### PR DESCRIPTION
### Motivation
- Capture feasibility analysis for adopting Pi-like personal-agent UX patterns for Alpha Solver while preserving evidence and safety boundaries.
- Provide an implementation-neutral recommendation that favors Alpha-native, local-first operator-assistant behavior and explicitly blocks direct Inflection Pi integration in this lane.

### Description
- Add a docs-only evidence packet at `docs/evals/runs/alpha-solver-pi-like-agent-ux-feasibility-001/` containing `README.md`, `ux-pattern-analysis.md`, `operator-assistant-design.md`, `risks-and-boundaries.md`, `integration-options.md`, `recommendation.md`, `selected-next-lane.md`, `evidence-boundary.md`, and `non-actions.md` which capture the verdict `PI_LIKE_AGENT_UX_FEASIBILITY_CAPTURED` and the selected next lane `ALPHA-SOLVER-OPERATOR-ASSISTANT-UX-PATTERN-SPEC-001`.
- Document recommended interaction patterns, allowed/disallowed memory sources, tone rules, stop-condition reminders, risk mappings, integration options (recommend Option A: capture UX principles only), and explicit non-actions to preserve evidence boundaries and prevent runtime or external-service changes.
- This change is docs-only and does not modify runtime code, call external services, or use private data.

### Testing
- Ran `find docs/evals/runs/alpha-solver-pi-like-agent-ux-feasibility-001 -maxdepth 1 -type f | sort | xargs -n1 basename` to verify all expected files are present, and it succeeded.
- Ran a Python completeness/assertion check (a short script that verifies required files exist and that the text contains `PI_LIKE_AGENT_UX_FEASIBILITY_CAPTURED` and the no-integration guidance) and it succeeded.
- Inspected the new markdown files with `nl`/file listing to confirm contents and structure, and the inspection succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e74ea95d8832997bab281fb013024)