### PR TITLE
docs: complete local-operator-harness design note and set selected-next to operator-decision (PR #576)

### DIFF
--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -1,13 +1,13 @@
 # Alpha Solver — Current State
 
-> Source-of-truth navigation doc. Last verified **2026-06-15** for PR **#576** branch repair.
+> Source-of-truth navigation doc. Last verified **2026-06-15** for PR **#577** replacement branch repair.
 > Docs-only; no provider/runtime claims.
 
 ## Current verified phase
 
-**Post-#576 posture: the Alpha-native local operator harness design note is complete, and an explicit operator decision is required before any next lane.**
+**Post-#577 posture: the Alpha-native local operator harness design note is complete, and an explicit operator decision is required before any next lane.**
 
-The merged #569–#574 wave updated the repository from the post-#568 blocked Value Read state to a broader documentation-and-boundary posture. PR #576 then completed `ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001` as a docs-only Alpha-native local operator harness design note.
+The merged #569–#574 wave updated the repository from the post-#568 blocked Value Read state to a broader documentation-and-boundary posture. PR #576 was superseded by PR #577 and should be closed unmerged. PR #577 completes `ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001` as a docs-only Alpha-native local operator harness design note.
 
 The current control posture is now `OPERATOR_DECISION_REQUIRED_AFTER_LOCAL_OPERATOR_HARNESS_DESIGN_NOTE_001`: no further implementation or execution lane is selected automatically. The operator must explicitly choose one future path before any new lane:
 
@@ -23,8 +23,8 @@ These are docs, gate, helper, static/research, and blocked-attempt artifacts. Th
 
 | Field | Value |
 |-------|-------|
-| Latest verified PR in this wave | **#576** — Alpha-native local operator harness design note completed by this PR |
-| PR branch state at verification | **#576 open / pending merge** on `adonisdv23/Alpha-Solver` |
+| Latest verified PR in this wave | **#577** — Alpha-native local operator harness design note completed by this PR |
+| PR branch state at verification | **#577 replacement merge candidate** on `adonisdv23/Alpha-Solver`; PR #576 superseded and should be closed unmerged |
 | Closed-unmerged superseded PR | **#561** — superseded by merged PR #562 |
 | Current controlling posture | Operator decision required after completed Alpha-native local operator harness design note |
 | Selected next state | **`OPERATOR_DECISION_REQUIRED_AFTER_LOCAL_OPERATOR_HARNESS_DESIGN_NOTE_001`** |
@@ -49,7 +49,8 @@ These are docs, gate, helper, static/research, and blocked-attempt artifacts. Th
 | #572 | Local Ollama singlepath operator helper | Adds an operator helper script for the local-only lane; helper existence is not a successful run. |
 | #573 | Local Ollama singlepath blocked attempt | Records exact-model preflight success and failed-closed timeout/backend error; no local answer or quality evidence. |
 | #574 | `18 - PI.DEV-HARNESS-FEASIBILITY` | Records `BORROW_PATTERNS_ONLY_NO_INTEGRATION` for Pi.dev harness research. |
-| #576 | `ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001` | Completes the docs-only Alpha-native local operator harness design note; no implementation or execution authorization. |
+| #576 | Superseded local operator harness design note PR | Superseded by PR #577; should be closed unmerged and not cited as the completion artifact. |
+| #577 | `ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001` | Completes the docs-only Alpha-native local operator harness design note; no implementation or execution authorization. |
 
 See [`EVIDENCE_INDEX.md`](EVIDENCE_INDEX.md) for the PR status ledger and [`LANE_REGISTRY.md`](LANE_REGISTRY.md) for lifecycle classification.
 

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -1,21 +1,21 @@
 # Alpha Solver — Current State
 
-> Source-of-truth navigation doc. Last verified **2026-06-15** after live
-> GitHub API verification of **0 open PRs** and merged PRs **#569–#574**.
+> Source-of-truth navigation doc. Last verified **2026-06-15** for PR **#576** branch repair.
 > Docs-only; no provider/runtime claims.
 
 ## Current verified phase
 
-**Post-#574 backlog/current-state sync posture; selected next lane is an Alpha-native local operator harness design note.**
+**Post-#576 posture: the Alpha-native local operator harness design note is complete, and an explicit operator decision is required before any next lane.**
 
-The merged #569–#574 wave updated the repository from the post-#568 blocked Value Read state to a broader documentation-and-boundary posture:
+The merged #569–#574 wave updated the repository from the post-#568 blocked Value Read state to a broader documentation-and-boundary posture. PR #576 then completed `ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001` as a docs-only Alpha-native local operator harness design note.
 
-- PR #569 refreshed the current-state, lane, evidence, and MVP scorecard docs after PR #568 recorded `VALUE_READ_BLOCKED`.
-- PR #570 refreshed the founder memo for the post-#568 state.
-- PR #571 added a blocked `/v1/solve` exposure gate packet.
-- PR #572 added a local Ollama singlepath operator helper.
-- PR #573 recorded a blocked local Ollama singlepath attempt: exact `gemma3:4b` preflight passed, but the local helper failed closed with a timeout/backend error and produced no local model answer.
-- PR #574 recorded Pi.dev harness feasibility research and recommended borrowing patterns only, with no direct integration.
+The current control posture is now `OPERATOR_DECISION_REQUIRED_AFTER_LOCAL_OPERATOR_HARNESS_DESIGN_NOTE_001`: no further implementation or execution lane is selected automatically. The operator must explicitly choose one future path before any new lane:
+
+- authorize a separate local harness implementation/spec lane, or
+- return to Value Read execution authorization, or
+- stop and keep the design note as reference material.
+
+This document does not choose for the operator.
 
 These are docs, gate, helper, static/research, and blocked-attempt artifacts. They do not prove provider behavior, model quality, value, readiness, benchmark success, security/privacy completion, local Ollama validation, `/v1/solve` readiness, production/public readiness, or Alpha superiority.
 
@@ -23,12 +23,12 @@ These are docs, gate, helper, static/research, and blocked-attempt artifacts. Th
 
 | Field | Value |
 |-------|-------|
-| Latest verified merged PR in this wave | **#574** — Pi.dev harness feasibility research note |
-| Live open PR state at verification | **0 open PRs** on `adonisdv23/Alpha-Solver` |
+| Latest verified PR in this wave | **#576** — Alpha-native local operator harness design note completed by this PR |
+| PR branch state at verification | **#576 open / pending merge** on `adonisdv23/Alpha-Solver` |
 | Closed-unmerged superseded PR | **#561** — superseded by merged PR #562 |
-| Current controlling posture | Docs/research sync after blocked Value Read, blocked `/v1/solve` exposure gate, blocked local Ollama attempt, and Pi.dev no-integration decision |
-| Selected next lane | **`ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001`** |
-| Strategic boundary | Convert useful Pi.dev-style operator-harness patterns into Alpha-native design only, without installing Pi.dev, calling providers, exposing runtime surfaces, or claiming readiness/value evidence |
+| Current controlling posture | Operator decision required after completed Alpha-native local operator harness design note |
+| Selected next state | **`OPERATOR_DECISION_REQUIRED_AFTER_LOCAL_OPERATOR_HARNESS_DESIGN_NOTE_001`** |
+| Strategic boundary | No implementation, UI, runtime, dependency, provider, local-model, Pi.dev, `/v1/solve`, dashboard/public API, Google Sheets, benchmark, Value Read, readiness, security/privacy, or superiority work is authorized until the operator chooses a future path |
 
 ## Completed post-552 / post-565 / post-568 infrastructure lanes
 
@@ -49,20 +49,23 @@ These are docs, gate, helper, static/research, and blocked-attempt artifacts. Th
 | #572 | Local Ollama singlepath operator helper | Adds an operator helper script for the local-only lane; helper existence is not a successful run. |
 | #573 | Local Ollama singlepath blocked attempt | Records exact-model preflight success and failed-closed timeout/backend error; no local answer or quality evidence. |
 | #574 | `18 - PI.DEV-HARNESS-FEASIBILITY` | Records `BORROW_PATTERNS_ONLY_NO_INTEGRATION` for Pi.dev harness research. |
+| #576 | `ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001` | Completes the docs-only Alpha-native local operator harness design note; no implementation or execution authorization. |
 
 See [`EVIDENCE_INDEX.md`](EVIDENCE_INDEX.md) for the PR status ledger and [`LANE_REGISTRY.md`](LANE_REGISTRY.md) for lifecycle classification.
 
-## Selected next lane
+## Selected next state
 
-**`ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001`** is the recommended next active lane.
+**`OPERATOR_DECISION_REQUIRED_AFTER_LOCAL_OPERATOR_HARNESS_DESIGN_NOTE_001`** is the current global selected next state.
 
-Purpose:
+This is a decision state, not an implementation lane. It means no implementation is authorized, no UI is authorized, no runtime work is authorized, no dependency work is authorized, no provider call is authorized, no local model call is authorized, no Pi.dev install/run/integration is authorized, no `/v1/solve` exposure is authorized, no dashboard or public API exposure is authorized, no Google Sheets mutation is authorized, no benchmark or Value Read execution is authorized, and no readiness, value, security/privacy, provider, local-Ollama, Pi.dev integration, or Alpha superiority claim is authorized.
 
-1. Define Alpha-native local operator-harness concepts inspired by Pi.dev patterns without importing or integrating Pi.dev.
-2. Map prompt packets to named local templates and define a local session evidence format, branch labels, export redaction, and interrupt/follow-up semantics.
-3. Preserve Alpha Solver's repo-native specs, evidence boundaries, budget guardrails, local-first posture, and no-runtime-change boundary.
+The operator must explicitly choose one future path before any new lane:
 
-This lane does **not** itself authorize provider calls, token use, credential access, billing inspection, hosted model calls, local model calls, Pi.dev installation, Pi.dev execution, package installation, dashboard exposure, `/v1/solve` exposure, public API exposure, Google Sheets mutation, benchmark execution, or value/readiness/security/privacy/provider/local-Ollama/Alpha-superiority claims unless a future operator authorization explicitly supplies those boundaries.
+1. authorize a separate local harness implementation/spec lane, or
+2. return to Value Read execution authorization, or
+3. stop and keep the design note as reference material.
+
+This source-of-truth state does not choose for the operator and does not automatically authorize a successor lane.
 
 ## Open deferrals (see [`DEFERRAL_REGISTER.md`](DEFERRAL_REGISTER.md))
 

--- a/docs/EVIDENCE_INDEX.md
+++ b/docs/EVIDENCE_INDEX.md
@@ -1,6 +1,6 @@
-# Evidence Index — Post-#576 operator-decision state
+# Evidence Index — Post-#577 operator-decision state
 
-> Source-of-truth evidence ledger. Verification date **2026-06-15** for PR **#576** branch repair.
+> Source-of-truth evidence ledger. Verification date **2026-06-15** for PR **#577** replacement branch repair.
 
 ## How to read "evidence value"
 
@@ -28,18 +28,19 @@ The entries below are design, documentation, gate, helper, static-checking, meth
 | #572 | Add local Ollama singlepath operator helper | ✅ merged 2026-06-15 | `scripts/run_local_ollama_singlepath_operator.sh`; local-lab packet docs | Adds an operator helper for the local-only Ollama lane. | Helper existence is not a successful local model run, quality proof, benchmark, or readiness evidence. | completed |
 | #573 | Record blocked local Ollama singlepath attempt | ✅ merged 2026-06-15 | `docs/evals/runs/alpha-solver-local-model-lab-ollama-singlepath-001/local-run-artifact-2026-06-15.md` | Records exact `gemma3:4b` preflight success followed by failed-closed timeout/backend error; no local model answer was generated. | Does not prove local model quality, local Ollama validation, Value Read success, runtime readiness, or Alpha superiority. | blocked evidence |
 | #574 | Add pi.dev harness feasibility research note | ✅ merged 2026-06-15 | `docs/evals/runs/alpha-solver-pi-dev-harness-feasibility-018/README.md` | Records `BORROW_PATTERNS_ONLY_NO_INTEGRATION` for Pi.dev harness research. | Does not install, run, or integrate Pi.dev; does not authorize providers, package installs, runtime exposure, or readiness claims. | completed |
-| #576 | Add Alpha-native local operator harness design note | PR-open / merged pending | `docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/` | Docs-only design note for Alpha-native local operator harness patterns. | Does not prove implementation, runtime behavior, UI readiness, provider behavior, local model behavior, Pi.dev integration, Value Read success, benchmark success, production readiness, public readiness, security/privacy completion, or Alpha superiority. | pending merge / completed after merge |
+| #576 | Add Alpha-native local operator harness design note | closed unmerged / superseded by #577 | superseded by #577 | No merged evidence artifact from #576. | Must not be cited as the merged completion artifact for this lane. | superseded |
+| #577 | Add Alpha-native local operator harness design note | merged after PR completion | `docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/` | Docs-only Alpha-native local operator harness design note. | Does not prove implementation, runtime behavior, UI readiness, provider behavior, local model behavior, Pi.dev integration, Value Read success, benchmark success, production readiness, public readiness, security/privacy completion, or Alpha superiority. | completed |
 
 ## Current selected next state
 
 `OPERATOR_DECISION_REQUIRED_AFTER_LOCAL_OPERATOR_HARNESS_DESIGN_NOTE_001` is the selected next state. This is a decision state, not an implementation lane.
 
-PR #576 completes `ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001` after merge. The completed packet does not automatically authorize a successor lane. Future implementation or execution requires a separate explicit operator-authorized lane.
+PR #576 is superseded by PR #577 and should be closed unmerged. PR #577 completes `ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001` after merge. The completed packet does not automatically authorize a successor lane. Future implementation or execution requires a separate explicit operator-authorized lane.
 
 The selected state authorizes no implementation, UI, runtime work, dependency work, provider call, local model call, Pi.dev install/run/integration, `/v1/solve` exposure, dashboard or public API exposure, Google Sheets mutation, benchmark execution, Value Read execution, or readiness/value/security/privacy/provider/local-Ollama/Pi.dev-integration/Alpha-superiority claim.
 
 ## Evidence boundary
 
-The post-#576 state supports only bounded statements that the repository contains merged or pending-merge docs/design/static-checking/scaffold/gate/helper/blocked-attempt/research artifacts for no-echo gating, false-premise perturbations, claim-safety linting, calibrated confidence, needs-human protocol guidance, higher-headroom cases, prompt-contract methodology, a local Ollama lab scaffold/helper, blocked Value Read evidence, blocked `/v1/solve` exposure evidence, a failed-closed local Ollama attempt, and Pi.dev patterns-only research.
+The post-#577 state supports only bounded statements that the repository contains docs/design/static-checking/scaffold/gate/helper/blocked-attempt/research artifacts for no-echo gating, false-premise perturbations, claim-safety linting, calibrated confidence, needs-human protocol guidance, higher-headroom cases, prompt-contract methodology, a local Ollama lab scaffold/helper, blocked Value Read evidence, blocked `/v1/solve` exposure evidence, a failed-closed local Ollama attempt, and Pi.dev patterns-only research.
 
 It does **not** support claims of provider validation, local Ollama validation, hosted-model validation, token use, benchmark success, value, readiness, security/privacy completion, public API readiness, `/v1/solve` readiness, dashboard readiness, Pi.dev integration, Google Sheets synchronization, or Alpha superiority.

--- a/docs/EVIDENCE_INDEX.md
+++ b/docs/EVIDENCE_INDEX.md
@@ -1,7 +1,6 @@
-# Evidence Index — Post-#574 backlog/current-state sync
+# Evidence Index — Post-#576 operator-decision state
 
-> Source-of-truth evidence ledger. Verification date **2026-06-15**. Live GitHub
-> API verification confirmed **0 open PRs** and merged PRs **#569–#574**.
+> Source-of-truth evidence ledger. Verification date **2026-06-15** for PR **#576** branch repair.
 
 ## How to read "evidence value"
 
@@ -29,13 +28,18 @@ The entries below are design, documentation, gate, helper, static-checking, meth
 | #572 | Add local Ollama singlepath operator helper | ✅ merged 2026-06-15 | `scripts/run_local_ollama_singlepath_operator.sh`; local-lab packet docs | Adds an operator helper for the local-only Ollama lane. | Helper existence is not a successful local model run, quality proof, benchmark, or readiness evidence. | completed |
 | #573 | Record blocked local Ollama singlepath attempt | ✅ merged 2026-06-15 | `docs/evals/runs/alpha-solver-local-model-lab-ollama-singlepath-001/local-run-artifact-2026-06-15.md` | Records exact `gemma3:4b` preflight success followed by failed-closed timeout/backend error; no local model answer was generated. | Does not prove local model quality, local Ollama validation, Value Read success, runtime readiness, or Alpha superiority. | blocked evidence |
 | #574 | Add pi.dev harness feasibility research note | ✅ merged 2026-06-15 | `docs/evals/runs/alpha-solver-pi-dev-harness-feasibility-018/README.md` | Records `BORROW_PATTERNS_ONLY_NO_INTEGRATION` for Pi.dev harness research. | Does not install, run, or integrate Pi.dev; does not authorize providers, package installs, runtime exposure, or readiness claims. | completed |
+| #576 | Add Alpha-native local operator harness design note | PR-open / merged pending | `docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/` | Docs-only design note for Alpha-native local operator harness patterns. | Does not prove implementation, runtime behavior, UI readiness, provider behavior, local model behavior, Pi.dev integration, Value Read success, benchmark success, production readiness, public readiness, security/privacy completion, or Alpha superiority. | pending merge / completed after merge |
 
-## Current selected next lane
+## Current selected next state
 
-`ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001` is the selected next active lane. It should create an Alpha-native local operator-harness design note inspired by safe Pi.dev patterns without installing or integrating Pi.dev, calling providers/models, exposing runtime surfaces, or mutating Google Sheets. PR #568 remains blocked-state evidence only, PR #571 remains blocked exposure evidence, and PR #573 remains failed-closed local-lab evidence only.
+`OPERATOR_DECISION_REQUIRED_AFTER_LOCAL_OPERATOR_HARNESS_DESIGN_NOTE_001` is the selected next state. This is a decision state, not an implementation lane.
+
+PR #576 completes `ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001` after merge. The completed packet does not automatically authorize a successor lane. Future implementation or execution requires a separate explicit operator-authorized lane.
+
+The selected state authorizes no implementation, UI, runtime work, dependency work, provider call, local model call, Pi.dev install/run/integration, `/v1/solve` exposure, dashboard or public API exposure, Google Sheets mutation, benchmark execution, Value Read execution, or readiness/value/security/privacy/provider/local-Ollama/Pi.dev-integration/Alpha-superiority claim.
 
 ## Evidence boundary
 
-The post-#574 state supports only bounded statements that the repository contains merged docs/design/static-checking/scaffold/gate/helper/blocked-attempt/research artifacts for no-echo gating, false-premise perturbations, claim-safety linting, calibrated confidence, needs-human protocol guidance, higher-headroom cases, prompt-contract methodology, a local Ollama lab scaffold/helper, blocked Value Read evidence, blocked `/v1/solve` exposure evidence, a failed-closed local Ollama attempt, and Pi.dev patterns-only research.
+The post-#576 state supports only bounded statements that the repository contains merged or pending-merge docs/design/static-checking/scaffold/gate/helper/blocked-attempt/research artifacts for no-echo gating, false-premise perturbations, claim-safety linting, calibrated confidence, needs-human protocol guidance, higher-headroom cases, prompt-contract methodology, a local Ollama lab scaffold/helper, blocked Value Read evidence, blocked `/v1/solve` exposure evidence, a failed-closed local Ollama attempt, and Pi.dev patterns-only research.
 
 It does **not** support claims of provider validation, local Ollama validation, hosted-model validation, token use, benchmark success, value, readiness, security/privacy completion, public API readiness, `/v1/solve` readiness, dashboard readiness, Pi.dev integration, Google Sheets synchronization, or Alpha superiority.

--- a/docs/LANE_REGISTRY.md
+++ b/docs/LANE_REGISTRY.md
@@ -1,7 +1,7 @@
 # Lane Registry
 
-> Source-of-truth lane lifecycle registry. Verification date **2026-06-15** after
-> live GitHub API verification of **0 open PRs** and merged PRs **#569–#574**.
+> Source-of-truth lane lifecycle registry. Verification date **2026-06-15** for
+> PR **#576** branch repair.
 
 ## Lifecycle classes
 
@@ -11,13 +11,13 @@
 
 | Lane | State | Evidence |
 |------|-------|----------|
-| Post-#574 backlog/current-state sync posture | **current control posture** | PRs #569–#574 are merged. The newest evidence is docs/research/gate/helper work: post-#568 source-of-truth sync, founder memo refresh, blocked `/v1/solve` exposure gate, local Ollama helper, failed-closed local Ollama attempt, and Pi.dev no-integration feasibility note. |
+| Post-#576 operator-decision posture | **current control posture** | PR #576 completes `ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001` as a docs-only design note. The current selected state is an operator decision requirement, not an implementation lane. |
 
-## Next ready
+## Next ready / current selected state
 
-| Lane | State | Notes |
-|------|-------|-------|
-| **`ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001`** | **selected next** | Alpha-native design note only. Borrow useful Pi.dev-style operator-harness patterns without installing Pi.dev, integrating Pi.dev, changing runtime behavior, exposing `/v1/solve`, calling providers/models, or mutating Google Sheets. |
+| State | Lifecycle | Notes |
+|-------|-----------|-------|
+| **`OPERATOR_DECISION_REQUIRED_AFTER_LOCAL_OPERATOR_HARNESS_DESIGN_NOTE_001`** | **selected next state; not an implementation lane** | The operator must explicitly choose whether to authorize a separate local harness implementation/spec lane, return to Value Read execution authorization, or stop and keep the design note as reference material. No implementation, UI, runtime, dependency, provider, local-model, Pi.dev, `/v1/solve`, dashboard/public API, Google Sheets, benchmark, Value Read, readiness, security/privacy, or superiority work is authorized. |
 
 ## Completed (kept as evidence)
 
@@ -36,6 +36,7 @@
 - Local Ollama singlepath operator helper (PR #572) — local-only helper added; no successful model run implied.
 - Local Ollama singlepath blocked attempt (PR #573) — exact `gemma3:4b` model preflight passed, then helper failed closed with timeout/backend error and produced no local answer.
 - `18 - PI.DEV-HARNESS-FEASIBILITY` (PR #574) — `BORROW_PATTERNS_ONLY_NO_INTEGRATION` research note.
+- `ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001` (PR #576) — docs-only Alpha-native local operator harness design note; completed by PR #576 with no implementation or execution authorization.
 
 ## Superseded
 
@@ -43,7 +44,8 @@
 |-----------|---------------|-----|
 | PR #561 — `Add needs-human escalation protocol` | PR #562 | #561 is closed unmerged; #562 merged the docs-only needs-human protocol. |
 | Older smoke-authorization selected-next pointers | Post-#568 and post-#574 selected-next lanes in this registry and [`CURRENT_STATE.md`](CURRENT_STATE.md) | The #557–#574 wave changed the active posture to Value Read blocked evidence, exposure/local-lab gates, and an Alpha-native harness design next step. |
-| `ALPHA-SOLVER-VALUE-READ-EXECUTION-PACKET-AUTHORIZATION-001` as immediate global next | PR #574's proposed `ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001` | Value Read execution remains blocked; the newest merged research note selects a safer docs-only harness design lane. |
+| `ALPHA-SOLVER-VALUE-READ-EXECUTION-PACKET-AUTHORIZATION-001` as immediate global next | `OPERATOR_DECISION_REQUIRED_AFTER_LOCAL_OPERATOR_HARNESS_DESIGN_NOTE_001` | Value Read execution remains blocked until the operator explicitly returns to Value Read execution authorization. |
+| `ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001` as selected next | PR #576 completed that lane | Future operators must not be sent back to the completed design-note lane; the global selected state is now operator decision required. |
 
 ## Blocked / not authorized
 
@@ -60,7 +62,7 @@
 
 - PR #561 lane as a standalone needs-human protocol PR — closed unmerged and superseded by PR #562.
 - Any merged packet lane verbatim — packets are immutable evidence; create a new lane id instead.
-- Any selected-next pointer that predates this post-#574 sync if it conflicts with `ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001`.
+- Any selected-next pointer that conflicts with `OPERATOR_DECISION_REQUIRED_AFTER_LOCAL_OPERATOR_HARNESS_DESIGN_NOTE_001`.
 - Direct Pi.dev integration from PR #574's research lane — the recorded verdict is patterns-only/no-integration.
 
 ## Forward path (single track)
@@ -87,7 +89,10 @@ ALPHA-SOLVER-VALUE-READ-SIMULATION-PACKET-REFRESH-POST-565-001 / PR #568 artifac
 #574 Pi.dev harness feasibility ← BORROW_PATTERNS_ONLY_NO_INTEGRATION
         │
         ▼
-ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001 ← selected next; Alpha-native docs-only design lane
+ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001 ← completed by PR #576; docs-only design note
+        │
+        ▼
+OPERATOR_DECISION_REQUIRED_AFTER_LOCAL_OPERATOR_HARNESS_DESIGN_NOTE_001 ← selected next state; decision only, not an implementation lane
 ```
 
 This registry does not authorize any provider call, local model call, Pi.dev install/run/integration, runtime exposure, public API exposure, Google Sheets mutation, or readiness/value/security/privacy/provider/local-Ollama/Alpha-superiority claim.

--- a/docs/LANE_REGISTRY.md
+++ b/docs/LANE_REGISTRY.md
@@ -1,7 +1,7 @@
 # Lane Registry
 
 > Source-of-truth lane lifecycle registry. Verification date **2026-06-15** for
-> PR **#576** branch repair.
+> PR **#577** replacement branch repair.
 
 ## Lifecycle classes
 
@@ -11,7 +11,7 @@
 
 | Lane | State | Evidence |
 |------|-------|----------|
-| Post-#576 operator-decision posture | **current control posture** | PR #576 completes `ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001` as a docs-only design note. The current selected state is an operator decision requirement, not an implementation lane. |
+| Post-#577 operator-decision posture | **current control posture** | PR #576 is superseded and should be closed unmerged. PR #577 completes `ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001` as a docs-only design note. The current selected state is an operator decision requirement, not an implementation lane. |
 
 ## Next ready / current selected state
 
@@ -36,7 +36,7 @@
 - Local Ollama singlepath operator helper (PR #572) — local-only helper added; no successful model run implied.
 - Local Ollama singlepath blocked attempt (PR #573) — exact `gemma3:4b` model preflight passed, then helper failed closed with timeout/backend error and produced no local answer.
 - `18 - PI.DEV-HARNESS-FEASIBILITY` (PR #574) — `BORROW_PATTERNS_ONLY_NO_INTEGRATION` research note.
-- `ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001` (PR #576) — docs-only Alpha-native local operator harness design note; completed by PR #576 with no implementation or execution authorization.
+- `ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001` (PR #577) — docs-only Alpha-native local operator harness design note; completed by PR #577 with no implementation or execution authorization.
 
 ## Superseded
 
@@ -45,7 +45,8 @@
 | PR #561 — `Add needs-human escalation protocol` | PR #562 | #561 is closed unmerged; #562 merged the docs-only needs-human protocol. |
 | Older smoke-authorization selected-next pointers | Post-#568 and post-#574 selected-next lanes in this registry and [`CURRENT_STATE.md`](CURRENT_STATE.md) | The #557–#574 wave changed the active posture to Value Read blocked evidence, exposure/local-lab gates, and an Alpha-native harness design next step. |
 | `ALPHA-SOLVER-VALUE-READ-EXECUTION-PACKET-AUTHORIZATION-001` as immediate global next | `OPERATOR_DECISION_REQUIRED_AFTER_LOCAL_OPERATOR_HARNESS_DESIGN_NOTE_001` | Value Read execution remains blocked until the operator explicitly returns to Value Read execution authorization. |
-| `ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001` as selected next | PR #576 completed that lane | Future operators must not be sent back to the completed design-note lane; the global selected state is now operator decision required. |
+| PR #576 - Add Alpha-native local operator harness design note | PR #577 | PR #577 includes the design note plus source-of-truth closeout and green checks; #576 should be closed unmerged and not cited as merged evidence. |
+| `ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001` as selected next | PR #577 completed that lane | Future operators must not be sent back to the completed design-note lane; the global selected state is now operator decision required. |
 
 ## Blocked / not authorized
 
@@ -89,7 +90,7 @@ ALPHA-SOLVER-VALUE-READ-SIMULATION-PACKET-REFRESH-POST-565-001 / PR #568 artifac
 #574 Pi.dev harness feasibility ← BORROW_PATTERNS_ONLY_NO_INTEGRATION
         │
         ▼
-ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001 ← completed by PR #576; docs-only design note
+#577 local operator harness design note completed
         │
         ▼
 OPERATOR_DECISION_REQUIRED_AFTER_LOCAL_OPERATOR_HARNESS_DESIGN_NOTE_001 ← selected next state; decision only, not an implementation lane

--- a/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/README.md
+++ b/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/README.md
@@ -1,0 +1,53 @@
+# Alpha-native Local Operator Harness Design Note
+
+## Lane ID
+
+`ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001`
+
+## Verdict
+
+`DESIGN_NOTE_ONLY_NO_RUNTIME_NO_PI_INTEGRATION`
+
+## TLDR
+
+This packet converts the post-#574 Pi.dev patterns-only decision into an Alpha-native, paper-only local operator harness concept. It borrows safe interaction patterns such as named prompt packets, explicit operator actions, session-tree evidence, export discipline, interrupt/follow-up semantics, message-card fields, local-first defaults, and future package/skill review gates. It does not install, run, vendor, or integrate Pi.dev, and it does not change runtime, API, dashboard, provider, model, scoring, routing, or Google Sheets behavior.
+
+## Evidence boundary
+
+This packet is documentation-only design evidence. It is not execution evidence, not value evidence, not provider evidence, not local-model evidence, not benchmark evidence, not readiness evidence, not security/privacy completion evidence, not `/v1/solve` exposure evidence, not dashboard exposure evidence, not Pi.dev integration evidence, and not Alpha superiority evidence.
+
+The packet records only a bounded design proposal and safety boundaries for possible future operator-harness work. Any future implementation, tool activation, package/skill use, model call, provider call, local run, or external export requires separate explicit operator authorization.
+
+## Files reviewed
+
+Primary source files reviewed from live repo state:
+
+- `docs/CURRENT_STATE.md`
+- `docs/LANE_REGISTRY.md`
+- `docs/EVIDENCE_INDEX.md`
+- `docs/evals/runs/alpha-solver-pi-dev-harness-feasibility-018/README.md`
+- `docs/evals/runs/alpha-solver-local-model-lab-ollama-singlepath-001/local-run-artifact-2026-06-15.md`
+- `docs/evals/runs/alpha-solver-value-read-simulation-packet-refresh-post-565-001/manual-run-artifact-2026-06-15.md`
+
+## Design summary
+
+The proposed Alpha-native local operator harness is a repo-local review pattern, not a runtime product. It would organize future operator work around:
+
+1. named local prompt templates that point back to committed packets;
+2. explicit operator actions with approval gates and stop reasons;
+3. session evidence records with raw-output pointers, score pointers, branch labels, redaction status, and non-claims;
+4. message cards that expose answerability, confidence, assumptions, false-premise flags, hidden constraints, needs-human state, derivation/no-echo status, route explanation, evidence links, and next-safe-action;
+5. interrupt, follow-up, and evidence-review semantics that stop or queue work instead of silently continuing;
+6. local-first, no-upload defaults and package/skill review rules before any future tooling.
+
+## Non-actions
+
+This packet does not perform or authorize any action listed in `non-actions.md`, including Pi.dev installation/execution/integration, dependency installation, provider calls, model calls, credential access, runtime/API/dashboard changes, `/v1/solve` exposure, Google Sheets mutation, benchmark/scoring/routing/council changes, or feature activation for shell/file/MCP/email/calendar/memory tooling.
+
+## Non-claims
+
+This packet does not make any claim listed in `non-claims.md`, including value, readiness, provider, local-model, benchmark, production, public-use, security/privacy completion, partnership, dashboard, `/v1/solve`, Pi.dev integration, or Alpha superiority claims.
+
+## Recommended next action
+
+Keep this as a completed design note and require an explicit operator decision before any implementation, tool activation, dependency change, model/provider call, runtime exposure, or external export.

--- a/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/alpha-native-harness-design-note.md
+++ b/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/alpha-native-harness-design-note.md
@@ -1,0 +1,54 @@
+# Alpha-native Harness Design Note
+
+## Purpose
+
+This note defines a concise Alpha-native local operator harness concept for future review. The design adapts safe operator-workflow patterns recorded after the Pi.dev feasibility review while preserving Alpha Solver's repo-native specs, evidence boundaries, budget guardrails, and no-runtime-change posture.
+
+## Design concept
+
+An Alpha-native local operator harness would be a local evidence-workbench pattern that helps an operator run authorized repo tasks in a disciplined sequence:
+
+1. choose a committed packet or prompt template by name;
+2. declare the branch label, task id, evidence boundary, and stop conditions before work begins;
+3. record each operator action as an explicit step with an approval state;
+4. preserve raw outputs by pointer, not by uncontrolled copy/paste;
+5. attach score pointers, redaction state, non-claims, stop reason, and operator decision;
+6. export only sanitized evidence artifacts after review.
+
+For this lane, the harness remains a paper design. No executable automation, provider adapter, local model adapter, dashboard panel, API endpoint, routing change, scoring engine, or package integration is added.
+
+## Why this is not a generic chat UI
+
+The design is evidence-first, not chat-first. A generic chat UI centers a conversation stream. The Alpha-native concept centers lane ids, prompt sources, evidence boundaries, stop conditions, score pointers, non-claims, and export discipline.
+
+The proposed message card is not merely a prettier assistant answer. It is a structured review surface for Alpha's existing discrimination wedge:
+
+- answerability and confidence are recorded before broad claims;
+- assumptions, false premises, hidden constraints, and needs-human conditions are visible;
+- derivation/no-echo status distinguishes substantive reasoning from prompt reflection;
+- route explanations and evidence links make provenance inspectable;
+- next-safe-action prevents uncontrolled continuation.
+
+## Why this is not Pi.dev integration
+
+This lane does not install, run, vendor, copy, configure, depend on, or runtime-link Pi.dev. It borrows only high-level workflow ideas that are safe to describe in Alpha's own docs: named prompt packets, explicit operator actions, session-tree evidence, export discipline, interrupt/follow-up semantics, message/evidence-card concepts, local-first defaults, and review rules for any future package or skill.
+
+Any future Pi.dev experiment would require a separate threat model, package/provenance review, sandbox, no-secret fixture workspace, provider/key policy, export policy, and explicit operator authorization. This design note does not grant that authorization.
+
+## Support for Alpha's wedge
+
+### Discrimination
+
+The harness concept keeps discrimination dimensions visible during operator review: false-premise detection, hidden-constraint handling, no-echo substantive derivation, needs-human mapping, confidence calibration, claim-boundary discipline, and evidence-conflict handling. It does not score those dimensions automatically; it specifies where future authorized evidence and score pointers would be recorded.
+
+### Stopping
+
+The harness concept treats stopping as a first-class outcome. A stopped session can be valid evidence if it records the stop condition, missing authorization, missing raw output, failed preflight, evidence conflict, or needs-human gate. This mirrors the blocked Value Read artifact and the failed-closed local Ollama attempt: stopped work must not be converted into success, value, or readiness claims.
+
+### Evidence
+
+The harness concept separates prompt source, raw output pointer, score pointer, redaction status, operator decision, and non-claims. This prevents a session transcript from being mistaken for scored evidence, runtime validation, provider validation, or model-quality evidence.
+
+### Provenance
+
+Each session record would name the lane id, branch label, task id, prompt source, repo commit when available, artifact pointers, and export decisions. Provenance is local-first and review-gated by default.

--- a/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/checks-run.md
+++ b/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/checks-run.md
@@ -1,0 +1,19 @@
+# Checks Run
+
+This file records checks for the docs-only design packet and PR #576 source-of-truth repair. It does not record runtime execution, model/provider calls, benchmark execution, scoring, dashboard exposure, `/v1/solve` exposure, or Google Sheets mutation.
+
+| Check | Status | Notes |
+| --- | --- | --- |
+| `git diff --check` | Pass | Whitespace check only. |
+| `python scripts/check_narrative_claim_safety.py docs/CURRENT_STATE.md docs/LANE_REGISTRY.md docs/EVIDENCE_INDEX.md docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/*.md` | Pass | Narrative claim-safety linter scanned the changed source-of-truth Markdown and every Markdown file in the packet. This is not a completeness claim. |
+| `python scripts/check_local_llm_evidence_boundaries.py docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/*.md` | Pass | Local LLM evidence-boundary static check scanned the packet Markdown files. |
+| `python -m pytest -q tests/test_local_llm_evidence_boundaries.py::test_current_relevant_docs_pass_static_check` | Pass | Reproduced the prior CI/test failure path and confirmed the packet now passes the relevant static check. |
+| `python -m pytest -q` | Pass | Full local test suite passed with expected skips and deprecation warnings. |
+
+## CI/test failure cause identified
+
+The failing `test`/`unit` path was reproducible locally as `tests/test_local_llm_evidence_boundaries.py::test_current_relevant_docs_pass_static_check`. The static evidence-boundary checker flagged `docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/interrupt-followup-semantics.md` because the phrase `Alpha superiority` appeared without nearby boundary language. This repair rewrites that line to explicit evidence-boundary wording.
+
+## Non-execution attestation
+
+During packet preparation and branch repair, Pi.dev was not installed, run, copied, vendored, or integrated; dependencies were not added; providers were not called; tokens were not used; credentials were not accessed; hosted models were not run; local models were not run; models were not pulled or installed; dashboard behavior was not exposed; `/v1/solve` was not exposed; public API behavior was not exposed; runtime/API/dashboard code was not modified; package/skill/shell/file/MCP/email/calendar/memory features were not activated; benchmark/scoring/routing/council/model-comparison/local-model-registry/provider behavior was not added; and Google Sheets were not mutated.

--- a/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/checks-run.md
+++ b/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/checks-run.md
@@ -1,6 +1,6 @@
 # Checks Run
 
-This file records checks for the docs-only design packet and PR #576 source-of-truth repair. It does not record runtime execution, model/provider calls, benchmark execution, scoring, dashboard exposure, `/v1/solve` exposure, or Google Sheets mutation.
+This file records checks for the docs-only design packet and PR #577 replacement source-of-truth repair. It does not record runtime execution, model/provider calls, benchmark execution, scoring, dashboard exposure, `/v1/solve` exposure, or Google Sheets mutation.
 
 | Check | Status | Notes |
 | --- | --- | --- |
@@ -16,4 +16,4 @@ The failing `test`/`unit` path was reproducible locally as `tests/test_local_llm
 
 ## Non-execution attestation
 
-During packet preparation and branch repair, Pi.dev was not installed, run, copied, vendored, or integrated; dependencies were not added; providers were not called; tokens were not used; credentials were not accessed; hosted models were not run; local models were not run; models were not pulled or installed; dashboard behavior was not exposed; `/v1/solve` was not exposed; public API behavior was not exposed; runtime/API/dashboard code was not modified; package/skill/shell/file/MCP/email/calendar/memory features were not activated; benchmark/scoring/routing/council/model-comparison/local-model-registry/provider behavior was not added; and Google Sheets were not mutated.
+During packet preparation and PR #577 branch repair, Pi.dev was not installed, run, copied, vendored, or integrated; dependencies were not added; providers were not called; tokens were not used; credentials were not accessed; hosted models were not run; local models were not run; models were not pulled or installed; dashboard behavior was not exposed; `/v1/solve` was not exposed; public API behavior was not exposed; runtime/API/dashboard code was not modified; package/skill/shell/file/MCP/email/calendar/memory features were not activated; benchmark/scoring/routing/council/model-comparison/local-model-registry/provider behavior was not added; and Google Sheets were not mutated.

--- a/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/interrupt-followup-semantics.md
+++ b/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/interrupt-followup-semantics.md
@@ -1,0 +1,58 @@
+# Interrupt and Follow-up Semantics
+
+This document defines paper-only operator semantics for a future Alpha-native local operator harness. It does not implement runtime orchestration or UI behavior.
+
+## Operator interrupt
+
+An operator interrupt is an explicit instruction to stop the current action immediately and preserve the current evidence state. The session must record:
+
+- who or what initiated the interrupt;
+- the current task id and operator action;
+- whether raw output exists;
+- whether raw output is authorized to preserve;
+- the stop reason;
+- the next-safe-action.
+
+An interrupt must not silently convert into a new provider call, model call, file operation, package install, external upload, or runtime exposure.
+
+## Stop-condition
+
+A stop-condition is a predeclared boundary that requires halting or escalation. Examples:
+
+- missing operator authorization;
+- request to use tokens, credentials, providers, hosted models, or local models;
+- request to install packages or activate tools;
+- request to expose dashboard, public API behavior, or `/v1/solve`;
+- evidence conflict or missing raw output;
+- needs-human/legal/safety/security/privacy boundary;
+- unsupported claim attempt; evidence boundary applies to value, readiness, benchmark, provider, local-model, public-use, and Alpha-superiority wording.
+
+## Queued follow-up
+
+A queued follow-up is a future task request recorded without execution. It should include:
+
+- follow-up id;
+- requested action;
+- required authorization;
+- required evidence inputs;
+- blocked claims;
+- proposed next-safe-action.
+
+Queued follow-ups do not imply authorization. They are planning entries only.
+
+## Approval gate
+
+An approval gate is a required operator decision before crossing a boundary. Approval gates are required before any future:
+
+- implementation;
+- dependency or package change;
+- Pi.dev experiment;
+- provider or model call;
+- credential or token use;
+- dashboard, API, or `/v1/solve` exposure;
+- Google Sheets or external-ledger mutation;
+- benchmark, scoring, routing, council, registry, or comparison behavior.
+
+## Evidence-review intervention
+
+An evidence-review intervention is an operator action that pauses interpretation until provenance, raw-output pointers, score pointers, redaction state, and non-claims are checked. It should be used when a transcript, output, or summary could be mistaken for stronger evidence than it supports.

--- a/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/message-card-and-evidence-trail-spec.md
+++ b/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/message-card-and-evidence-trail-spec.md
@@ -1,0 +1,64 @@
+# Message Card and Evidence Trail Spec
+
+This is a paper-only UI/spec for an Alpha message card and evidence trail. It does not add runtime UI, dashboard UI, API behavior, public exposure, provider behavior, or model behavior.
+
+## Alpha message card fields
+
+| Field | Purpose | Example bounded values |
+| --- | --- | --- |
+| `answerability` | State whether the task can be answered under current evidence. | `answerable`, `needs_clarification`, `blocked`, `should_escalate`. |
+| `confidence` | Record confidence level with reason. | `low`, `medium`, `high`, plus a short evidence reason. |
+| `assumptions` | List assumptions detected in the user task or packet. | `operator wants docs-only design`, `no execution authorized`. |
+| `false_premise_flag` | Mark whether the prompt contains an unsupported premise. | `none_detected`, `possible`, `detected`. |
+| `hidden_constraints` | Name constraints that must govern the answer. | `no provider calls`, `no runtime changes`, `no Pi.dev integration`. |
+| `needs_human` | Indicate whether operator/human review is required before continuation. | `false`, `true: implementation authorization required`. |
+| `will_not_claim` | Record claims the answer refuses to make. | `value evidence`, `production readiness`, `Alpha superiority`. |
+| `derivation_no_echo_status` | Distinguish substantive synthesis from prompt echo. | `derived_from_sources`, `summary_only`, `blocked_no_derivation`. |
+| `route_explanation` | Explain why the answer path was chosen. | `docs-only lane selected by current-state and lane registry`. |
+| `evidence_links` | Link to repo evidence paths or local pointers. | `docs/CURRENT_STATE.md`, packet files, raw-output pointer if authorized. |
+| `next_safe_action` | Name the next action that stays inside evidence boundaries. | `require operator decision before implementation`. |
+
+## Message card outline
+
+```text
+Answerability: <value>
+Confidence: <level and reason>
+Assumptions: <list>
+False-premise flag: <value>
+Hidden constraints: <list>
+Needs-human: <state and reason>
+Will-not-claim: <list>
+Derivation/no-echo status: <status>
+Route explanation: <bounded route>
+Evidence links: <repo paths or local pointers>
+Next-safe-action: <one action>
+```
+
+## Evidence-trail screen outline
+
+A future local-only evidence-trail screen could display:
+
+1. lane id and branch label;
+2. prompt source and named operator action;
+3. session-tree steps in chronological order;
+4. raw output pointer, if authorized output exists;
+5. score pointer, if authorized scoring exists;
+6. stop reason and operator decision;
+7. non-claims attached to the session;
+8. redaction/export status;
+9. next-safe-action.
+
+The screen would be local-only by default. It would not upload evidence, expose dashboards, expose `/v1/solve`, call providers, call local models, or mutate external ledgers.
+
+## Blind-compare review outline
+
+If a future authorized lane includes blind comparison, the evidence trail should keep these phases separate:
+
+1. **Case registration:** task id, prompt source, evidence boundary, and non-claims are locked.
+2. **Output collection:** raw Output A and Output B pointers are preserved under the authorized mechanism.
+3. **Blind scoring:** scores are recorded before unblinding.
+4. **Unblind step:** identity mapping is revealed only after score lock.
+5. **Interpretation:** conclusions are limited to the case set, scoring rubric, and evidence boundary.
+6. **Export review:** redaction and non-claims are checked before any sanitized artifact is committed.
+
+No blind-compare behavior is implemented in this lane.

--- a/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/non-actions.md
+++ b/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/non-actions.md
@@ -1,0 +1,34 @@
+# Non-actions
+
+This lane explicitly does not do or authorize the following:
+
+- install Pi.dev;
+- run Pi.dev;
+- copy Pi.dev code;
+- vendor Pi.dev;
+- add Pi.dev as a dependency;
+- add any dependency;
+- install packages;
+- modify runtime code;
+- modify API code;
+- modify dashboard code;
+- expose `/v1/solve`;
+- expose dashboard behavior;
+- expose public API behavior;
+- call providers;
+- use provider tokens;
+- access credentials;
+- inspect billing;
+- run hosted models;
+- run local models;
+- pull or install models;
+- mutate Google Sheets;
+- add benchmark behavior;
+- add scoring behavior;
+- add routing behavior;
+- add council behavior;
+- add model-comparison behavior;
+- add local model registry behavior;
+- add provider behavior;
+- activate shell/file/MCP/email/calendar/memory features for a future harness;
+- create production, public, runtime, provider, local model, benchmark, security/privacy, value, partnership, or Alpha superiority claims.

--- a/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/non-claims.md
+++ b/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/non-claims.md
@@ -1,0 +1,26 @@
+# Non-claims
+
+This design packet does not claim:
+
+- Alpha Solver value has been measured;
+- Alpha Solver beats, outperforms, or is superior to any baseline, provider, model, product, or workflow;
+- no claim that Alpha Solver has production, public, MVP, pilot, customer, or runtime readiness;
+- no claim that any provider behavior has validation evidence;
+- any hosted model was called;
+- any local model was called;
+- no claim that local Ollama behavior has validation evidence;
+- the prior failed-closed local Ollama attempt produced quality evidence;
+- a benchmark was run;
+- blind scoring was performed;
+- discrimination delta was measured;
+- `/v1/solve` is ready or exposed;
+- dashboard behavior is ready or exposed;
+- public API behavior is ready or exposed;
+- security/privacy review is complete;
+- credentials, tokens, billing, or subscriptions were reviewed;
+- Pi.dev is installed, approved, integrated, runtime-linked, or safe for Alpha Solver use;
+- no claim that Pi.dev provider behavior or package behavior has validation evidence;
+- package/skill tooling is approved;
+- Google Sheets or external ledgers were updated;
+- a future implementation is authorized;
+- a future local operator harness would be safe without separate threat modeling, review, sandboxing, and operator approval.

--- a/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/operator-action-template-map.md
+++ b/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/operator-action-template-map.md
@@ -1,0 +1,29 @@
+# Operator Action Template Map
+
+This is a paper-only map from repo prompt packets to possible named local operator actions. It defines names and review intent only. It does not create executable automation.
+
+| Example local action name | Prompt/source packet | Intended operator use | Required boundary before use |
+| --- | --- | --- | --- |
+| `open-current-state-context` | `docs/CURRENT_STATE.md` | Review the current selected lane, blocked activities, and non-claims. | Inspect-only docs review. |
+| `open-lane-registry-context` | `docs/LANE_REGISTRY.md` | Confirm lifecycle status and avoid reopening superseded or blocked lanes. | Inspect-only docs review. |
+| `open-evidence-ledger-context` | `docs/EVIDENCE_INDEX.md` | Check what existing artifacts can and cannot support. | Inspect-only docs review. |
+| `review-pi-patterns-only-note` | `docs/evals/runs/alpha-solver-pi-dev-harness-feasibility-018/README.md` | Extract safe high-level patterns without integration. | No Pi.dev install, run, dependency, or code copy. |
+| `record-local-harness-design-note` | This packet | Draft Alpha-native design artifacts and boundaries. | Docs-only writing; no runtime change. |
+| `prepare-value-read-authorization-return` | `docs/evals/runs/alpha-solver-value-read-simulation-packet-refresh-post-565-001/manual-run-artifact-2026-06-15.md` | Return to Value Read authorization only if the operator wants value evidence next. | Separate explicit execution authorization required. |
+| `review-local-ollama-blocked-attempt` | `docs/evals/runs/alpha-solver-local-model-lab-ollama-singlepath-001/local-run-artifact-2026-06-15.md` | Preserve failed-closed local-run lessons without rerunning or changing model behavior. | No model call, pull, install, timeout extension, or rerun unless separately authorized. |
+| `draft-message-card` | `.specs/ALPHA-SOLVER-CALIBRATED-CONFIDENCE-OUTPUT-CONTRACT-001.md` and this packet | Sketch an evidence card with answerability, confidence, assumptions, and non-claims. | Paper-only UI/spec; no runtime UI. |
+| `apply-needs-human-boundary` | `.specs/ALPHA-SOLVER-ESCALATION-NEEDS-HUMAN-PROTOCOL-001.md` | Mark a task as needs-human when scope or risk requires escalation. | No autonomous continuation past escalation. |
+| `lint-narrative-claims` | `scripts/check_narrative_claim_safety.py` | Run static claim-safety lint on docs artifacts. | Static lint only; not completeness or readiness evidence. |
+
+## Naming convention
+
+Future local action names should be short imperative labels:
+
+- start with a verb: `open`, `review`, `record`, `prepare`, `draft`, `apply`, `lint`;
+- name the evidence source or decision boundary;
+- avoid names that imply execution unless execution is separately authorized;
+- avoid names that imply provider/model/runtime behavior.
+
+## Explicit non-automation boundary
+
+This map does not add commands, scripts, configs, packages, routes, dashboard components, model calls, provider calls, or MCP tools. It is a vocabulary for future human/operator review only.

--- a/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/security-data-boundary-checklist.md
+++ b/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/security-data-boundary-checklist.md
@@ -1,0 +1,29 @@
+# Security and Data Boundary Checklist
+
+This checklist is mandatory for interpreting this design note. Every item is a blocked action for this lane.
+
+- No external upload.
+- No provider calls.
+- No token use.
+- No credentials.
+- No model calls.
+- No hosted model calls.
+- No local model calls.
+- No model pull or install.
+- No dashboard exposure.
+- No `/v1/solve` exposure.
+- No public API exposure.
+- No Google Sheets mutation.
+- No Pi.dev install.
+- No Pi.dev run.
+- No Pi.dev integration.
+- No Pi.dev vendoring or code copy.
+- No package install.
+- No dependency addition.
+- No shell feature activation for a future harness.
+- No file-operation feature activation for a future harness.
+- No MCP feature activation for a future harness.
+- No email feature activation.
+- No calendar feature activation.
+- No memory feature activation.
+- No credentials, auth files, env files, billing pages, subscription pages, or private token stores may be inspected for this lane.

--- a/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/selected-next-lane.md
+++ b/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/selected-next-lane.md
@@ -1,0 +1,27 @@
+# Selected Next State
+
+## Recommendation
+
+After merge, this packet completes `ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001` as a docs-only Alpha-native local operator harness design note.
+
+## Global source-of-truth update
+
+This PR updates `docs/CURRENT_STATE.md`, `docs/LANE_REGISTRY.md`, and `docs/EVIDENCE_INDEX.md` so the global selected next state is:
+
+`OPERATOR_DECISION_REQUIRED_AFTER_LOCAL_OPERATOR_HARNESS_DESIGN_NOTE_001`
+
+That state is an operator decision requirement, not an implementation lane.
+
+## One next action only
+
+Ask the operator to choose whether to:
+
+- authorize a separate implementation/spec lane for a local-only harness,
+- return to Value Read execution authorization if the operator wants value evidence next, or
+- stop and keep the design note as reference material.
+
+Default: no implementation, no UI work, no runtime work, no dependency change, no provider call, no hosted model call, no local model call, no Pi.dev install/run/integration, no dashboard exposure, no `/v1/solve` exposure, no public API exposure, no Google Sheets mutation, no benchmark or Value Read execution, and no readiness/value/security/privacy/provider/local-Ollama/Pi.dev-integration/Alpha-superiority claim without a new explicit operator-authorized lane.
+
+## Boundary
+
+No further lane is authorized automatically. Future implementation or execution requires a separate explicit operator-authorized lane.

--- a/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/selected-next-lane.md
+++ b/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/selected-next-lane.md
@@ -2,11 +2,11 @@
 
 ## Recommendation
 
-After merge, this packet completes `ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001` as a docs-only Alpha-native local operator harness design note.
+After PR #577 merges, this packet completes `ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001` as a docs-only Alpha-native local operator harness design note. PR #576 is superseded by PR #577 and should be closed unmerged.
 
 ## Global source-of-truth update
 
-This PR updates `docs/CURRENT_STATE.md`, `docs/LANE_REGISTRY.md`, and `docs/EVIDENCE_INDEX.md` so the global selected next state is:
+PR #577 updates `docs/CURRENT_STATE.md`, `docs/LANE_REGISTRY.md`, and `docs/EVIDENCE_INDEX.md` so the global selected next state is:
 
 `OPERATOR_DECISION_REQUIRED_AFTER_LOCAL_OPERATOR_HARNESS_DESIGN_NOTE_001`
 

--- a/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/session-evidence-format.md
+++ b/docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/session-evidence-format.md
@@ -1,0 +1,62 @@
+# Session Evidence Format
+
+This is a paper-only format for future Alpha-native local operator sessions. It is not a runtime schema and does not create storage, UI, API, or automation.
+
+## Required fields
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `session_id` | yes | Stable local identifier, for example `alpha-local-harness-YYYY-MM-DD-###`. |
+| `branch_label` | yes | Human-readable branch or lane label. |
+| `task_id` | yes | Packet case id, lane id, or operator task id. |
+| `lane_id` | yes | Controlling lane id. |
+| `repo_commit` | recommended | Commit SHA inspected or changed, when applicable. |
+| `prompt_source` | yes | Repo path and section for the prompt/template source. |
+| `operator_action` | yes | Named local operator action from the template map or future approved equivalent. |
+| `evidence_boundary` | yes | Short statement of what the session can and cannot support. |
+| `raw_output_pointer` | conditional | Local pointer to raw output if generated under authorization; otherwise `none`. |
+| `score_pointer` | conditional | Local pointer to blind scores/rubric output if scoring occurred under authorization; otherwise `none`. |
+| `non_claims` | yes | Claims that the session must not support. |
+| `stop_reason` | yes | `completed_docs_only`, `blocked_missing_authorization`, `blocked_no_raw_output`, `failed_closed`, `needs_human`, `evidence_conflict`, or another explicit reason. |
+| `operator_decision` | yes | `stop`, `continue_within_scope`, `queue_followup`, `escalate_to_human`, or `export_sanitized`. |
+| `export_status` | yes | `not_exported`, `sanitized_export_ready`, `exported_sanitized`, or `blocked_export`. |
+| `redaction_status` | yes | `not_needed`, `pending_review`, `redacted`, or `blocked_contains_sensitive_material`. |
+| `external_upload` | yes | Must default to `no`. |
+| `provider_or_model_call` | yes | Must record `none` unless a future lane explicitly authorizes otherwise. |
+
+## Example record shape
+
+```yaml
+session_id: alpha-local-harness-2026-06-15-001
+branch_label: local-operator-harness-design-note
+task_id: ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001
+lane_id: ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001
+repo_commit: pending
+prompt_source: docs/CURRENT_STATE.md#selected-next-lane
+operator_action: record-local-harness-design-note
+evidence_boundary: docs-only design note; no runtime, provider, model, dashboard, API, or Pi.dev integration evidence
+raw_output_pointer: none
+score_pointer: none
+non_claims:
+  - no value evidence
+  - no runtime readiness evidence
+  - no Pi.dev integration evidence
+  - no Alpha superiority evidence
+stop_reason: completed_docs_only
+operator_decision: stop
+export_status: sanitized_export_ready
+redaction_status: not_needed
+external_upload: no
+provider_or_model_call: none
+```
+
+## Export and redaction fields
+
+A future session should not be exported until the operator records:
+
+- whether raw output exists and where it is stored;
+- whether the raw output contains secrets, credentials, private prompts, private traces, personal data, or private workspace paths;
+- whether redaction has been reviewed;
+- whether the export is summary-only or includes sanitized excerpts;
+- which non-claims must accompany the export;
+- whether the export creates any public-surface, provider, model, value, or readiness confusion.


### PR DESCRIPTION
### Motivation

- Close the gap where global source-of-truth docs still pointed future operators back to the completed `ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001` lane and ensure no implementation is authorized automatically. 
- Record that PR #576 completes the docs-only Alpha-native local operator harness design note and move the global selected-next pointer to a decision-only state: `OPERATOR_DECISION_REQUIRED_AFTER_LOCAL_OPERATOR_HARNESS_DESIGN_NOTE_001`.

### Description

- Update `docs/CURRENT_STATE.md` to record PR #576 completion, set the current selected-next state to `OPERATOR_DECISION_REQUIRED_AFTER_LOCAL_OPERATOR_HARNESS_DESIGN_NOTE_001`, and state the operator must explicitly choose any future path. 
- Update `docs/LANE_REGISTRY.md` to mark `ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001` as completed by PR #576 and make `OPERATOR_DECISION_REQUIRED_AFTER_LOCAL_OPERATOR_HARNESS_DESIGN_NOTE_001` the selected next state (decision only). 
- Update `docs/EVIDENCE_INDEX.md` to add a PR #576 row (docs-only design note) and set the current selected-next state to `OPERATOR_DECISION_REQUIRED_AFTER_LOCAL_OPERATOR_HARNESS_DESIGN_NOTE_001`. 
- Adjust packet-local files under `docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/` including `selected-next-lane.md`, `checks-run.md`, and `interrupt-followup-semantics.md` to reflect the completed packet, the global docs update, and stronger evidence-boundary wording; add the packet README and associated docs describing non-actions and non-claims.

### Testing

- Reproduced the failing CI path and identified the cause as a narrative evidence-boundary linter finding triggered by the phrase `Alpha superiority` lacking nearby boundary language in `interrupt-followup-semantics.md`, then repaired the wording. 
- Ran `git diff --check` (pass), the narrative claim-safety linter `python scripts/check_narrative_claim_safety.py` against the changed files (pass), and the local LLM evidence-boundary static checker `python scripts/check_local_llm_evidence_boundaries.py` against the packet files (pass). 
- Re-ran the failing test `python -m pytest -q tests/test_local_llm_evidence_boundaries.py::test_current_relevant_docs_pass_static_check` (pass) and then `python -m pytest -q` for the full suite which completed with expected skips and deprecation warnings (pass for the changed-paths).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3069663c0083299995c6cd59f3578c)