### PR TITLE
Record PR #568 as VALUE_READ_BLOCKED and update MVP scorecard + docs; select controlled execution next lane

### DIFF
--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -1,13 +1,13 @@
 # Alpha Solver — Current State
 
 > Source-of-truth navigation doc. Last verified **2026-06-15** after live
-> GitHub verification of PRs #557–#565. Docs-only; no provider/runtime claims.
+> GitHub verification of PRs #566–#568. Docs-only; no provider/runtime claims.
 
 ## Current verified phase
 
-**Post-#565 infrastructure consolidation; no open PRs at verification time; selected next lane is a docs/eval packet refresh.**
+**Post-#568 Value Read blocked state; selected next lane is an explicitly authorized Value Read execution packet/lane.**
 
-The merged #557–#565 wave moved the repository from stale smoke-authorisation pointers to a Value Read infrastructure/design posture:
+The merged #566–#568 wave refreshed the post-565 Value Read packet and recorded a stopped manual run artifact. The prior #557–#565 wave moved the repository from stale smoke-authorisation pointers to a Value Read infrastructure/design posture:
 
 - PR #557 merged the post-552 **no-echo substantive generation gate**.
 - PR #558 merged the **false-premise and hidden-constraint perturbation case set**.
@@ -25,12 +25,12 @@ These are infrastructure, design, methodology, and docs/tooling artifacts. They 
 
 | Field | Value |
 |-------|-------|
-| Latest verified merged PR in this consolidation wave | **#565** — `Add local Ollama singlepath lab lane` |
+| Latest verified merged PR in this consolidation wave | **#568** — blocked/stopped manual Value Read artifact committed |
 | Live open PR state at verification | **0 open PRs** on `adonisdv23/Alpha-Solver` |
 | Closed-unmerged superseded PR | **#561** — superseded by merged PR #562 |
-| Current controlling posture | Post-#565 docs/eval infrastructure consolidation; no provider/model execution authorized |
-| Selected next lane | **`ALPHA-SOLVER-VALUE-READ-SIMULATION-PACKET-REFRESH-POST-565-001`** |
-| Strategic boundary | Refresh the Value Read simulation packet against the merged infrastructure before any execution/evidence promotion |
+| Current controlling posture | `VALUE_READ_BLOCKED`; PR #568 generated no outputs and no scores |
+| Selected next lane | **`ALPHA-SOLVER-VALUE-READ-EXECUTION-PACKET-AUTHORIZATION-001`** |
+| Strategic boundary | Convert the blocked PR #568 Value Read state into a controlled authorization packet/lane before any output generation or evidence promotion |
 
 ## Completed post-552 / post-565 infrastructure lanes
 
@@ -49,15 +49,15 @@ See [`EVIDENCE_INDEX.md`](EVIDENCE_INDEX.md) for the PR status ledger and [`LANE
 
 ## Selected next lane
 
-**`ALPHA-SOLVER-VALUE-READ-SIMULATION-PACKET-REFRESH-POST-565-001`** is the recommended next active lane.
+**`ALPHA-SOLVER-VALUE-READ-EXECUTION-PACKET-AUTHORIZATION-001`** is the recommended next active lane.
 
 Purpose:
 
-1. Refresh the Value Read simulation packet so it explicitly incorporates the merged #557–#565 infrastructure.
-2. Preserve the evidence boundary: design/simulation packet refresh only unless a later lane separately authorizes execution.
-3. Align future Value Read prompts/scoring with the no-echo gate, false-premise set, claim-safety linter, calibrated-confidence contract, needs-human protocol, higher-headroom cases, prompt-contract methodology, and local Ollama scaffold boundaries.
+1. Create a controlled Value Read execution packet/lane after the PR #568 blocked artifact.
+2. Include complete per-case prompts, raw-output preservation, blinding-map storage, output-generation boundary, and explicit operator authorization requirements.
+3. Keep PR #568 as blocked-state evidence only; do not treat it as Alpha value evidence.
 
-This lane does **not** authorize provider calls, token use, credential access, billing inspection, hosted model calls, local model calls, dashboard exposure, `/v1/solve` exposure, public API exposure, Google Sheets mutation, benchmark execution, or value/readiness claims.
+This lane does **not** itself authorize provider calls, token use, credential access, billing inspection, hosted model calls, local model calls, dashboard exposure, `/v1/solve` exposure, public API exposure, Google Sheets mutation, benchmark execution, or value/readiness claims unless a future operator authorization explicitly supplies those boundaries.
 
 ## Open deferrals (see [`DEFERRAL_REGISTER.md`](DEFERRAL_REGISTER.md))
 
@@ -69,7 +69,7 @@ This lane does **not** authorize provider calls, token use, credential access, b
 ## What is blocked / not authorized
 
 - Provider calls, hosted model calls, local model calls, token use, credential access, billing inspection, dashboard exposure, `/v1/solve` exposure, public API exposure, and Google Sheets mutation.
-- Value experiment execution and Alpha-vs-baseline claims. The post-#565 infrastructure can support better packet design, but it is not execution evidence.
+- Value experiment execution and Alpha-vs-baseline claims. PR #568 is `VALUE_READ_BLOCKED`: it generated no Alpha outputs, baseline outputs, blind scores, or measured discrimination-delta.
 - Security/privacy completion, production readiness, public MVP readiness, benchmark validation/superiority, broad-user readiness, autonomous readiness, provider validation, local Ollama validation, or Alpha superiority.
 
 ## What must not be claimed

--- a/docs/EVIDENCE_INDEX.md
+++ b/docs/EVIDENCE_INDEX.md
@@ -1,9 +1,7 @@
-# Evidence Index — Post-#565 consolidation
+# Evidence Index — Post-#568 blocked Value Read state
 
 > Source-of-truth evidence ledger. Verification date **2026-06-15**. Live GitHub
-> API verification confirmed PRs #557, #558, #559, #560, #562, #563, #564, and
-> #565 are merged; PR #561 is closed unmerged; and the repository had `0` open
-> PRs at verification time.
+> API verification confirmed PRs #566, #567, and #568 are merged.
 
 ## How to read "evidence value"
 
@@ -22,10 +20,13 @@ The entries below are design, documentation, static-checking, methodology, or sc
 | #563 | Add higher-headroom Value Read case set (design-only) | ✅ merged 2026-06-15 | `.specs/ALPHA-SOLVER-EVAL-HIGHER-HEADROOM-CASESET-001.md`; `docs/evals/HIGHER_HEADROOM_VALUE_READ_CASE_SET.md` | Adds higher-headroom synthetic Value Read candidate cases. | Does not score outputs, prove lift, or establish benchmark success. | completed |
 | #564 | Add prompt-contract simulation methodology | ✅ merged 2026-06-15 | `docs/evals/runs/alpha-solver-prompt-contract-simulation-methodology-001/` | Records methodology for prompt-contract simulation. | Does not execute a simulation, call providers, or prove value. | completed |
 | #565 | Add local Ollama singlepath lab lane | ✅ merged 2026-06-15 | `.specs/ALPHA-SOLVER-LOCAL-MODEL-LAB-OLLAMA-SINGLEPATH-001.md`; `docs/evals/runs/alpha-solver-local-model-lab-ollama-singlepath-001/` | Records a local-only Ollama singlepath lab scaffold. | Does not run Ollama, run a local model, validate a provider, expose an API, or prove readiness. | completed |
+| #566 | Post-565 Value Read simulation packet refresh | ✅ merged 2026-06-15 | `docs/evals/runs/alpha-solver-value-read-simulation-packet-refresh-post-565-001/` | Refreshes the packet lane for post-565 infrastructure. | Does not prove value, run providers/models, or score outputs. | completed |
+| #567 | Value Read packet follow-up / pre-run state | ✅ merged 2026-06-15 | `docs/evals/runs/alpha-solver-value-read-simulation-packet-refresh-post-565-001/` | Commits the packet state inspected by the manual-run artifact. | Does not itself prove value or readiness. | completed |
+| #568 | Manual Value Read simulation run artifact — stopped | ✅ merged 2026-06-15 | `docs/evals/runs/alpha-solver-value-read-simulation-packet-refresh-post-565-001/manual-run-artifact-2026-06-15.md` | Records `VALUE_READ_BLOCKED`: stopped before output generation and scoring; no Alpha/baseline outputs, blind scores, or discrimination-delta. | Does not claim Alpha value, superiority, provider/local/runtime behavior, endpoint/dashboard/public API behavior, Google Sheets mutation, external ledger mutation, MVP validation, or readiness. | blocked evidence |
 
 ## Current selected next lane
 
-`ALPHA-SOLVER-VALUE-READ-SIMULATION-PACKET-REFRESH-POST-565-001` is the selected next active lane unless newer live repo evidence supersedes it. The lane is limited to refreshing the Value Read simulation packet against the merged #557–#565 infrastructure and preserving evidence boundaries.
+`ALPHA-SOLVER-VALUE-READ-EXECUTION-PACKET-AUTHORIZATION-001` is the selected next active lane. It should create an explicitly authorized Value Read execution packet/lane with complete per-case prompts, raw-output preservation, blinding-map storage, output-generation boundary, and explicit operator authorization requirements. PR #568 remains blocked-state evidence only.
 
 ## Evidence boundary
 

--- a/docs/LANE_REGISTRY.md
+++ b/docs/LANE_REGISTRY.md
@@ -1,7 +1,7 @@
 # Lane Registry
 
 > Source-of-truth lane lifecycle registry. Verification date **2026-06-15** after
-> live GitHub verification of PRs #557–#565 and current open PR state.
+> live GitHub verification of PRs #566–#568.
 
 ## Lifecycle classes
 
@@ -11,13 +11,13 @@
 
 | Lane | State | Evidence |
 |------|-------|----------|
-| Post-#565 consolidation | **current control posture** | PRs #557, #558, #559, #560, #562, #563, #564, and #565 are merged; PR #561 is closed unmerged and superseded by #562; live open PR count was `0` at verification. |
+| Post-#568 Value Read blocked state | **current control posture** | PRs #566, #567, and #568 are merged. PR #568 committed a stopped manual Value Read artifact with no output generation and no scoring. |
 
 ## Next ready
 
 | Lane | State | Notes |
 |------|-------|-------|
-| **`ALPHA-SOLVER-VALUE-READ-SIMULATION-PACKET-REFRESH-POST-565-001`** | **selected next** | Docs/eval packet refresh only. Incorporates merged no-echo, false-premise, claim-safety, calibrated-confidence, needs-human, higher-headroom, prompt-contract, and local Ollama scaffold artifacts without running providers or models. |
+| **`ALPHA-SOLVER-VALUE-READ-EXECUTION-PACKET-AUTHORIZATION-001`** | **selected next** | Controlled execution authorization packet/lane only. Must include complete per-case prompts, raw-output preservation, blinding-map storage, output-generation boundary, and explicit operator authorization requirements before any outputs are generated. |
 
 ## Completed (kept as evidence)
 
@@ -29,6 +29,7 @@
 - `ALPHA-SOLVER-EVAL-HIGHER-HEADROOM-CASESET-001` (PR #563) — higher-headroom Value Read case set.
 - `ALPHA-SOLVER-PROMPT-CONTRACT-SIMULATION-METHODOLOGY-001` (PR #564) — prompt-contract simulation methodology.
 - `ALPHA-SOLVER-LOCAL-MODEL-LAB-OLLAMA-SINGLEPATH-001` (PR #565) — local Ollama singlepath lab scaffold.
+- `ALPHA-SOLVER-VALUE-READ-SIMULATION-PACKET-REFRESH-POST-565-001` (PRs #566–#568) — packet refresh plus blocked manual-run artifact; no Alpha/baseline outputs or scores.
 
 ## Superseded
 
@@ -45,7 +46,7 @@
 | Local model / Ollama execution | Current #565 scaffold is design/local-lab lane only | Separate operator-managed local run authorization and preserved evidence boundaries. |
 | Dashboard, `/v1/solve`, public API exposure | Not part of the selected next lane | Separate exposure/readiness/security lane. |
 | Google Sheets or backlog workbook mutation | Repo task boundary | Operator-managed external ledger process only. |
-| Value/readiness/provider/security/privacy/Alpha-superiority claims | No execution or validation evidence in this lane | Properly scoped future evidence with pre-registered boundaries. |
+| Value/readiness/provider/security/privacy/Alpha-superiority claims | PR #568 generated no outputs and no scores; no execution or validation evidence exists | Properly scoped future evidence with pre-registered boundaries. |
 
 ## Do not run again (as-is)
 
@@ -66,7 +67,10 @@
 #565 local Ollama singlepath scaffold
         │
         ▼
-ALPHA-SOLVER-VALUE-READ-SIMULATION-PACKET-REFRESH-POST-565-001 ← selected next; docs/eval packet refresh only
+ALPHA-SOLVER-VALUE-READ-SIMULATION-PACKET-REFRESH-POST-565-001 / PR #568 artifact ← VALUE_READ_BLOCKED
+        │
+        ▼
+ALPHA-SOLVER-VALUE-READ-EXECUTION-PACKET-AUTHORIZATION-001 ← selected next; controlled authorization packet/lane only
 ```
 
 This registry does not authorize any provider call, local model call, runtime exposure, public API exposure, Google Sheets mutation, or readiness/value claim.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-> Refreshed **2026-06-15** for the post-#565 current-state consolidation.
+> Refreshed **2026-06-15** for the post-#568 blocked Value Read state.
 > The old PR #91–#99 list below is **historical** and no longer the current
 > roadmap. Source of truth for current state:
 > [`CURRENT_STATE.md`](CURRENT_STATE.md). This roadmap makes **no** readiness,
@@ -8,13 +8,13 @@
 
 ## Current phase
 
-**Post-#565 Value Read infrastructure consolidation.** Live GitHub verification on 2026-06-15 confirmed PRs #557, #558, #559, #560, #562, #563, #564, and #565 are merged; PR #561 is closed unmerged and superseded by #562; and there were `0` open PRs.
+**Post-#568 blocked Value Read state.** Live GitHub verification on 2026-06-15 confirmed PRs #566, #567, and #568 are merged. PR #568 committed a manual Value Read artifact that stopped before output generation and scoring.
 
-The recently merged infrastructure records no-echo gating, false-premise / hidden-constraint cases, claim-safety linting, calibrated-confidence vocabulary, needs-human protocol guidance, higher-headroom Value Read cases, prompt-contract simulation methodology, and a local Ollama singlepath scaffold. These are not provider/model/value/readiness evidence.
+The prior infrastructure records no-echo gating, false-premise / hidden-constraint cases, claim-safety linting, calibrated-confidence vocabulary, needs-human protocol guidance, higher-headroom Value Read cases, prompt-contract simulation methodology, and a local Ollama singlepath scaffold. PR #568 does not add provider/model/value/readiness evidence; it records `VALUE_READ_BLOCKED` with no Alpha outputs, baseline outputs, blind scores, or discrimination-delta.
 
 ## Current next lane
 
-**`ALPHA-SOLVER-VALUE-READ-SIMULATION-PACKET-REFRESH-POST-565-001`** — refresh the Value Read simulation packet so future packet design explicitly incorporates the merged #557–#565 infrastructure. This is docs/eval packet work only and does not authorize provider calls, token use, credential access, billing inspection, hosted model calls, local model calls, dashboard exposure, `/v1/solve` exposure, public API exposure, Google Sheets mutation, benchmark execution, or value/readiness claims.
+**`ALPHA-SOLVER-VALUE-READ-EXECUTION-PACKET-AUTHORIZATION-001`** — create an explicitly authorized Value Read execution packet/lane with complete per-case prompts, raw-output preservation, blinding-map storage, output-generation boundary, and explicit operator authorization requirements. This is controlled authorization/design work only until a future authorization supplies execution boundaries; it does not authorize provider calls, token use, credential access, billing inspection, hosted model calls, local model calls, dashboard exposure, `/v1/solve` exposure, public API exposure, Google Sheets mutation, benchmark execution, or value/readiness claims by itself.
 
 ## Active deferrals
 
@@ -27,7 +27,7 @@ See [`DEFERRAL_REGISTER.md`](DEFERRAL_REGISTER.md).
 
 ## Near-term roadmap (docs-only governance / Value Read packet phase)
 
-1. Refresh the Value Read simulation packet for post-#565 infrastructure: `ALPHA-SOLVER-VALUE-READ-SIMULATION-PACKET-REFRESH-POST-565-001`.
+1. Create the controlled Value Read execution authorization packet/lane: `ALPHA-SOLVER-VALUE-READ-EXECUTION-PACKET-AUTHORIZATION-001`.
 2. Keep no-echo, false-premise, hidden-constraint, confidence, needs-human, higher-headroom, and claim-safety boundaries explicit in any later packet.
 3. Keep local Ollama work as scaffold/design unless a future operator-managed lane separately authorizes a local run.
 4. Keep provider calls, hosted/local model runs, public surfaces, and Google Sheets mutation out of scope until separately authorized.

--- a/docs/VALUE_EXPERIMENT_DIRECTION.md
+++ b/docs/VALUE_EXPERIMENT_DIRECTION.md
@@ -27,9 +27,9 @@ this framing:
 
 ## Selected next packet lane
 
-**`ALPHA-SOLVER-VALUE-READ-SIMULATION-PACKET-REFRESH-POST-565-001`** is the selected next active lane. It should refresh the Value Read simulation packet against the merged #557–#565 infrastructure before any execution or evidence promotion.
+**`ALPHA-SOLVER-VALUE-READ-EXECUTION-PACKET-AUTHORIZATION-001`** is the selected next active lane after the PR #568 blocked manual-run artifact. It should create an explicitly authorized Value Read execution packet/lane before any output generation, execution, or evidence promotion.
 
-The refresh should incorporate:
+The next packet/lane should incorporate:
 
 - no-echo substantive generation gating;
 - false-premise and hidden-constraint perturbation cases;
@@ -62,5 +62,5 @@ The refresh should incorporate:
   this lane.
 - This direction makes **no** claim of benchmark validation, benchmark
   superiority, or broad-user readiness.
-- The selected next lane is a packet refresh only; it does not run providers, use tokens, inspect credentials or billing, run hosted/local models, expose dashboards, expose `/v1/solve`, expose a public API, mutate Google Sheets, or claim value/readiness/provider validation/security/privacy completion/Alpha superiority.
+- PR #568 is blocked-state evidence only: it did not generate Alpha outputs, baseline outputs, blind scores, or discrimination-delta. The selected next lane must not run providers, use tokens, inspect credentials or billing, run hosted/local models, expose dashboards, expose `/v1/solve`, expose a public API, mutate Google Sheets, or claim value/readiness/provider validation/security/privacy completion/Alpha superiority unless a future operator authorization explicitly supplies those boundaries.
 - Later protocol execution remains blocked until a future authorized lane explicitly satisfies its prerequisites and evidence boundaries (see [`LANE_REGISTRY.md`](LANE_REGISTRY.md)).

--- a/docs/evals/runs/alpha-solver-mvp-readiness-scorecard-001/README.md
+++ b/docs/evals/runs/alpha-solver-mvp-readiness-scorecard-001/README.md
@@ -1,12 +1,12 @@
 # ALPHA-SOLVER-MVP-READINESS-SCORECARD-001
 
-Verdict: `MVP_SCORECARD_UPDATED_POST_552_VALUE_READ_BLOCKED`
+Verdict: `VALUE_READ_BLOCKED_POST_568`
 
 This packet is an internal MVP readiness evidence and non-claims scorecard. It is not an MVP readiness claim, public-readiness claim, production-readiness claim, provider-validation claim, runtime-readiness claim, dashboard-readiness claim, benchmark claim, value-evidence claim, or Alpha-superiority claim.
 
 ## Purpose
 
-Update the MVP scorecard using the actual manual discrimination Value Read status and the post-#552 evidence state. The Value Read did not produce simulation or runtime scores; it produced a blocked verdict for runtime/provider execution and no simulation run. #552 provides partial local exact-echo remediation only, so the next lane must be a post-#552 successor no-echo/substantive-generation gate rather than the already-landed prompt-consumption wiring fix.
+Update the MVP scorecard using the committed PR #568 blocked manual Value Read artifact. PR #568 records `VALUE_READ_BLOCKED`: the run stopped before output generation and scoring, and it produced no Alpha outputs, baseline outputs, blind scores, or measured discrimination-delta. The packet-level next lane is now a controlled Value Read execution authorization packet/lane, not the historical post-#552 no-echo successor lane.
 
 ## Source context inspected
 
@@ -18,6 +18,7 @@ Update the MVP scorecard using the actual manual discrimination Value Read statu
 - `docs/evals/runs/alpha-solver-manual-discrimination-value-read-001/evidence-boundary.md`
 - Existing MVP scorecard packet files in this directory.
 - Post-#552 repository state represented by merged PR #552 partial local exact-echo remediation.
+- PR #568 committed artifact: `docs/evals/runs/alpha-solver-value-read-simulation-packet-refresh-post-565-001/manual-run-artifact-2026-06-15.md`.
 
 ## Required outputs
 
@@ -33,6 +34,10 @@ Update the MVP scorecard using the actual manual discrimination Value Read statu
 
 ## Decision summary
 
-Selected next lane: `ALPHA-SOLVER-NO-ECHO-SUBSTANTIVE-GENERATION-GATE-POST-552-SUCCESSOR-001`.
+Selected next lane: `ALPHA-SOLVER-VALUE-READ-EXECUTION-PACKET-AUTHORIZATION-001`.
 
-#552 provides partial local exact-echo remediation for controlled fixtures and unsupported SAFE-OUT-style clarification. It does not prove broad no-echo behavior, general answer quality, provider behavior, runtime readiness, benchmark success, value, public readiness, production readiness, or Alpha superiority. Therefore the immediate next evidence lane is a post-#552 successor no-echo/substantive-generation gate or derivation check, not the already-landed prompt-consumption wiring fix.
+Decision label: controlled Value Read execution authorization packet.
+
+PR #568 recorded `VALUE_READ_BLOCKED`; it generated no Alpha outputs, baseline outputs, blind scores, or measured discrimination-delta. The next lane must create complete per-case prompts, raw-output preservation paths, blinding-map storage, output-generation boundary, score-lock/unblind rules, and explicit operator authorization requirements before any output generation.
+
+The old post-#552 no-echo successor lane, `ALPHA-SOLVER-NO-ECHO-SUBSTANTIVE-GENERATION-GATE-POST-552-SUCCESSOR-001`, remains historical/completed evidence context only. It is not the selected next lane after PR #568. This packet does not authorize provider calls, token use, credential access, hosted model calls, local model calls, endpoint calls, dashboard exposure, `/v1/solve`, public API exposure, Google Sheets mutation, or value/readiness/superiority claims.

--- a/docs/evals/runs/alpha-solver-mvp-readiness-scorecard-001/scorecard.md
+++ b/docs/evals/runs/alpha-solver-mvp-readiness-scorecard-001/scorecard.md
@@ -1,26 +1,36 @@
 # MVP readiness scorecard
 
-Verdict: `MVP_SCORECARD_UPDATED_POST_552_VALUE_READ_BLOCKED`
+Verdict: `VALUE_READ_BLOCKED_POST_568`
 
 ## 1. TLDR
 
-The MVP scorecard is updated with the actual manual discrimination Value Read status and the post-#552 evidence state: **blocked, not executed**. #552 provides partial local exact-echo remediation for controlled fixtures and unsupported SAFE-OUT-style clarification. It does not prove broad no-echo behavior, general answer quality, provider behavior, runtime readiness, benchmark success, value, public readiness, production readiness, or Alpha superiority. Track S simulation was not run, and Track R runtime/provider execution remains blocked. Therefore the immediate next evidence lane is a post-#552 successor no-echo/substantive-generation gate or derivation check, not the already-landed prompt-consumption wiring fix.
+The MVP scorecard is updated from the committed PR #568 manual-run artifact: the post-565 Value Read attempt was **stopped before output generation and scoring**. The artifact contains no Alpha outputs, no baseline outputs, no blind scores, and no measured discrimination-delta. This is a controlled blocked state, not value evidence, benchmark evidence, MVP validation, provider validation, runtime readiness, public readiness, production readiness, or Alpha superiority evidence.
 
-## 2. Readiness judgment
+## 2. Live verification and input artifact
 
-**Not MVP ready. Not public ready. Not production ready. Not provider ready.**
+Live GitHub verification on 2026-06-15 confirmed the relevant PRs are merged:
 
-The actual Value Read result is a blocked verdict, not a simulation result and not runtime evidence:
+- PR #566 — merged 2026-06-15, merge commit `b2ef888abb64e3ff56745fc78f2afa28e15c7cdc`.
+- PR #567 — merged 2026-06-15, merge commit `9234e6425295a13047c76bad2038e99331b28c55`.
+- PR #568 — merged 2026-06-15, merge commit `4a7cfb61293035043dce802b5aaa6b05c1d078da`.
 
-- Value Read lane: `ALPHA-SOLVER-MANUAL-DISCRIMINATION-VALUE-READ-001`.
-- Track S simulation result: `not run / no scores`.
-- Track R runtime/provider result: `not run / blocked`.
-- Runtime blocked verdicts preserved by the Value Read packet: `BLOCKED_NO_ECHO_PROOF_MISSING` and `BLOCKED_OPERATOR_AUTHORIZATION_MISSING`.
-- Post-#552 evidence state: partial local exact-echo remediation landed for controlled fixtures and unsupported SAFE-OUT-style clarification, but broad no-echo/substantive-generation behavior remains unproven.
+Input artifact used: [`manual-run-artifact-2026-06-15.md`](../alpha-solver-value-read-simulation-packet-refresh-post-565-001/manual-run-artifact-2026-06-15.md).
 
-This scorecard treats the blocked Value Read and #552 as bounded local evidence only. It does not convert the blocked run, #552 partial remediation, prompt-contract templates, or local documentation into value, runtime, provider, benchmark, public, production, or readiness evidence.
+The PR #568 artifact records `Outcome | Stopped before output generation and scoring`. It also records that no Alpha, baseline, provider, hosted-model, local-model, endpoint, dashboard, public-API, or runtime outputs were generated or collected.
 
-## 3. Scorecard table
+## 3. Closed scorecard decision
+
+Closed decision: `VALUE_READ_BLOCKED`.
+
+Reason: the committed artifact is a stopped/blocked manual Value Read artifact. It states that the packet was preparation-only, did not contain outputs, and could not be used to generate Alpha/baseline answers or perform blind scoring under the packet-only evidence boundary. No live repo evidence reviewed in this lane supports any different closed decision.
+
+## 4. Readiness judgment
+
+**Not MVP ready. Not public ready. Not production ready. Not provider ready. Not runtime ready.**
+
+The PR #568 artifact is not an executed Value Read result. It does not support claims that Alpha Solver has generated value evidence, outperformed a baseline, completed an eval, completed a benchmark, validated provider behavior, validated a hosted model, validated a local model, exposed `/v1/solve`, exposed dashboard behavior, exposed public API behavior, mutated Google Sheets, or updated any external ledger.
+
+## 5. Scorecard table
 
 Scale:
 
@@ -33,81 +43,54 @@ Scale:
 
 | Required dimension | Score | Current read | Evidence boundary | Consequence |
 | --- | ---: | --- | --- | --- |
-| Discrimination signal | 0 | Blocked; no Alpha-vs-baseline outputs exist. | Manual Value Read task bank and rubric exist, but Track S and Track R did not run. | No value, superiority, or wedge claim. |
-| False-premise catch behavior | 0 | Unmeasured. | False-premise tasks are present in the task bank, but no outputs or scores exist. | Cannot claim false-premise reliability. |
-| Hidden-constraint surfacing | 0 | Unmeasured. | Hidden-constraint tasks are present in the task bank, but no outputs or scores exist. | Cannot claim hidden-constraint handling. |
-| Near-echo avoidance | 1 | Partial local exact-echo remediation landed in #552, but broad no-echo/substantive-generation behavior remains unproven. | #552 is local fixture evidence only; the Value Read has no post-#552 scores or runtime/provider outputs. | Rerun or create a post-#552 successor gate before value or provider lanes. |
-| Confidence usefulness | 1 | Designed only. | Alpha-side envelope requires `confidence_level`, assumptions, missing evidence, and boundary fields, but no scored answers exist. | Keep as rubric requirement; do not claim usefulness. |
-| Escalation usefulness | 1 | Designed only. | Task bank and scoring dimensions include needs-human escalation, but no scored answers exist. | Keep as rubric requirement; do not claim user-visible escalation quality. |
-| Operator decision quality | 2 | Conservative decision quality is present in documentation only. | The scorecard and Value Read correctly stop on no-echo and authorization blockers. | Supports internal governance, not MVP readiness. |
-| Claim boundary discipline | 3 | Strong documentation discipline; answer-quality boundary untested. | Existing packets repeatedly forbid readiness, superiority, runtime, provider, public, and benchmark claims. | Permits conservative internal statements only. |
-| Runtime/provider/local readiness boundaries | 2 | Boundaries are explicit; runtime/provider evidence is absent. | Track separation is documented: simulation must not be mixed with runtime/provider evidence; Track R is blocked. | Blocks paid/provider work until prerequisites and authorization exist. |
-| Next-lane clarity | 4 | Clear after correction. | The selected lane is `ALPHA-SOLVER-NO-ECHO-SUBSTANTIVE-GENERATION-GATE-POST-552-SUCCESSOR-001`, a post-#552 successor gate, not the already-landed wiring fix. | Rerun/check post-#552 no-echo/substantive generation before any Value Read/provider/public lane. |
+| Discrimination-delta signal | 0 | Not measured. | PR #568 generated no Alpha/baseline outputs and no blind scores. | No value, superiority, wedge, or benchmark claim. |
+| False-premise catch behavior | 0 | Unmeasured. | Cases were listed, but no answers were produced or scored. | Cannot claim false-premise reliability. |
+| Hidden-constraint surfacing | 0 | Unmeasured. | Cases were listed, but no answers were produced or scored. | Cannot claim hidden-constraint handling. |
+| No-echo / substantive derivation outcome | 0 | Unmeasured in the Value Read. | The PR #568 artifact preserves no output text to inspect for echoing or derivation. | Cannot promote no-echo behavior to value evidence. |
+| Confidence / needs-human usefulness | 0 | Unmeasured. | Needs-human/confidence cases are in the task list, but no scored answers exist. | Cannot claim usefulness in practice. |
+| Claim-boundary discipline | 3 | Documentation discipline is strong; answer behavior untested. | The artifact stops instead of fabricating outputs or overclaiming. | Supports conservative governance only, not MVP readiness. |
+| Contested cases / score lock | 0 | No contested cases were adjudicated; all 19 cases are invalid for scoring. | No raw Output A / Output B packets exist. | No score interpretation is possible. |
+| Runtime/provider/local readiness boundaries | 2 | Boundaries are explicit; execution evidence is absent. | The artifact records no provider calls, hosted/local model calls, endpoints, dashboard, public API, or runtime outputs. | Blocks runtime/provider/public claims. |
+| Next-lane clarity | 4 | Clear controlled next lane selected. | Exactly one next lane is selected below. | Move only to an authorized execution packet/lane, not evidence promotion. |
 
-## 4. Permitted claims
+## 6. Permitted claims
 
-- The MVP scorecard has been updated with the actual Value Read blocked verdict.
-- The manual discrimination Value Read was designed but not executed.
-- Track S simulation produced no results.
-- Track R runtime/provider testing did not run and produced no runtime/provider outputs.
-- #552 provides partial local exact-echo remediation for controlled fixtures and unsupported SAFE-OUT-style clarification only.
-- The next evidence-bound lane is a post-#552 no-echo/substantive-generation successor gate before any value or provider lane.
-- Current documentation shows conservative evidence-boundary discipline and correctly prevents readiness overclaiming.
+- PRs #566, #567, and #568 are merged according to live GitHub verification performed for this update.
+- The PR #568 manual Value Read attempt stopped before output generation and scoring.
+- No Alpha outputs, baseline outputs, blind scores, or measured discrimination-delta exist in the PR #568 artifact.
+- The scorecard decision is `VALUE_READ_BLOCKED`.
+- The selected next lane is an explicitly authorized Value Read execution packet/lane with complete prompts and preservation/blinding requirements.
 
-## 5. Forbidden claims
+## 7. Forbidden claims
 
-Do not claim any of the following:
+Do not claim any of the following from PR #568 or this scorecard update:
 
-- MVP readiness.
-- Public exposure readiness.
-- Production readiness.
-- Runtime readiness.
-- Provider readiness or provider validation.
-- Dashboard readiness.
-- `/v1/solve` readiness.
-- Benchmark success.
-- Alpha superiority over a baseline.
-- Discrimination value has been proven.
-- False-premise or hidden-constraint behavior has been validated.
-- Confidence or escalation fields are useful in practice.
-- Simulation evidence exists for this Value Read.
-- Runtime evidence exists for this Value Read.
-- Provider outputs exist for this Value Read.
-- #552 proves broad no-echo closure, general answer quality, provider behavior, runtime readiness, benchmark success, value, public readiness, production readiness, or Alpha superiority.
-- The blocked Value Read or #552 authorizes paid/provider work.
-- Google Sheets or backlog ledgers were updated.
+- MVP readiness, public readiness, production readiness, runtime readiness, provider readiness, dashboard readiness, `/v1/solve` readiness, public API readiness, security/privacy completion, benchmark success, value validation, or Alpha superiority.
+- That Alpha outputs, baseline outputs, blind scores, discrimination-delta, no-echo behavior, false-premise behavior, hidden-constraint behavior, confidence usefulness, needs-human usefulness, or claim-boundary behavior were measured.
+- That provider calls, hosted model calls, local model calls, endpoint calls, dashboard behavior, `/v1/solve` behavior, public API behavior, runtime behavior, Google Sheets mutation, or external ledger mutation occurred.
 
-## 6. Recommended next lane
+## 8. Selected next lane
 
-Selected next lane: `ALPHA-SOLVER-NO-ECHO-SUBSTANTIVE-GENERATION-GATE-POST-552-SUCCESSOR-001`.
+Selected next lane: `ALPHA-SOLVER-VALUE-READ-EXECUTION-PACKET-AUTHORIZATION-001`.
 
-Rationale: #552 should be treated as partial local exact-echo remediation, not broad no-echo closure. The immediate next evidence step is to rerun or create a successor no-echo/substantive-generation gate using the post-#552 state before any Value Read execution, provider work, release-candidate, paid/provider, or public-exposure lane. Provider work remains blocked unless explicit operator authorization is supplied with model, project/billing boundary, cost cap, token cap, max request count, exact synthetic fixture, redaction/data-sharing boundary, and stop conditions.
+Purpose: create an explicitly authorized Value Read execution packet/lane that contains complete per-case prompts, raw-output preservation requirements, blinding-map storage requirements, a clear output-generation boundary, and explicit operator authorization requirements before any Alpha/baseline output generation occurs.
 
-## 7. Stop conditions
+Minimum unblock requirements:
 
-Stop and do not proceed to value, provider, public, or release-candidate lanes if any condition applies:
+1. Complete per-case prompts for every Value Read case.
+2. Explicit authorization for the output-generation mechanism, including whether it is manual, hosted provider, local model, endpoint, or another bounded path.
+3. Raw Alpha and baseline output preservation paths.
+4. Blind Output A / Output B packet construction rules.
+5. Blinding-map storage path and unblind-after-score-lock rule.
+6. Score-lock procedure before unblinding.
+7. Non-claims and stop conditions matching this scorecard boundary.
 
-- Post-#552 Alpha output still echoes the prompt or lacks substantive derivation.
-- Post-#552 no-echo/substantive-generation successor gate remains blocked or absent.
-- Provider authorization is missing or incomplete, including model, project/billing boundary, cost cap, token cap, max request count, exact synthetic fixture, redaction/data-sharing boundary, and stop conditions.
-- Track S simulation outputs are mislabeled as runtime/provider evidence.
-- Any answer or packet claims MVP, public, production, provider, runtime, dashboard, benchmark, or Alpha-superiority readiness from this blocked Value Read.
-- DEF-002/public exposure blockers are used as if closed without explicit closure or operator risk acceptance.
-- Google Sheets/backlog workbooks would need to be edited from this repo task.
+## 9. Blocked claims and actions
 
-## Legacy category mapping
+Blocked until a future authorized lane supplies valid evidence:
 
-The previous scorecard categories remain conservatively interpreted as follows:
-
-| Category | Updated read after Value Read blocked verdict |
-| --- | --- |
-| Core product value evidence | Blocked; no executed Value Read result. |
-| Provider smoke and billing boundary | Provider work remains blocked without explicit authorization. |
-| No-echo substantive generation gate | #552 partially remediated local exact echo; successor gate still required. |
-| Security and privacy closure | Not claimably closed; public exposure remains blocked. |
-| Runtime entrypoint clarity | Mapped only; no runtime readiness claim. |
-| Public exposure gate | Blocked. |
-| Test and CI health | Not changed by this docs-only update. |
-| Documentation and backlog hygiene | Scorecard updated; Google Sheets not touched. |
-| Demo readiness | Internal boundary narration only; no external/live demo readiness. |
-| Investor/incubator narrative readiness | Boundary-heavy internal narrative only; no traction/readiness claim. |
+- Alpha/baseline output generation.
+- Blind scoring and discrimination-delta measurement.
+- Provider calls, hosted model calls, local model calls, endpoint calls, dashboard exposure, `/v1/solve` exposure, public API exposure, and runtime behavior claims.
+- Google Sheets mutation and external ledger mutation.
+- Any MVP, value, benchmark, public, production, runtime, provider, security/privacy, or Alpha-superiority claim.

--- a/docs/evals/runs/alpha-solver-mvp-readiness-scorecard-001/selected-next-lane.md
+++ b/docs/evals/runs/alpha-solver-mvp-readiness-scorecard-001/selected-next-lane.md
@@ -1,26 +1,48 @@
 # Selected next lane
 
-Selected next lane: `ALPHA-SOLVER-NO-ECHO-SUBSTANTIVE-GENERATION-GATE-POST-552-SUCCESSOR-001`
+Selected next lane: `ALPHA-SOLVER-VALUE-READ-EXECUTION-PACKET-AUTHORIZATION-001`
 
-Decision label: **post-#552 no-echo/substantive-generation gate successor rerun first**.
+Decision label: **controlled Value Read execution authorization packet**.
 
 ## Rationale
 
-#552 provides partial local exact-echo remediation for controlled fixtures and unsupported SAFE-OUT-style clarification. It does not prove broad no-echo behavior, general answer quality, provider behavior, runtime readiness, benchmark success, value, public readiness, production readiness, or Alpha superiority.
+PR #568 recorded `VALUE_READ_BLOCKED`. The committed manual-run artifact stopped before output generation and scoring. It generated no Alpha outputs, no baseline outputs, no blind scores, and no measured discrimination-delta.
 
-The actual manual discrimination Value Read result is blocked, not scored. Track S simulation was not run. Track R runtime/provider execution stopped before producing runtime/provider outputs because no Value Read readiness proof or provider authorization exists.
+The next lane must therefore create a controlled execution authorization packet/lane before any output generation occurs. That packet/lane must define complete per-case prompts, raw-output preservation paths, blinding-map storage, output-generation boundary, score-lock and unblind rules, and explicit operator authorization requirements.
 
-The next lane must therefore rerun or create a successor no-echo/substantive-generation gate against the post-#552 state before any Value Read execution, provider smoke, release-candidate, paid/provider, or public-exposure lane is considered. This does not reselect the already-landed prompt-consumption wiring fix.
+The PR #568 artifact is blocked-state evidence only. It must not be treated as value evidence, benchmark evidence, MVP validation evidence, provider validation evidence, runtime readiness evidence, public readiness evidence, production readiness evidence, or Alpha-superiority evidence.
 
-## Not selected
+## Required next-lane contents
 
-- `ALPHA-SOLVER-PROMPT-CONSUMPTION-WIRING-FIX-001` — not selected because #552 already landed partial local exact-echo remediation.
-- `Continue value-read refinement` — not selected as the immediate evidence lane because post-#552 no-echo/substantive-generation behavior must be checked first.
-- `Open next release candidate` — not supported by a blocked Value Read.
-- `Keep docs-only and stop` — not selected because there is an actionable narrow successor evidence gate.
-- `Block paid/provider work` — enforced as a boundary until post-#552 no-echo/substantive-generation evidence exists and explicit operator authorization exists, but not selected as the next documentation lane.
-- `Block public exposure` — enforced as a boundary until security/public/readiness gates are closed or explicitly risk-accepted, but not selected as the next documentation lane.
+The selected next lane must include all of the following before any Alpha or baseline output generation:
 
-## Future route after successor gate
+1. Complete per-case prompts for every Value Read case.
+2. Raw Alpha and baseline output preservation paths.
+3. Blinding-map storage requirements.
+4. Output-generation boundary, including the allowed mechanism and stop conditions.
+5. Score-lock procedure before unblinding.
+6. Unblind-after-score-lock rules.
+7. Explicit operator authorization requirements.
+8. Non-claims and evidence-boundary language matching the blocked PR #568 state.
 
-If the post-#552 successor gate passes narrowly, the operator may choose a narrow value-read simulation or an explicitly authorized runtime/provider Value Read. Simulation results must remain labeled as simulation and must not be promoted to runtime evidence. Runtime/provider work remains blocked unless explicit operator authorization supplies model, project/billing boundary, cost cap, token cap, max request count, exact synthetic fixture, redaction/data-sharing boundary, and stop conditions.
+## Not authorized by this selection
+
+This selected next lane does **not** authorize:
+
+- provider calls;
+- token use;
+- credential access;
+- billing inspection;
+- hosted model calls;
+- local model calls;
+- endpoint calls;
+- dashboard exposure;
+- `/v1/solve` exposure;
+- public API exposure;
+- Google Sheets mutation;
+- external ledger mutation;
+- value, readiness, benchmark, provider-validation, runtime-readiness, production-readiness, public-use, MVP-validation, security/privacy, or Alpha-superiority claims.
+
+## Historical / completed context
+
+`ALPHA-SOLVER-NO-ECHO-SUBSTANTIVE-GENERATION-GATE-POST-552-SUCCESSOR-001` remains historical/completed evidence context in this packet. It is **not** the selected next lane after PR #568.


### PR DESCRIPTION
### Motivation

- The committed PR #568 manual-run artifact records a Value Read that was stopped before output generation and scoring, so the scorecard and source-of-truth docs must reflect a closed `VALUE_READ_BLOCKED` decision and preserve the evidence/non-claim boundaries. 
- The next step must be an explicit, controlled execution authorization packet/lane (not an immediate provider or runtime run), so the repo-selected next lane must be updated accordingly.

### Description

- Update the MVP readiness scorecard verdict to `VALUE_READ_BLOCKED_POST_568` and record the closed decision `VALUE_READ_BLOCKED`, the input artifact used, the blocked/no-output/no-score findings, permitted/forbidden claims, and the selected next lane. 
- Convert the repo state/docs to reflect the post-#568 blocked Value Read posture and select `ALPHA-SOLVER-VALUE-READ-EXECUTION-PACKET-AUTHORIZATION-001` as the single next lane with explicit requirements for prompts, raw-output preservation, blinding-map storage, output-generation boundaries, and operator authorization. 
- Add PR #566/#567/#568 entries and preserve PR #568 as blocked evidence in the evidence index and lane registry, and update `ROADMAP.md` and `VALUE_EXPERIMENT_DIRECTION.md` to match the blocked-state guidance. 
- Files changed: `docs/evals/runs/alpha-solver-mvp-readiness-scorecard-001/scorecard.md`, `docs/CURRENT_STATE.md`, `docs/LANE_REGISTRY.md`, `docs/EVIDENCE_INDEX.md`, `docs/ROADMAP.md`, and `docs/VALUE_EXPERIMENT_DIRECTION.md`.

### Testing

- Ran `git diff --check` and it reported no whitespace/patch errors, and the changes were committed successfully. 
- Ran the narrative claim-safety linter via `python scripts/check_narrative_claim_safety.py` over the modified docs and it passed (`ALPHA-SOLVER-NARRATIVE-CLAIM-SAFETY-LINTER-001 passed`). 
- Ran a small Python assertions script that checks the expected markers (`VALUE_READ_BLOCKED` and the new selected next lane) are present in the updated docs and it reported `docs-consistency-pass`. 
- A PR object was prepared with title and body via the repo helper (`make_pr`) but the environment did not return an external GitHub PR URL.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fae6af2f48329af025a9c482bc590)