### PR TITLE
Add post-#568 founder memo refresh

### DIFF
--- a/docs/FOUNDER_MEMO_REFRESH_POST_568.md
+++ b/docs/FOUNDER_MEMO_REFRESH_POST_568.md
@@ -1,0 +1,184 @@
+# Founder Memo Refresh — Post-#568 Value Read Blocked State
+
+Date: 2026-06-15
+
+Source boundary: current committed repository state after the post-565 merge wave, the PR #568 manual Value Read stopped-run artifact, the updated MVP readiness scorecard, and committed evidence summaries. This memo is founder-facing strategy and narrative guidance only. It is not value evidence, readiness evidence, runtime evidence, provider evidence, security evidence, public-readiness evidence, or Alpha-superiority evidence.
+
+## TLDR
+
+Alpha Solver is currently best described as a claim-safe evaluation and reasoning-governance project with a sharpened wedge around discrimination: detecting false premises, surfacing hidden constraints, refusing to echo unsupported claims, marking needs-human situations, calibrating confidence, and keeping narrative claims inside the evidence boundary.
+
+The most recent Value Read attempt is blocked: PR #568 stopped before output generation and scoring. There are no Alpha outputs, baseline outputs, blind scores, or measured discrimination-delta. Claim-boundary note: the MVP scorecard therefore closes as `VALUE_READ_BLOCKED_POST_568`, not as an MVP-readiness finding.
+
+Founder/investor conversations can be exploratory if framed as "we have a disciplined hypothesis and evidence-governance substrate; the next proof is an authorized blinded Value Read." Claim-boundary note: they should not be framed as a market-proven offering, benchmark winner, deployable system, provider-backed result, public MVP, or measured Alpha advantage.
+
+## Readiness judgment
+
+**Exploratory founder/investor conversations: yes, with strict caveats.**
+
+Appropriate conversation goal:
+
+- Test whether the wedge resonates.
+- Recruit design partners or reviewers for a bounded evaluation.
+- Explain the unusually conservative evidence discipline.
+- Ask what proof would change a buyer's or investor's mind.
+
+Inappropriate conversation goal:
+
+- Pitch product-market fit as established.
+- Pitch measured model superiority.
+- Pitch a production platform.
+- Claim public, runtime, provider, local-model, dashboard, `/v1/solve`, security, or privacy readiness.
+- Claim Alpha has already produced measured value.
+
+## Founder memo
+
+### 1. What Alpha Solver is now
+
+Claim-boundary note: Alpha Solver is not yet an evidence-backed product claim. In the current repo state, it is a disciplined evidence and evaluation system for testing whether an AI-assisted reasoning layer can do more than produce polished answers. The current emphasis is on whether outputs can preserve answerability boundaries, detect traps, and avoid unsafe narrative escalation.
+
+The strongest present asset is not runtime proof. It is the repository's structured evaluation posture: specs, case sets, scoring packets, claim-safety boundaries, confidence vocabulary, escalation guidance, and a stopped-run artifact that refused to invent evidence when the packet did not authorize output generation.
+
+### 2. The actual wedge
+
+The wedge is **discrimination under ambiguity**, not generic answer generation.
+
+Alpha Solver is trying to prove that an answer layer can notice when a request contains traps or unsupported premises and then respond in a way that is more decision-useful than a polished but overconfident answer. The relevant behaviors are:
+
+- **Discrimination:** distinguish material answerability and claim-boundary traps from ordinary requests.
+- **False-premise detection:** catch prompts that ask the system to accept a premise not supported by the evidence.
+- **Hidden-constraint surfacing:** identify constraints such as no provider calls, no public claim, no mutation, no legal advice, or inspect-only scope.
+- **Needs-human escalation:** mark cases where a human must review before action, especially legal, safety, evidence-conflict, or irreversible-decision contexts.
+- **No-echo / derivation:** avoid simply restating prompt text or desired conclusions; produce bounded reasoning or a safe refusal/clarification instead.
+- **Confidence:** separate low-confidence, assumption-bound, or blocked answers from supported answers.
+- **Claim safety:** prevent founder, demo, and evidence narratives from converting design artifacts into unsupported readiness or superiority claims.
+
+This wedge is especially relevant if buyers care less about answer prettiness and more about avoiding false certainty, unsupported claims, hidden operational violations, and unsafe automation handoffs.
+
+### 3. What evidence exists
+
+Committed evidence currently supports these bounded statements:
+
+- The post-552/post-565 repo contains docs, specs, and design artifacts for no-echo/substantive generation gating, false-premise and hidden-constraint cases, claim-safety linting, calibrated confidence, needs-human escalation, higher-headroom Value Read cases, prompt-contract simulation methodology, and a local Ollama lab scaffold.
+- The post-565 Value Read packet was refreshed as a preparation/design artifact.
+- PR #568 records a manual Value Read stopped state: no Alpha outputs, no baseline outputs, no blind scores, and no discrimination-delta.
+- The MVP scorecard was updated to reflect `VALUE_READ_BLOCKED_POST_568`.
+- The selected next lane is a controlled Value Read execution authorization packet with complete prompts, raw-output preservation, blinding-map storage, score-lock rules, and explicit operator authorization boundaries.
+- Claim-boundary discipline is itself evidenced: the repo records a blocked verdict rather than fabricating results.
+
+### 4. What evidence is still missing
+
+The missing evidence is exactly the evidence needed to turn a disciplined hypothesis into a proof:
+
+- Complete per-case prompts for the Value Read execution lane.
+- Explicit authorization for the output-generation mechanism.
+- Preserved raw Alpha and baseline outputs.
+- Blinded Output A / Output B packets.
+- Blind scores locked before unblinding.
+- A measured discrimination-delta, if any.
+- Case-level evidence for false-premise detection, hidden-constraint handling, no-echo derivation, needs-human mapping, confidence calibration, and claim-boundary behavior.
+- Adjudication notes for contested cases.
+- Any runtime, provider, local-model, endpoint, dashboard, `/v1/solve`, public API, production, or security/privacy evidence.
+- Any customer, buyer, design-partner, usage, retention, deployment, or willingness-to-pay evidence.
+
+### 5. Whether the project is ready for exploratory founder/investor conversations
+
+Yes, but only as a pre-proof conversation.
+
+The honest positioning is: Alpha Solver has a clear problem hypothesis and a disciplined proof plan, but the most recent proof attempt stopped before output generation. That is not a failure of the wedge; it is a boundary-preserving blocked state. The founder should use conversations to validate whether the wedge matters enough to justify the next proof step.
+
+The conversation should invite scrutiny:
+
+- "Would a blinded comparison on false-premise, hidden-constraint, escalation, confidence, and claim-safety cases be meaningful to you?"
+- "Which failure modes would make this valuable or worthless?"
+- "What domain-specific cases should be in the next packet?"
+- "What proof threshold would make this worth a pilot conversation later?"
+
+### 6. What must be proven before pitching seriously
+
+Before a serious investor/customer pitch, Alpha Solver needs at least one completed, bounded proof artifact:
+
+1. An authorized Value Read execution packet.
+2. Complete prompts and output-generation boundaries.
+3. Raw Alpha and baseline outputs preserved.
+4. Blinded scoring completed and locked.
+5. Unblinded result interpreted narrowly.
+6. Evidence showing whether Alpha actually improves discrimination behavior on the defined cases.
+7. Clear failure analysis for any misses or over-escalations.
+8. A claim-safe narrative that distinguishes design evidence from measured behavior.
+
+Only after that should the founder discuss measured value, and even then only within the exact scope of the evaluation.
+
+### 7. What not to say
+
+Must not claim:
+
+- "Alpha Solver is MVP ready."
+- "Alpha Solver is production ready." <!-- claim-safety-ignore: rationale=quoted forbidden claim in must-not-claim list -->
+- "Alpha Solver is public ready." <!-- claim-safety-ignore: rationale=quoted forbidden claim in must-not-claim list -->
+- "Alpha Solver is runtime/provider/local-model ready."
+- "The Value Read proved Alpha beats a baseline."
+- "The system has validated model quality."
+- "The dashboard or `/v1/solve` path is ready."
+- "Security/privacy is complete."
+- "We have proven product-market fit." <!-- claim-safety-ignore: rationale=quoted forbidden claim in must-not-claim list -->
+- "We have validated value."
+- "Local Ollama quality is proven."
+- "Alpha is superior."
+
+### 8. Suggested one-liner
+
+Alpha Solver is building an evidence-bound reasoning layer that tests whether AI answers can detect false premises, hidden constraints, unsafe handoffs, and unsupported claims instead of merely sounding confident.
+
+### 9. Suggested demo story that does not overclaim
+
+Use a narrated, non-runtime demo of the evaluation design:
+
+1. Show a false-premise founder memo prompt that asks for an unsupported public claim.
+2. Show the desired discrimination behavior: correct the premise, preserve the evidence boundary, lower confidence where needed, and avoid turning design artifacts into traction claims.
+3. Show a hidden-constraint prompt where the right answer is not "do the task" but "stay inspect-only, do not call providers, preserve raw outputs, and escalate if authorization is missing."
+4. Show a needs-human prompt where the correct behavior is to mark escalation rather than produce action-ready legal, safety, or irreversible operational advice.
+5. End by showing the PR #568 blocked verdict and scorecard: the project did not fake outputs, and the next proof is to run a properly authorized blinded Value Read.
+
+This demo story should be described as a proof plan and governance demonstration, not as measured Alpha performance.
+
+### 10. Next proof step
+
+Create `ALPHA-SOLVER-VALUE-READ-EXECUTION-PACKET-AUTHORIZATION-001` with:
+
+- complete per-case prompts;
+- exact output-generation authorization boundaries;
+- raw Alpha and baseline output preservation paths;
+- blinded Output A / Output B construction rules;
+- blinding-map storage;
+- score-lock-before-unblind procedure;
+- stop conditions and non-claims matching the current blocked state.
+
+Then execute only within the authorized boundary and interpret the result narrowly.
+
+## Investor objections and honest answers
+
+| Objection | Honest answer |
+| --- | --- |
+| "Do you have proof this beats a baseline?" | Not yet. The current Value Read is blocked and has no Alpha/baseline outputs or blind scores. The next proof step is an authorized blinded Value Read. |
+| "Is this an MVP?" | Not by the current scorecard. The scorecard verdict is `VALUE_READ_BLOCKED_POST_568`, and it explicitly does not support MVP readiness. |
+| "Can customers use it now?" | The repo evidence does not support public, production, runtime, provider, dashboard, `/v1/solve`, or security/privacy readiness claims. |
+| "What is differentiated if there are no results?" | The differentiated hypothesis is the wedge and the evidence discipline: discrimination over answer polish, with explicit false-premise, hidden-constraint, escalation, confidence, no-echo, and claim-safety dimensions. It remains to be proven. |
+| "Why care about a stopped run?" | Because it demonstrates claim discipline: the project refused to manufacture outputs outside the packet boundary. That is governance evidence, not value evidence. |
+| "What would change the story?" | A completed authorized Value Read with preserved raw outputs, locked blind scores, unblinded results, and case-level analysis showing whether discrimination improved. |
+
+## Required next proof
+
+The required next proof is not another narrative memo. It is a controlled execution authorization packet followed by a completed blinded Value Read. Until then, the strongest fair claim is that Alpha Solver has a rigorous evaluation hypothesis and guardrail-rich documentation, not that the system has proven value.
+
+## Suggested one-liner
+
+Alpha Solver is an evidence-bound reasoning layer for catching false premises, hidden constraints, unsafe handoffs, and unsupported claims before an AI answer becomes an overconfident decision.
+
+## Suggested demo story
+
+"Here is a prompt that tries to make the system claim a Value Read proved superiority. A normal answer might polish the claim. Alpha Solver's intended behavior is to catch the false premise, state that the latest Value Read is blocked, lower confidence, avoid public-readiness language, and route the founder to the next authorized proof step. We have not yet proven that behavior in a completed blinded run; the next milestone is to run exactly that test with preserved outputs and score-locking."
+
+## Forbidden claims
+
+Do not claim product-market fit, validated value, benchmark success, benchmark superiority, Alpha superiority, MVP readiness, public readiness, production readiness, runtime readiness, provider validation, hosted-model validation, local-model quality, local Ollama validation, dashboard readiness, `/v1/solve` readiness, public API readiness, security/privacy completion, customer traction, buyer validation, or design-partner validation unless a future committed artifact directly supports the specific claim.

--- a/docs/FOUNDER_MEMO_REFRESH_POST_568.md
+++ b/docs/FOUNDER_MEMO_REFRESH_POST_568.md
@@ -154,7 +154,7 @@ Create `ALPHA-SOLVER-VALUE-READ-EXECUTION-PACKET-AUTHORIZATION-001` with:
 - score-lock-before-unblind procedure;
 - stop conditions and non-claims matching the current blocked state.
 
-Then execute only within the authorized boundary and interpret the result narrowly.
+After that packet is reviewed and merged, execution remains blocked until the operator separately authorizes the output-generation mechanism and all required boundaries are present. If a later execution lane is explicitly authorized, execute only within that authorized boundary and interpret the result narrowly.
 
 ## Investor objections and honest answers
 
@@ -169,7 +169,7 @@ Then execute only within the authorized boundary and interpret the result narrow
 
 ## Required next proof
 
-The required next proof is not another narrative memo. It is a controlled execution authorization packet followed by a completed blinded Value Read. Until then, the strongest fair claim is that Alpha Solver has a rigorous evaluation hypothesis and guardrail-rich documentation, not that the system has proven value.
+The required next proof is not another narrative memo. It starts with a controlled execution authorization packet; any completed blinded Value Read remains a separate later step that requires explicit operator authorization for the output-generation mechanism and all required boundaries. Until then, the strongest fair claim is that Alpha Solver has a rigorous evaluation hypothesis and guardrail-rich documentation, not that the system has proven value.
 
 ## Suggested one-liner
 


### PR DESCRIPTION
### Motivation
- Capture a founder-facing, claim-safe summary of the repository state after the post-#565 merge wave and the PR #568 manual Value Read that stopped before output generation and scoring.
- Explain the current wedge (discrimination: false-premise detection, hidden-constraint surfacing, needs-human escalation, no-echo derivation, confidence, and claim safety) and set clear boundaries for investor/founder conversations.
- Preserve a narrow, evidence-bound next-step plan (create an authorized blinded Value Read execution packet) while preventing unsupported readiness or superiority claims.

### Description
- Add `docs/FOUNDER_MEMO_REFRESH_POST_568.md`, a founder memo that summarizes what Alpha Solver is now, the actual wedge, existing evidence, missing evidence, readiness guidance, investor objections with honest answers, a safe demo story, a suggested one-liner, and the required next proof step.
- The memo explicitly records the `VALUE_READ_BLOCKED_POST_568` state and selects `ALPHA-SOLVER-VALUE-READ-EXECUTION-PACKET-AUTHORIZATION-001` as the controlled next lane.
- Minor claim-safety inline suppressions were added in the memo where quoting forbidden claims was necessary to preserve the original "must not claim" wording while satisfying the narrative linter.
- This is a docs-only change; no runtime, provider, API, or product code paths were modified.

### Testing
- Ran the narrative claim-safety linter against the new file with `python scripts/check_narrative_claim_safety.py docs/FOUNDER_MEMO_REFRESH_POST_568.md`, fixed linter findings, and re-ran the linter which passed. 
- Ran the test suite with `python -m pytest -q`, which completed (tests ran with warnings and a few skipped provider-specific tests) and did not block this docs commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fb63f45b4832988760407e4f5bcdb)