### PR TITLE
docs: prepare post-577 Value Read execution authorization decision

### DIFF
--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -1,21 +1,15 @@
 # Alpha Solver — Current State
 
-> Source-of-truth navigation doc. Last verified **2026-06-15** for PR **#577** replacement branch repair.
+> Source-of-truth navigation doc. Last verified **2026-06-15** for post-#577 Value Read execution authorization decision packet.
 > Docs-only; no provider/runtime claims.
 
 ## Current verified phase
 
-**Post-#577 posture: the Alpha-native local operator harness design note is complete, and an explicit operator decision is required before any next lane.**
+**Post-#577 Value Read authorization-decision posture: the execution authorization decision packet is prepared, and operator review is required before any output-generation run.**
 
 The merged #569–#574 wave updated the repository from the post-#568 blocked Value Read state to a broader documentation-and-boundary posture. PR #576 was superseded by PR #577 and should be closed unmerged. PR #577 completes `ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001` as a docs-only Alpha-native local operator harness design note.
 
-The current control posture is now `OPERATOR_DECISION_REQUIRED_AFTER_LOCAL_OPERATOR_HARNESS_DESIGN_NOTE_001`: no further implementation or execution lane is selected automatically. The operator must explicitly choose one future path before any new lane:
-
-- authorize a separate local harness implementation/spec lane, or
-- return to Value Read execution authorization, or
-- stop and keep the design note as reference material.
-
-This document does not choose for the operator.
+The current control posture is now `OPERATOR_REVIEW_REQUIRED_AFTER_VALUE_READ_EXECUTION_AUTHORIZATION_DECISION_POST_577_001`: the operator decision to return to the Value Read execution authorization path has been recorded as a docs-only authorization-decision packet, but no output-generation run is authorized automatically. The operator must explicitly approve a future output-generation mechanism before anything runs.
 
 These are docs, gate, helper, static/research, and blocked-attempt artifacts. They do not prove provider behavior, model quality, value, readiness, benchmark success, security/privacy completion, local Ollama validation, `/v1/solve` readiness, production/public readiness, or Alpha superiority.
 
@@ -23,12 +17,12 @@ These are docs, gate, helper, static/research, and blocked-attempt artifacts. Th
 
 | Field | Value |
 |-------|-------|
-| Latest verified PR in this wave | **#577** — Alpha-native local operator harness design note completed by this PR |
-| PR branch state at verification | **#577 replacement merge candidate** on `adonisdv23/Alpha-Solver`; PR #576 superseded and should be closed unmerged |
+| Latest verified completed lane in this wave | **`ALPHA-SOLVER-VALUE-READ-EXECUTION-AUTHORIZATION-DECISION-POST-577-001`** |
+| Live pre-edit verification | PR #577 merged; PR #576 closed unmerged and superseded by #577; no open PRs at verification time |
 | Closed-unmerged superseded PR | **#561** — superseded by merged PR #562 |
-| Current controlling posture | Operator decision required after completed Alpha-native local operator harness design note |
-| Selected next state | **`OPERATOR_DECISION_REQUIRED_AFTER_LOCAL_OPERATOR_HARNESS_DESIGN_NOTE_001`** |
-| Strategic boundary | No implementation, UI, runtime, dependency, provider, local-model, Pi.dev, `/v1/solve`, dashboard/public API, Google Sheets, benchmark, Value Read, readiness, security/privacy, or superiority work is authorized until the operator chooses a future path |
+| Current controlling posture | Operator review required after completed Value Read execution authorization-decision packet |
+| Selected next state | **`OPERATOR_REVIEW_REQUIRED_AFTER_VALUE_READ_EXECUTION_AUTHORIZATION_DECISION_POST_577_001`** |
+| Strategic boundary | No provider call, local-model call, output generation, scoring, unblinding, runtime endpoint, dashboard, public API exposure, Google Sheets mutation, benchmark, readiness claim, value claim, provider claim, local-model claim, security/privacy claim, or Alpha-superiority claim is authorized until the operator explicitly approves a future output-generation mechanism |
 
 ## Completed post-552 / post-565 / post-568 infrastructure lanes
 
@@ -51,22 +45,17 @@ These are docs, gate, helper, static/research, and blocked-attempt artifacts. Th
 | #574 | `18 - PI.DEV-HARNESS-FEASIBILITY` | Records `BORROW_PATTERNS_ONLY_NO_INTEGRATION` for Pi.dev harness research. |
 | #576 | Superseded local operator harness design note PR | Superseded by PR #577; should be closed unmerged and not cited as the completion artifact. |
 | #577 | `ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001` | Completes the docs-only Alpha-native local operator harness design note; no implementation or execution authorization. |
+| post-577 lane | `ALPHA-SOLVER-VALUE-READ-EXECUTION-AUTHORIZATION-DECISION-POST-577-001` | Completes a docs-only authorization-decision packet for returning to Value Read execution authorization review; no output generation, scoring, provider/local-model call, endpoint exposure, or value/readiness claim. |
 
 See [`EVIDENCE_INDEX.md`](EVIDENCE_INDEX.md) for the PR status ledger and [`LANE_REGISTRY.md`](LANE_REGISTRY.md) for lifecycle classification.
 
 ## Selected next state
 
-**`OPERATOR_DECISION_REQUIRED_AFTER_LOCAL_OPERATOR_HARNESS_DESIGN_NOTE_001`** is the current global selected next state.
+**`OPERATOR_REVIEW_REQUIRED_AFTER_VALUE_READ_EXECUTION_AUTHORIZATION_DECISION_POST_577_001`** is the current global selected next state.
 
-This is a decision state, not an implementation lane. It means no implementation is authorized, no UI is authorized, no runtime work is authorized, no dependency work is authorized, no provider call is authorized, no local model call is authorized, no Pi.dev install/run/integration is authorized, no `/v1/solve` exposure is authorized, no dashboard or public API exposure is authorized, no Google Sheets mutation is authorized, no benchmark or Value Read execution is authorized, and no readiness, value, security/privacy, provider, local-Ollama, Pi.dev integration, or Alpha superiority claim is authorized.
+This is a review state, not an execution lane. It means the Value Read execution authorization-decision packet is prepared, but no output generation is authorized until the operator explicitly approves a future mechanism, models/providers if any, cost/token caps if any, data boundary, stop conditions, output paths, scoring packet, blinding-map storage, and claim boundaries.
 
-The operator must explicitly choose one future path before any new lane:
-
-1. authorize a separate local harness implementation/spec lane, or
-2. return to Value Read execution authorization, or
-3. stop and keep the design note as reference material.
-
-This source-of-truth state does not choose for the operator and does not automatically authorize a successor lane.
+This selected state authorizes no provider call, local model call, output generation, scoring, unblinding, runtime endpoint, dashboard, public API exposure, Google Sheets mutation, benchmark, readiness claim, value claim, provider claim, local-model claim, security/privacy claim, or Alpha superiority claim.
 
 ## Open deferrals (see [`DEFERRAL_REGISTER.md`](DEFERRAL_REGISTER.md))
 
@@ -78,7 +67,7 @@ This source-of-truth state does not choose for the operator and does not automat
 ## What is blocked / not authorized
 
 - Provider calls, hosted model calls, local model calls, token use, credential access, billing inspection, dashboard exposure, `/v1/solve` exposure, public API exposure, Pi.dev installation/execution/integration, package-install experiments, and Google Sheets mutation.
-- Value experiment execution and Alpha-vs-baseline claims. PR #568 is `VALUE_READ_BLOCKED`: it generated no Alpha outputs, baseline outputs, blind scores, or measured discrimination-delta.
+- Value experiment execution and Alpha-vs-baseline claims. PR #568 is `VALUE_READ_BLOCKED`: it generated no Alpha outputs, baseline outputs, blind scores, or measured discrimination-delta. The post-577 authorization-decision lane prepares only an authorization-decision packet and still does not authorize execution.
 - Local Ollama validation claims. PR #573 records a failed-closed local timeout/backend error and no local model answer.
 - Security/privacy completion, production readiness, public MVP readiness, benchmark validation/superiority, broad-user readiness, autonomous readiness, provider validation, local Ollama validation, `/v1/solve` readiness, dashboard readiness, or Alpha superiority.
 

--- a/docs/EVIDENCE_INDEX.md
+++ b/docs/EVIDENCE_INDEX.md
@@ -1,6 +1,6 @@
-# Evidence Index — Post-#577 operator-decision state
+# Evidence Index — Post-#577 Value Read authorization-decision state
 
-> Source-of-truth evidence ledger. Verification date **2026-06-15** for PR **#577** replacement branch repair.
+> Source-of-truth evidence ledger. Verification date **2026-06-15** for post-#577 Value Read execution authorization decision packet.
 
 ## How to read "evidence value"
 
@@ -29,18 +29,19 @@ The entries below are design, documentation, gate, helper, static-checking, meth
 | #573 | Record blocked local Ollama singlepath attempt | ✅ merged 2026-06-15 | `docs/evals/runs/alpha-solver-local-model-lab-ollama-singlepath-001/local-run-artifact-2026-06-15.md` | Records exact `gemma3:4b` preflight success followed by failed-closed timeout/backend error; no local model answer was generated. | Does not prove local model quality, local Ollama validation, Value Read success, runtime readiness, or Alpha superiority. | blocked evidence |
 | #574 | Add pi.dev harness feasibility research note | ✅ merged 2026-06-15 | `docs/evals/runs/alpha-solver-pi-dev-harness-feasibility-018/README.md` | Records `BORROW_PATTERNS_ONLY_NO_INTEGRATION` for Pi.dev harness research. | Does not install, run, or integrate Pi.dev; does not authorize providers, package installs, runtime exposure, or readiness claims. | completed |
 | #576 | Add Alpha-native local operator harness design note | closed unmerged / superseded by #577 | superseded by #577 | No merged evidence artifact from #576. | Must not be cited as the merged completion artifact for this lane. | superseded |
-| #577 | Add Alpha-native local operator harness design note | merged after PR completion | `docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/` | Docs-only Alpha-native local operator harness design note. | Does not prove implementation, runtime behavior, UI readiness, provider behavior, local model behavior, Pi.dev integration, Value Read success, benchmark success, production readiness, public readiness, security/privacy completion, or Alpha superiority. | completed |
+| #577 | Add Alpha-native local operator harness design note | ✅ merged 2026-06-15 | `docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/` | Docs-only Alpha-native local operator harness design note. | Does not prove implementation, runtime behavior, UI readiness, provider behavior, local model behavior, Pi.dev integration, Value Read success, benchmark success, production readiness, public readiness, security/privacy completion, or Alpha superiority. | completed |
+| post-577 lane | docs: prepare post-577 Value Read execution authorization decision | completed | `docs/evals/runs/alpha-solver-value-read-execution-authorization-decision-post-577-001/` | Docs-only authorization-decision packet for operator review before any future Value Read output-generation run. | Does not authorize or perform output generation, scoring, unblinding, provider calls, local model runs, runtime endpoints, dashboard/public API exposure, Google Sheets mutation, benchmarks, readiness claims, value claims, provider claims, local-model claims, security/privacy claims, or Alpha-superiority claims. | completed |
 
 ## Current selected next state
 
-`OPERATOR_DECISION_REQUIRED_AFTER_LOCAL_OPERATOR_HARNESS_DESIGN_NOTE_001` is the selected next state. This is a decision state, not an implementation lane.
+`OPERATOR_REVIEW_REQUIRED_AFTER_VALUE_READ_EXECUTION_AUTHORIZATION_DECISION_POST_577_001` is the selected next state. This is a review state, not an execution lane.
 
-PR #576 is superseded by PR #577 and should be closed unmerged. PR #577 completes `ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001` after merge. The completed packet does not automatically authorize a successor lane. Future implementation or execution requires a separate explicit operator-authorized lane.
+`ALPHA-SOLVER-VALUE-READ-EXECUTION-AUTHORIZATION-DECISION-POST-577-001` is completed as a docs-only authorization-decision packet. The operator must explicitly authorize a future output-generation mechanism before anything runs.
 
-The selected state authorizes no implementation, UI, runtime work, dependency work, provider call, local model call, Pi.dev install/run/integration, `/v1/solve` exposure, dashboard or public API exposure, Google Sheets mutation, benchmark execution, Value Read execution, or readiness/value/security/privacy/provider/local-Ollama/Pi.dev-integration/Alpha-superiority claim.
+The selected state authorizes no provider call, local model call, output generation, scoring, unblinding, runtime endpoint, dashboard or public API exposure, Google Sheets mutation, benchmark execution, readiness claim, value claim, provider claim, local-model claim, security/privacy claim, or Alpha-superiority claim.
 
 ## Evidence boundary
 
-The post-#577 state supports only bounded statements that the repository contains docs/design/static-checking/scaffold/gate/helper/blocked-attempt/research artifacts for no-echo gating, false-premise perturbations, claim-safety linting, calibrated confidence, needs-human protocol guidance, higher-headroom cases, prompt-contract methodology, a local Ollama lab scaffold/helper, blocked Value Read evidence, blocked `/v1/solve` exposure evidence, a failed-closed local Ollama attempt, and Pi.dev patterns-only research.
+The post-#577 authorization-decision state supports only bounded statements that the repository contains docs/design/static-checking/scaffold/gate/helper/blocked-attempt/research artifacts for no-echo gating, false-premise perturbations, claim-safety linting, calibrated confidence, needs-human protocol guidance, higher-headroom cases, prompt-contract methodology, a local Ollama lab scaffold/helper, blocked Value Read evidence, blocked `/v1/solve` exposure evidence, a failed-closed local Ollama attempt, Pi.dev patterns-only research, and a docs-only Value Read execution authorization-decision packet.
 
 It does **not** support claims of provider validation, local Ollama validation, hosted-model validation, token use, benchmark success, value, readiness, security/privacy completion, public API readiness, `/v1/solve` readiness, dashboard readiness, Pi.dev integration, Google Sheets synchronization, or Alpha superiority.

--- a/docs/LANE_REGISTRY.md
+++ b/docs/LANE_REGISTRY.md
@@ -45,9 +45,11 @@
 |-----------|---------------|-----|
 | PR #561 — `Add needs-human escalation protocol` | PR #562 | #561 is closed unmerged; #562 merged the docs-only needs-human protocol. |
 | Older smoke-authorization selected-next pointers | Post-#568 and post-#574 selected-next lanes in this registry and [`CURRENT_STATE.md`](CURRENT_STATE.md) | The #557–#574 wave changed the active posture to Value Read blocked evidence, exposure/local-lab gates, and an Alpha-native harness design next step. |
-| `ALPHA-SOLVER-VALUE-READ-EXECUTION-PACKET-AUTHORIZATION-001` as immediate global next | `OPERATOR_DECISION_REQUIRED_AFTER_LOCAL_OPERATOR_HARNESS_DESIGN_NOTE_001` | Value Read execution remains blocked until the operator explicitly returns to Value Read execution authorization. |
+| `ALPHA-SOLVER-VALUE-READ-EXECUTION-PACKET-AUTHORIZATION-001` as older immediate next pointer | Historical pointer; not current selected state | Value Read execution remains blocked unless the operator separately authorizes a future output-generation lane. |
+| `ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001` as selected next after PR #575 | PR #577 completed that lane | Future operators must not be routed back to the completed design-note lane. |
 | PR #576 - Add Alpha-native local operator harness design note | PR #577 | PR #577 includes the design note plus source-of-truth closeout and green checks; #576 should be closed unmerged and not cited as merged evidence. |
-| `ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001` as selected next | PR #577 completed that lane | Future operators must not be sent back to the completed design-note lane; the global selected state is now operator decision required. |
+| `OPERATOR_DECISION_REQUIRED_AFTER_LOCAL_OPERATOR_HARNESS_DESIGN_NOTE_001` as post-#577 decision state | `ALPHA-SOLVER-VALUE-READ-EXECUTION-AUTHORIZATION-DECISION-POST-577-001` | This was the decision-only state after PR #577. PR #578 records the operator decision to return to Value Read execution authorization review by completing the docs-only authorization-decision packet. |
+| `ALPHA-SOLVER-VALUE-READ-EXECUTION-AUTHORIZATION-DECISION-POST-577-001` | `OPERATOR_REVIEW_REQUIRED_AFTER_VALUE_READ_EXECUTION_AUTHORIZATION_DECISION_POST_577_001` | PR #578 completes the docs-only authorization-decision packet. The current selected state is operator review only, not an execution lane. |
 
 ## Blocked / not authorized
 

--- a/docs/LANE_REGISTRY.md
+++ b/docs/LANE_REGISTRY.md
@@ -1,7 +1,7 @@
 # Lane Registry
 
 > Source-of-truth lane lifecycle registry. Verification date **2026-06-15** for
-> PR **#577** replacement branch repair.
+> post-#577 Value Read execution authorization decision packet.
 
 ## Lifecycle classes
 
@@ -11,13 +11,13 @@
 
 | Lane | State | Evidence |
 |------|-------|----------|
-| Post-#577 operator-decision posture | **current control posture** | PR #576 is superseded and should be closed unmerged. PR #577 completes `ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001` as a docs-only design note. The current selected state is an operator decision requirement, not an implementation lane. |
+| Post-#577 Value Read authorization-decision posture | **current control posture** | `ALPHA-SOLVER-VALUE-READ-EXECUTION-AUTHORIZATION-DECISION-POST-577-001` is completed as a docs-only decision packet. The current selected state is operator review required, not an execution lane. |
 
 ## Next ready / current selected state
 
 | State | Lifecycle | Notes |
 |-------|-----------|-------|
-| **`OPERATOR_DECISION_REQUIRED_AFTER_LOCAL_OPERATOR_HARNESS_DESIGN_NOTE_001`** | **selected next state; not an implementation lane** | The operator must explicitly choose whether to authorize a separate local harness implementation/spec lane, return to Value Read execution authorization, or stop and keep the design note as reference material. No implementation, UI, runtime, dependency, provider, local-model, Pi.dev, `/v1/solve`, dashboard/public API, Google Sheets, benchmark, Value Read, readiness, security/privacy, or superiority work is authorized. |
+| **`OPERATOR_REVIEW_REQUIRED_AFTER_VALUE_READ_EXECUTION_AUTHORIZATION_DECISION_POST_577_001`** | **selected next state; review state, not an execution lane** | The operator must explicitly approve any future output-generation mechanism before anything runs. No provider call, local model call, output generation, scoring, unblinding, runtime endpoint, dashboard/public API, Google Sheets mutation, benchmark, readiness claim, value claim, provider claim, local-model claim, security/privacy claim, or Alpha-superiority claim is authorized. |
 
 ## Completed (kept as evidence)
 
@@ -37,6 +37,7 @@
 - Local Ollama singlepath blocked attempt (PR #573) — exact `gemma3:4b` model preflight passed, then helper failed closed with timeout/backend error and produced no local answer.
 - `18 - PI.DEV-HARNESS-FEASIBILITY` (PR #574) — `BORROW_PATTERNS_ONLY_NO_INTEGRATION` research note.
 - `ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001` (PR #577) — docs-only Alpha-native local operator harness design note; completed by PR #577 with no implementation or execution authorization.
+- `ALPHA-SOLVER-VALUE-READ-EXECUTION-AUTHORIZATION-DECISION-POST-577-001` (stable post-merge state) — docs-only authorization-decision packet; no output generation, scoring, provider/local-model call, endpoint exposure, or value/readiness claim.
 
 ## Superseded
 
@@ -63,7 +64,7 @@
 
 - PR #561 lane as a standalone needs-human protocol PR — closed unmerged and superseded by PR #562.
 - Any merged packet lane verbatim — packets are immutable evidence; create a new lane id instead.
-- Any selected-next pointer that conflicts with `OPERATOR_DECISION_REQUIRED_AFTER_LOCAL_OPERATOR_HARNESS_DESIGN_NOTE_001`.
+- Any selected-next pointer that conflicts with `OPERATOR_REVIEW_REQUIRED_AFTER_VALUE_READ_EXECUTION_AUTHORIZATION_DECISION_POST_577_001`.
 - Direct Pi.dev integration from PR #574's research lane — the recorded verdict is patterns-only/no-integration.
 
 ## Forward path (single track)
@@ -93,7 +94,10 @@ ALPHA-SOLVER-VALUE-READ-SIMULATION-PACKET-REFRESH-POST-565-001 / PR #568 artifac
 #577 local operator harness design note completed
         │
         ▼
-OPERATOR_DECISION_REQUIRED_AFTER_LOCAL_OPERATOR_HARNESS_DESIGN_NOTE_001 ← selected next state; decision only, not an implementation lane
+ALPHA-SOLVER-VALUE-READ-EXECUTION-AUTHORIZATION-DECISION-POST-577-001 ← docs-only packet; no output generation
+        │
+        ▼
+OPERATOR_REVIEW_REQUIRED_AFTER_VALUE_READ_EXECUTION_AUTHORIZATION_DECISION_POST_577_001 ← selected next state; review only, not an execution lane
 ```
 
-This registry does not authorize any provider call, local model call, Pi.dev install/run/integration, runtime exposure, public API exposure, Google Sheets mutation, or readiness/value/security/privacy/provider/local-Ollama/Alpha-superiority claim.
+This registry does not authorize any provider call, local model call, output generation, scoring, unblinding, Pi.dev install/run/integration, runtime endpoint, dashboard exposure, public API exposure, Google Sheets mutation, benchmark, or readiness/value/security/privacy/provider/local-Ollama/Alpha-superiority claim.

--- a/docs/evals/runs/alpha-solver-value-read-execution-authorization-decision-post-577-001/README.md
+++ b/docs/evals/runs/alpha-solver-value-read-execution-authorization-decision-post-577-001/README.md
@@ -1,0 +1,55 @@
+# Value Read Execution Authorization Decision Packet — Post-577
+
+## Lane ID
+
+`ALPHA-SOLVER-VALUE-READ-EXECUTION-AUTHORIZATION-DECISION-POST-577-001`
+
+## Verdict
+
+`AUTHORIZATION_DECISION_PACKET_PREPARED_NO_OUTPUT_GENERATION`
+
+## TLDR
+
+This docs-only lane records the operator decision to return to the Value Read execution authorization path after PR #577. It prepares an authorization-decision packet only. It does not execute the Value Read, generate Alpha outputs, generate baseline outputs, score outputs, unblind anything, call providers, run local models, expose endpoints, expose dashboards, mutate Google Sheets, or make readiness, value, provider, local-model, benchmark, public-use, security/privacy, or Alpha-superiority claims.
+
+## Source files reviewed
+
+- `docs/CURRENT_STATE.md`
+- `docs/LANE_REGISTRY.md`
+- `docs/EVIDENCE_INDEX.md`
+- `docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/README.md`
+- `docs/evals/runs/alpha-solver-local-operator-harness-design-note-001/selected-next-lane.md`
+- `docs/evals/runs/alpha-solver-value-read-simulation-packet-refresh-post-565-001/README.md`
+- `docs/evals/runs/alpha-solver-value-read-simulation-packet-refresh-post-565-001/manual-run-artifact-2026-06-15.md`
+- `docs/evals/runs/alpha-solver-value-read-simulation-packet-refresh-post-565-001/task-selection.md`
+- `docs/evals/runs/alpha-solver-value-read-simulation-packet-refresh-post-565-001/operator-run-template.md`
+- `docs/evals/runs/alpha-solver-value-read-simulation-packet-refresh-post-565-001/blind-scoring-template.md`
+- `docs/evals/runs/alpha-solver-value-read-simulation-packet-refresh-post-565-001/scoring-rubric.md`
+- `docs/evals/runs/alpha-solver-value-read-simulation-packet-refresh-post-565-001/evidence-boundary.md`
+- `docs/evals/runs/alpha-solver-value-read-simulation-packet-refresh-post-565-001/non-claims.md`
+
+## Evidence boundary
+
+PR #568 remains `VALUE_READ_BLOCKED`: no Alpha outputs exist, no baseline outputs exist, no blind scores exist, no discrimination-delta was measured, no Value Read result exists, no provider or local-model output was generated, no runtime endpoint evidence exists, and no readiness or value claim is supported.
+
+PR #577 completed the Alpha-native local operator harness design note, but it did not create value evidence or authorize execution. This packet is limited to decision-preparation evidence for a future operator review.
+
+## Decision summary
+
+The selected path returns to Value Read execution authorization review. The packet defines what a future output-generation run would still need before it can be authorized, including a complete prompt set, raw-output preservation paths, scorer packet, blinding-map storage, operator authorization, claim boundaries, and stop conditions. This packet does not automatically authorize any execution.
+
+## Selected next state
+
+After this lane is merged, the selected next state is:
+
+`OPERATOR_REVIEW_REQUIRED_AFTER_VALUE_READ_EXECUTION_AUTHORIZATION_DECISION_POST_577_001`
+
+This is a review state, not an execution lane.
+
+## Non-actions
+
+See `non-actions.md`. This lane performs no output generation, scoring, provider call, local-model run, endpoint exposure, dashboard exposure, public API exposure, Google Sheets mutation, benchmark, runtime change, API change, dashboard change, dependency addition, routing change, council change, or local model registry change.
+
+## Non-claims
+
+See `non-claims.md`. This lane supports no readiness, value, provider, local-model, benchmark, production, public-use, security/privacy, partnership, Pi.dev integration, Google Sheets synchronization, runtime, endpoint, dashboard, or Alpha-superiority claim.

--- a/docs/evals/runs/alpha-solver-value-read-execution-authorization-decision-post-577-001/authorization-decision.md
+++ b/docs/evals/runs/alpha-solver-value-read-execution-authorization-decision-post-577-001/authorization-decision.md
@@ -1,0 +1,17 @@
+# Authorization Decision
+
+## What is being authorized for review
+
+This packet authorizes operator review of whether a future, separately approved Value Read output-generation run should proceed. The review may inspect prerequisites, boundaries, artifact paths, scoring sequence, and stop conditions.
+
+## What remains unauthorized
+
+No execution is authorized by this packet. Alpha output generation, baseline output generation, provider calls, hosted model calls, local model runs, token use, credential access, scoring, unblinding, runtime endpoint use, dashboard use, public API exposure, Google Sheets mutation, and benchmark or readiness interpretation remain unauthorized.
+
+## Prerequisites for any future output-generation run
+
+A later run requires explicit operator authorization that names the mechanism, allowed models or providers if any, cost and token caps if any, data boundary, stop conditions, output paths, prompt set, scoring packet, blinding-map storage, claim boundaries, and reviewer responsibilities.
+
+## No automatic execution
+
+Merging this packet only completes the authorization-decision packet. It does not start, schedule, imply, or authorize Value Read execution.

--- a/docs/evals/runs/alpha-solver-value-read-execution-authorization-decision-post-577-001/blinding-score-lock-unblind-rules.md
+++ b/docs/evals/runs/alpha-solver-value-read-execution-authorization-decision-post-577-001/blinding-score-lock-unblind-rules.md
@@ -1,0 +1,10 @@
+# Blinding, Score Lock, and Unblind Rules
+
+1. Prepare blinded Output A / Output B materials before any scorer review.
+2. Remove source identity, model identity, route identity, desired winner, prior totals, and unblinding-map references from scorer-facing packets.
+3. Scorers must not infer or discuss output identity before score lock.
+4. Scores freeze with reviewer identity, timestamp, rubric version, and case ID.
+5. Contested scores must be flagged with notes; do not force agreement by exposing identities.
+6. No unblinding may occur before blind scores are locked.
+7. Unblinding requires operator approval after score lock.
+8. Interpretation after unblinding must remain simulation-only and preserve all non-claims.

--- a/docs/evals/runs/alpha-solver-value-read-execution-authorization-decision-post-577-001/checks-run.md
+++ b/docs/evals/runs/alpha-solver-value-read-execution-authorization-decision-post-577-001/checks-run.md
@@ -1,0 +1,9 @@
+# Checks Run
+
+Checks for this docs-only packet:
+
+- `git diff --check` — passed.
+- `python scripts/check_narrative_claim_safety.py <changed markdown files>` — passed for changed Markdown files.
+- `python scripts/check_local_llm_evidence_boundaries.py <changed markdown files>` — passed; the checker reported 0 scanned files because the changed paths did not match its local-LLM-specific scan scope.
+- `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-value-read-execution-authorization-decision-post-577-001` — passed for the new packet directory.
+- Repo docs/source-of-truth consistency checks — checked for applicable existing scripts; no dedicated current-state/lane-registry/evidence-index consistency script was found.

--- a/docs/evals/runs/alpha-solver-value-read-execution-authorization-decision-post-577-001/execution-prerequisites.md
+++ b/docs/evals/runs/alpha-solver-value-read-execution-authorization-decision-post-577-001/execution-prerequisites.md
@@ -1,0 +1,16 @@
+# Execution Prerequisites
+
+Before any future Value Read output generation, all prerequisites below must be complete and explicitly approved by the operator:
+
+1. Frozen prompt set with complete per-case user tasks and required answerability fields.
+2. Raw Alpha output preservation path.
+3. Raw baseline output preservation path.
+4. Blind scorer packet path with source identities removed.
+5. Operator-only blinding map storage path.
+6. Scoring rubric and reviewer roster.
+7. Explicit operator authorization text naming the output-generation mechanism.
+8. Allowed models/providers, if any, and a statement if none are allowed.
+9. Cost, token, runtime, and data-boundary caps, if any.
+10. Claim boundaries and non-claims to carry into every artifact.
+11. Stop conditions, including ambiguous mechanism, missing paths, missing scorer packet, missing map storage, incomplete prompt set, unauthorized provider/token/credential use, unauthorized local-model use, and any runtime/public endpoint involvement.
+12. Confirmation that scoring freezes before unblinding and that contested scores remain flagged rather than forced.

--- a/docs/evals/runs/alpha-solver-value-read-execution-authorization-decision-post-577-001/execution-scope-and-boundary.md
+++ b/docs/evals/runs/alpha-solver-value-read-execution-authorization-decision-post-577-001/execution-scope-and-boundary.md
@@ -1,0 +1,17 @@
+# Execution Scope and Boundary
+
+## Allowed future scope, only if separately authorized
+
+A future lane may be allowed to generate Value Read Alpha and baseline outputs for the frozen packet cases, preserve raw outputs, prepare blinded scorer packets, lock blind scores, unblind only after score lock, and interpret results narrowly as simulation-only evidence.
+
+## Forbidden scope in this lane
+
+This lane forbids output generation, scoring, unblinding, provider calls, hosted model calls, local model runs, credentials, billing inspection, runtime endpoint use, dashboard use, public API exposure, Google Sheets mutation, dependency addition, routing changes, council changes, benchmarks, and readiness or value claims.
+
+## Simulation/no-provider separation
+
+Simulation/no-provider work may prepare prompts, paths, templates, and boundaries. It may not produce model outputs unless a later authorization explicitly defines the non-provider mechanism.
+
+## Runtime/provider/local-model separation
+
+Runtime, provider, hosted-model, and local-model execution are separate authorization categories. A future operator approval must name each allowed category explicitly. Silence is denial.

--- a/docs/evals/runs/alpha-solver-value-read-execution-authorization-decision-post-577-001/non-actions.md
+++ b/docs/evals/runs/alpha-solver-value-read-execution-authorization-decision-post-577-001/non-actions.md
@@ -1,0 +1,18 @@
+# Non-Actions
+
+This lane does not:
+
+- execute the Value Read;
+- generate Alpha outputs;
+- generate baseline outputs;
+- score outputs;
+- create filled blind-score sheets;
+- create a real unblinding map;
+- unblind anything;
+- call providers or hosted models;
+- use tokens, credentials, or billing data;
+- run local models, pull models, or install models;
+- expose `/v1/solve`, dashboards, runtime endpoints, or public APIs;
+- mutate Google Sheets or external ledgers;
+- modify runtime, API, dashboard, routing, council, benchmark, provider, local-model registry, or dependency behavior;
+- make readiness, value, provider, local-model, benchmark, public-use, production, security/privacy, partnership, Pi.dev integration, Google Sheets, or Alpha-superiority claims.

--- a/docs/evals/runs/alpha-solver-value-read-execution-authorization-decision-post-577-001/non-claims.md
+++ b/docs/evals/runs/alpha-solver-value-read-execution-authorization-decision-post-577-001/non-claims.md
@@ -1,0 +1,15 @@
+# Non-Claims
+
+This lane does not claim:
+
+- Alpha Solver value has been measured;
+- Alpha Solver beats, outperforms, or is safer than any baseline;
+- any Alpha output exists;
+- any baseline output exists;
+- any blind score exists;
+- any discrimination-delta was measured;
+- any Value Read result exists;
+- any provider, hosted model, or local model was called;
+- tokens, costs, credentials, or billing were used or inspected;
+- runtime endpoint, `/v1/solve`, dashboard, public API, or Google Sheets behavior was exercised;
+- production, MVP, public, deployment, benchmark, security, privacy, operator, provider, local-model, partnership, Pi.dev integration, or Alpha-superiority readiness.

--- a/docs/evals/runs/alpha-solver-value-read-execution-authorization-decision-post-577-001/operator-authorization-template.md
+++ b/docs/evals/runs/alpha-solver-value-read-execution-authorization-decision-post-577-001/operator-authorization-template.md
@@ -1,0 +1,24 @@
+# Operator Authorization Template
+
+A future output-generation run requires exact operator authorization text in this form:
+
+```text
+I authorize a future Value Read output-generation run for lane <LANE_ID>.
+
+Allowed mechanism: <manual simulation / provider / hosted model / local model / other, with exact scope>.
+Allowed models/providers, if any: <names or `none`>.
+Provider tokens or credentials authorized: <yes/no; if yes, exact boundary>.
+Local model execution authorized: <yes/no; if yes, exact model and no-pull/no-install policy>.
+Cost/token/runtime caps: <caps or `none because no provider/local execution is authorized`>.
+Data boundary: <committed synthetic packet only / other exact boundary>.
+Prompt set: <path>.
+Raw Alpha output path: <path>.
+Raw baseline output path: <path>.
+Blind scorer packet path: <path>.
+Operator-only blinding map path: <path>.
+Final interpretation path: <path>.
+Stop conditions: <explicit list>.
+Claim boundaries: no readiness, value, provider, local-model, benchmark, production, public-use, security/privacy, endpoint, dashboard, Google Sheets, or Alpha-superiority claim unless separately supported by preserved evidence.
+```
+
+Without this exact future authorization, no output-generation run is authorized.

--- a/docs/evals/runs/alpha-solver-value-read-execution-authorization-decision-post-577-001/raw-artifact-preservation-plan.md
+++ b/docs/evals/runs/alpha-solver-value-read-execution-authorization-decision-post-577-001/raw-artifact-preservation-plan.md
@@ -1,0 +1,13 @@
+# Raw Artifact Preservation Plan
+
+This plan names future paths only. It does not create outputs, scorer packets, scores, maps, or interpretations.
+
+| Artifact | Future path if separately authorized |
+| --- | --- |
+| Raw Alpha outputs | `docs/evals/runs/alpha-solver-value-read-execution-authorized-<date>/raw/alpha/` |
+| Raw baseline outputs | `docs/evals/runs/alpha-solver-value-read-execution-authorized-<date>/raw/baseline/` |
+| Blind scorer packet | `docs/evals/runs/alpha-solver-value-read-execution-authorized-<date>/blind-scorer-packet/` |
+| Operator-only unblinding map | `docs/evals/runs/alpha-solver-value-read-execution-authorized-<date>/operator-only/unblinding-map.md` |
+| Final interpretation | `docs/evals/runs/alpha-solver-value-read-execution-authorized-<date>/final-interpretation.md` |
+
+Raw outputs must be preserved before editing, scoring, summarizing, or interpreting. Operator notes must remain separate from raw model or baseline outputs.

--- a/docs/evals/runs/alpha-solver-value-read-execution-authorization-decision-post-577-001/selected-next-lane.md
+++ b/docs/evals/runs/alpha-solver-value-read-execution-authorization-decision-post-577-001/selected-next-lane.md
@@ -1,0 +1,11 @@
+# Selected Next State
+
+This lane completes the authorization-decision packet for:
+
+`ALPHA-SOLVER-VALUE-READ-EXECUTION-AUTHORIZATION-DECISION-POST-577-001`
+
+After merge, the selected next state should be:
+
+`OPERATOR_REVIEW_REQUIRED_AFTER_VALUE_READ_EXECUTION_AUTHORIZATION_DECISION_POST_577_001`
+
+This is a review state, not an execution lane. No execution is authorized until the operator explicitly approves a future output-generation run with mechanism, boundaries, artifact paths, stop conditions, and claim boundaries.

--- a/docs/evals/runs/alpha-solver-value-read-execution-authorization-decision-post-577-001/selected-next-state.md
+++ b/docs/evals/runs/alpha-solver-value-read-execution-authorization-decision-post-577-001/selected-next-state.md
@@ -1,0 +1,11 @@
+# Selected Next State
+
+This lane completes the authorization-decision packet for:
+
+`ALPHA-SOLVER-VALUE-READ-EXECUTION-AUTHORIZATION-DECISION-POST-577-001`
+
+After merge, the selected next state should be:
+
+`OPERATOR_REVIEW_REQUIRED_AFTER_VALUE_READ_EXECUTION_AUTHORIZATION_DECISION_POST_577_001`
+
+This is a review state, not an execution lane. No execution is authorized until the operator explicitly approves a future output-generation run with mechanism, boundaries, artifact paths, stop conditions, and claim boundaries.

--- a/docs/evals/runs/alpha-solver-value-read-execution-authorization-decision-post-577-001/stop-conditions.md
+++ b/docs/evals/runs/alpha-solver-value-read-execution-authorization-decision-post-577-001/stop-conditions.md
@@ -1,0 +1,15 @@
+# Stop Conditions
+
+Stop before output generation or interpretation if any of the following is true:
+
+- Output-generation mechanism is ambiguous.
+- Any provider token, credential, billing access, or hosted service is required but not explicitly authorized.
+- Local model execution is required but not explicitly authorized.
+- Prompt set is incomplete.
+- Raw-output preservation path is missing.
+- Scoring packet is missing.
+- Blinding map storage is missing.
+- Claim boundaries are missing.
+- Any runtime endpoint, public endpoint, `/v1/solve`, dashboard, public API, or Google Sheets mutation is involved.
+- Scorer-facing material exposes identity before score lock.
+- Raw output is missing, edited before preservation, or contaminated with private data, secrets, or unauthorized execution metadata.


### PR DESCRIPTION
### Motivation

- Record the operator decision to return to the Value Read execution authorization path by preparing a docs-only authorization-decision packet and ensure no output-generation, provider/local-model, scoring, or unblinding activity is authorized. 
- Preserve strict evidence boundaries and operator-review gating so a future run requires explicit, exact operator authorization before any mechanism or credentials are used. 

### Description

- Add a new docs-only packet at `docs/evals/runs/alpha-solver-value-read-execution-authorization-decision-post-577-001/` containing `README.md`, `authorization-decision.md`, `execution-prerequisites.md`, `execution-scope-and-boundary.md`, `raw-artifact-preservation-plan.md`, `blinding-score-lock-unblind-rules.md`, `operator-authorization-template.md`, `stop-conditions.md`, `non-actions.md`, `non-claims.md`, `selected-next-state.md`, `selected-next-lane.md`, and `checks-run.md`. 
- Update source-of-truth docs `docs/CURRENT_STATE.md`, `docs/LANE_REGISTRY.md`, and `docs/EVIDENCE_INDEX.md` to record the new lane `ALPHA-SOLVER-VALUE-READ-EXECUTION-AUTHORIZATION-DECISION-POST-577-001` and set the selected next state to `OPERATOR_REVIEW_REQUIRED_AFTER_VALUE_READ_EXECUTION_AUTHORIZATION_DECISION_POST_577_001`. 
- Specify the packet verdict `AUTHORIZATION_DECISION_PACKET_PREPARED_NO_OUTPUT_GENERATION` and explicitly forbid execution, scoring, provider/local-model calls, endpoints, dashboard/public API exposure, Google Sheets mutation, and all readiness/value/security/privacy/superiority claims. 

### Testing

- Ran `git diff --check` and validated there were no whitespace or diff-check issues, and the check passed. 
- Ran the narrative claim-safety linter `python scripts/check_narrative_claim_safety.py <changed markdown files>` against the changed Markdown files and it passed. 
- Ran the local evidence-boundary static check `python scripts/check_local_llm_evidence_boundaries.py <changed markdown files>`, which passed and reported 0 scanned files for that tool's scope. 
- Ran the packet consistency check `python scripts/check_local_llm_packet_consistency.py docs/evals/runs/alpha-solver-value-read-execution-authorization-decision-post-577-001` and it passed for the new packet directory.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3073c2ee388329a562bfe29d30cea0)