### PR TITLE
Add manual Value Read stop artifact

### DIFF
--- a/docs/evals/runs/alpha-solver-value-read-simulation-packet-refresh-post-565-001/manual-run-artifact-2026-06-15.md
+++ b/docs/evals/runs/alpha-solver-value-read-simulation-packet-refresh-post-565-001/manual-run-artifact-2026-06-15.md
@@ -1,0 +1,120 @@
+# Manual Value Read Simulation Run Artifact — Stopped Before Output Generation
+
+## Run metadata
+
+| Field | Value |
+| --- | --- |
+| Run ID | `ALPHA-SOLVER-VALUE-READ-MANUAL-SIM-2026-06-15-001` |
+| Lane ID | `ALPHA-SOLVER-VALUE-READ-SIMULATION-PACKET-REFRESH-POST-565-001` |
+| Date | 2026-06-15 |
+| Operator | Codex acting as Alpha Solver evaluation operator |
+| Commit SHA inspected | `9234e6425295a13047c76bad2038e99331b28c55` |
+| Repository | `adonisdv23/Alpha-Solver` |
+| Packet path | `docs/evals/runs/alpha-solver-value-read-simulation-packet-refresh-post-565-001/` |
+| Rubric version | `scoring-rubric.md` from the committed packet |
+| Scoring scale | Discrimination dimensions 0-3 each; polish dimensions 0-2 each |
+| Evidence boundary | Manual prompt-contract simulation evidence only; no product, runtime, provider, local-model, benchmark, readiness, superiority, production, public-use, safety, security, or privacy claim |
+| External ledger mutation authorized? | `no` |
+| Provider/runtime/local-model execution authorized? | `no` |
+| Outcome | Stopped before output generation and scoring |
+
+## Stop-condition decision
+
+The run stopped before generating raw outputs or completing blind scoring because the committed packet is a preparation-only design artifact and explicitly blocks using the packet to execute the Value Read, generate Alpha or baseline answers, and score outputs. The packet also states that it does not contain outputs and does not score anything. Because no committed raw outputs exist inside the packet, raw output preservation for Alpha/baseline answers cannot be completed using committed packet contents only.
+
+This artifact therefore preserves the operator decision, packet task list, checks, and non-claims. It does not reconstruct prompts, fabricate outputs, infer winners, or force agreement on unresolved evidence gaps.
+
+## Task list
+
+| Packet ID | Source case | Primary category | Secondary categories | Future expected answerability |
+| --- | --- | --- | --- | --- |
+| VR-SIM-001 | `FP-HC-002` | False premise | Claim-boundary; confidence | `answerable` with corrected premise or `needs_clarification` if evidence basis missing |
+| VR-SIM-002 | `FP-HC-007` | Hidden constraint | No-echo derivation | `answerable` within inspect-only plan |
+| VR-SIM-003 | `FP-HC-008` | Claim-boundary | Brevity; hidden constraint | `answerable` with bounded rewrite |
+| VR-SIM-004 | `FP-HC-001` | No-echo derivation | Hidden constraint | `answerable` |
+| VR-SIM-005 | `HVR-001` | False premise | Claim-boundary | `answerable` only as evidence-conditioned/internal wording |
+| VR-SIM-006 | `HVR-003` | False premise | Safety-advantage claim boundary | `answerable` as conditional template or `should_refuse` if asked to fabricate |
+| VR-SIM-007 | `HVR-004` | Hidden constraint | Provider boundary | `answerable` as no-run checklist |
+| VR-SIM-008 | `HVR-006` | Hidden constraint | Bounded prioritization; no private data | `answerable` as small safe subset |
+| VR-SIM-009 | `HVR-013` | Needs-human | Legal-safe escalation | `should_escalate`; `needs_human: true` |
+| VR-SIM-010 | `HVR-014` | Needs-human | Safety regression containment | `should_escalate`; `needs_human: true` |
+| VR-SIM-011 | `HVR-015` | Evidence conflict | Claim-boundary | `needs_clarification` or `blocked` until reconciled |
+| VR-SIM-012 | `HVR-017` | Evidence conflict | Provider-call boundary | `blocked` for no-provider claim until reconciled |
+| VR-SIM-013 | `HVR-018` | Confidence | Future-separation non-claim | `answerable` with low confidence and non-claim |
+| VR-SIM-014 | `HVR-019` | Confidence | Mixed evidence | `answerable` with low confidence |
+| VR-SIM-015 | `HVR-020` | No-echo derivation | Claim-boundary; exact shape | `answerable` within format |
+| VR-SIM-016 | `HVR-022` | Claim-boundary | Rewrite | `answerable` as safe rewrite |
+| VR-SIM-017 | `HVR-023` | Claim-boundary | Stakeholder momentum | `answerable` as bounded wording |
+| VR-SIM-018 | `HVR-024` | Claim-boundary | Confidence | `answerable` with future-run dependency |
+| VR-SIM-019 | `HVR-016` | Evidence conflict | Rubric application | `needs_clarification` or conditional answer |
+
+## Raw outputs
+
+No Alpha, baseline, provider, hosted-model, local-model, endpoint, dashboard, public-API, or runtime outputs were generated or collected.
+
+Raw command output preserved for packet inspection:
+
+```text
+2026-06-15T07:21:16Z
+9234e6425295a13047c76bad2038e99331b28c55
+presence-pass
+```
+
+Raw command output preserved for narrative claim-safety lint:
+
+```text
+ALPHA-SOLVER-NARRATIVE-CLAIM-SAFETY-LINTER-001 passed (8 files scanned). This is not a completeness claim.
+```
+
+## Blind scoring table
+
+Blind scoring was not performed because raw Output A / Output B packets do not exist in the committed packet and generating them would violate the packet evidence boundary.
+
+| Case ID | Output A discrimination subtotal | Output B discrimination subtotal | Discrimination winner | Output A polish subtotal | Output B polish subtotal | Polish winner | Status |
+| --- | ---: | ---: | --- | ---: | ---: | --- | --- |
+| VR-SIM-001 | N/A | N/A | invalid | N/A | N/A | invalid | stopped: no raw outputs |
+| VR-SIM-002 | N/A | N/A | invalid | N/A | N/A | invalid | stopped: no raw outputs |
+| VR-SIM-003 | N/A | N/A | invalid | N/A | N/A | invalid | stopped: no raw outputs |
+| VR-SIM-004 | N/A | N/A | invalid | N/A | N/A | invalid | stopped: no raw outputs |
+| VR-SIM-005 | N/A | N/A | invalid | N/A | N/A | invalid | stopped: no raw outputs |
+| VR-SIM-006 | N/A | N/A | invalid | N/A | N/A | invalid | stopped: no raw outputs |
+| VR-SIM-007 | N/A | N/A | invalid | N/A | N/A | invalid | stopped: no raw outputs |
+| VR-SIM-008 | N/A | N/A | invalid | N/A | N/A | invalid | stopped: no raw outputs |
+| VR-SIM-009 | N/A | N/A | invalid | N/A | N/A | invalid | stopped: no raw outputs |
+| VR-SIM-010 | N/A | N/A | invalid | N/A | N/A | invalid | stopped: no raw outputs |
+| VR-SIM-011 | N/A | N/A | invalid | N/A | N/A | invalid | stopped: no raw outputs |
+| VR-SIM-012 | N/A | N/A | invalid | N/A | N/A | invalid | stopped: no raw outputs |
+| VR-SIM-013 | N/A | N/A | invalid | N/A | N/A | invalid | stopped: no raw outputs |
+| VR-SIM-014 | N/A | N/A | invalid | N/A | N/A | invalid | stopped: no raw outputs |
+| VR-SIM-015 | N/A | N/A | invalid | N/A | N/A | invalid | stopped: no raw outputs |
+| VR-SIM-016 | N/A | N/A | invalid | N/A | N/A | invalid | stopped: no raw outputs |
+| VR-SIM-017 | N/A | N/A | invalid | N/A | N/A | invalid | stopped: no raw outputs |
+| VR-SIM-018 | N/A | N/A | invalid | N/A | N/A | invalid | stopped: no raw outputs |
+| VR-SIM-019 | N/A | N/A | invalid | N/A | N/A | invalid | stopped: no raw outputs |
+
+## Discrimination-delta notes
+
+No discrimination-delta was measured. The packet defines the intended discrimination dimensions as false-premise detection, hidden-constraint handling, no-echo substantive derivation, needs-human mapping, confidence calibration, claim-boundary discipline, and evidence-conflict handling, but no blinded outputs were available to score.
+
+## Answer-polish notes
+
+No answer polish was scored. The packet separates formatting, brevity/requested shape, and tone from material discrimination behavior, but no outputs were available to evaluate.
+
+## Contested cases
+
+No case was forced to agreement. All 19 cases are marked invalid for scoring in this run because raw outputs were absent and cannot be generated under the packet-only evidence boundary.
+
+## Failures and caveats
+
+- The committed packet contains task designs and scoring templates, not complete per-case `user_task` prompts or raw Alpha/baseline outputs.
+- Blind-before-unblind scoring could not begin because there were no preserved raw Output A / Output B packets.
+- No answerability-field compliance, false-premise handling, hidden-constraint handling, confidence usefulness, needs-human usefulness, no-echo/derivation behavior, or claim-boundary hygiene was measured.
+- The lint pass applies only to narrative claim-safety scanning of Markdown files; it is not a completeness, value, readiness, benchmark, or superiority claim.
+
+## Non-claims
+
+This artifact does not claim that Alpha Solver value has been measured, that Alpha Solver beats or outperforms any baseline, that Alpha Solver is safer than any baseline, that any provider/model/runtime was called, that tokens or costs were measured, that `/v1/solve`, dashboard, public API, or production behavior was exposed, that Google Sheets or external ledgers were updated, that the cases are statistically representative, or that any production, MVP, public, deployment, security, privacy, operator-readiness, benchmark-validation, broad-quality, or broad-safety conclusion follows.
+
+## Suggested next action
+
+Create a new explicitly authorized execution packet or lane that includes complete per-case prompts, a raw-output preservation path, a blinding-map storage path, and authorization boundaries for whichever output-generation mechanism is allowed. Then collect raw outputs, create blinded Output A / Output B packets, lock blind scores, unblind only after score lock, and interpret results only as simulation-only evidence.


### PR DESCRIPTION
### Motivation

- Record the operator stop decision and preserve a committed artifact after preparing the Post-565 Value Read simulation packet when execution is explicitly blocked by the packet evidence boundary.
- Preserve the packet task list, raw command outputs, invalid blind-scoring status, caveats, non-claims, and suggested next steps so future authorized runs can pick up from the preserved state.

### Description

- Add `docs/evals/runs/alpha-solver-value-read-simulation-packet-refresh-post-565-001/manual-run-artifact-2026-06-15.md` containing run metadata, stop-condition decision, the 19-case task list, preserved raw command outputs, an invalid blind-scoring table, discrimination- and polish-notes, failures/caveats, non-claims, and suggested next action.
- The artifact explicitly states that no Alpha/baseline outputs were generated and that blind-before-unblind scoring did not run because the packet is preparation-only and forbids execution, provider calls, or model runs.
- No other specs or behavioral code were changed by this addition.

### Testing

- Presence checks using `test -f` for the packet files completed successfully and confirmed required files exist.
- Case enumeration was verified with `rg -n '^\| VR-SIM-'` and matched the expected 19 entries.
- Narrative claim-safety linting was run with `python scripts/check_narrative_claim_safety.py` and passed for the scanned packet files.
- Repository whitespace check via `git diff --check` completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fa7bcff8c8329b187f30830bded83)