### PR TITLE
Add local-to-paid graduation gate evidence packet

### DIFF
--- a/docs/evals/runs/alpha-solver-local-to-paid-graduation-gate-001/README.md
+++ b/docs/evals/runs/alpha-solver-local-to-paid-graduation-gate-001/README.md
@@ -1,0 +1,32 @@
+# ALPHA-SOLVER-LOCAL-TO-PAID-GRADUATION-GATE-001
+
+Verdict: `LOCAL_TO_PAID_GATE_BLOCKED_OPERATOR_AUTHORIZATION_REQUIRED`
+
+## TLDR
+
+This packet defines the local-to-paid graduation gate for deciding when Alpha Solver may move from free local Ollama/fake-provider testing to a paid hosted-provider smoke. It is a gate only: it does not call OpenAI or any hosted provider, does not use tokens, does not run a value experiment, does not expose `/v1/solve` or dashboards, and does not update Google Sheets.
+
+The gate is currently captured but not ready for a paid run because explicit per-run operator authorization is missing and the no-echo/substantive-generation blocker remains open. The next safe paid-provider action is not a provider call; it is an authorization-refresh packet that supplies the exact model, project boundary, cost cap, token cap, max run count, and synthetic fixture for a tiny smoke.
+
+## Source context reviewed
+
+- Local model catalog: `docs/evals/runs/alpha-solver-local-model-catalog-001/`
+- Local multi-model smoke harness: `docs/evals/runs/alpha-solver-local-multi-model-smoke-harness-001/`
+- Local routing matrix/opportunity map: `docs/evals/runs/alpha-solver-local-model-catalog-001/routing-opportunity-map.md`
+- No-echo/substantive generation gate: `docs/evals/runs/alpha-solver-no-echo-substantive-generation-gate-001/`
+- Value experiment protocol and pilot prep: `docs/evals/runs/alpha-solver-value-experiment-protocol-001/` and `docs/evals/runs/alpha-solver-value-experiment-execution-pilot-001/`
+- Public exposure readiness gate: `docs/evals/runs/alpha-solver-public-exposure-readiness-gate-001/`
+- Provider cost controls: `docs/evals/runs/alpha-solver-def-002-provider-cost-caps-stop-control-001/`
+- Provider authorization/data-sharing predecessors: `docs/evals/runs/openai-project-billing-boundary-attestation-retry-001/`, `docs/evals/runs/openai-data-sharing-operator-attestation-001/`, and `docs/evals/runs/local-openai-token-smoke-capture-retry-002/`
+
+## Packet files
+
+- [graduation-criteria.md](graduation-criteria.md)
+- [local-evidence-checklist.md](local-evidence-checklist.md)
+- [paid-provider-authorization-checklist.md](paid-provider-authorization-checklist.md)
+- [cost-and-token-boundary.md](cost-and-token-boundary.md)
+- [stop-conditions.md](stop-conditions.md)
+- [decision.md](decision.md)
+- [selected-next-lane.md](selected-next-lane.md)
+- [evidence-boundary.md](evidence-boundary.md)
+- [non-actions.md](non-actions.md)

--- a/docs/evals/runs/alpha-solver-local-to-paid-graduation-gate-001/cost-and-token-boundary.md
+++ b/docs/evals/runs/alpha-solver-local-to-paid-graduation-gate-001/cost-and-token-boundary.md
@@ -1,0 +1,24 @@
+# Cost and token boundary
+
+## Required boundary before any paid smoke
+
+A paid hosted-provider smoke must define all limits before execution:
+
+- Maximum number of runs.
+- Maximum number of provider requests.
+- Maximum input tokens.
+- Maximum output tokens.
+- Maximum total tokens.
+- Maximum estimated provider cost.
+- A local kill/stop procedure if accounting is unclear.
+- A rule that any retry requires a new authorization unless explicitly included in the max run count.
+
+## Current boundary assessment
+
+Provider cost caps and stop controls have partial fake-provider evidence only. They do not prove exact provider billing accuracy, exact hosted-provider accounting, or safety under public traffic.
+
+The blocked `local-openai-token-smoke-capture-retry-002` authorization did not supply explicit cost cap, token cap, model, project boundary, max run count, or exact synthetic fixture in the execution prompt. Therefore, this gate cannot authorize a paid call.
+
+## Minimum first-smoke recommendation
+
+If a later authorization-refresh lane is completed, the first paid action should be a single synthetic connectivity/no-echo smoke with the smallest practical token budget. It must stop after one response or first error, whichever occurs first, unless the refreshed authorization explicitly permits a bounded retry.

--- a/docs/evals/runs/alpha-solver-local-to-paid-graduation-gate-001/decision.md
+++ b/docs/evals/runs/alpha-solver-local-to-paid-graduation-gate-001/decision.md
@@ -1,0 +1,28 @@
+# Decision
+
+Verdict: `LOCAL_TO_PAID_GATE_BLOCKED_OPERATOR_AUTHORIZATION_REQUIRED`
+
+## Rationale
+
+The gate is now captured, but the project is not ready to make a paid hosted-provider call from this packet.
+
+Primary blockers:
+
+1. Explicit per-run operator authorization is missing for provider, model, project boundary, cost cap, token cap, max run count, and synthetic fixture.
+2. The current no-echo/substantive-generation gate is blocked because the local Alpha path echoed prompts.
+3. Provider cost-cap controls are partial fake-provider evidence and do not prove exact hosted-provider billing behavior.
+4. Public exposure remains no-go; `/v1/solve`, dashboards, and public routes must not be exposed.
+5. The value experiment protocol is preregistered only and unexecuted; it cannot be run until the no-echo precondition and paid-provider authorization gates are satisfied.
+
+## Missing prerequisites
+
+- Authorization-refresh packet for the exact tiny smoke.
+- Exact synthetic fixture approved for provider submission.
+- Explicit cost cap and token cap.
+- Explicit model and project/account boundary.
+- Operator data-sharing/redaction approval for the exact fixture.
+- Successful no-echo/substantive-output evidence before any value experiment.
+
+## Next safe paid-provider action, if any
+
+No paid-provider call is authorized by this packet. The only next safe paid-provider-adjacent action is a docs-only authorization-refresh lane that captures the missing fields and then decides whether a subsequent tiny synthetic smoke may proceed.

--- a/docs/evals/runs/alpha-solver-local-to-paid-graduation-gate-001/evidence-boundary.md
+++ b/docs/evals/runs/alpha-solver-local-to-paid-graduation-gate-001/evidence-boundary.md
@@ -1,0 +1,20 @@
+# Evidence boundary
+
+This packet is a graduation gate definition and current-state decision. It is not a provider run, not a local model run, not a value experiment, not a benchmark, not a security/privacy closure, and not public-exposure evidence.
+
+## What this packet supports
+
+- A documented list of conditions required before moving from local/fake-provider work to a paid hosted-provider smoke.
+- A current verdict that paid-provider execution is blocked pending operator authorization and no-echo/value prerequisites.
+- A narrow next lane for authorization refresh.
+
+## What this packet does not support
+
+- Hosted-provider behavior claims.
+- Local model quality claims.
+- Alpha Solver superiority claims.
+- Benchmark validation claims.
+- MVP, production, public, dashboard, or `/v1/solve` readiness claims.
+- Exact billing-accuracy claims.
+- DEF-002 or security/privacy closure claims.
+- Any claim that local results prove hosted-provider results.

--- a/docs/evals/runs/alpha-solver-local-to-paid-graduation-gate-001/graduation-criteria.md
+++ b/docs/evals/runs/alpha-solver-local-to-paid-graduation-gate-001/graduation-criteria.md
@@ -1,0 +1,31 @@
+# Graduation criteria
+
+A move from free local/fake-provider testing to a paid hosted-provider smoke is allowed only when every required category below is satisfied for the exact proposed run. Passing this gate authorizes at most a tiny smoke; it does not authorize value experiments, public exposure, production traffic, benchmark claims, or Alpha superiority claims.
+
+## Gate categories
+
+| Category | Required condition | Current state | Gate result |
+| --- | --- | --- | --- |
+| 1. Local model smoke state | A local/fake-provider smoke lane must identify the candidate path, fixture shape, artifact schema, and failure handling without claiming model quality. | Local model catalog is captured. Multi-model smoke harness is fake-transport only and explicitly not behavior/model-quality evidence. | Captured, not sufficient by itself. |
+| 2. No-echo/substantive generation state | The Alpha path intended for paid testing must produce substantive non-echo output or the paid run must be scoped as provider-connectivity-only and not a value run. | The no-echo gate is blocked because the Alpha path echoed prompts in all four synthetic cases. | Blocker for value experiments; allows only a connectivity smoke if separately authorized. |
+| 3. Routing matrix readiness | The route/model under test must be selected from documented routing opportunities with explicit misroute and fallback handling. | Routing opportunity map exists, but it is an opportunity map and not implemented routing evidence. | Not ready for routing claims. |
+| 4. Provider billing/project authorization state | The operator must provide explicit per-run model, project boundary, cost cap, token cap, max run count, and exact synthetic fixture. | Prior project/billing boundary attestation exists, but retry-002 authorization is incomplete. | Blocked. |
+| 5. Cost cap and token cap state | The paid run must have hard pre-run caps and a stop rule that prevents additional calls after cap ambiguity or cap exhaustion. | Provider cost-cap controls are partial and fake-provider only; local retry authorization omitted explicit caps. | Blocked until exact per-run caps are supplied. |
+| 6. Data-sharing and redaction state | The operator must acknowledge provider data sharing for the exact fixture and confirm no secrets/sensitive data are included. | Prior data-sharing attestation exists; the exact retry-002 fixture was not supplied in the blocked run prompt. | Needs refresh for the exact run. |
+| 7. Security no-go blockers | No public exposure, dashboard exposure, credential exposure, unsafe CORS/auth posture, or DEF-002 closure claim may be required for the run. | Public exposure gate is no-go; DEF-002 remains open. | Allows only non-public, local operator-supervised smoke if authorized. |
+| 8. Value experiment preregistration state | Value experiment protocol must be frozen before value execution, and Alpha must pass the no-echo precondition. | Protocol exists but is unexecuted; no-echo precondition fails. | Blocks value experiment execution. |
+| 9. Operator approval state | Operator must explicitly approve the exact next paid action after seeing this gate and its stop conditions. | Not captured in this packet. | Blocked. |
+| 10. Stop conditions | Stop conditions must be explicit, checkable, and stronger than the planned action. | Captured in this packet. | Captured, but not sufficient without authorization. |
+
+## Minimal ready state for a tiny paid smoke
+
+`LOCAL_TO_PAID_GATE_CAPTURED_READY_FOR_TINY_SMOKE` is allowed only if all of the following are true:
+
+1. The action is explicitly limited to a tiny synthetic connectivity/no-echo smoke.
+2. The exact hosted provider, model, project/account boundary, fixture, max run count, max request count, max token count, and max estimated cost are documented.
+3. The fixture contains no secrets, sensitive personal data, proprietary customer data, or live user payloads.
+4. The operator signs off that provider terms, data-sharing, retention, and billing exposure are acceptable for that fixture.
+5. Stop conditions are accepted before the call.
+6. The result will be labeled smoke evidence only, not value, benchmark, production, or public-readiness evidence.
+
+The current packet does not satisfy these conditions.

--- a/docs/evals/runs/alpha-solver-local-to-paid-graduation-gate-001/local-evidence-checklist.md
+++ b/docs/evals/runs/alpha-solver-local-to-paid-graduation-gate-001/local-evidence-checklist.md
@@ -1,0 +1,16 @@
+# Local evidence checklist
+
+| Evidence item | Source | Status | Interpretation |
+| --- | --- | --- | --- |
+| Local model catalog | `alpha-solver-local-model-catalog-001` | Present | Catalog only; no models installed or called by that lane. |
+| Local multi-model smoke harness | `alpha-solver-local-multi-model-smoke-harness-001` | Present | Fake-transport-only harness; useful for artifact shape and operator workflow, not model behavior. |
+| Local routing matrix/opportunities | `alpha-solver-local-model-catalog-001/routing-opportunity-map.md` | Present | Future routing opportunities are documented; routing is not implemented or validated by this evidence. |
+| No-echo/substantive gate | `alpha-solver-no-echo-substantive-generation-gate-001` | Failing/blocking | Alpha local path echoed prompts and must not be used for value claims. |
+| Value experiment protocol | `alpha-solver-value-experiment-protocol-001` | Present | Protocol only; not executed and not value evidence. |
+| Value pilot preparation | `alpha-solver-value-experiment-execution-pilot-001` | Present as prep context | Does not override the no-echo or operator-authorization blockers. |
+| Public exposure readiness | `alpha-solver-public-exposure-readiness-gate-001` | No-go | Public exposure, dashboard readiness, and `/v1/solve` readiness remain blocked. |
+| Provider cost controls | `alpha-solver-def-002-provider-cost-caps-stop-control-001` | Partial | Fake-provider evidence only; not exact billing validation. |
+
+## Local evidence conclusion
+
+Local evidence supports designing a narrow paid-provider gate. It does not prove hosted-provider behavior, Alpha value, benchmark performance, public readiness, or production readiness. The current no-echo blocker prevents any value experiment and limits any possible paid action to a separately authorized tiny synthetic smoke.

--- a/docs/evals/runs/alpha-solver-local-to-paid-graduation-gate-001/non-actions.md
+++ b/docs/evals/runs/alpha-solver-local-to-paid-graduation-gate-001/non-actions.md
@@ -1,0 +1,14 @@
+# Non-actions
+
+This lane did not:
+
+- Call OpenAI or any other hosted provider.
+- Use provider tokens or incur provider cost.
+- Call Ollama or run local models.
+- Run value experiments or generate paired outputs.
+- Claim local results prove hosted-provider results.
+- Claim Alpha Solver superiority, benchmark validation, MVP readiness, production readiness, public readiness, dashboard readiness, or `/v1/solve` readiness.
+- Expose API, dashboard, `/v1/solve`, credentials, or deployment surfaces.
+- Inspect private billing pages, payment methods, invoices, balances, quotas, credentials, or provider account details.
+- Modify runtime, provider, API, dashboard, credential, billing, test, or CI code.
+- Update Google Sheets, backlog workbooks, or external planning ledgers.

--- a/docs/evals/runs/alpha-solver-local-to-paid-graduation-gate-001/paid-provider-authorization-checklist.md
+++ b/docs/evals/runs/alpha-solver-local-to-paid-graduation-gate-001/paid-provider-authorization-checklist.md
@@ -1,0 +1,25 @@
+# Paid-provider authorization checklist
+
+A paid provider call is forbidden unless every item is complete for the exact next run.
+
+| Authorization field | Required content | Current status |
+| --- | --- | --- |
+| Provider | Exact hosted provider name. | Missing for this gate. |
+| Model | Exact model identifier. | Missing for this gate; missing in `local-openai-token-smoke-capture-retry-002`. |
+| Project/account boundary | Redacted but explicit project/account boundary approved for this run. | Prior attestation exists, but exact retry authorization was incomplete. |
+| Purpose | Must be `tiny synthetic smoke` or narrower. | Not approved by this packet. |
+| Max run count | Exact maximum number of invocations. | Missing. |
+| Max request count | Exact maximum HTTP/API requests. | Missing. |
+| Token cap | Exact input/output/total token cap or stricter equivalent. | Missing. |
+| Cost cap | Exact USD or provider-credit cap. | Missing. |
+| Synthetic fixture | Exact prompt payload to send, frozen before the run. | Missing for the blocked retry. |
+| Data-sharing acknowledgement | Operator confirms the fixture may be sent to the provider under provider terms. | Needs run-specific refresh. |
+| Redaction review | Operator confirms fixture and logs contain no secrets/sensitive data. | Needs run-specific refresh. |
+| Stop conditions | Operator accepts stop conditions before execution. | Captured here, not approved. |
+| Result boundary | Operator accepts that results are smoke-only and non-value evidence. | Needs approval. |
+
+## Authorization verdict
+
+Current status: `BLOCKED_OPERATOR_AUTHORIZATION_REQUIRED`.
+
+The next safe paid-provider action, if the operator still wants to proceed, is an authorization-refresh lane only. It must not call providers. It should fill the missing fields above and then select a subsequent tiny smoke lane only if all fields are complete.

--- a/docs/evals/runs/alpha-solver-local-to-paid-graduation-gate-001/selected-next-lane.md
+++ b/docs/evals/runs/alpha-solver-local-to-paid-graduation-gate-001/selected-next-lane.md
@@ -1,0 +1,14 @@
+# Selected next lane
+
+Selected next lane: `LOCAL-OPENAI-TOKEN-SMOKE-CAPTURE-RETRY-002-AUTHORIZATION-REFRESH`
+
+## Scope
+
+This selected lane is documentation/authorization only. It should collect the exact provider, model, project/account boundary, synthetic fixture, max run count, request cap, token cap, cost cap, data-sharing acknowledgement, redaction confirmation, and stop-condition approval for a possible subsequent tiny synthetic smoke.
+
+## Not selected
+
+- Paid hosted-provider smoke execution — not selected because authorization fields are missing.
+- Value experiment execution — not selected because the no-echo precondition is failing and paid-provider authorization is missing.
+- Public exposure, dashboard exposure, or `/v1/solve` exposure — not selected because the public exposure gate is no-go.
+- Google Sheets/backlog update lane — not selected and not authorized.

--- a/docs/evals/runs/alpha-solver-local-to-paid-graduation-gate-001/stop-conditions.md
+++ b/docs/evals/runs/alpha-solver-local-to-paid-graduation-gate-001/stop-conditions.md
@@ -1,0 +1,18 @@
+# Stop conditions
+
+Stop immediately and do not make or continue paid-provider calls if any condition below is true.
+
+1. Operator authorization is missing, ambiguous, stale, or not tied to the exact provider/model/fixture/run.
+2. The fixture contains secrets, credentials, private keys, billing details, sensitive personal data, proprietary customer data, or live user payloads.
+3. Project/account boundary, model, cost cap, token cap, request cap, or max run count is missing.
+4. Any cap is reached, cannot be measured, or conflicts across artifacts.
+5. The provider returns an authentication, quota, billing, policy, safety, timeout, or malformed-response error.
+6. The response echoes the prompt/system text instead of producing a bounded substantive smoke output.
+7. The run would require exposing API, dashboard, `/v1/solve`, public routes, credentials, or deployment surfaces.
+8. The run would require Google Sheets updates or external planning-ledger mutation.
+9. The operator attempts to interpret smoke output as value, benchmark validation, Alpha superiority, public readiness, production readiness, or hosted-provider validation.
+10. DEF-002/security/privacy blockers become relevant to the exact action and have not been explicitly resolved or risk-accepted for that action.
+11. The action expands from a tiny smoke into a value experiment, benchmark, multi-user demo, or production-like workload.
+12. Any evidence file cannot be preserved with redaction and boundary labels.
+
+A stopped run should record `STOP_INCONCLUSIVE` unless the reason is the known missing operator authorization blocker, in which case the verdict should remain `LOCAL_TO_PAID_GATE_BLOCKED_OPERATOR_AUTHORIZATION_REQUIRED`.


### PR DESCRIPTION
### Motivation

- Provide a formal gate that defines exact conditions required to move Alpha Solver from free local/fake-provider testing to a paid hosted-provider tiny smoke. 
- Capture and centralize the required evidence categories (no-echo, routing, billing/authorization, cost/token caps, data-sharing, security blockers, operator approval, stop-conditions) so paid runs are strictly scoped and auditable. 
- Preserve the repo-wide non-execution policy and evidence boundaries by making this a documentation-only packet that explicitly forbids provider calls, token use, value experiments, `/v1/solve` exposure, dashboard exposure, and Google Sheets/backlog mutations.

### Description

- Added a new evidence packet under `docs/evals/runs/alpha-solver-local-to-paid-graduation-gate-001/` containing `README.md`, `graduation-criteria.md`, `local-evidence-checklist.md`, `paid-provider-authorization-checklist.md`, `cost-and-token-boundary.md`, `stop-conditions.md`, `decision.md`, `selected-next-lane.md`, `evidence-boundary.md`, and `non-actions.md`. 
- The packet enumerates the ten required gate categories, documents the minimal ready-state for a tiny paid smoke, and records the current verdict `LOCAL_TO_PAID_GATE_BLOCKED_OPERATOR_AUTHORIZATION_REQUIRED`. 
- Defines an explicit next step of a docs-only authorization-refresh lane (`LOCAL-OPENAI-TOKEN-SMOKE-CAPTURE-RETRY-002-AUTHORIZATION-REFRESH`) and prescribes exact per-run authorization fields that must be supplied before any paid call. 
- Emphasizes hard boundaries and non-claims (no hosted-provider behavior claims, no billing-accuracy claims, no Alpha superiority or production/public readiness claims) and provides concrete stop conditions to abort any attempted paid action.

### Testing

- Ran the repo static document/evidence checks: `python scripts/check_local_llm_doc_paths.py`, `python scripts/check_local_llm_packet_consistency.py`, and `python scripts/check_local_llm_evidence_boundaries.py`, and all three checks passed. 
- Ran the full test suite with `python -m pytest -q`, which completed successfully (tests passed with warnings); the provider live-smoke test `tests/providers/test_openai_live_smoke.py` was skipped as expected because live OpenAI gating variables were not set. 
- All changes are documentation-only and did not invoke any hosted providers, use tokens, or alter runtime/provider/test code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e74f9f3c88329bdf69990b5987b5e)