### PR TITLE
Add local Ollama singlepath operator helper

### DIFF
--- a/docs/evals/runs/alpha-solver-local-model-lab-ollama-singlepath-001/README.md
+++ b/docs/evals/runs/alpha-solver-local-model-lab-ollama-singlepath-001/README.md
@@ -12,6 +12,10 @@ This packet defines a single-model, single-path local Ollama lab lane for a tiny
 - Execution surface: operator-only local CLI path
 - Evidence status: local non-behavior/smoke evidence only, unless a separate approved scoring lane changes that status
 
+## Operator-local helper script
+
+The helper script `scripts/run_local_ollama_singlepath_operator.sh` is operator-local only. It must be run by the human operator on the same machine where Ollama is already installed and serving `http://127.0.0.1:11434`. The script preserves the packet boundary: it checks only for the exact first-column model tag `gemma3:4b`, refuses suffix variants, does not run `ollama pull`, does not install models, does not call hosted providers, and runs only the committed synthetic singlepath command against `http://127.0.0.1:11434/api/chat`.
+
 ## Packet files
 
 - `local-prerequisites.md` records prerequisites that must be confirmed locally before any real Ollama run.

--- a/scripts/run_local_ollama_singlepath_operator.sh
+++ b/scripts/run_local_ollama_singlepath_operator.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENDPOINT_URL="http://127.0.0.1:11434/api/chat"
+MODEL="gemma3:4b"
+PROMPT="Synthetic local-only fixture: summarize this toy note in one sentence. Note: Ada put two blue blocks and one red block in a box."
+VERDICT="FAILED_LOCAL_LAB_OTHER"
+PREFLIGHT_RESULT="NOT_RUN"
+COMMAND_EXIT_STATUS="NOT_RUN"
+STDOUT_FILE=""
+STDERR_FILE=""
+OLLAMA_LIST_FILE=""
+
+cleanup() {
+  [[ -n "${STDOUT_FILE}" && -f "${STDOUT_FILE}" ]] && rm -f "${STDOUT_FILE}"
+  [[ -n "${STDERR_FILE}" && -f "${STDERR_FILE}" ]] && rm -f "${STDERR_FILE}"
+  [[ -n "${OLLAMA_LIST_FILE}" && -f "${OLLAMA_LIST_FILE}" ]] && rm -f "${OLLAMA_LIST_FILE}"
+}
+trap cleanup EXIT
+
+print_non_claims() {
+  cat <<'NONCLAIMS'
+non-claims:
+  - no local model quality claim
+  - no Value Read success claim
+  - no hosted provider validation claim
+  - no production readiness claim
+  - no public readiness claim
+  - no benchmark success claim
+  - no runtime readiness claim
+  - no Alpha superiority claim
+  - no /v1/solve, dashboard, public API, Google Sheets, provider-token, model-pull, model-install, registry-sweep, fallback-model, or tag-substitution claim
+NONCLAIMS
+}
+
+print_result_block() {
+  echo
+  echo "=== LOCAL OLLAMA SINGLEPATH OPERATOR RESULT ==="
+  echo "preflight exact model check result: ${PREFLIGHT_RESULT}"
+  echo "command exit status: ${COMMAND_EXIT_STATUS}"
+  echo "raw stdout:"
+  if [[ -n "${STDOUT_FILE}" && -s "${STDOUT_FILE}" ]]; then
+    cat "${STDOUT_FILE}"
+  else
+    echo "<empty>"
+  fi
+  echo "raw stderr if available:"
+  if [[ -n "${STDERR_FILE}" && -s "${STDERR_FILE}" ]]; then
+    cat "${STDERR_FILE}"
+  else
+    echo "<empty>"
+  fi
+  echo "operator verdict: ${VERDICT}"
+  print_non_claims
+}
+
+echo "=== ALPHA SOLVER LOCAL OLLAMA SINGLEPATH OPERATOR HELPER ==="
+echo "Evidence boundary: operator-local smoke helper only."
+echo "Run this only on the same local machine where Ollama is already installed and serving ${ENDPOINT_URL}."
+echo "This script does not run ollama pull, install models, call hosted providers, use provider tokens, access credentials, expose /v1/solve, expose dashboard/public API behavior, mutate Google Sheets, sweep registries, use fallback models, or substitute model tags."
+echo "Exact required first-column ollama model tag: ${MODEL}"
+echo
+
+STDOUT_FILE="$(mktemp)"
+STDERR_FILE="$(mktemp)"
+OLLAMA_LIST_FILE="$(mktemp)"
+
+if ollama list >"${OLLAMA_LIST_FILE}" 2>"${STDERR_FILE}" && awk 'NR > 1 {print $1}' "${OLLAMA_LIST_FILE}" | grep -Fxq "${MODEL}"; then
+  PREFLIGHT_RESULT="PRESENT_EXACT_MODEL_${MODEL}"
+else
+  PREFLIGHT_RESULT="ABSENT_EXACT_MODEL_${MODEL}"
+  VERDICT="BLOCKED_LOCAL_LAB_EXACT_MODEL_ABSENT"
+  COMMAND_EXIT_STATUS="NOT_RUN"
+  : >"${STDOUT_FILE}"
+  print_result_block
+  exit 1
+fi
+
+set +e
+python -m alpha.local_llm.operator_cli --enable-local-llm --endpoint-url http://127.0.0.1:11434/api/chat --model gemma3:4b --timeout-seconds 30 --prompt "Synthetic local-only fixture: summarize this toy note in one sentence. Note: Ada put two blue blocks and one red block in a box." >"${STDOUT_FILE}" 2>"${STDERR_FILE}"
+COMMAND_EXIT_STATUS="$?"
+set -e
+
+if [[ "${COMMAND_EXIT_STATUS}" == "0" ]]; then
+  VERDICT="SUCCESS_LOCAL_SMOKE"
+elif grep -Eiq 'connection refused|failed to connect|could not connect|connection error|connection reset|endpoint|unreachable|timed out|timeout|127\.0\.0\.1:11434|localhost:11434' "${STDOUT_FILE}" "${STDERR_FILE}"; then
+  VERDICT="BLOCKED_LOCAL_LAB_ENDPOINT_UNREACHABLE"
+else
+  VERDICT="FAILED_LOCAL_LAB_OTHER"
+fi
+
+print_result_block
+
+if [[ "${COMMAND_EXIT_STATUS}" == "0" ]]; then
+  exit 0
+fi
+exit 1


### PR DESCRIPTION
### Motivation

- Provide an operator-local script to execute the committed Ollama singlepath lab packet locally without touching cloud providers, tokens, model pulls, or installing models. 
- Enforce strict local-only evidence boundaries and exact-model/operator checks to prevent accidental provider use or tag substitution.

### Description

- Add `scripts/run_local_ollama_singlepath_operator.sh`, a POSIX shell helper that starts with `set -euo pipefail` and prints a clear evidence-boundary header. 
- The script validates the exact first `ollama list` column using `awk ... | grep -Fxq 'gemma3:4b'` and blocks with `BLOCKED_LOCAL_LAB_EXACT_MODEL_ABSENT` if the exact tag is not present. 
- It does not run `ollama pull` or install models, uses endpoint `http://127.0.0.1:11434/api/chat`, and runs the exact command `python -m alpha.local_llm.operator_cli --enable-local-llm --endpoint-url http://127.0.0.1:11434/api/chat --model gemma3:4b --timeout-seconds 30 --prompt "Synthetic local-only fixture: summarize this toy note in one sentence. Note: Ada put two blue blocks and one red block in a box."`. 
- The script emits a result block containing the preflight exact model check result, command exit status, raw stdout, raw stderr if available, the operator verdict (one of `SUCCESS_LOCAL_SMOKE`, `BLOCKED_LOCAL_LAB_EXACT_MODEL_ABSENT`, `BLOCKED_LOCAL_LAB_ENDPOINT_UNREACHABLE`, or `FAILED_LOCAL_LAB_OTHER`), and explicit non-claims. 
- Update `docs/evals/runs/alpha-solver-local-model-lab-ollama-singlepath-001/README.md` with a note that the helper is operator-local only and must be run on the machine where Ollama serves `http://127.0.0.1:11434`.

### Testing

- Ran `bash -n scripts/run_local_ollama_singlepath_operator.sh` to verify script syntax and it passed. 
- Ran `git diff --check` and it passed with no whitespace errors. 
- Ran `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-local-model-lab-ollama-singlepath-001` and it passed. 
- Ran `python scripts/check_local_llm_evidence_boundaries.py docs/evals/runs/alpha-solver-local-model-lab-ollama-singlepath-001/README.md docs/evals/runs/alpha-solver-local-model-lab-ollama-singlepath-001/evidence-boundary.md docs/evals/runs/alpha-solver-local-model-lab-ollama-singlepath-001/non-claims.md` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a303d51816c8329bfddecc1fa7f64a7)