### PR TITLE
docs: add clean-room operator console bridge design packet (ALPHA-SOLVER-OPERATOR-CONSOLE-BRIDGE-001)

### DIFF
--- a/docs/evals/runs/alpha-solver-operator-console-bridge-001/README.md
+++ b/docs/evals/runs/alpha-solver-operator-console-bridge-001/README.md
@@ -1,0 +1,21 @@
+# ALPHA-SOLVER-OPERATOR-CONSOLE-BRIDGE-001
+
+This packet defines the clean-room operator console bridge design lane for Alpha Solver.
+It is a documentation-only replacement packet for the abandoned contaminated PR #547.
+No material was copied, cherry-picked, merged, rebased, or repaired from PR #547.
+
+## Packet contents
+
+- `auth-and-boundary-map.md` — authentication, authorization, and trust-boundary map.
+- `bridge-design.md` — proposed local bridge shape and operator-console responsibilities.
+- `evidence-boundary.md` — evidence limits and claims this packet can support.
+- `implementation-summary.md` — implementation status for this lane.
+- `local-only-runbook.md` — local-only operator flow for future validation.
+- `non-actions.md` — explicit work not performed in this packet.
+- `residual-risks.md` — remaining design and validation risks.
+- `selected-next-lane.md` — recommended next lane after this packet.
+- `test-evidence.md` — checks run for this docs-only packet.
+
+## Scope
+
+The lane captures intended design constraints for a local operator console bridge. It does not implement a bridge, does not alter runtime behavior, does not add credentials, and does not expand any network boundary.

--- a/docs/evals/runs/alpha-solver-operator-console-bridge-001/README.md
+++ b/docs/evals/runs/alpha-solver-operator-console-bridge-001/README.md
@@ -1,21 +1,33 @@
 # ALPHA-SOLVER-OPERATOR-CONSOLE-BRIDGE-001
 
-This packet defines the clean-room operator console bridge design lane for Alpha Solver.
-It is a documentation-only replacement packet for the abandoned contaminated PR #547.
-No material was copied, cherry-picked, merged, rebased, or repaired from PR #547.
+## Verdict
+
+`OPERATOR_CONSOLE_BRIDGE_BLOCKED_SECURITY_DECISION_REQUIRED`
+
+This packet defines the clean-room operator console bridge design lane for Alpha Solver. It is a documentation-only replacement packet for abandoned contaminated PR #547. No material was copied, cherry-picked, merged, rebased, or repaired from PR #547.
+
+## Dependency state
+
+- PR #546 sidecar feasibility packet exists and remains a prerequisite context for this lane.
+- PR #549 API-shape compatibility gate exists and must be preserved as a gating dependency.
+- Current Alpha Solver `/v1/solve` is not assumed OpenAI-compatible.
+- Current `/v1/solve` uses Alpha Solver's request shape, including the required `query` field.
+- Operator console bridge implementation remains blocked pending the sidecar API-shape/security gate.
 
 ## Packet contents
 
-- `auth-and-boundary-map.md` — authentication, authorization, and trust-boundary map.
-- `bridge-design.md` — proposed local bridge shape and operator-console responsibilities.
-- `evidence-boundary.md` — evidence limits and claims this packet can support.
-- `implementation-summary.md` — implementation status for this lane.
-- `local-only-runbook.md` — local-only operator flow for future validation.
+- `auth-and-boundary-map.md` — authentication, authorization, API-shape, and trust-boundary map.
+- `bridge-design.md` — local bridge design constraints and blocked request-mapping dependency.
+- `evidence-boundary.md` — evidence limits and claims this packet cannot support.
+- `implementation-summary.md` — implementation status and blocked gate verdict.
+- `local-only-runbook.md` — gated local-only operator flow for future validation.
 - `non-actions.md` — explicit work not performed in this packet.
-- `residual-risks.md` — remaining design and validation risks.
-- `selected-next-lane.md` — recommended next lane after this packet.
+- `residual-risks.md` — remaining design, API-shape, and security risks.
+- `selected-next-lane.md` — required next gate lane.
 - `test-evidence.md` — checks run for this docs-only packet.
 
 ## Scope
 
 The lane captures intended design constraints for a local operator console bridge. It does not implement a bridge, does not alter runtime behavior, does not add credentials, and does not expand any network boundary.
+
+No endpoint, CLI bridge, public route, deployment, UI implementation, provider call, token use, credential access, local model call, or Google Sheets update occurred.

--- a/docs/evals/runs/alpha-solver-operator-console-bridge-001/auth-and-boundary-map.md
+++ b/docs/evals/runs/alpha-solver-operator-console-bridge-001/auth-and-boundary-map.md
@@ -1,0 +1,36 @@
+# Authentication and Boundary Map
+
+## Actors
+
+- **Local operator**: a human using the console on a trusted workstation.
+- **Operator console**: a future UI or CLI surface that requests local bridge actions.
+- **Local bridge**: a future localhost-only adapter that may translate console requests into approved Alpha Solver commands.
+- **Alpha Solver runtime**: existing solver entrypoints and supporting scripts.
+
+## Boundary principles
+
+1. The bridge should bind to loopback only by default.
+2. The bridge should fail closed when authentication or origin checks are absent.
+3. The bridge should not accept remote network traffic unless a later spec explicitly authorizes it.
+4. The bridge should not embed long-lived secrets in repo files, logs, docs, or examples.
+5. The console should request only allowlisted operations with bounded inputs.
+
+## Authentication shape
+
+A future implementation should prefer short-lived local session credentials or an explicit operator start token. The token should be generated at bridge startup, displayed only to the local operator, and never persisted by default.
+
+## Authorization shape
+
+Authorization should be command-scoped. Each callable bridge operation should declare:
+
+- operation name;
+- accepted parameters;
+- validation rules;
+- side-effect class;
+- expected output envelope;
+- redaction requirements;
+- stop conditions.
+
+## Evidence boundary
+
+This file is a design map only. It does not prove that current code enforces these controls.

--- a/docs/evals/runs/alpha-solver-operator-console-bridge-001/auth-and-boundary-map.md
+++ b/docs/evals/runs/alpha-solver-operator-console-bridge-001/auth-and-boundary-map.md
@@ -1,25 +1,50 @@
 # Authentication and Boundary Map
 
+## Verdict
+
+`OPERATOR_CONSOLE_BRIDGE_BLOCKED_SECURITY_DECISION_REQUIRED`
+
 ## Actors
 
 - **Local operator**: a human using the console on a trusted workstation.
-- **Operator console**: a future UI or CLI surface that requests local bridge actions.
-- **Local bridge**: a future localhost-only adapter that may translate console requests into approved Alpha Solver commands.
+- **Operator console**: a future UI or CLI surface that requests local bridge actions after the gate passes.
+- **Local bridge**: a future localhost-only adapter that may translate console requests into approved Alpha Solver commands after request mapping is resolved.
 - **Alpha Solver runtime**: existing solver entrypoints and supporting scripts.
+
+## Dependency state
+
+PR #546 sidecar feasibility packet exists. PR #549 API-shape compatibility gate exists. Current `/v1/solve` is not assumed OpenAI-compatible and requires Alpha Solver's request shape, including `query`.
+
+## Boundary status table
+
+| Boundary | Status now | Required gate decision |
+| --- | --- | --- |
+| Clean-room replacement for PR #547 | Resolved in this packet | Preserve no-copy, no-cherry-pick, no-repair boundary. |
+| Documentation-only packet scope | Resolved in this packet | Keep changes limited to packet documentation. |
+| API-shape/request mapping | Blocked pending gate | Decide and test mapping into `/v1/solve` with required `query`. |
+| Response envelope mapping | Blocked pending gate | Define response-envelope mapping for console rendering. |
+| Sidecar-to-model bypass prevention | Blocked pending gate | Prove direct sidecar-to-model and sidecar-to-Ollama routing stay forbidden. |
+| Sidecar-to-provider bypass prevention | Blocked pending gate | Prove hosted provider calls cannot bypass Alpha Solver controls. |
+| CORS/CSRF | Blocked pending gate | Define UI-origin controls and fail-closed tests. |
+| Telemetry/audit identity | Blocked pending gate | Define operator/session identity propagation and audit rules. |
+| Retention/replay | Blocked pending gate | Define UI session retention and replay boundaries. |
+| Token handling | Blocked pending gate | Define short-lived local credentials without repo persistence. |
+| Auth and tenancy | Blocked pending gate | Preserve existing auth and tenancy boundaries for any UI-originated request. |
+| Cost and policy controls | Blocked pending gate | Preserve policy, SAFE-OUT, cost, and evidence boundaries. |
 
 ## Boundary principles
 
-1. The bridge should bind to loopback only by default.
-2. The bridge should fail closed when authentication or origin checks are absent.
+1. The bridge should bind to loopback only by default after the selected gate passes.
+2. The bridge should fail closed when authentication or origin checks are not satisfied.
 3. The bridge should not accept remote network traffic unless a later spec explicitly authorizes it.
 4. The bridge should not embed long-lived secrets in repo files, logs, docs, or examples.
 5. The console should request only allowlisted operations with bounded inputs.
 
-## Authentication shape
+## Authentication shape candidate
 
 A future implementation should prefer short-lived local session credentials or an explicit operator start token. The token should be generated at bridge startup, displayed only to the local operator, and never persisted by default.
 
-## Authorization shape
+## Authorization shape candidate
 
 Authorization should be command-scoped. Each callable bridge operation should declare:
 

--- a/docs/evals/runs/alpha-solver-operator-console-bridge-001/bridge-design.md
+++ b/docs/evals/runs/alpha-solver-operator-console-bridge-001/bridge-design.md
@@ -1,0 +1,38 @@
+# Bridge Design
+
+## Goal
+
+Define a narrow local bridge pattern that lets an operator console invoke approved Alpha Solver actions without changing existing solver contracts in this packet.
+
+## Proposed bridge responsibilities
+
+- expose a localhost-only control surface;
+- validate operator requests before dispatch;
+- translate approved requests into existing commands or functions;
+- preserve deterministic inputs where required by existing specs;
+- capture structured results for the console;
+- redact secrets and sensitive paths from logs;
+- return clear fail-closed errors when a request is outside the allowlist.
+
+## Non-goals
+
+- no public web service;
+- no hosted provider fallback;
+- no new solver behavior;
+- no background daemon requirement;
+- no credential persistence;
+- no changes to portable or modular entrypoint semantics.
+
+## Request lifecycle
+
+1. Operator starts the bridge locally.
+2. Bridge emits a short-lived local session token.
+3. Console connects to loopback and presents the token.
+4. Bridge validates origin, token, operation, and parameters.
+5. Bridge dispatches only allowlisted local work.
+6. Bridge returns a structured response with redaction applied.
+7. Bridge exits or expires credentials according to operator-configured lifetime.
+
+## Allowlist-first model
+
+The bridge should start with no implicit command execution. Each operation must be added deliberately with tests and documentation.

--- a/docs/evals/runs/alpha-solver-operator-console-bridge-001/bridge-design.md
+++ b/docs/evals/runs/alpha-solver-operator-console-bridge-001/bridge-design.md
@@ -1,18 +1,32 @@
 # Bridge Design
 
+## Verdict
+
+`OPERATOR_CONSOLE_BRIDGE_BLOCKED_SECURITY_DECISION_REQUIRED`
+
 ## Goal
 
-Define a narrow local bridge pattern that lets an operator console invoke approved Alpha Solver actions without changing existing solver contracts in this packet.
+Define a narrow local bridge pattern that lets an operator console invoke approved Alpha Solver actions only after the sidecar API-shape/security gate resolves request mapping and security boundaries.
 
 ## Proposed bridge responsibilities
 
-- expose a localhost-only control surface;
+- expose a localhost-only control surface only after the required gate passes;
 - validate operator requests before dispatch;
 - translate approved requests into existing commands or functions;
 - preserve deterministic inputs where required by existing specs;
 - capture structured results for the console;
 - redact secrets and sensitive paths from logs;
 - return clear fail-closed errors when a request is outside the allowlist.
+
+## API-shape and request-mapping dependency
+
+- Current `/v1/solve` is not assumed OpenAI-compatible.
+- Current `/v1/solve` requires Alpha Solver request shape, including `query`.
+- Any console or UI bridge must not assume OpenAI-compatible chat/completions shape.
+- A future bridge must define and test request mapping and response-envelope mapping before implementation.
+- Direct sidecar-to-model, direct sidecar-to-provider, and direct sidecar-to-Ollama routing remain forbidden.
+- The bridge must preserve Alpha Solver router, policy, SAFE-OUT, evidence, auth, tenancy, CORS/CSRF, cost, telemetry, retention, and replay boundaries.
+- PR #546 sidecar feasibility context and PR #549 API-shape compatibility gate are required dependency state for this bridge lane.
 
 ## Non-goals
 
@@ -21,18 +35,20 @@ Define a narrow local bridge pattern that lets an operator console invoke approv
 - no new solver behavior;
 - no background daemon requirement;
 - no credential persistence;
-- no changes to portable or modular entrypoint semantics.
+- no changes to portable or modular entrypoint semantics;
+- no bridge implementation before `ALPHA-SOLVER-OPERATOR-UI-SIDECAR-API-SHAPE-SECURITY-GATE-001` passes.
 
-## Request lifecycle
+## Request lifecycle candidate after gate approval
 
 1. Operator starts the bridge locally.
 2. Bridge emits a short-lived local session token.
 3. Console connects to loopback and presents the token.
 4. Bridge validates origin, token, operation, and parameters.
-5. Bridge dispatches only allowlisted local work.
-6. Bridge returns a structured response with redaction applied.
-7. Bridge exits or expires credentials according to operator-configured lifetime.
+5. Bridge applies the gate-approved request mapping.
+6. Bridge dispatches only allowlisted local work through Alpha Solver boundaries.
+7. Bridge returns a gate-approved response-envelope mapping with redaction applied.
+8. Bridge exits or expires credentials according to operator-configured lifetime.
 
 ## Allowlist-first model
 
-The bridge should start with no implicit command execution. Each operation must be added deliberately with tests and documentation.
+The bridge should start with no implicit command execution. Each operation must be added deliberately with tests and documentation after the selected gate lane resolves API-shape and security blockers.

--- a/docs/evals/runs/alpha-solver-operator-console-bridge-001/evidence-boundary.md
+++ b/docs/evals/runs/alpha-solver-operator-console-bridge-001/evidence-boundary.md
@@ -1,0 +1,24 @@
+# Evidence Boundary
+
+## Supported claims
+
+This packet supports only the following claims:
+
+- a clean documentation packet was created for `ALPHA-SOLVER-OPERATOR-CONSOLE-BRIDGE-001`;
+- the packet describes a local-only operator console bridge design;
+- the packet records explicit non-actions, residual risks, and next-lane guidance;
+- the packet does not intentionally modify runtime behavior.
+
+## Unsupported claims
+
+This packet does not support claims that:
+
+- an operator console bridge exists;
+- authentication, authorization, or loopback enforcement has been implemented;
+- any end-to-end console flow has been executed;
+- PR #547 was reviewed, repaired, reused, or cleaned;
+- bridge security properties are proven in code.
+
+## Contamination boundary
+
+PR #547 is treated as abandoned and contaminated. This replacement packet is authored as a new clean-room documentation artifact from the lane objective and repository conventions only.

--- a/docs/evals/runs/alpha-solver-operator-console-bridge-001/evidence-boundary.md
+++ b/docs/evals/runs/alpha-solver-operator-console-bridge-001/evidence-boundary.md
@@ -1,11 +1,17 @@
 # Evidence Boundary
 
+## Verdict
+
+`OPERATOR_CONSOLE_BRIDGE_BLOCKED_SECURITY_DECISION_REQUIRED`
+
 ## Supported claims
 
 This packet supports only the following claims:
 
 - a clean documentation packet was created for `ALPHA-SOLVER-OPERATOR-CONSOLE-BRIDGE-001`;
-- the packet describes a local-only operator console bridge design;
+- the packet describes a local-only operator console bridge design that is blocked pending the sidecar API-shape/security gate;
+- PR #546 sidecar feasibility packet exists and PR #549 API-shape compatibility gate exists;
+- current `/v1/solve` is not assumed OpenAI-compatible and uses Alpha Solver's request shape, including `query`;
 - the packet records explicit non-actions, residual risks, and next-lane guidance;
 - the packet does not intentionally modify runtime behavior.
 
@@ -17,7 +23,19 @@ This packet does not support claims that:
 - authentication, authorization, or loopback enforcement has been implemented;
 - any end-to-end console flow has been executed;
 - PR #547 was reviewed, repaired, reused, or cleaned;
-- bridge security properties are proven in code.
+- bridge security properties are proven in code;
+- operator console readiness has been established;
+- UI readiness has been established;
+- endpoint readiness has been established;
+- runtime readiness has been established;
+- public readiness has been established;
+- provider readiness has been established;
+- production readiness has been established;
+- sidecar integration success has been established;
+- API-shape compatibility success has been established;
+- request mapping success has been established;
+- benchmark validation has been established;
+- Alpha superiority has been established.
 
 ## Contamination boundary
 

--- a/docs/evals/runs/alpha-solver-operator-console-bridge-001/implementation-summary.md
+++ b/docs/evals/runs/alpha-solver-operator-console-bridge-001/implementation-summary.md
@@ -1,0 +1,19 @@
+# Implementation Summary
+
+## Change type
+
+Documentation only.
+
+## Files added
+
+This lane adds a packet under:
+
+`docs/evals/runs/alpha-solver-operator-console-bridge-001/`
+
+## Behavior changes
+
+None. No Python, shell, configuration, dependency, CI, or runtime entrypoint files are changed by this packet.
+
+## Intended value
+
+The packet gives future implementation work a bounded design target for a local operator console bridge while preserving current Alpha Solver behavior and sensitive boundary constraints.

--- a/docs/evals/runs/alpha-solver-operator-console-bridge-001/implementation-summary.md
+++ b/docs/evals/runs/alpha-solver-operator-console-bridge-001/implementation-summary.md
@@ -1,5 +1,9 @@
 # Implementation Summary
 
+## Verdict
+
+`OPERATOR_CONSOLE_BRIDGE_BLOCKED_SECURITY_DECISION_REQUIRED`
+
 ## Change type
 
 Documentation only.
@@ -10,10 +14,18 @@ This lane adds a packet under:
 
 `docs/evals/runs/alpha-solver-operator-console-bridge-001/`
 
+## Dependency state
+
+PR #546 sidecar feasibility packet exists. PR #549 API-shape compatibility gate exists. Current `/v1/solve` is not assumed OpenAI-compatible and uses Alpha Solver's request shape, including the required `query` field.
+
 ## Behavior changes
 
-None. No Python, shell, configuration, dependency, CI, or runtime entrypoint files are changed by this packet.
+None. No Python, shell, configuration, dependency, CI, endpoint, CLI bridge, provider, model, token, credential, deployment, Google Sheets, or runtime entrypoint files are changed by this packet.
+
+## Blocked implementation status
+
+Operator console bridge implementation is blocked pending `ALPHA-SOLVER-OPERATOR-UI-SIDECAR-API-SHAPE-SECURITY-GATE-001`. No runtime implementation occurred.
 
 ## Intended value
 
-The packet gives future implementation work a bounded design target for a local operator console bridge while preserving current Alpha Solver behavior and sensitive boundary constraints.
+The packet gives future implementation work a bounded design target for a local operator console bridge while preserving current Alpha Solver behavior, API-shape dependency state, and sensitive boundary constraints.

--- a/docs/evals/runs/alpha-solver-operator-console-bridge-001/local-only-runbook.md
+++ b/docs/evals/runs/alpha-solver-operator-console-bridge-001/local-only-runbook.md
@@ -1,0 +1,29 @@
+# Local-Only Runbook
+
+This runbook is for a future implementation lane. It is not evidence that a bridge exists today.
+
+## Preconditions
+
+- Workstation is trusted by the operator.
+- Repository checkout is clean and on the intended branch.
+- Bridge implementation has an explicit spec and tests.
+- No remote exposure has been enabled.
+
+## Future smoke flow
+
+1. Start the bridge with loopback binding only.
+2. Confirm the bind address is `127.0.0.1` or equivalent local-only loopback.
+3. Capture the short-lived startup token from the local terminal.
+4. Connect the operator console from the same host.
+5. Submit one allowlisted read-only request.
+6. Verify non-allowlisted requests fail closed.
+7. Verify missing or invalid credentials fail closed.
+8. Stop the bridge and confirm credentials expire.
+
+## Required future artifacts
+
+- command transcript with secrets redacted;
+- bridge bind-address evidence;
+- allowlist pass/fail evidence;
+- credential failure evidence;
+- stop-condition evidence.

--- a/docs/evals/runs/alpha-solver-operator-console-bridge-001/local-only-runbook.md
+++ b/docs/evals/runs/alpha-solver-operator-console-bridge-001/local-only-runbook.md
@@ -1,29 +1,42 @@
 # Local-Only Runbook
 
-This runbook is for a future implementation lane. It is not evidence that a bridge exists today.
+## Verdict
 
-## Preconditions
+`OPERATOR_CONSOLE_BRIDGE_BLOCKED_SECURITY_DECISION_REQUIRED`
 
+This runbook is for a later implementation candidate only after `ALPHA-SOLVER-OPERATOR-UI-SIDECAR-API-SHAPE-SECURITY-GATE-001` passes. It is not evidence that a bridge exists today, and it does not authorize implementation before the API-shape/security gate.
+
+## Preconditions after gate approval
+
+- PR #546 sidecar feasibility context and PR #549 API-shape compatibility gate dependency state are preserved.
 - Workstation is trusted by the operator.
 - Repository checkout is clean and on the intended branch.
 - Bridge implementation has an explicit spec and tests.
+- `/v1/solve` request mapping includes Alpha Solver's required `query` field.
+- Response-envelope mapping is defined and tested.
 - No remote exposure has been enabled.
 
-## Future smoke flow
+## Future smoke flow after gate approval
 
 1. Start the bridge with loopback binding only.
 2. Confirm the bind address is `127.0.0.1` or equivalent local-only loopback.
 3. Capture the short-lived startup token from the local terminal.
 4. Connect the operator console from the same host.
-5. Submit one allowlisted read-only request.
+5. Submit one allowlisted read-only request through the gate-approved request mapping.
 6. Verify non-allowlisted requests fail closed.
 7. Verify missing or invalid credentials fail closed.
-8. Stop the bridge and confirm credentials expire.
+8. Verify direct sidecar-to-model, sidecar-to-provider, and sidecar-to-Ollama routing fail closed.
+9. Stop the bridge and confirm credentials expire.
 
 ## Required future artifacts
 
 - command transcript with secrets redacted;
 - bridge bind-address evidence;
+- API-shape and request mapping evidence;
+- response-envelope mapping evidence;
 - allowlist pass/fail evidence;
 - credential failure evidence;
+- CORS/CSRF evidence;
+- telemetry/audit identity evidence;
+- retention/replay evidence;
 - stop-condition evidence.

--- a/docs/evals/runs/alpha-solver-operator-console-bridge-001/non-actions.md
+++ b/docs/evals/runs/alpha-solver-operator-console-bridge-001/non-actions.md
@@ -1,0 +1,14 @@
+# Non-Actions
+
+This packet intentionally does not:
+
+- implement an operator console bridge;
+- alter `alpha_solver_portable.py`;
+- alter `alpha-solver-v91-python.py`;
+- alter `alpha_solver_entry.py`;
+- add a web server, daemon, API route, or socket listener;
+- add or change credentials;
+- change environment-variable requirements;
+- modify backlog workbooks;
+- modify MCP, routing, SAFE-OUT, budget guard, determinism, observability, replay, or SolverEnvelope behavior;
+- reuse commits, patches, text, or files from PR #547.

--- a/docs/evals/runs/alpha-solver-operator-console-bridge-001/non-actions.md
+++ b/docs/evals/runs/alpha-solver-operator-console-bridge-001/non-actions.md
@@ -1,14 +1,30 @@
 # Non-Actions
 
+## Verdict
+
+`OPERATOR_CONSOLE_BRIDGE_BLOCKED_SECURITY_DECISION_REQUIRED`
+
 This packet intentionally does not:
 
 - implement an operator console bridge;
+- implement an OpenAI-compatible shim;
+- implement native sidecar request mapping;
+- add a bridge endpoint;
+- add a CLI bridge;
+- expose `/v1/solve`;
+- run a sidecar;
+- connect Open WebUI, LibreChat, AnythingLLM, or any UI;
+- call local or hosted models;
 - alter `alpha_solver_portable.py`;
 - alter `alpha-solver-v91-python.py`;
 - alter `alpha_solver_entry.py`;
 - add a web server, daemon, API route, or socket listener;
 - add or change credentials;
+- use tokens;
+- access credentials;
 - change environment-variable requirements;
+- update Google Sheets;
 - modify backlog workbooks;
+- modify PR #546 or PR #549 artifacts;
 - modify MCP, routing, SAFE-OUT, budget guard, determinism, observability, replay, or SolverEnvelope behavior;
 - reuse commits, patches, text, or files from PR #547.

--- a/docs/evals/runs/alpha-solver-operator-console-bridge-001/residual-risks.md
+++ b/docs/evals/runs/alpha-solver-operator-console-bridge-001/residual-risks.md
@@ -1,14 +1,25 @@
 # Residual Risks
 
-## Design risks
+## Verdict
 
-- The exact bridge transport is not selected in this packet.
-- The operation allowlist is not enumerated to implementation granularity.
-- Token lifetime, storage, and rotation requirements need a concrete spec.
-- Console output redaction rules need testable fixtures.
+`OPERATOR_CONSOLE_BRIDGE_BLOCKED_SECURITY_DECISION_REQUIRED`
 
-## Implementation risks
+## Dependency risks
 
+- API-shape compatibility unresolved.
+- `/v1/solve` request mapping unresolved.
+- OpenAI-compatible shim decision unresolved.
+- Native sidecar request mapping unresolved.
+- Response-envelope rendering unresolved.
+- PR #546 sidecar feasibility context and PR #549 API-shape compatibility gate must remain preserved by later work.
+
+## Security and boundary risks
+
+- Direct provider/model bypass prevention unresolved.
+- UI-originated CORS/CSRF unresolved.
+- UI-originated telemetry identity unresolved.
+- Retention/replay for UI sessions unresolved.
+- RAG/private-file ingestion remains forbidden unless separately approved.
 - A future bridge could accidentally expose a non-loopback interface.
 - A future bridge could permit generic command execution instead of allowlisted operations.
 - Logs could leak prompts, paths, tokens, or environment-derived secrets.
@@ -16,7 +27,8 @@
 
 ## Mitigations for next work
 
+- Select `ALPHA-SOLVER-OPERATOR-UI-SIDECAR-API-SHAPE-SECURITY-GATE-001` before any implementation lane.
 - Require fail-closed tests before any bridge merge.
 - Add explicit bind-address checks.
-- Keep bridge operations narrow and read-only for the first implementation lane.
-- Treat credential and redaction tests as merge blockers.
+- Keep bridge operations narrow and read-only for the first later implementation candidate.
+- Treat credential, CORS/CSRF, telemetry, retention, replay, and redaction tests as merge blockers.

--- a/docs/evals/runs/alpha-solver-operator-console-bridge-001/residual-risks.md
+++ b/docs/evals/runs/alpha-solver-operator-console-bridge-001/residual-risks.md
@@ -1,0 +1,22 @@
+# Residual Risks
+
+## Design risks
+
+- The exact bridge transport is not selected in this packet.
+- The operation allowlist is not enumerated to implementation granularity.
+- Token lifetime, storage, and rotation requirements need a concrete spec.
+- Console output redaction rules need testable fixtures.
+
+## Implementation risks
+
+- A future bridge could accidentally expose a non-loopback interface.
+- A future bridge could permit generic command execution instead of allowlisted operations.
+- Logs could leak prompts, paths, tokens, or environment-derived secrets.
+- Runtime entrypoint behavior could drift if bridge dispatch is not isolated.
+
+## Mitigations for next work
+
+- Require fail-closed tests before any bridge merge.
+- Add explicit bind-address checks.
+- Keep bridge operations narrow and read-only for the first implementation lane.
+- Treat credential and redaction tests as merge blockers.

--- a/docs/evals/runs/alpha-solver-operator-console-bridge-001/selected-next-lane.md
+++ b/docs/evals/runs/alpha-solver-operator-console-bridge-001/selected-next-lane.md
@@ -1,19 +1,25 @@
 # Selected Next Lane
 
-## Recommended next lane
+## Verdict
 
-Create a spec-backed, read-only local bridge spike that exposes one harmless operator status operation over loopback only.
+`OPERATOR_CONSOLE_BRIDGE_BLOCKED_SECURITY_DECISION_REQUIRED`
 
-## Entry criteria
+## Selected next lane
 
-- A spec identifies the first operation, transport, authentication mechanism, and stop conditions.
-- Tests define loopback-only behavior and fail-closed credential behavior.
-- The implementation plan avoids changing solver entrypoint semantics.
+`ALPHA-SOLVER-OPERATOR-UI-SIDECAR-API-SHAPE-SECURITY-GATE-001`
 
-## Exit criteria
+The operator console bridge must not move directly into implementation. The selected next lane is the sidecar API-shape/security gate because PR #546 establishes sidecar feasibility context and PR #549 establishes that API-shape compatibility must be gated before a console or UI bridge can safely map requests.
 
-- One read-only operation succeeds locally with valid short-lived credentials.
-- Invalid credentials fail closed.
-- Non-allowlisted operations fail closed.
-- Bind-address evidence confirms local-only exposure.
-- Logs show required redaction behavior.
+## Future implementation candidate
+
+`ALPHA-SOLVER-OPERATOR-CONSOLE-BRIDGE-LOCAL-ONLY-IMPLEMENTATION-001`
+
+This lane is only a future implementation candidate after the selected sidecar API-shape/security gate passes. It is not selected now.
+
+## Gate exit requirements before implementation selection
+
+- Decide whether the console path uses an OpenAI-compatible shim or native sidecar request mapping.
+- Define and test `/v1/solve` request mapping for Alpha Solver's required `query` field.
+- Define and test response-envelope mapping for console rendering.
+- Prove the sidecar cannot bypass Alpha Solver router, policy, SAFE-OUT, evidence, auth, tenancy, CORS/CSRF, cost, telemetry, retention, or replay boundaries.
+- Confirm direct sidecar-to-model, direct sidecar-to-provider, and direct sidecar-to-Ollama routing remain forbidden.

--- a/docs/evals/runs/alpha-solver-operator-console-bridge-001/selected-next-lane.md
+++ b/docs/evals/runs/alpha-solver-operator-console-bridge-001/selected-next-lane.md
@@ -1,0 +1,19 @@
+# Selected Next Lane
+
+## Recommended next lane
+
+Create a spec-backed, read-only local bridge spike that exposes one harmless operator status operation over loopback only.
+
+## Entry criteria
+
+- A spec identifies the first operation, transport, authentication mechanism, and stop conditions.
+- Tests define loopback-only behavior and fail-closed credential behavior.
+- The implementation plan avoids changing solver entrypoint semantics.
+
+## Exit criteria
+
+- One read-only operation succeeds locally with valid short-lived credentials.
+- Invalid credentials fail closed.
+- Non-allowlisted operations fail closed.
+- Bind-address evidence confirms local-only exposure.
+- Logs show required redaction behavior.

--- a/docs/evals/runs/alpha-solver-operator-console-bridge-001/test-evidence.md
+++ b/docs/evals/runs/alpha-solver-operator-console-bridge-001/test-evidence.md
@@ -1,0 +1,15 @@
+# Test Evidence
+
+## Checks for this packet
+
+This is a documentation-only packet. Validation should confirm the packet contains exactly the required file set and does not modify runtime code.
+
+## Expected checks
+
+- `git status --short`
+- `find docs/evals/runs/alpha-solver-operator-console-bridge-001 -maxdepth 1 -type f | sort`
+- optional docs grep or line-count inspection for the lane ID and contamination boundary
+
+## Runtime tests
+
+No runtime tests are expected for this docs-only lane because no executable behavior changes are included.

--- a/docs/evals/runs/alpha-solver-operator-console-bridge-001/test-evidence.md
+++ b/docs/evals/runs/alpha-solver-operator-console-bridge-001/test-evidence.md
@@ -1,15 +1,21 @@
 # Test Evidence
 
+## Verdict
+
+`OPERATOR_CONSOLE_BRIDGE_BLOCKED_SECURITY_DECISION_REQUIRED`
+
 ## Checks for this packet
 
-This is a documentation-only packet. Validation should confirm the packet contains exactly the required file set and does not modify runtime code.
+This is a documentation-only packet. Validation should confirm the packet contains exactly the required file set, references PR #546 and PR #549, preserves the API-shape/request mapping blocker for `/v1/solve` with required `query`, and does not modify runtime code.
 
 ## Expected checks
 
-- `git status --short`
-- `find docs/evals/runs/alpha-solver-operator-console-bridge-001 -maxdepth 1 -type f | sort`
-- optional docs grep or line-count inspection for the lane ID and contamination boundary
+- `git fetch origin main`
+- `git diff --name-only origin/main...HEAD`
+- content validation for required phrases and forbidden readiness claims
+- `git diff --check`
+- optional focused non-provider tests for API auth, CORS boundary, `/v1/solve` auth/tenancy, and local LLM smoke harness coverage
 
 ## Runtime tests
 
-No runtime tests are expected for this docs-only lane because no executable behavior changes are included.
+No provider-backed tests are expected for this docs-only lane because no executable behavior changes are included and no local or hosted model calls occurred.


### PR DESCRIPTION
### Motivation

- Provide a clean-room, docs-only design packet for the operator console bridge lane `ALPHA-SOLVER-OPERATOR-CONSOLE-BRIDGE-001` as a safe replacement for an abandoned contaminated change. 
- Capture clear design constraints, auth/boundary guidance, non-actions, residual risks, and next-lane guidance to bound future implementation work. 

### Description

- Add exactly 10 documentation files under `docs/evals/runs/alpha-solver-operator-console-bridge-001/` including `README.md`, `auth-and-boundary-map.md`, `bridge-design.md`, `evidence-boundary.md`, `implementation-summary.md`, `local-only-runbook.md`, `non-actions.md`, `residual-risks.md`, `selected-next-lane.md`, and `test-evidence.md`. 
- Document a loopback-first, fail-closed authentication and authorization shape and an allowlist-first bridge request lifecycle without selecting a transport or implementing runtime behavior. 
- Explicitly state non-actions and contamination boundaries so the packet does not modify code, credentials, CI, or reuse content from the abandoned PR. 
- Keep the change documentation-only and preserve existing runtime semantics by avoiding any Python, shell, config, or entrypoint edits. 

### Testing

- Verified the packet contains exactly the expected file set with a focused Python file-set check, which succeeded. 
- Confirmed the file listing via `find docs/evals/runs/alpha-solver-operator-console-bridge-001 -maxdepth 1 -type f | sort`, which matched the required files. 
- Ran `python -m pytest -q` which completed successfully for this docs-only change, with only expected skips and deprecation warnings reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2efa3331f08329b3de10d63ec24bcc)