### PR TITLE
docs(ui): add sidecar API-shape compatibility gate

### DIFF
--- a/docs/evals/runs/alpha-solver-operator-ui-sidecar-feasibility-001/README.md
+++ b/docs/evals/runs/alpha-solver-operator-ui-sidecar-feasibility-001/README.md
@@ -10,7 +10,7 @@ Alpha Solver can plausibly improve operator usability by sitting behind an exist
 UI sidecar -> Alpha Solver controlled endpoint -> Alpha Solver router/policy/evidence layer -> local or hosted model backend
 ```
 
-The UI must not talk directly to Ollama, OpenAI, or any other model backend for Alpha Solver workflows. This packet is docs-only and records feasibility, boundary requirements, and the next security decision lane. No UI was deployed, no endpoint was exposed, no credentials were connected, and no repo data was uploaded to RAG or external services.
+The UI must not talk directly to Ollama, OpenAI, or any other model backend for Alpha Solver workflows. This packet is docs-only and records feasibility, boundary requirements, and the next API-shape/security decision lane. No UI was deployed, no endpoint was exposed, no credentials were connected, and no repo data was uploaded to RAG or external services.
 
 ## Packet files
 
@@ -25,4 +25,4 @@ The UI must not talk directly to Ollama, OpenAI, or any other model backend for 
 
 ## Primary recommendation
 
-Use a **minimal local console first**, then evaluate **Open WebUI in endpoint-only sidecar mode** after security gates define endpoint exposure, auth, data retention, upload/RAG disablement, and routing-bypass controls.
+Run `ALPHA-SOLVER-OPERATOR-UI-SIDECAR-API-SHAPE-SECURITY-GATE-001` before any endpoint-only sidecar trial. The gate should decide whether to use a minimal Alpha-native local console, an OpenAI-compatible shim, a sidecar native request mapper, or no sidecar integration yet.

--- a/docs/evals/runs/alpha-solver-operator-ui-sidecar-feasibility-001/alpha-boundary-preservation.md
+++ b/docs/evals/runs/alpha-solver-operator-ui-sidecar-feasibility-001/alpha-boundary-preservation.md
@@ -10,17 +10,19 @@
 
 ## Required controls before any UI trial
 
-1. **Endpoint allowlist:** the sidecar may call only the Alpha Solver controlled endpoint.
-2. **Provider lockdown:** users cannot add direct Ollama/OpenAI/OpenRouter/Anthropic/etc. endpoints for Alpha Solver workflows.
-3. **Upload/RAG off by default:** document upload, embedding, knowledge bases, workspace sync, and file injection remain disabled unless a separate evidence-ingestion lane approves them.
-4. **Tooling off by default:** plugins, code execution, terminal access, web search, MCP, OpenAPI tools, auto-approved tools, and pipelines remain disabled.
-5. **Envelope-first display:** UI renders Alpha Solver answer, route, safety state, evidence references, and stop conditions without rewriting them as free-form chat metadata.
-6. **Retention decision:** conversation storage, deletion, export, and audit retention must be explicitly specified before shared use.
-7. **Auth decision:** local-only usage can defer multi-user auth; shared usage requires authn/authz and per-user audit identity.
+1. **API-shape compatibility gate:** the sidecar cannot be pointed at `/v1/solve` until an OpenAI-compatible shim/adapter, confirmed native request mapping, or approved bridge lane accounts for Alpha Solver's required `query` field and preserves Alpha Solver router, policy, SAFE-OUT, evidence, auth, tenancy, CORS, cost, and observability boundaries.
+2. **Endpoint allowlist:** the sidecar may call only the Alpha Solver controlled endpoint.
+3. **Provider lockdown:** users cannot add direct Ollama/OpenAI/OpenRouter/Anthropic/etc. endpoints for Alpha Solver workflows.
+4. **Upload/RAG off by default:** document upload, embedding, knowledge bases, workspace sync, and file injection remain disabled unless a separate evidence-ingestion lane approves them.
+5. **Tooling off by default:** plugins, code execution, terminal access, web search, MCP, OpenAPI tools, auto-approved tools, and pipelines remain disabled.
+6. **Envelope-first display:** UI renders Alpha Solver answer, route, safety state, evidence references, and stop conditions without rewriting them as free-form chat metadata.
+7. **Retention decision:** conversation storage, deletion, export, and audit retention must be explicitly specified before shared use.
+8. **Auth decision:** local-only usage can defer multi-user auth; shared usage requires authn/authz and per-user audit identity.
 
 ## Boundary test questions for any future implementation
 
 - Can a user make the UI call a model directly without Alpha Solver?
+- Can the sidecar send Alpha Solver the required `/v1/solve` `query` request shape, or is it assuming an OpenAI-compatible chat/completions shape?
 - Can a user upload a private repo file into UI RAG or memory?
 - Can the UI summarize or transform evidence in a way that looks authoritative but is not in the SolverEnvelope?
 - Can a plugin/tool/pipeline invoke external services with prompt or repo data?

--- a/docs/evals/runs/alpha-solver-operator-ui-sidecar-feasibility-001/recommendation.md
+++ b/docs/evals/runs/alpha-solver-operator-ui-sidecar-feasibility-001/recommendation.md
@@ -6,20 +6,22 @@
 
 ## Recommended sidecar pattern
 
-Start with a **minimal local Alpha Solver operator console**. Use it to prove the envelope-first UX before introducing a full external UI.
+The next lane is **not direct sidecar deployment**. Start with a security/API-shape decision gate before any endpoint-only sidecar trial.
 
-A later Open WebUI experiment can be considered only as an **endpoint-only sidecar** after security/exposure gates decide how to lock down direct providers, upload/RAG, tools, memory, web search, code execution, auth, and retention.
+The selected next lane is `ALPHA-SOLVER-OPERATOR-UI-SIDECAR-API-SHAPE-SECURITY-GATE-001`. It should decide whether to use a minimal Alpha-native local console, an OpenAI-compatible shim, a sidecar native request mapper, or no sidecar integration yet.
 
 ## Ranking for early MVP
 
-1. **Custom minimal console** — best boundary preservation and lowest bypass risk.
-2. **Open WebUI endpoint-only sidecar** — best off-the-shelf candidate after lockdown decisions.
-3. **LibreChat endpoint-only sidecar** — plausible fallback if ChatGPT-like UX is favored and provider sprawl is controlled.
-4. **AnythingLLM** — defer; document/RAG/workspace orientation is not aligned with this safety-first lane.
+1. **Security/API-shape decision gate** — decide whether a minimal Alpha-native local console, OpenAI-compatible shim, sidecar native request mapper, or no integration is appropriate.
+2. **Custom minimal console** — best boundary preservation and lowest bypass risk if the gate selects Alpha-native UX.
+3. **Open WebUI endpoint-only sidecar** — blocked until lockdown decisions and API-shape compatibility are proven.
+4. **LibreChat endpoint-only sidecar** — blocked until lockdown decisions and API-shape compatibility are proven.
+5. **AnythingLLM** — defer; document/RAG/workspace orientation is not aligned with this safety-first lane.
 
 ## Do-not-integrate-yet warnings
 
 - Do not connect any UI directly to Ollama, OpenAI, or other model backends for Alpha Solver workflows.
+- Do not point Open WebUI, LibreChat, or a custom endpoint shell directly at `/v1/solve` unless the API-shape compatibility gate confirms an OpenAI-compatible shim/adapter, confirmed native request mapping, or approved bridge lane.
 - Do not enable document upload, RAG, memory, knowledge bases, workspace sync, web search, tools, code execution, MCP, OpenAPI tools, pipelines, or auto-approved agents.
 - Do not expose Alpha Solver endpoints to a browser or network until auth, CORS, CSRF, rate limiting, audit identity, and retention are specified.
 - Do not treat UI chat history as authoritative evidence.

--- a/docs/evals/runs/alpha-solver-operator-ui-sidecar-feasibility-001/risks-and-non-goals.md
+++ b/docs/evals/runs/alpha-solver-operator-ui-sidecar-feasibility-001/risks-and-non-goals.md
@@ -2,6 +2,7 @@
 
 ## Main risks
 
+- **API-shape mismatch:** Open WebUI, LibreChat, or a custom endpoint shell may send an OpenAI-compatible request shape to `/v1/solve`, which currently requires Alpha Solver's `query` request shape, and fail before router, policy, SAFE-OUT, evidence, auth, tenancy, CORS, cost, and observability boundaries are reached.
 - **Routing bypass:** UI connects directly to local or hosted models.
 - **Evidence confusion:** UI RAG, memory, or notes become untracked evidence sources.
 - **Credential exposure:** UI stores provider keys or permits users to add providers.
@@ -18,5 +19,5 @@
 - No credentials or provider keys.
 - No production mounting of an external UI.
 - No RAG ingestion of private repo data.
-- No product-readiness or public-readiness claim.
+- No endpoint, UI, runtime, provider, production, or public readiness claim.
 - No replacement of Alpha Solver routing, policy, evidence, SAFE-OUT, determinism, replay, observability, or SolverEnvelope semantics.

--- a/docs/evals/runs/alpha-solver-operator-ui-sidecar-feasibility-001/selected-next-lane.md
+++ b/docs/evals/runs/alpha-solver-operator-ui-sidecar-feasibility-001/selected-next-lane.md
@@ -2,14 +2,18 @@
 
 ## Selected lane
 
-**ALPHA-SOLVER-OPERATOR-UI-SIDECAR-SECURITY-GATES-001**
+**ALPHA-SOLVER-OPERATOR-UI-SIDECAR-API-SHAPE-SECURITY-GATE-001**
 
 ## Purpose
 
-Decide the security and exposure gates required before any UI sidecar can be connected to an Alpha Solver controlled endpoint.
+Decide the security and API-shape gates required before any UI sidecar can be connected to an Alpha Solver controlled endpoint. This is not direct sidecar deployment.
 
 ## Required decisions
 
+- Confirm that Alpha Solver's current route contract is not assumed OpenAI-compatible.
+- Account for the current `/v1/solve` request shape, including the required `query` field.
+- Decide whether the next implementation should be a minimal Alpha-native local console, an OpenAI-compatible shim, a sidecar native request mapper, or no sidecar integration yet.
+- If considering Open WebUI, LibreChat, or a custom endpoint, prove that the trial is blocked until an approved compatibility path exists.
 - Endpoint exposure model: local-only, loopback, LAN, or authenticated shared deployment.
 - Authn/authz model and per-user audit identity.
 - CORS/CSRF/session constraints for browser-based sidecars.
@@ -19,6 +23,6 @@ Decide the security and exposure gates required before any UI sidecar can be con
 - Evidence-envelope rendering contract.
 - Configuration test plan proving the UI cannot bypass Alpha Solver routing.
 
-## Initial implementation lane after security gates
+## Initial implementation lane after this gate
 
-If gates pass, implement a **minimal local operator console prototype** rather than integrating a full third-party UI first.
+If gates pass, implement only the selected approved lane. The default preference remains a **minimal local operator console prototype** rather than integrating a full third-party UI first. Open WebUI, LibreChat, or custom endpoint integration remains blocked unless an OpenAI-compatible shim/adapter, confirmed native request mapping, or separate approved bridge lane preserves Alpha Solver router, policy, SAFE-OUT, evidence, auth, tenancy, CORS, cost, and observability boundaries.

--- a/docs/evals/runs/alpha-solver-operator-ui-sidecar-feasibility-001/sidecar-architecture-options.md
+++ b/docs/evals/runs/alpha-solver-operator-ui-sidecar-feasibility-001/sidecar-architecture-options.md
@@ -11,6 +11,16 @@ UI sidecar
 
 This keeps model selection, policy enforcement, evidence handling, budget/determinism controls, and SolverEnvelope rendering in Alpha Solver rather than the UI.
 
+## API-shape compatibility gate
+
+Current Alpha Solver route contract is not assumed OpenAI-compatible. The current `/v1/solve` surface uses Alpha Solver's request shape, including a required `query` field, so Open WebUI, LibreChat, or custom endpoint trials are blocked before any endpoint-only sidecar trial unless one of the following is true:
+
+- an OpenAI-compatible shim/adapter exists in front of Alpha Solver and preserves Alpha Solver router, policy, SAFE-OUT, evidence, auth, tenancy, CORS, cost, and observability boundaries;
+- the sidecar has a confirmed native request mapping to Alpha Solver's `/v1/solve` request/response shape;
+- a separate approved bridge lane implements and tests that compatibility layer.
+
+The direct UI-to-model path remains forbidden. The direct sidecar-to-provider path remains forbidden. The direct sidecar-to-Ollama path remains forbidden. No endpoint, public exposure, runtime readiness, UI readiness, provider readiness, or production readiness is claimed.
+
 ## Disallowed architecture
 
 ```text
@@ -34,13 +44,13 @@ This bypasses Alpha Solver routing and can produce responses with no Alpha Solve
 - Configure one provider: Alpha Solver controlled endpoint only.
 - Disable or hide direct model endpoints, uploads, knowledge bases, web search, tools, code execution, pipelines, MCP, OpenAPI tool import, memory, and autonomous agents until individually approved.
 - Treat Open WebUI as a shell, not as a policy or evidence engine.
-- Candidate for later MVP if security gates prove configuration lockdown is reliable.
+- Candidate for later MVP only if security gates and the API-shape compatibility gate prove configuration lockdown and request/response compatibility are reliable.
 
 ### Option C: LibreChat endpoint-only sidecar later
 
 - Configure custom endpoint to Alpha Solver only.
 - Lock down provider addition, credentials, plugins/tools, file upload/RAG, and user-level endpoint overrides.
-- Consider only if Open WebUI is too broad or if LibreChat's ChatGPT-like UX is preferred.
+- Consider only if Open WebUI is too broad or if LibreChat's ChatGPT-like UX is preferred, and only after the API-shape compatibility gate confirms a safe request/response mapping.
 
 ### Option D: AnythingLLM document workspace sidecar
 


### PR DESCRIPTION
### Motivation

- Follow-up to merged PR #546 to address a post-merge review gap without reverting that change. 
- The operator UI sidecar packet lacked an explicit API-shape compatibility gate and could have allowed endpoint-only sidecar trials to point UIs at `/v1/solve`, which currently expects an Alpha-specific request shape including a required `query` field. 
- The intent is to prevent mismatched OpenAI-compatible UI request shapes (e.g., Open WebUI, LibreChat, custom endpoints) from failing early or bypassing Alpha Solver router, policy, SAFE-OUT, evidence, auth, tenancy, CORS, cost, and observability boundaries. 

### Description

- Added an `API-shape compatibility gate` section to `docs/evals/runs/alpha-solver-operator-ui-sidecar-feasibility-001/sidecar-architecture-options.md` that states `/v1/solve` is not assumed OpenAI-compatible, documents the required `query` field, and blocks endpoint-only sidecar trials unless an OpenAI-compatible shim/adapter, a confirmed native request mapping, or an approved bridge lane exists. 
- Updated `docs/evals/runs/alpha-solver-operator-ui-sidecar-feasibility-001/recommendation.md` and `docs/evals/runs/alpha-solver-operator-ui-sidecar-feasibility-001/selected-next-lane.md` to make the next lane `ALPHA-SOLVER-OPERATOR-UI-SIDECAR-API-SHAPE-SECURITY-GATE-001` and to instruct that the next lane decide between a minimal Alpha-native local console, an OpenAI-compatible shim, a sidecar native request mapper, or no sidecar integration yet. 
- Updated `docs/evals/runs/alpha-solver-operator-ui-sidecar-feasibility-001/alpha-boundary-preservation.md` and `docs/evals/runs/alpha-solver-operator-ui-sidecar-feasibility-001/risks-and-non-goals.md` to require the API-shape gate before pointing a sidecar at `/v1/solve`, add the `API-shape mismatch` risk, and to tighten readiness wording; and adjusted `README.md` to reference the API-shape/security decision lane. 
- This is docs-only: no runtime code, API routes, deployments, provider calls, credential access, model calls, or other runtime artifacts were added or changed. 

### Testing

- Ran the packet validation snippet that searches the packet MD files for required phrases and forbids readiness claims, using `python - <<'PY' ... PY`, and it reported `ui sidecar api-shape gate validation passed`. 
- Ran `git diff --check` to verify whitespace/patch cleanliness and then ran `python -m pytest -q tests/test_local_llm_packet_consistency.py`, which completed with all tests passing. 
- Current commit SHA for this change is `4b9340e5fccea1bdef7a5e3e41fa6841996cfd66`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2eedecdcbc832987e37a4b21052a36)