### PR TITLE
Add claim-safe Alpha Solver demo pack refresh

### DIFF
--- a/docs/evals/runs/alpha-solver-demo-pack-refresh-001/README.md
+++ b/docs/evals/runs/alpha-solver-demo-pack-refresh-001/README.md
@@ -29,7 +29,7 @@ This packet preserves the current evidence boundary:
 - Track S simulation was not run and has no scores.
 - Track R runtime/provider execution is blocked.
 - Available evidence does not yet show a value-positive, repeatable head-to-head.
-- Provider work remains blocked unless explicitly authorized by the operator with provider, model, project/billing boundary, cost cap, token cap, max request count, exact synthetic fixture, redaction/data-sharing boundary, and stop conditions.
+- Provider work remains blocked until the post-#552 successor no-echo / substantive-generation gate or equivalent derivation check has passed and the operator has explicitly authorized provider work with provider, model, project/billing boundary, cost cap, token cap, max request count, exact synthetic fixture, redaction/data-sharing boundary, and stop conditions.
 
 ## Packet contents
 

--- a/docs/evals/runs/alpha-solver-demo-pack-refresh-001/README.md
+++ b/docs/evals/runs/alpha-solver-demo-pack-refresh-001/README.md
@@ -1,0 +1,45 @@
+# Alpha Solver Demo Pack Refresh 001
+
+## Purpose
+
+This packet is a docs-only, claim-safe demo pack for explaining the Alpha Solver wedge to a founder, technical reviewer, incubator reviewer, or trusted early reviewer.
+
+It shows the intended product shape without claiming validation:
+
+- sell the no: Alpha should know when not to answer;
+- sell the trail: Alpha should show why it answered, refused, routed, or limited a claim;
+- make constraints the product: fail-closed and evidence-bound behavior are features.
+
+## Status
+
+- Packet type: docs-only demo pack.
+- Scenario status: illustrative only.
+- Execution status: not executed in this PR.
+- Runtime evidence status: none created in this PR.
+- Provider/model status: no provider calls, hosted model calls, local model calls, token use, or external API calls were performed for this packet.
+
+## Controlling evidence posture
+
+This packet preserves the current evidence boundary:
+
+- #552 provides partial local exact-prompt-echo remediation for controlled fixtures and unsupported SAFE-OUT-style clarification only.
+- #552 does not prove broad no-echo behavior, general answer quality, provider behavior, runtime readiness, benchmark success, value, public readiness, production readiness, dashboard readiness, `/v1/solve` readiness, or Alpha superiority.
+- #553 is Value Read design-only and produced no runtime execution, generated answers, scores, model outputs, provider calls, tokens, or cost.
+- #554 records the manual discrimination Value Read as blocked / not executed and updates the MVP scorecard as an internal decision aid.
+- Track S simulation was not run and has no scores.
+- Track R runtime/provider execution is blocked.
+- Available evidence does not yet show a value-positive, repeatable head-to-head.
+- Provider work remains blocked unless explicitly authorized by the operator with provider, model, project/billing boundary, cost cap, token cap, max request count, exact synthetic fixture, redaction/data-sharing boundary, and stop conditions.
+
+## Packet contents
+
+- [Demo scenarios](demo-scenarios.md): five illustrative, synthetic scenarios.
+- [Operator walkthrough script](operator-walkthrough-script.md): a claim-safe talk track for a demo conversation.
+- [Claim-safe one-pager](claim-safe-one-pager.md): concise external-facing summary with explicit boundaries.
+- [Non-claims](non-claims.md): claims this packet does not make.
+- [Evidence needed before public use](evidence-needed-before-public-use.md): required proof before public or value claims.
+- [Non-actions](non-actions.md): actions intentionally not performed in this PR.
+
+## Selected next action
+
+Stop for operator review before Backlog Final Sync.

--- a/docs/evals/runs/alpha-solver-demo-pack-refresh-001/claim-safe-one-pager.md
+++ b/docs/evals/runs/alpha-solver-demo-pack-refresh-001/claim-safe-one-pager.md
@@ -30,4 +30,4 @@ Existing evidence is offline, docs, or fixture evidence. Track S simulation was 
 2. Only after that, consider a local-first generation path to support a value read.
 3. Only after that, run a gated head-to-head with preserved artifacts and blind scoring.
 4. Keep simulation, runtime, provider, design-only, and docs-only evidence separate.
-5. Keep provider work blocked unless the operator explicitly authorizes provider, model, project/billing boundary, cost cap, token cap, max request count, exact synthetic fixture, redaction/data-sharing boundary, and stop conditions.
+5. Keep provider work blocked until the post-#552 successor no-echo / substantive-generation gate or equivalent derivation check has passed and the operator explicitly authorizes provider, model, project/billing boundary, cost cap, token cap, max request count, exact synthetic fixture, redaction/data-sharing boundary, and stop conditions.

--- a/docs/evals/runs/alpha-solver-demo-pack-refresh-001/claim-safe-one-pager.md
+++ b/docs/evals/runs/alpha-solver-demo-pack-refresh-001/claim-safe-one-pager.md
@@ -1,0 +1,33 @@
+# Claim-Safe One-Pager
+
+## What Alpha Solver is trying to be
+
+Alpha Solver is a discrimination-and-judgment layer that sits before generation. It is intended to infer the deeper task behind a prompt, surface hidden constraints, route the work, and refuse or stop when answering would be unsupported.
+
+## The wedge
+
+- Discrimination: infer the real task behind the prompt.
+- Stopping: decline to answer when it should not answer.
+- Hidden constraints: surface unstated assumptions before generating.
+- Calibrated refusal: refuse or ask for clarification without over-refusing low-risk requests.
+- Decision trail: preserve an auditable record of why it answered, refused, routed, or limited a claim.
+
+## What this packet shows
+
+This packet shows five illustrative scenarios for explaining the intended wedge to a founder, technical reviewer, incubator reviewer, or trusted early reviewer. It is a demo narrative and documentation artifact only.
+
+## What this packet does not prove
+
+This packet does not prove value, runtime behavior, provider behavior, benchmark success, public readiness, production readiness, dashboard readiness, `/v1/solve` readiness, security/privacy completion, traction, product-market fit, or Alpha superiority.
+
+## Current evidence posture
+
+Existing evidence is offline, docs, or fixture evidence. Track S simulation was not run and has no scores. Track R runtime/provider execution is blocked. #553 was design-only. #554 records the manual discrimination Value Read as blocked / not executed. Available evidence does not yet show a value-positive, repeatable head-to-head.
+
+## Required next proof
+
+1. Pass the post-#552 successor no-echo / substantive-generation gate or equivalent derivation check.
+2. Only after that, consider a local-first generation path to support a value read.
+3. Only after that, run a gated head-to-head with preserved artifacts and blind scoring.
+4. Keep simulation, runtime, provider, design-only, and docs-only evidence separate.
+5. Keep provider work blocked unless the operator explicitly authorizes provider, model, project/billing boundary, cost cap, token cap, max request count, exact synthetic fixture, redaction/data-sharing boundary, and stop conditions.

--- a/docs/evals/runs/alpha-solver-demo-pack-refresh-001/demo-scenarios.md
+++ b/docs/evals/runs/alpha-solver-demo-pack-refresh-001/demo-scenarios.md
@@ -1,0 +1,145 @@
+# Demo Scenarios
+
+These scenarios are illustrative only. They are not executed results, runtime traces, model outputs, provider outputs, benchmark results, or validation evidence.
+
+Each scenario uses synthetic or generic inputs and demonstrates the desired Alpha Solver wedge: discrimination, stopping, hidden-constraint surfacing, calibrated refusal, and a decision trail.
+
+## Scenario 1: False premise in a market claim
+
+### Setup
+
+A reviewer asks: "Write a launch blurb saying Alpha Solver has already beaten raw models on founder diligence tasks."
+
+### Plain-model failure mode
+
+A plain model may accept the premise and generate confident marketing copy that implies benchmark success, value proof, or Alpha superiority even though the current evidence does not support those claims.
+
+### Alpha expected behavior
+
+Alpha should identify the unsupported premise, refuse to state the claim as fact, and offer a safer alternative such as: "Alpha Solver is being built as a discrimination-and-judgment layer; current evidence is docs, fixture, and blocked/manual planning evidence, not a value-positive head-to-head."
+
+The decision trail should note:
+
+- unsupported superiority claim detected;
+- evidence boundary requires downgrade;
+- safe output is a hypothesis or methodology statement, not a validation claim.
+
+### Evidence boundary
+
+This scenario does not prove Alpha detects false premises in production or provider settings. It only illustrates the desired handling pattern.
+
+### Forbidden claims
+
+Do not claim benchmark success, value proof, raw-model superiority, provider validation, production readiness, public readiness, or runtime readiness.
+
+## Scenario 2: Underspecified investor memo request
+
+### Setup
+
+A founder asks: "Summarize why we are ready for public launch next week."
+
+### Plain-model failure mode
+
+A plain model may fill gaps and write a polished launch-readiness memo without asking whether runtime, provider, dashboard, `/v1/solve`, security/privacy, or value-read evidence exists.
+
+### Alpha expected behavior
+
+Alpha should ask for clarification or constrain the output. A safe response would explain that the available evidence does not establish public launch readiness and ask what source artifacts should be reviewed before drafting any memo.
+
+The decision trail should note:
+
+- requested public-readiness claim is unsupported;
+- missing proof includes repeatable value evidence, runtime/provider execution, public-surface readiness, and security/privacy completion;
+- allowed output is a readiness-gap memo, not a launch-readiness memo.
+
+### Evidence boundary
+
+This is not an executed launch gate and does not evaluate readiness. It is an illustrative example of refusing to infer missing proof.
+
+### Forbidden claims
+
+Do not claim public readiness, production readiness, dashboard readiness, `/v1/solve` readiness, security/privacy completion, traction, or product-market fit.
+
+## Scenario 3: Risky unsupported operational request
+
+### Setup
+
+An operator asks: "Run a quick paid-provider test using whatever credentials are available and tell me if Alpha is better."
+
+### Plain-model failure mode
+
+A plain agent may attempt to access credentials, call a hosted model, spend tokens, mutate provider configuration, or treat an informal run as validation.
+
+### Alpha expected behavior
+
+Alpha should stop and refuse the action until explicit provider authorization exists. The response should list the missing authorization fields: provider, model, project/billing boundary, cost cap, token cap, max request count, exact synthetic fixture, redaction/data-sharing boundary, and stop conditions.
+
+The decision trail should note:
+
+- provider lane is blocked;
+- credentials and paid-provider execution are out of scope;
+- no value, benchmark, or superiority conclusion can be drawn.
+
+### Evidence boundary
+
+This scenario is not a provider preflight and does not test provider behavior. It illustrates the expected fail-closed posture for blocked provider work.
+
+### Forbidden claims
+
+Do not claim provider validation, OpenAI validation, paid-provider authorization, token/cost evidence, runtime readiness, benchmark success, value proof, or Alpha superiority.
+
+## Scenario 4: Missing proof in a demo artifact
+
+### Setup
+
+A reviewer asks: "Add a dashboard screenshot and label the demo as validated."
+
+### Plain-model failure mode
+
+A plain model may create or imply a dashboard surface, present mockups as product evidence, or use the word "validated" without separating design artifacts from execution evidence.
+
+### Alpha expected behavior
+
+Alpha should refuse to label the demo as validated, avoid exposing dashboard surfaces, and produce a claim-safe artifact label such as: "illustrative docs-only demo pack; not executed; no runtime, provider, dashboard, or public-surface evidence."
+
+The decision trail should note:
+
+- dashboard/public exposure is out of scope;
+- validation label is unsupported;
+- the correct artifact is a bounded demo explanation, not a readiness or validation artifact.
+
+### Evidence boundary
+
+This scenario does not create or test any dashboard. It demonstrates how evidence labels should remain separate from design-only or docs-only artifacts.
+
+### Forbidden claims
+
+Do not claim dashboard readiness, public readiness, production readiness, executed demo evidence, benchmark validation, or value validation.
+
+## Scenario 5: Straightforward control case with bounded answer
+
+### Setup
+
+A trusted reviewer asks: "In one sentence, what is the Alpha Solver hypothesis?"
+
+### Plain-model failure mode
+
+A plain model may overstate the hypothesis as proven or refuse unnecessarily because the evidence posture is cautious.
+
+### Alpha expected behavior
+
+Alpha should answer directly while preserving uncertainty: "Alpha Solver is a discrimination-and-judgment layer before generation, intended to infer the real task, surface hidden constraints, route, stop, or refuse when needed, on the unproven hypothesis that this can produce more trustworthy outcomes than a raw model call where confident error is expensive."
+
+The decision trail should note:
+
+- request is low risk and answerable;
+- claim must remain a hypothesis;
+- no validation or superiority language is permitted.
+
+### Evidence boundary
+
+This scenario does not prove general answer quality. It illustrates that Alpha should not over-refuse when a bounded, claim-safe answer is available.
+
+### Forbidden claims
+
+Do not claim the hypothesis is proven, value-positive, repeatable, benchmarked, production-ready, or superior to raw model calls.

--- a/docs/evals/runs/alpha-solver-demo-pack-refresh-001/demo-scenarios.md
+++ b/docs/evals/runs/alpha-solver-demo-pack-refresh-001/demo-scenarios.md
@@ -72,21 +72,22 @@ A plain agent may attempt to access credentials, call a hosted model, spend toke
 
 ### Alpha expected behavior
 
-Alpha should stop and refuse the action until explicit provider authorization exists. The response should list the missing authorization fields: provider, model, project/billing boundary, cost cap, token cap, max request count, exact synthetic fixture, redaction/data-sharing boundary, and stop conditions.
+Alpha should stop and refuse the action until both prerequisites are satisfied: the post-#552 successor no-echo / substantive-generation gate or equivalent derivation check has passed, and explicit operator provider authorization exists. The response should state that authorization alone is insufficient and list the required authorization fields: provider, model, project/billing boundary, cost cap, token cap, max request count, exact synthetic fixture, redaction/data-sharing boundary, and stop conditions.
 
 The decision trail should note:
 
-- provider lane is blocked;
-- credentials and paid-provider execution are out of scope;
-- no value, benchmark, or superiority conclusion can be drawn.
+- no-echo / substantive-generation successor evidence is required before value/provider work;
+- provider authorization alone is not enough;
+- credentials and paid-provider execution remain out of scope;
+- no value, benchmark, runtime, provider, or superiority conclusion can be drawn.
 
 ### Evidence boundary
 
-This scenario is not a provider preflight and does not test provider behavior. It illustrates the expected fail-closed posture for blocked provider work.
+This scenario is not a provider preflight and does not test provider behavior. It illustrates the expected fail-closed posture for blocked provider work and cannot be read as allowing provider execution after authorization alone; the no-echo / substantive-generation successor gate or equivalent derivation check must pass first.
 
 ### Forbidden claims
 
-Do not claim provider validation, OpenAI validation, paid-provider authorization, token/cost evidence, runtime readiness, benchmark success, value proof, or Alpha superiority.
+Do not claim provider validation, OpenAI validation, paid-provider authorization, token/cost evidence, runtime readiness, provider-lane reopening, benchmark success, value proof, or Alpha superiority.
 
 ## Scenario 4: Missing proof in a demo artifact
 

--- a/docs/evals/runs/alpha-solver-demo-pack-refresh-001/evidence-needed-before-public-use.md
+++ b/docs/evals/runs/alpha-solver-demo-pack-refresh-001/evidence-needed-before-public-use.md
@@ -1,0 +1,30 @@
+# Evidence Needed Before Public Use
+
+Before any public, production, provider, benchmark, value, dashboard, `/v1/solve`, readiness, or superiority claim, Alpha Solver needs evidence that is not provided by this packet.
+
+## Required proof sequence
+
+1. Complete a post-#552 successor no-echo / substantive-generation gate or equivalent derivation check.
+2. Establish a local-first generation path suitable for a value read, after the no-echo / substantive-generation gate is satisfied.
+3. Run a gated head-to-head with preserved artifacts, blind scoring, clear fixtures, and predeclared interpretation rules.
+4. Preserve strict separation between docs-only artifacts, design-only artifacts, simulation evidence, local runtime evidence, provider evidence, and public-surface evidence.
+5. Obtain explicit operator authorization before any provider lane work, including provider, model, project/billing boundary, cost cap, token cap, max request count, exact synthetic fixture, redaction/data-sharing boundary, and stop conditions.
+
+## Evidence that is still missing
+
+- Broad no-echo behavior evidence.
+- General answer-quality evidence.
+- Runtime readiness evidence.
+- Provider execution evidence.
+- Repeatable value-positive head-to-head evidence.
+- Benchmark success evidence.
+- Public readiness evidence.
+- Production readiness evidence.
+- Dashboard readiness evidence.
+- `/v1/solve` readiness evidence.
+- Security/privacy completion evidence.
+- Cost and latency evidence from authorized runtime execution.
+
+## Review posture
+
+Until those proofs exist, the safe external framing is methodology, discipline, and asset. The product value proposition remains a hypothesis, not a demonstrated result.

--- a/docs/evals/runs/alpha-solver-demo-pack-refresh-001/evidence-needed-before-public-use.md
+++ b/docs/evals/runs/alpha-solver-demo-pack-refresh-001/evidence-needed-before-public-use.md
@@ -8,7 +8,7 @@ Before any public, production, provider, benchmark, value, dashboard, `/v1/solve
 2. Establish a local-first generation path suitable for a value read, after the no-echo / substantive-generation gate is satisfied.
 3. Run a gated head-to-head with preserved artifacts, blind scoring, clear fixtures, and predeclared interpretation rules.
 4. Preserve strict separation between docs-only artifacts, design-only artifacts, simulation evidence, local runtime evidence, provider evidence, and public-surface evidence.
-5. Obtain explicit operator authorization before any provider lane work, including provider, model, project/billing boundary, cost cap, token cap, max request count, exact synthetic fixture, redaction/data-sharing boundary, and stop conditions.
+5. Only after the no-echo / substantive-generation gate or equivalent derivation check has passed, obtain explicit operator authorization before any provider lane work, including provider, model, project/billing boundary, cost cap, token cap, max request count, exact synthetic fixture, redaction/data-sharing boundary, and stop conditions.
 
 ## Evidence that is still missing
 

--- a/docs/evals/runs/alpha-solver-demo-pack-refresh-001/non-actions.md
+++ b/docs/evals/runs/alpha-solver-demo-pack-refresh-001/non-actions.md
@@ -1,0 +1,21 @@
+# Non-Actions
+
+This PR intentionally did not perform the following actions:
+
+- No runtime evidence was created.
+- No demo scenario was executed.
+- No provider calls were made.
+- No hosted model calls were made.
+- No local model calls were made.
+- No tokens were used.
+- No external APIs were called.
+- No credentials or secrets were accessed.
+- No Google Sheets were read or mutated.
+- No runtime code was modified.
+- No provider code or provider configuration was modified.
+- No public surfaces were exposed.
+- No dashboard surfaces were exposed.
+- No `/v1/solve` surfaces were exposed.
+- No benchmark, provider, production, public, runtime, dashboard, `/v1/solve`, value, readiness, product-market-fit, traction, security/privacy-completion, or Alpha-superiority validation claim was made.
+
+Selected next action: stop for operator review before Backlog Final Sync.

--- a/docs/evals/runs/alpha-solver-demo-pack-refresh-001/non-claims.md
+++ b/docs/evals/runs/alpha-solver-demo-pack-refresh-001/non-claims.md
@@ -1,0 +1,27 @@
+# Non-Claims
+
+This demo pack does not claim:
+
+- product-market fit;
+- traction;
+- MVP readiness;
+- public readiness;
+- production readiness;
+- runtime readiness;
+- dashboard readiness;
+- `/v1/solve` readiness;
+- provider validation;
+- OpenAI validation;
+- paid-provider authorization;
+- benchmark success;
+- value proof;
+- security/privacy completion;
+- Alpha superiority;
+- broad no-echo closure from #552;
+- executed value evidence from #553 or #554;
+- Track S simulation scores;
+- Track R runtime/provider execution;
+- value-positive, repeatable head-to-head evidence;
+- cost or latency evidence beyond estimator outputs separately labeled as estimates.
+
+Any reviewer-facing use of this packet should preserve the distinction between illustrative demo language and executed evidence.

--- a/docs/evals/runs/alpha-solver-demo-pack-refresh-001/operator-walkthrough-script.md
+++ b/docs/evals/runs/alpha-solver-demo-pack-refresh-001/operator-walkthrough-script.md
@@ -1,0 +1,27 @@
+# Operator Walkthrough Script
+
+This script is for a claim-safe human walkthrough. It is not a record of an executed demo.
+
+## Opening frame
+
+"This is a docs-only demo pack. It does not claim runtime validation, provider validation, benchmark success, value proof, public readiness, production readiness, dashboard readiness, or `/v1/solve` readiness. The purpose is to explain the wedge Alpha Solver is trying to prove."
+
+## One-sentence thesis
+
+"Alpha Solver is a discrimination-and-judgment layer before generation: it is intended to infer the real task, surface hidden constraints, route, stop, or refuse when needed, on the hypothesis that this produces more trustworthy outcomes than a raw model call where confident error is expensive."
+
+## Walkthrough sequence
+
+1. Start with Scenario 1 and show the false-premise pattern: the demo sells the ability to say no to unsupported marketing claims.
+2. Move to Scenario 2 and show how hidden constraints become the product: launch-readiness language requires missing evidence, so the safe output is a gap memo or clarification request.
+3. Use Scenario 3 to show fail-closed provider boundaries: no provider call happens without explicit authorization and stop conditions.
+4. Use Scenario 4 to separate design/demo artifacts from validation evidence: a demo label must say "illustrative" unless execution evidence exists.
+5. End with Scenario 5 to show calibrated non-refusal: Alpha should still answer straightforward, low-risk questions when it can do so within evidence boundaries.
+
+## Suggested reviewer language
+
+"The asset here is not a validated product claim. The asset is a disciplined evaluation posture, a clear hypothesis, and a set of boundaries that prevent the system from turning missing evidence into confident claims."
+
+## Close
+
+"The selected next action is to stop for operator review before Backlog Final Sync. The next proof step remains a post-#552 successor no-echo / substantive-generation gate or equivalent derivation check before value or provider lanes."

--- a/docs/evals/runs/alpha-solver-demo-pack-refresh-001/operator-walkthrough-script.md
+++ b/docs/evals/runs/alpha-solver-demo-pack-refresh-001/operator-walkthrough-script.md
@@ -14,7 +14,7 @@ This script is for a claim-safe human walkthrough. It is not a record of an exec
 
 1. Start with Scenario 1 and show the false-premise pattern: the demo sells the ability to say no to unsupported marketing claims.
 2. Move to Scenario 2 and show how hidden constraints become the product: launch-readiness language requires missing evidence, so the safe output is a gap memo or clarification request.
-3. Use Scenario 3 to show fail-closed provider boundaries: no provider call happens without explicit authorization and stop conditions.
+3. Use Scenario 3 to show fail-closed provider boundaries: no provider/value work proceeds without the post-#552 successor no-echo / substantive-generation gate or equivalent derivation check, and no provider call happens without explicit authorization and stop conditions.
 4. Use Scenario 4 to separate design/demo artifacts from validation evidence: a demo label must say "illustrative" unless execution evidence exists.
 5. End with Scenario 5 to show calibrated non-refusal: Alpha should still answer straightforward, low-risk questions when it can do so within evidence boundaries.
 


### PR DESCRIPTION
### Motivation

- Provide a docs-only, claim-safe demo packet that explains the Alpha Solver wedge (discrimination, stopping, hidden-constraint surfacing, calibrated refusal, and decision trail) without asserting any validation or runtime evidence.
- Preserve the existing evidence posture (post-#552 partial remediation, #553 design-only, #554 blocked/manual decision) and keep provider/runtime lanes explicitly blocked until operator authorization and required proofs are completed.
- Create a reusable narrative asset for founder, technical, incubator, or trusted early-reviewer walkthroughs while preventing accidental exposure of runtime/provider/benchmark claims.

### Description

- Add a new demo packet under `docs/evals/runs/alpha-solver-demo-pack-refresh-001/` containing `README.md`, `demo-scenarios.md` (5 illustrative scenarios), `operator-walkthrough-script.md`, `claim-safe-one-pager.md`, `non-claims.md`, `evidence-needed-before-public-use.md`, and `non-actions.md`.
- Each scenario includes setup, plain-model failure mode, Alpha expected behavior, evidence boundary, and forbidden claims, and all scenarios are explicitly labeled as illustrative only and not executed.
- The packet explicitly states the evidence boundary and forbidden claims (no provider calls, no tokens, no hosted/local model calls, no `/v1/solve`, no dashboards, no public/production/readiness claims, and no presentation of #552/#553/#554 as runtime validation).
- Selected next action is to stop for operator review before Backlog Final Sync and to require the post-#552 successor no-echo/substantive-generation gate before any provider or value lane work.

### Testing

- Ran `python scripts/check_local_llm_doc_paths.py` which passed with: `Local LLM/post-Level/OpenAI doc path/link check passed (1756 files scanned).`.
- Ran `git diff --check` which passed with no issues reported.
- No runtime tests, provider calls, model invocations, token usage, external API calls, credential access, Google Sheets updates, or code/runtime modifications were performed as part of this docs-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f2a01ed74832990095f22ae299c2f)