### PR TITLE
docs: sync post-574 current state

### DIFF
--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -1,38 +1,36 @@
 # Alpha Solver — Current State
 
 > Source-of-truth navigation doc. Last verified **2026-06-15** after live
-> GitHub verification of PRs #566–#568. Docs-only; no provider/runtime claims.
+> GitHub API verification of **0 open PRs** and merged PRs **#569–#574**.
+> Docs-only; no provider/runtime claims.
 
 ## Current verified phase
 
-**Post-#568 Value Read blocked state; selected next lane is an explicitly authorized Value Read execution packet/lane.**
+**Post-#574 backlog/current-state sync posture; selected next lane is an Alpha-native local operator harness design note.**
 
-The merged #566–#568 wave refreshed the post-565 Value Read packet and recorded a stopped manual run artifact. The prior #557–#565 wave moved the repository from stale smoke-authorisation pointers to a Value Read infrastructure/design posture:
+The merged #569–#574 wave updated the repository from the post-#568 blocked Value Read state to a broader documentation-and-boundary posture:
 
-- PR #557 merged the post-552 **no-echo substantive generation gate**.
-- PR #558 merged the **false-premise and hidden-constraint perturbation case set**.
-- PR #559 merged the **narrative claim-safety linter**.
-- PR #560 merged the **calibrated-confidence output contract**.
-- PR #561 is **closed unmerged** and superseded by PR #562.
-- PR #562 merged the docs-only **needs-human escalation protocol**.
-- PR #563 merged the **higher-headroom Value Read case set**.
-- PR #564 merged the **prompt-contract simulation methodology**.
-- PR #565 merged the **local Ollama singlepath lab lane**.
+- PR #569 refreshed the current-state, lane, evidence, and MVP scorecard docs after PR #568 recorded `VALUE_READ_BLOCKED`.
+- PR #570 refreshed the founder memo for the post-#568 state.
+- PR #571 added a blocked `/v1/solve` exposure gate packet.
+- PR #572 added a local Ollama singlepath operator helper.
+- PR #573 recorded a blocked local Ollama singlepath attempt: exact `gemma3:4b` preflight passed, but the local helper failed closed with a timeout/backend error and produced no local model answer.
+- PR #574 recorded Pi.dev harness feasibility research and recommended borrowing patterns only, with no direct integration.
 
-These are infrastructure, design, methodology, and docs/tooling artifacts. They do not prove provider behavior, model quality, value, readiness, benchmark success, security/privacy completion, or Alpha superiority.
+These are docs, gate, helper, static/research, and blocked-attempt artifacts. They do not prove provider behavior, model quality, value, readiness, benchmark success, security/privacy completion, local Ollama validation, `/v1/solve` readiness, production/public readiness, or Alpha superiority.
 
 ## At a glance
 
 | Field | Value |
 |-------|-------|
-| Latest verified merged PR in this consolidation wave | **#568** — blocked/stopped manual Value Read artifact committed |
+| Latest verified merged PR in this wave | **#574** — Pi.dev harness feasibility research note |
 | Live open PR state at verification | **0 open PRs** on `adonisdv23/Alpha-Solver` |
 | Closed-unmerged superseded PR | **#561** — superseded by merged PR #562 |
-| Current controlling posture | `VALUE_READ_BLOCKED`; PR #568 generated no outputs and no scores |
-| Selected next lane | **`ALPHA-SOLVER-VALUE-READ-EXECUTION-PACKET-AUTHORIZATION-001`** |
-| Strategic boundary | Convert the blocked PR #568 Value Read state into a controlled authorization packet/lane before any output generation or evidence promotion |
+| Current controlling posture | Docs/research sync after blocked Value Read, blocked `/v1/solve` exposure gate, blocked local Ollama attempt, and Pi.dev no-integration decision |
+| Selected next lane | **`ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001`** |
+| Strategic boundary | Convert useful Pi.dev-style operator-harness patterns into Alpha-native design only, without installing Pi.dev, calling providers, exposing runtime surfaces, or claiming readiness/value evidence |
 
-## Completed post-552 / post-565 infrastructure lanes
+## Completed post-552 / post-565 / post-568 infrastructure lanes
 
 | PR | Lane / artifact | Evidence value |
 |----|-----------------|----------------|
@@ -44,34 +42,42 @@ These are infrastructure, design, methodology, and docs/tooling artifacts. They 
 | #563 | `ALPHA-SOLVER-EVAL-HIGHER-HEADROOM-CASESET-001` | Adds higher-headroom Value Read cases for later bounded simulations/evals. |
 | #564 | `ALPHA-SOLVER-PROMPT-CONTRACT-SIMULATION-METHODOLOGY-001` | Records prompt-contract simulation methodology. |
 | #565 | `ALPHA-SOLVER-LOCAL-MODEL-LAB-OLLAMA-SINGLEPATH-001` | Records a local Ollama singlepath lab lane scaffold; no local model run is implied. |
+| #566–#568 | `ALPHA-SOLVER-VALUE-READ-SIMULATION-PACKET-REFRESH-POST-565-001` | Refreshes the Value Read packet and records `VALUE_READ_BLOCKED`; no Alpha/baseline outputs or scores. |
+| #569 | Post-#568 current-state sync | Updates source-of-truth docs and MVP scorecard to the blocked Value Read state. |
+| #570 | Founder memo refresh | Updates narrative positioning for the post-#568 blocked state. |
+| #571 | `14 - V1 Solve Exposure Gate Packet` | Records `/v1/solve` exposure as `BLOCKED`; route existence is not public readiness. |
+| #572 | Local Ollama singlepath operator helper | Adds an operator helper script for the local-only lane; helper existence is not a successful run. |
+| #573 | Local Ollama singlepath blocked attempt | Records exact-model preflight success and failed-closed timeout/backend error; no local answer or quality evidence. |
+| #574 | `18 - PI.DEV-HARNESS-FEASIBILITY` | Records `BORROW_PATTERNS_ONLY_NO_INTEGRATION` for Pi.dev harness research. |
 
 See [`EVIDENCE_INDEX.md`](EVIDENCE_INDEX.md) for the PR status ledger and [`LANE_REGISTRY.md`](LANE_REGISTRY.md) for lifecycle classification.
 
 ## Selected next lane
 
-**`ALPHA-SOLVER-VALUE-READ-EXECUTION-PACKET-AUTHORIZATION-001`** is the recommended next active lane.
+**`ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001`** is the recommended next active lane.
 
 Purpose:
 
-1. Create a controlled Value Read execution packet/lane after the PR #568 blocked artifact.
-2. Include complete per-case prompts, raw-output preservation, blinding-map storage, output-generation boundary, and explicit operator authorization requirements.
-3. Keep PR #568 as blocked-state evidence only; do not treat it as Alpha value evidence.
+1. Define Alpha-native local operator-harness concepts inspired by Pi.dev patterns without importing or integrating Pi.dev.
+2. Map prompt packets to named local templates and define a local session evidence format, branch labels, export redaction, and interrupt/follow-up semantics.
+3. Preserve Alpha Solver's repo-native specs, evidence boundaries, budget guardrails, local-first posture, and no-runtime-change boundary.
 
-This lane does **not** itself authorize provider calls, token use, credential access, billing inspection, hosted model calls, local model calls, dashboard exposure, `/v1/solve` exposure, public API exposure, Google Sheets mutation, benchmark execution, or value/readiness claims unless a future operator authorization explicitly supplies those boundaries.
+This lane does **not** itself authorize provider calls, token use, credential access, billing inspection, hosted model calls, local model calls, Pi.dev installation, Pi.dev execution, package installation, dashboard exposure, `/v1/solve` exposure, public API exposure, Google Sheets mutation, benchmark execution, or value/readiness/security/privacy/provider/local-Ollama/Alpha-superiority claims unless a future operator authorization explicitly supplies those boundaries.
 
 ## Open deferrals (see [`DEFERRAL_REGISTER.md`](DEFERRAL_REGISTER.md))
 
 - **DEF-001** — Self Operator execution evidence: substantially advanced within local-only scope; does not prove provider/runtime readiness.
-- **DEF-002** — Product security/privacy review: open.
+- **DEF-002** — Product security/privacy review: open; `/v1/solve` exposure remains blocked by PR #571.
 - **DEF-003** — Prior Fable delta-audit custody/replacement: open.
 - **DEF-004** — Audit custody/provenance: open unless repo evidence shows otherwise.
 
 ## What is blocked / not authorized
 
-- Provider calls, hosted model calls, local model calls, token use, credential access, billing inspection, dashboard exposure, `/v1/solve` exposure, public API exposure, and Google Sheets mutation.
+- Provider calls, hosted model calls, local model calls, token use, credential access, billing inspection, dashboard exposure, `/v1/solve` exposure, public API exposure, Pi.dev installation/execution/integration, package-install experiments, and Google Sheets mutation.
 - Value experiment execution and Alpha-vs-baseline claims. PR #568 is `VALUE_READ_BLOCKED`: it generated no Alpha outputs, baseline outputs, blind scores, or measured discrimination-delta.
-- Security/privacy completion, production readiness, public MVP readiness, benchmark validation/superiority, broad-user readiness, autonomous readiness, provider validation, local Ollama validation, or Alpha superiority.
+- Local Ollama validation claims. PR #573 records a failed-closed local timeout/backend error and no local model answer.
+- Security/privacy completion, production readiness, public MVP readiness, benchmark validation/superiority, broad-user readiness, autonomous readiness, provider validation, local Ollama validation, `/v1/solve` readiness, dashboard readiness, or Alpha superiority.
 
 ## What must not be claimed
 
-This phase does **not** support claims of value, OpenAI validation, provider validation, local Ollama validation, runtime readiness, production readiness, public MVP readiness, security/privacy completion, DEF-002 resolved, DEF-003 resolved, benchmark validation, benchmark superiority, broad-user readiness, autonomous readiness, `/v1/solve` readiness, dashboard readiness, or Alpha superiority.
+This phase does **not** support claims of value, OpenAI validation, provider validation, local Ollama validation, Pi.dev integration, runtime readiness, production readiness, public MVP readiness, security/privacy completion, DEF-002 resolved, DEF-003 resolved, benchmark validation, benchmark superiority, broad-user readiness, autonomous readiness, `/v1/solve` readiness, dashboard readiness, Google Sheets synchronization, or Alpha superiority.

--- a/docs/EVIDENCE_INDEX.md
+++ b/docs/EVIDENCE_INDEX.md
@@ -1,11 +1,11 @@
-# Evidence Index — Post-#568 blocked Value Read state
+# Evidence Index — Post-#574 backlog/current-state sync
 
 > Source-of-truth evidence ledger. Verification date **2026-06-15**. Live GitHub
-> API verification confirmed PRs #566, #567, and #568 are merged.
+> API verification confirmed **0 open PRs** and merged PRs **#569–#574**.
 
 ## How to read "evidence value"
 
-The entries below are design, documentation, static-checking, methodology, or scaffold evidence. They are not provider validation, local-model validation, value evidence, benchmark evidence, production readiness evidence, security/privacy completion evidence, or Alpha-superiority evidence.
+The entries below are design, documentation, gate, helper, static-checking, methodology, blocked-attempt, or research evidence. They are not provider validation, local-model validation, value evidence, benchmark evidence, production readiness evidence, security/privacy completion evidence, `/v1/solve` readiness evidence, Pi.dev integration evidence, or Alpha-superiority evidence.
 
 ## PR table
 
@@ -23,13 +23,19 @@ The entries below are design, documentation, static-checking, methodology, or sc
 | #566 | Post-565 Value Read simulation packet refresh | ✅ merged 2026-06-15 | `docs/evals/runs/alpha-solver-value-read-simulation-packet-refresh-post-565-001/` | Refreshes the packet lane for post-565 infrastructure. | Does not prove value, run providers/models, or score outputs. | completed |
 | #567 | Value Read packet follow-up / pre-run state | ✅ merged 2026-06-15 | `docs/evals/runs/alpha-solver-value-read-simulation-packet-refresh-post-565-001/` | Commits the packet state inspected by the manual-run artifact. | Does not itself prove value or readiness. | completed |
 | #568 | Manual Value Read simulation run artifact — stopped | ✅ merged 2026-06-15 | `docs/evals/runs/alpha-solver-value-read-simulation-packet-refresh-post-565-001/manual-run-artifact-2026-06-15.md` | Records `VALUE_READ_BLOCKED`: stopped before output generation and scoring; no Alpha/baseline outputs, blind scores, or discrimination-delta. | Does not claim Alpha value, superiority, provider/local/runtime behavior, endpoint/dashboard/public API behavior, Google Sheets mutation, external ledger mutation, MVP validation, or readiness. | blocked evidence |
+| #569 | Record PR #568 as VALUE_READ_BLOCKED and update MVP scorecard + docs; select controlled execution next lane | ✅ merged 2026-06-15 | `docs/CURRENT_STATE.md`; `docs/LANE_REGISTRY.md`; `docs/EVIDENCE_INDEX.md` | Refreshes source-of-truth docs for the blocked Value Read state after #568. | Does not create Value Read success, provider/runtime readiness, or Sheet synchronization evidence. | completed |
+| #570 | Add post-#568 founder memo refresh | ✅ merged 2026-06-15 | founder memo documentation | Refreshes narrative positioning for the blocked Value Read state. | Does not prove value, readiness, or superiority. | completed |
+| #571 | docs: add v1 solve exposure gate packet (BLOCKED) | ✅ merged 2026-06-15 | `docs/evals/runs/14-v1-solve-exposure-gate/README.md` | Records `/v1/solve` public exposure as `BLOCKED` pending auth, tenancy, logging, redaction, rate-limit, CORS/ingress, monitoring, incident-response, rollback, and authorization closure. | Does not expose `/v1/solve` or prove runtime/public/security/privacy readiness. | blocked evidence |
+| #572 | Add local Ollama singlepath operator helper | ✅ merged 2026-06-15 | `scripts/run_local_ollama_singlepath_operator.sh`; local-lab packet docs | Adds an operator helper for the local-only Ollama lane. | Helper existence is not a successful local model run, quality proof, benchmark, or readiness evidence. | completed |
+| #573 | Record blocked local Ollama singlepath attempt | ✅ merged 2026-06-15 | `docs/evals/runs/alpha-solver-local-model-lab-ollama-singlepath-001/local-run-artifact-2026-06-15.md` | Records exact `gemma3:4b` preflight success followed by failed-closed timeout/backend error; no local model answer was generated. | Does not prove local model quality, local Ollama validation, Value Read success, runtime readiness, or Alpha superiority. | blocked evidence |
+| #574 | Add pi.dev harness feasibility research note | ✅ merged 2026-06-15 | `docs/evals/runs/alpha-solver-pi-dev-harness-feasibility-018/README.md` | Records `BORROW_PATTERNS_ONLY_NO_INTEGRATION` for Pi.dev harness research. | Does not install, run, or integrate Pi.dev; does not authorize providers, package installs, runtime exposure, or readiness claims. | completed |
 
 ## Current selected next lane
 
-`ALPHA-SOLVER-VALUE-READ-EXECUTION-PACKET-AUTHORIZATION-001` is the selected next active lane. It should create an explicitly authorized Value Read execution packet/lane with complete per-case prompts, raw-output preservation, blinding-map storage, output-generation boundary, and explicit operator authorization requirements. PR #568 remains blocked-state evidence only.
+`ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001` is the selected next active lane. It should create an Alpha-native local operator-harness design note inspired by safe Pi.dev patterns without installing or integrating Pi.dev, calling providers/models, exposing runtime surfaces, or mutating Google Sheets. PR #568 remains blocked-state evidence only, PR #571 remains blocked exposure evidence, and PR #573 remains failed-closed local-lab evidence only.
 
 ## Evidence boundary
 
-The post-#565 state supports only bounded statements that the repository contains merged docs/design/static-checking/scaffold artifacts for no-echo gating, false-premise perturbations, claim-safety linting, calibrated confidence, needs-human protocol guidance, higher-headroom cases, prompt-contract methodology, and a local Ollama lab scaffold.
+The post-#574 state supports only bounded statements that the repository contains merged docs/design/static-checking/scaffold/gate/helper/blocked-attempt/research artifacts for no-echo gating, false-premise perturbations, claim-safety linting, calibrated confidence, needs-human protocol guidance, higher-headroom cases, prompt-contract methodology, a local Ollama lab scaffold/helper, blocked Value Read evidence, blocked `/v1/solve` exposure evidence, a failed-closed local Ollama attempt, and Pi.dev patterns-only research.
 
-It does **not** support claims of provider validation, local Ollama validation, hosted-model validation, token use, benchmark success, value, readiness, security/privacy completion, public API readiness, `/v1/solve` readiness, dashboard readiness, Google Sheets synchronization, or Alpha superiority.
+It does **not** support claims of provider validation, local Ollama validation, hosted-model validation, token use, benchmark success, value, readiness, security/privacy completion, public API readiness, `/v1/solve` readiness, dashboard readiness, Pi.dev integration, Google Sheets synchronization, or Alpha superiority.

--- a/docs/LANE_REGISTRY.md
+++ b/docs/LANE_REGISTRY.md
@@ -1,7 +1,7 @@
 # Lane Registry
 
 > Source-of-truth lane lifecycle registry. Verification date **2026-06-15** after
-> live GitHub verification of PRs #566–#568.
+> live GitHub API verification of **0 open PRs** and merged PRs **#569–#574**.
 
 ## Lifecycle classes
 
@@ -11,13 +11,13 @@
 
 | Lane | State | Evidence |
 |------|-------|----------|
-| Post-#568 Value Read blocked state | **current control posture** | PRs #566, #567, and #568 are merged. PR #568 committed a stopped manual Value Read artifact with no output generation and no scoring. |
+| Post-#574 backlog/current-state sync posture | **current control posture** | PRs #569–#574 are merged. The newest evidence is docs/research/gate/helper work: post-#568 source-of-truth sync, founder memo refresh, blocked `/v1/solve` exposure gate, local Ollama helper, failed-closed local Ollama attempt, and Pi.dev no-integration feasibility note. |
 
 ## Next ready
 
 | Lane | State | Notes |
 |------|-------|-------|
-| **`ALPHA-SOLVER-VALUE-READ-EXECUTION-PACKET-AUTHORIZATION-001`** | **selected next** | Controlled execution authorization packet/lane only. Must include complete per-case prompts, raw-output preservation, blinding-map storage, output-generation boundary, and explicit operator authorization requirements before any outputs are generated. |
+| **`ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001`** | **selected next** | Alpha-native design note only. Borrow useful Pi.dev-style operator-harness patterns without installing Pi.dev, integrating Pi.dev, changing runtime behavior, exposing `/v1/solve`, calling providers/models, or mutating Google Sheets. |
 
 ## Completed (kept as evidence)
 
@@ -30,29 +30,38 @@
 - `ALPHA-SOLVER-PROMPT-CONTRACT-SIMULATION-METHODOLOGY-001` (PR #564) — prompt-contract simulation methodology.
 - `ALPHA-SOLVER-LOCAL-MODEL-LAB-OLLAMA-SINGLEPATH-001` (PR #565) — local Ollama singlepath lab scaffold.
 - `ALPHA-SOLVER-VALUE-READ-SIMULATION-PACKET-REFRESH-POST-565-001` (PRs #566–#568) — packet refresh plus blocked manual-run artifact; no Alpha/baseline outputs or scores.
+- Post-#568 current-state sync (PR #569) — source-of-truth docs and MVP scorecard refresh for `VALUE_READ_BLOCKED`.
+- Founder memo refresh (PR #570) — narrative positioning for the blocked Value Read state.
+- `14 - V1 Solve Exposure Gate Packet` (PR #571) — `/v1/solve` public exposure is `BLOCKED`.
+- Local Ollama singlepath operator helper (PR #572) — local-only helper added; no successful model run implied.
+- Local Ollama singlepath blocked attempt (PR #573) — exact `gemma3:4b` model preflight passed, then helper failed closed with timeout/backend error and produced no local answer.
+- `18 - PI.DEV-HARNESS-FEASIBILITY` (PR #574) — `BORROW_PATTERNS_ONLY_NO_INTEGRATION` research note.
 
 ## Superseded
 
 | Lane / PR | Superseded by | Why |
 |-----------|---------------|-----|
 | PR #561 — `Add needs-human escalation protocol` | PR #562 | #561 is closed unmerged; #562 merged the docs-only needs-human protocol. |
-| Older smoke-authorization selected-next pointers | Post-#565 selected next lane in this registry and [`CURRENT_STATE.md`](CURRENT_STATE.md) | The #557–#565 wave changed the active posture to Value Read infrastructure consolidation. |
+| Older smoke-authorization selected-next pointers | Post-#568 and post-#574 selected-next lanes in this registry and [`CURRENT_STATE.md`](CURRENT_STATE.md) | The #557–#574 wave changed the active posture to Value Read blocked evidence, exposure/local-lab gates, and an Alpha-native harness design next step. |
+| `ALPHA-SOLVER-VALUE-READ-EXECUTION-PACKET-AUTHORIZATION-001` as immediate global next | PR #574's proposed `ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001` | Value Read execution remains blocked; the newest merged research note selects a safer docs-only harness design lane. |
 
 ## Blocked / not authorized
 
 | Lane / activity | Blocked by | Unblock condition |
 |-----------------|-----------|-------------------|
-| Provider calls / hosted model runs / token use | Hard boundary for current docs-only consolidation | Separate explicit operator authorization in a future lane. |
-| Local model / Ollama execution | Current #565 scaffold is design/local-lab lane only | Separate operator-managed local run authorization and preserved evidence boundaries. |
-| Dashboard, `/v1/solve`, public API exposure | Not part of the selected next lane | Separate exposure/readiness/security lane. |
-| Google Sheets or backlog workbook mutation | Repo task boundary | Operator-managed external ledger process only. |
-| Value/readiness/provider/security/privacy/Alpha-superiority claims | PR #568 generated no outputs and no scores; no execution or validation evidence exists | Properly scoped future evidence with pre-registered boundaries. |
+| Provider calls / hosted model runs / token use | Hard boundary for current docs-only sync | Separate explicit operator authorization in a future lane. |
+| Local model / Ollama execution | Current evidence includes a failed-closed local attempt, not validation | Separate operator-managed local run authorization and preserved evidence boundaries; do not treat #573 as quality/readiness evidence. |
+| Dashboard, `/v1/solve`, public API exposure | PR #571 exposure gate verdict is `BLOCKED` | Separate exposure/readiness/security lane after identity, tenancy, logging, redaction, rate-limit, CORS/ingress, monitoring, incident-response, rollback, and authorization questions are resolved. |
+| Pi.dev installation, execution, or integration | PR #574 recommends patterns-only/no-integration | Separate spec, threat model, package/provenance review, sandbox, no-secret workspace, provider/key policy, export policy, and operator authorization. |
+| Google Sheets or backlog workbook mutation | Repo task boundary | Operator-managed external ledger process only; this repo PR may include paste-ready sheet updates but must not mutate the Sheet. |
+| Value/readiness/provider/security/privacy/local-Ollama/Pi.dev/Alpha-superiority claims | No execution or validation evidence exists; #568 has no outputs/scores and #573 failed closed | Properly scoped future evidence with pre-registered boundaries. |
 
 ## Do not run again (as-is)
 
 - PR #561 lane as a standalone needs-human protocol PR — closed unmerged and superseded by PR #562.
 - Any merged packet lane verbatim — packets are immutable evidence; create a new lane id instead.
-- Any selected-next pointer that predates this post-#565 consolidation if it conflicts with `ALPHA-SOLVER-VALUE-READ-SIMULATION-PACKET-REFRESH-POST-565-001`.
+- Any selected-next pointer that predates this post-#574 sync if it conflicts with `ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001`.
+- Direct Pi.dev integration from PR #574's research lane — the recorded verdict is patterns-only/no-integration.
 
 ## Forward path (single track)
 
@@ -70,7 +79,15 @@
 ALPHA-SOLVER-VALUE-READ-SIMULATION-PACKET-REFRESH-POST-565-001 / PR #568 artifact ← VALUE_READ_BLOCKED
         │
         ▼
-ALPHA-SOLVER-VALUE-READ-EXECUTION-PACKET-AUTHORIZATION-001 ← selected next; controlled authorization packet/lane only
+#569 current-state sync
+#570 founder memo refresh
+#571 /v1/solve exposure gate ← BLOCKED
+#572 local Ollama helper
+#573 local Ollama attempt ← FAILED_CLOSED_TIMEOUT / no local answer
+#574 Pi.dev harness feasibility ← BORROW_PATTERNS_ONLY_NO_INTEGRATION
+        │
+        ▼
+ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001 ← selected next; Alpha-native docs-only design lane
 ```
 
-This registry does not authorize any provider call, local model call, runtime exposure, public API exposure, Google Sheets mutation, or readiness/value claim.
+This registry does not authorize any provider call, local model call, Pi.dev install/run/integration, runtime exposure, public API exposure, Google Sheets mutation, or readiness/value/security/privacy/provider/local-Ollama/Alpha-superiority claim.


### PR DESCRIPTION
### Motivation
- Live GitHub verification showed merged PRs through `#574` while the repo source-of-truth docs still described a post-#568 state, so the docs needed a targeted refresh to reflect the latest merged evidence and selected next lane.
- The refresh also needed to record recent docs/gate/helper/blocked-attempt/research artifacts and maintain explicit non-claim and blocked-action boundaries (no provider/local runs, no `/v1/solve` exposure, no Sheet mutation). 

### Description
- Update `docs/CURRENT_STATE.md` to reflect merged PRs `#569–#574`, summarize the post-#574 posture, and set the selected next lane to `ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001` while preserving blocked/non-claim language. 
- Update `docs/LANE_REGISTRY.md` to record the post-#574 lifecycle state, completed lanes (including the blocked `/v1/solve` gate and the failed-closed local Ollama attempt), superseded pointers, blocked activities (including `Pi.dev` integration), and the single-track forward path. 
- Update `docs/EVIDENCE_INDEX.md` to add evidence rows for PRs `#569–#574` and expand the evidence/non-claim wording to include gate/helper/blocked-attempt/research artifacts without claiming runtime/provider/local readiness. 
- This is a docs-only change and does not alter runtime code, tests, or execution surfaces. 

### Testing
- Verified live GitHub state via the GitHub API and confirmed `0 open PRs` and merged PRs through `#574`, and this check passed. 
- Ran `git diff --check` style validation and a focused Python assertion script that ensures the updated docs contain the expected `#574` and Google Sheets / non-claim language, and both checks passed. 
- Created a PR record for the docs-only sync and validated that the three updated files are consistent with the intended post-#574 narrative and blocked-action boundaries (all automated checks succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a305b2070c483298be57900b6612518)