### PR TITLE
Add Alpha-native local operator harness design note

### DIFF
--- a/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/README.md
+++ b/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/README.md
@@ -1,0 +1,53 @@
+# Alpha-native Local Operator Harness Design Note
+
+## Lane ID
+
+`ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001`
+
+## Verdict
+
+`DESIGN_NOTE_ONLY_NO_RUNTIME_NO_PI_INTEGRATION`
+
+## TLDR
+
+This packet converts the post-#574 Pi.dev patterns-only decision into an Alpha-native, paper-only local operator harness concept. It borrows safe interaction patterns such as named prompt packets, explicit operator actions, session-tree evidence, export discipline, interrupt/follow-up semantics, message-card fields, local-first defaults, and future package/skill review gates. It does not install, run, vendor, or integrate Pi.dev, and it does not change runtime, API, dashboard, provider, model, scoring, routing, or Google Sheets behavior.
+
+## Evidence boundary
+
+This packet is documentation-only design evidence. It is not execution evidence, not value evidence, not provider evidence, not local-model evidence, not benchmark evidence, not readiness evidence, not security/privacy completion evidence, not `/v1/solve` exposure evidence, not dashboard exposure evidence, not Pi.dev integration evidence, and not Alpha superiority evidence.
+
+The packet records only a bounded design proposal and safety boundaries for possible future operator-harness work. Any future implementation, tool activation, package/skill use, model call, provider call, local run, or external export requires separate explicit operator authorization.
+
+## Files reviewed
+
+Primary source files reviewed from live repo state:
+
+- `docs/CURRENT_STATE.md`
+- `docs/LANE_REGISTRY.md`
+- `docs/EVIDENCE_INDEX.md`
+- `docs/evals/runs/alpha-solver-pi-dev-harness-feasibility-018/README.md`
+- `docs/evals/runs/alpha-solver-local-model-lab-ollama-singlepath-001/local-run-artifact-2026-06-15.md`
+- `docs/evals/runs/alpha-solver-value-read-simulation-packet-refresh-post-565-001/manual-run-artifact-2026-06-15.md`
+
+## Design summary
+
+The proposed Alpha-native local operator harness is a repo-local review pattern, not a runtime product. It would organize future operator work around:
+
+1. named local prompt templates that point back to committed packets;
+2. explicit operator actions with approval gates and stop reasons;
+3. session evidence records with raw-output pointers, score pointers, branch labels, redaction status, and non-claims;
+4. message cards that expose answerability, confidence, assumptions, false-premise flags, hidden constraints, needs-human state, derivation/no-echo status, route explanation, evidence links, and next-safe-action;
+5. interrupt, follow-up, and evidence-review semantics that stop or queue work instead of silently continuing;
+6. local-first, no-upload defaults and package/skill review rules before any future tooling.
+
+## Non-actions
+
+This packet does not perform or authorize any action listed in `non-actions.md`, including Pi.dev installation/execution/integration, dependency installation, provider calls, model calls, credential access, runtime/API/dashboard changes, `/v1/solve` exposure, Google Sheets mutation, benchmark/scoring/routing/council changes, or feature activation for shell/file/MCP/email/calendar/memory tooling.
+
+## Non-claims
+
+This packet does not make any claim listed in `non-claims.md`, including value, readiness, provider, local-model, benchmark, production, public-use, security/privacy completion, partnership, dashboard, `/v1/solve`, Pi.dev integration, or Alpha superiority claims.
+
+## Recommended next action
+
+Keep this as a completed design note and require an explicit operator decision before any implementation, tool activation, dependency change, model/provider call, runtime exposure, or external export.

--- a/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/alpha-native-harness-design-note.md
+++ b/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/alpha-native-harness-design-note.md
@@ -1,0 +1,54 @@
+# Alpha-native Harness Design Note
+
+## Purpose
+
+This note defines a concise Alpha-native local operator harness concept for future review. The design adapts safe operator-workflow patterns recorded after the Pi.dev feasibility review while preserving Alpha Solver's repo-native specs, evidence boundaries, budget guardrails, and no-runtime-change posture.
+
+## Design concept
+
+An Alpha-native local operator harness would be a local evidence-workbench pattern that helps an operator run authorized repo tasks in a disciplined sequence:
+
+1. choose a committed packet or prompt template by name;
+2. declare the branch label, task id, evidence boundary, and stop conditions before work begins;
+3. record each operator action as an explicit step with an approval state;
+4. preserve raw outputs by pointer, not by uncontrolled copy/paste;
+5. attach score pointers, redaction state, non-claims, stop reason, and operator decision;
+6. export only sanitized evidence artifacts after review.
+
+For this lane, the harness remains a paper design. No executable automation, provider adapter, local model adapter, dashboard panel, API endpoint, routing change, scoring engine, or package integration is added.
+
+## Why this is not a generic chat UI
+
+The design is evidence-first, not chat-first. A generic chat UI centers a conversation stream. The Alpha-native concept centers lane ids, prompt sources, evidence boundaries, stop conditions, score pointers, non-claims, and export discipline.
+
+The proposed message card is not merely a prettier assistant answer. It is a structured review surface for Alpha's existing discrimination wedge:
+
+- answerability and confidence are recorded before broad claims;
+- assumptions, false premises, hidden constraints, and needs-human conditions are visible;
+- derivation/no-echo status distinguishes substantive reasoning from prompt reflection;
+- route explanations and evidence links make provenance inspectable;
+- next-safe-action prevents uncontrolled continuation.
+
+## Why this is not Pi.dev integration
+
+This lane does not install, run, vendor, copy, configure, depend on, or runtime-link Pi.dev. It borrows only high-level workflow ideas that are safe to describe in Alpha's own docs: named prompt packets, explicit operator actions, session-tree evidence, export discipline, interrupt/follow-up semantics, message/evidence-card concepts, local-first defaults, and review rules for any future package or skill.
+
+Any future Pi.dev experiment would require a separate threat model, package/provenance review, sandbox, no-secret fixture workspace, provider/key policy, export policy, and explicit operator authorization. This design note does not grant that authorization.
+
+## Support for Alpha's wedge
+
+### Discrimination
+
+The harness concept keeps discrimination dimensions visible during operator review: false-premise detection, hidden-constraint handling, no-echo substantive derivation, needs-human mapping, confidence calibration, claim-boundary discipline, and evidence-conflict handling. It does not score those dimensions automatically; it specifies where future authorized evidence and score pointers would be recorded.
+
+### Stopping
+
+The harness concept treats stopping as a first-class outcome. A stopped session can be valid evidence if it records the stop condition, missing authorization, missing raw output, failed preflight, evidence conflict, or needs-human gate. This mirrors the blocked Value Read artifact and the failed-closed local Ollama attempt: stopped work must not be converted into success, value, or readiness claims.
+
+### Evidence
+
+The harness concept separates prompt source, raw output pointer, score pointer, redaction status, operator decision, and non-claims. This prevents a session transcript from being mistaken for scored evidence, runtime validation, provider validation, or model-quality evidence.
+
+### Provenance
+
+Each session record would name the lane id, branch label, task id, prompt source, repo commit when available, artifact pointers, and export decisions. Provenance is local-first and review-gated by default.

--- a/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/checks-run.md
+++ b/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/checks-run.md
@@ -1,0 +1,14 @@
+# Checks Run
+
+This file records checks for the docs-only design packet. It does not record runtime execution, model/provider calls, benchmark execution, scoring, dashboard exposure, `/v1/solve` exposure, or Google Sheets mutation.
+
+| Check | Status | Notes |
+| --- | --- | --- |
+| `git diff --check` | Pass | Whitespace check only. |
+| `python scripts/check_narrative_claim_safety.py docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/README.md docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/alpha-native-harness-design-note.md docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/message-card-and-evidence-trail-spec.md docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/non-claims.md` | Pass | Narrative claim-safety linter scanned the requested new Markdown files. This is not a completeness claim. |
+| `test -f ...` minimum-file presence check | Pass | Confirmed all required packet files exist. |
+| `rg -n 'DESIGN_NOTE_ONLY_NO_RUNTIME_NO_PI_INTEGRATION|No Pi\.dev install|No provider calls|No `/v1/solve` exposure|No Google Sheets mutation' docs/evals/runs/alpha-solver-local-operator-harness-design-note-001` | Pass | Confirmed required verdict and selected hard-boundary phrases appear in the packet. |
+
+## Non-execution attestation
+
+During packet preparation, Pi.dev was not installed, run, copied, vendored, or integrated; dependencies were not added; providers were not called; tokens were not used; credentials were not accessed; hosted models were not run; local models were not run; models were not pulled or installed; dashboard behavior was not exposed; `/v1/solve` was not exposed; public API behavior was not exposed; runtime/API/dashboard code was not modified; package/skill/shell/file/MCP/email/calendar/memory features were not activated; benchmark/scoring/routing/council/model-comparison/local-model-registry/provider behavior was not added; and Google Sheets were not mutated.

--- a/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/interrupt-followup-semantics.md
+++ b/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/interrupt-followup-semantics.md
@@ -1,0 +1,58 @@
+# Interrupt and Follow-up Semantics
+
+This document defines paper-only operator semantics for a future Alpha-native local operator harness. It does not implement runtime orchestration or UI behavior.
+
+## Operator interrupt
+
+An operator interrupt is an explicit instruction to stop the current action immediately and preserve the current evidence state. The session must record:
+
+- who or what initiated the interrupt;
+- the current task id and operator action;
+- whether raw output exists;
+- whether raw output is authorized to preserve;
+- the stop reason;
+- the next-safe-action.
+
+An interrupt must not silently convert into a new provider call, model call, file operation, package install, external upload, or runtime exposure.
+
+## Stop-condition
+
+A stop-condition is a predeclared boundary that requires halting or escalation. Examples:
+
+- missing operator authorization;
+- request to use tokens, credentials, providers, hosted models, or local models;
+- request to install packages or activate tools;
+- request to expose dashboard, public API behavior, or `/v1/solve`;
+- evidence conflict or missing raw output;
+- needs-human/legal/safety/security/privacy boundary;
+- attempt to make value, readiness, benchmark, provider, local-model, public-use, or Alpha superiority claims without evidence.
+
+## Queued follow-up
+
+A queued follow-up is a future task request recorded without execution. It should include:
+
+- follow-up id;
+- requested action;
+- required authorization;
+- required evidence inputs;
+- blocked claims;
+- proposed next-safe-action.
+
+Queued follow-ups do not imply authorization. They are planning entries only.
+
+## Approval gate
+
+An approval gate is a required operator decision before crossing a boundary. Approval gates are required before any future:
+
+- implementation;
+- dependency or package change;
+- Pi.dev experiment;
+- provider or model call;
+- credential or token use;
+- dashboard, API, or `/v1/solve` exposure;
+- Google Sheets or external-ledger mutation;
+- benchmark, scoring, routing, council, registry, or comparison behavior.
+
+## Evidence-review intervention
+
+An evidence-review intervention is an operator action that pauses interpretation until provenance, raw-output pointers, score pointers, redaction state, and non-claims are checked. It should be used when a transcript, output, or summary could be mistaken for stronger evidence than it supports.

--- a/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/message-card-and-evidence-trail-spec.md
+++ b/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/message-card-and-evidence-trail-spec.md
@@ -1,0 +1,64 @@
+# Message Card and Evidence Trail Spec
+
+This is a paper-only UI/spec for an Alpha message card and evidence trail. It does not add runtime UI, dashboard UI, API behavior, public exposure, provider behavior, or model behavior.
+
+## Alpha message card fields
+
+| Field | Purpose | Example bounded values |
+| --- | --- | --- |
+| `answerability` | State whether the task can be answered under current evidence. | `answerable`, `needs_clarification`, `blocked`, `should_escalate`. |
+| `confidence` | Record confidence level with reason. | `low`, `medium`, `high`, plus a short evidence reason. |
+| `assumptions` | List assumptions detected in the user task or packet. | `operator wants docs-only design`, `no execution authorized`. |
+| `false_premise_flag` | Mark whether the prompt contains an unsupported premise. | `none_detected`, `possible`, `detected`. |
+| `hidden_constraints` | Name constraints that must govern the answer. | `no provider calls`, `no runtime changes`, `no Pi.dev integration`. |
+| `needs_human` | Indicate whether operator/human review is required before continuation. | `false`, `true: implementation authorization required`. |
+| `will_not_claim` | Record claims the answer refuses to make. | `value evidence`, `production readiness`, `Alpha superiority`. |
+| `derivation_no_echo_status` | Distinguish substantive synthesis from prompt echo. | `derived_from_sources`, `summary_only`, `blocked_no_derivation`. |
+| `route_explanation` | Explain why the answer path was chosen. | `docs-only lane selected by current-state and lane registry`. |
+| `evidence_links` | Link to repo evidence paths or local pointers. | `docs/CURRENT_STATE.md`, packet files, raw-output pointer if authorized. |
+| `next_safe_action` | Name the next action that stays inside evidence boundaries. | `require operator decision before implementation`. |
+
+## Message card outline
+
+```text
+Answerability: <value>
+Confidence: <level and reason>
+Assumptions: <list>
+False-premise flag: <value>
+Hidden constraints: <list>
+Needs-human: <state and reason>
+Will-not-claim: <list>
+Derivation/no-echo status: <status>
+Route explanation: <bounded route>
+Evidence links: <repo paths or local pointers>
+Next-safe-action: <one action>
+```
+
+## Evidence-trail screen outline
+
+A future local-only evidence-trail screen could display:
+
+1. lane id and branch label;
+2. prompt source and named operator action;
+3. session-tree steps in chronological order;
+4. raw output pointer, if authorized output exists;
+5. score pointer, if authorized scoring exists;
+6. stop reason and operator decision;
+7. non-claims attached to the session;
+8. redaction/export status;
+9. next-safe-action.
+
+The screen would be local-only by default. It would not upload evidence, expose dashboards, expose `/v1/solve`, call providers, call local models, or mutate external ledgers.
+
+## Blind-compare review outline
+
+If a future authorized lane includes blind comparison, the evidence trail should keep these phases separate:
+
+1. **Case registration:** task id, prompt source, evidence boundary, and non-claims are locked.
+2. **Output collection:** raw Output A and Output B pointers are preserved under the authorized mechanism.
+3. **Blind scoring:** scores are recorded before unblinding.
+4. **Unblind step:** identity mapping is revealed only after score lock.
+5. **Interpretation:** conclusions are limited to the case set, scoring rubric, and evidence boundary.
+6. **Export review:** redaction and non-claims are checked before any sanitized artifact is committed.
+
+No blind-compare behavior is implemented in this lane.

--- a/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/non-actions.md
+++ b/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/non-actions.md
@@ -1,0 +1,34 @@
+# Non-actions
+
+This lane explicitly does not do or authorize the following:
+
+- install Pi.dev;
+- run Pi.dev;
+- copy Pi.dev code;
+- vendor Pi.dev;
+- add Pi.dev as a dependency;
+- add any dependency;
+- install packages;
+- modify runtime code;
+- modify API code;
+- modify dashboard code;
+- expose `/v1/solve`;
+- expose dashboard behavior;
+- expose public API behavior;
+- call providers;
+- use provider tokens;
+- access credentials;
+- inspect billing;
+- run hosted models;
+- run local models;
+- pull or install models;
+- mutate Google Sheets;
+- add benchmark behavior;
+- add scoring behavior;
+- add routing behavior;
+- add council behavior;
+- add model-comparison behavior;
+- add local model registry behavior;
+- add provider behavior;
+- activate shell/file/MCP/email/calendar/memory features for a future harness;
+- create production, public, runtime, provider, local model, benchmark, security/privacy, value, partnership, or Alpha superiority claims.

--- a/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/non-claims.md
+++ b/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/non-claims.md
@@ -1,0 +1,26 @@
+# Non-claims
+
+This design packet does not claim:
+
+- Alpha Solver value has been measured;
+- Alpha Solver beats, outperforms, or is superior to any baseline, provider, model, product, or workflow;
+- no claim that Alpha Solver has production, public, MVP, pilot, customer, or runtime readiness;
+- no claim that any provider behavior has validation evidence;
+- any hosted model was called;
+- any local model was called;
+- no claim that local Ollama behavior has validation evidence;
+- the prior failed-closed local Ollama attempt produced quality evidence;
+- a benchmark was run;
+- blind scoring was performed;
+- discrimination delta was measured;
+- `/v1/solve` is ready or exposed;
+- dashboard behavior is ready or exposed;
+- public API behavior is ready or exposed;
+- security/privacy review is complete;
+- credentials, tokens, billing, or subscriptions were reviewed;
+- Pi.dev is installed, approved, integrated, runtime-linked, or safe for Alpha Solver use;
+- no claim that Pi.dev provider behavior or package behavior has validation evidence;
+- package/skill tooling is approved;
+- Google Sheets or external ledgers were updated;
+- a future implementation is authorized;
+- a future local operator harness would be safe without separate threat modeling, review, sandboxing, and operator approval.

--- a/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/operator-action-template-map.md
+++ b/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/operator-action-template-map.md
@@ -1,0 +1,29 @@
+# Operator Action Template Map
+
+This is a paper-only map from repo prompt packets to possible named local operator actions. It defines names and review intent only. It does not create executable automation.
+
+| Example local action name | Prompt/source packet | Intended operator use | Required boundary before use |
+| --- | --- | --- | --- |
+| `open-current-state-context` | `docs/CURRENT_STATE.md` | Review the current selected lane, blocked activities, and non-claims. | Inspect-only docs review. |
+| `open-lane-registry-context` | `docs/LANE_REGISTRY.md` | Confirm lifecycle status and avoid reopening superseded or blocked lanes. | Inspect-only docs review. |
+| `open-evidence-ledger-context` | `docs/EVIDENCE_INDEX.md` | Check what existing artifacts can and cannot support. | Inspect-only docs review. |
+| `review-pi-patterns-only-note` | `docs/evals/runs/alpha-solver-pi-dev-harness-feasibility-018/README.md` | Extract safe high-level patterns without integration. | No Pi.dev install, run, dependency, or code copy. |
+| `record-local-harness-design-note` | This packet | Draft Alpha-native design artifacts and boundaries. | Docs-only writing; no runtime change. |
+| `prepare-value-read-authorization-return` | `docs/evals/runs/alpha-solver-value-read-simulation-packet-refresh-post-565-001/manual-run-artifact-2026-06-15.md` | Return to Value Read authorization only if the operator wants value evidence next. | Separate explicit execution authorization required. |
+| `review-local-ollama-blocked-attempt` | `docs/evals/runs/alpha-solver-local-model-lab-ollama-singlepath-001/local-run-artifact-2026-06-15.md` | Preserve failed-closed local-run lessons without rerunning or changing model behavior. | No model call, pull, install, timeout extension, or rerun unless separately authorized. |
+| `draft-message-card` | `.specs/ALPHA-SOLVER-CALIBRATED-CONFIDENCE-OUTPUT-CONTRACT-001.md` and this packet | Sketch an evidence card with answerability, confidence, assumptions, and non-claims. | Paper-only UI/spec; no runtime UI. |
+| `apply-needs-human-boundary` | `.specs/ALPHA-SOLVER-ESCALATION-NEEDS-HUMAN-PROTOCOL-001.md` | Mark a task as needs-human when scope or risk requires escalation. | No autonomous continuation past escalation. |
+| `lint-narrative-claims` | `scripts/check_narrative_claim_safety.py` | Run static claim-safety lint on docs artifacts. | Static lint only; not completeness or readiness evidence. |
+
+## Naming convention
+
+Future local action names should be short imperative labels:
+
+- start with a verb: `open`, `review`, `record`, `prepare`, `draft`, `apply`, `lint`;
+- name the evidence source or decision boundary;
+- avoid names that imply execution unless execution is separately authorized;
+- avoid names that imply provider/model/runtime behavior.
+
+## Explicit non-automation boundary
+
+This map does not add commands, scripts, configs, packages, routes, dashboard components, model calls, provider calls, or MCP tools. It is a vocabulary for future human/operator review only.

--- a/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/security-data-boundary-checklist.md
+++ b/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/security-data-boundary-checklist.md
@@ -1,0 +1,29 @@
+# Security and Data Boundary Checklist
+
+This checklist is mandatory for interpreting this design note. Every item is a blocked action for this lane.
+
+- No external upload.
+- No provider calls.
+- No token use.
+- No credentials.
+- No model calls.
+- No hosted model calls.
+- No local model calls.
+- No model pull or install.
+- No dashboard exposure.
+- No `/v1/solve` exposure.
+- No public API exposure.
+- No Google Sheets mutation.
+- No Pi.dev install.
+- No Pi.dev run.
+- No Pi.dev integration.
+- No Pi.dev vendoring or code copy.
+- No package install.
+- No dependency addition.
+- No shell feature activation for a future harness.
+- No file-operation feature activation for a future harness.
+- No MCP feature activation for a future harness.
+- No email feature activation.
+- No calendar feature activation.
+- No memory feature activation.
+- No credentials, auth files, env files, billing pages, subscription pages, or private token stores may be inspected for this lane.

--- a/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/selected-next-lane.md
+++ b/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/selected-next-lane.md
@@ -1,0 +1,18 @@
+# Selected Next Lane
+
+## Recommendation
+
+Keep `ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001` as a completed design note and require an explicit operator decision before any implementation.
+
+## One next action only
+
+Ask the operator to choose whether to:
+
+- authorize a separate implementation/spec lane for a local-only harness, or
+- return to Value Read execution authorization if the operator wants value evidence next.
+
+Default: no implementation, no tool activation, no dependency change, no provider/model call, no runtime exposure, and no external export without a new explicit lane.
+
+## Global source-of-truth boundary
+
+This packet does not silently change `docs/CURRENT_STATE.md`, `docs/LANE_REGISTRY.md`, or `docs/EVIDENCE_INDEX.md` selected-next pointers.

--- a/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/session-evidence-format.md
+++ b/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/session-evidence-format.md
@@ -1,0 +1,62 @@
+# Session Evidence Format
+
+This is a paper-only format for future Alpha-native local operator sessions. It is not a runtime schema and does not create storage, UI, API, or automation.
+
+## Required fields
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `session_id` | yes | Stable local identifier, for example `alpha-local-harness-YYYY-MM-DD-###`. |
+| `branch_label` | yes | Human-readable branch or lane label. |
+| `task_id` | yes | Packet case id, lane id, or operator task id. |
+| `lane_id` | yes | Controlling lane id. |
+| `repo_commit` | recommended | Commit SHA inspected or changed, when applicable. |
+| `prompt_source` | yes | Repo path and section for the prompt/template source. |
+| `operator_action` | yes | Named local operator action from the template map or future approved equivalent. |
+| `evidence_boundary` | yes | Short statement of what the session can and cannot support. |
+| `raw_output_pointer` | conditional | Local pointer to raw output if generated under authorization; otherwise `none`. |
+| `score_pointer` | conditional | Local pointer to blind scores/rubric output if scoring occurred under authorization; otherwise `none`. |
+| `non_claims` | yes | Claims that the session must not support. |
+| `stop_reason` | yes | `completed_docs_only`, `blocked_missing_authorization`, `blocked_no_raw_output`, `failed_closed`, `needs_human`, `evidence_conflict`, or another explicit reason. |
+| `operator_decision` | yes | `stop`, `continue_within_scope`, `queue_followup`, `escalate_to_human`, or `export_sanitized`. |
+| `export_status` | yes | `not_exported`, `sanitized_export_ready`, `exported_sanitized`, or `blocked_export`. |
+| `redaction_status` | yes | `not_needed`, `pending_review`, `redacted`, or `blocked_contains_sensitive_material`. |
+| `external_upload` | yes | Must default to `no`. |
+| `provider_or_model_call` | yes | Must record `none` unless a future lane explicitly authorizes otherwise. |
+
+## Example record shape
+
+```yaml
+session_id: alpha-local-harness-2026-06-15-001
+branch_label: local-operator-harness-design-note
+task_id: ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001
+lane_id: ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001
+repo_commit: pending
+prompt_source: docs/CURRENT_STATE.md#selected-next-lane
+operator_action: record-local-harness-design-note
+evidence_boundary: docs-only design note; no runtime, provider, model, dashboard, API, or Pi.dev integration evidence
+raw_output_pointer: none
+score_pointer: none
+non_claims:
+  - no value evidence
+  - no runtime readiness evidence
+  - no Pi.dev integration evidence
+  - no Alpha superiority evidence
+stop_reason: completed_docs_only
+operator_decision: stop
+export_status: sanitized_export_ready
+redaction_status: not_needed
+external_upload: no
+provider_or_model_call: none
+```
+
+## Export and redaction fields
+
+A future session should not be exported until the operator records:
+
+- whether raw output exists and where it is stored;
+- whether the raw output contains secrets, credentials, private prompts, private traces, personal data, or private workspace paths;
+- whether redaction has been reviewed;
+- whether the export is summary-only or includes sanitized excerpts;
+- which non-claims must accompany the export;
+- whether the export creates any public-surface, provider, model, value, or readiness confusion.


### PR DESCRIPTION
### Motivation

- Convert the post-#574 Pi.dev patterns-only decision into an Alpha-native, docs-only local operator harness design note that captures useful operator-harness patterns while preserving strict no-runtime, no-provider, and no-install boundaries. 
- Define a repo-local, evidence-first workflow (named prompt templates, operator actions, session evidence, interrupt/follow-up semantics, and message/evidence-card ideas) without adding dependencies, runtime changes, provider calls, or external exports.

### Description

- Added a new docs-only packet at `docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/` containing the design note and supporting artifacts: `README.md`, `alpha-native-harness-design-note.md`, `operator-action-template-map.md`, `session-evidence-format.md`, `message-card-and-evidence-trail-spec.md`, `interrupt-followup-semantics.md`, `security-data-boundary-checklist.md`, `non-actions.md`, `non-claims.md`, `selected-next-lane.md`, and `checks-run.md`.
- Packet verdict set to `DESIGN_NOTE_ONLY_NO_RUNTIME_NO_PI_INTEGRATION` and the design explicitly borrows Pi.dev-style patterns only at a conceptual level while forbidding Pi.dev install/run/integration, provider/model calls, token/credential use, `/v1/solve` exposure, Google Sheets mutation, dependency additions, and runtime/API/dashboard changes.
- Key artifacts define: a concise Alpha-native harness concept, why this is not a generic chat UI, operator-action name vocabulary (no automation), a paper-only session evidence format (session id, branch label, task id, prompt source, raw-output pointer, score pointer, non-claims, stop reason, operator decision, export/redaction fields), message-card and evidence-trail spec, interrupt/follow-up semantics, and a security/data boundary checklist.
- Recommended next action is singular: keep this as a completed design note and require explicit operator decision before any implementation or execution, or alternatively return to Value Read execution authorization if the operator requests value evidence next.

### Testing

- Ran `git diff --check` and it passed whitespace checks (`PASS`).
- Ran narrative claim-safety lint: `python scripts/check_narrative_claim_safety.py docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/README.md docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/alpha-native-harness-design-note.md docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/message-card-and-evidence-trail-spec.md docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/non-claims.md` and the linter passed (`PASS`).
- Verified presence of required files with `test -f ...` style checks and confirmed required hard-boundary phrases via `rg -n 'DESIGN_NOTE_ONLY_NO_RUNTIME_NO_PI_INTEGRATION|No Pi\.dev install|No provider calls|No `/v1/solve` exposure|No Google Sheets mutation'` (all `PASS`).
- All recorded checks are summarized in the new `checks-run.md` inside the packet and succeeded; no runtime, provider, credential, or external actions were performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3062d36760832998c113763fc3d194)