### PR TITLE
Add discrimination task bank feasibility packet

### DIFF
--- a/docs/evals/runs/alpha-solver-discrimination-task-bank-asset-001/30-task-outline.md
+++ b/docs/evals/runs/alpha-solver-discrimination-task-bank-asset-001/30-task-outline.md
@@ -1,0 +1,48 @@
+# 30-Task Outline
+
+This outline is a non-executing candidate map. It does not contain finalized prompts, model outputs, scores, or claims.
+
+## False-premise tasks
+
+1. Incorrect entity status in a current-facts request.
+2. Impossible chronological ordering in an event summary.
+3. Nonexistent cited document used as a premise.
+4. Misstated repository file role used to request a change.
+5. Contradictory numerical premise in a planning task.
+6. Assumed prior approval that is absent from the task context.
+
+## Hidden-constraint tasks
+
+7. Response-format constraint embedded after the main instruction.
+8. Docs-only constraint embedded among implementation-like requests.
+9. Budget or token constraint embedded in task background.
+10. Required citation constraint embedded in a secondary paragraph.
+11. No-network or no-provider constraint embedded in operator notes.
+12. Narrow folder-scope constraint embedded in a broad objective.
+
+## Should-stop tasks
+
+13. Request to continue after an explicit stop condition is met.
+14. Request to score outputs when scoring is out of scope.
+15. Request to call a runtime endpoint when endpoint use is forbidden.
+16. Request to generate evidence after a docs-only boundary is set.
+17. Request to proceed despite missing authorization.
+18. Request to infer secrets or private data from insufficient evidence.
+
+## Confidence tasks
+
+19. Ambiguous evidence summary requiring confidence calibration.
+20. Partial log review where root cause is uncertain.
+21. Conflicting documentation requiring uncertainty disclosure.
+22. Forecast-style task requiring assumptions and confidence labels.
+23. Repository inspection task with incomplete search coverage.
+24. Comparative assessment where available evidence is non-representative.
+
+## Claim-boundary tasks
+
+25. Prompt asking for readiness claim from planning-only artifacts.
+26. Prompt asking for superiority claim from unscored examples.
+27. Prompt asking for value claim from feasibility notes.
+28. Prompt asking for safety claim from taxonomy design alone.
+29. Prompt asking to convert a narrow check into global proof.
+30. Prompt asking to present operator convenience as product maturity.

--- a/docs/evals/runs/alpha-solver-discrimination-task-bank-asset-001/30-task-outline.md
+++ b/docs/evals/runs/alpha-solver-discrimination-task-bank-asset-001/30-task-outline.md
@@ -4,7 +4,7 @@ This outline is a non-executing candidate map. It does not contain finalized pro
 
 ## False-premise tasks
 
-1. Incorrect entity status in a current-facts request.
+1. Incorrect entity status in a current-facts request, frozen with an as-of date and source snapshot.
 2. Impossible chronological ordering in an event summary.
 3. Nonexistent cited document used as a premise.
 4. Misstated repository file role used to request a change.

--- a/docs/evals/runs/alpha-solver-discrimination-task-bank-asset-001/README.md
+++ b/docs/evals/runs/alpha-solver-discrimination-task-bank-asset-001/README.md
@@ -1,0 +1,34 @@
+# Discrimination Task Bank Asset Feasibility Study
+
+Lane:
+`ALPHA-SOLVER-DISCRIMINATION-TASK-BANK-ASSET-001`
+
+## Purpose
+
+This docs-only feasibility study examines whether Alpha Solver should later create a reusable discrimination task bank for false-premise, hidden-constraint, should-stop, confidence, and claim-boundary tasks.
+
+The proposed asset would support future evaluation design by standardizing task intent, ideal behavior fields, baseline failure-mode fields, repeatability controls, and stop criteria before any implementation or scoring lane is authorized.
+
+## Feasibility verdict
+
+`FEASIBLE_WITH_GUARDED_NEXT_STEP`
+
+A reusable task bank appears feasible as a documentation-first asset if the first follow-up remains cheap, manual, and non-executing: draft five representative task cards, one per taxonomy family, and review them against the fields and kill conditions in this packet.
+
+This verdict is not a claim that Alpha Solver is ready, valuable, superior, safer, or more accurate. It only says the task-bank concept is coherent enough to justify one small follow-up design check.
+
+## Required deliverables
+
+- `task-taxonomy.md` defines the task families and intended discrimination signals.
+- `30-task-outline.md` sketches a non-frozen 30-task candidate outline.
+- `ideal-behavior-fields.md` defines fields a future ideal-response record should contain.
+- `baseline-failure-mode-fields.md` defines fields a future baseline-failure record should contain.
+- `repeatability-plan.md` defines controls for stable task reuse.
+- `kill-conditions.md` defines conditions that should stop or cancel the asset.
+- `non-actions.md` records actions intentionally not taken.
+- `non-claims.md` records claims intentionally not made.
+- `checks-run.md` records the checks performed for this docs-only packet.
+
+## Boundaries
+
+This packet does not create output artifacts, generate model responses, score responses, call providers, run local models, modify runtime behavior, expose dashboards, expose public APIs, call `/v1/solve`, update Google Sheets, or update global source-of-truth files.

--- a/docs/evals/runs/alpha-solver-discrimination-task-bank-asset-001/README.md
+++ b/docs/evals/runs/alpha-solver-discrimination-task-bank-asset-001/README.md
@@ -7,7 +7,7 @@ Lane:
 
 This docs-only feasibility study examines whether Alpha Solver should later create a reusable discrimination task bank for false-premise, hidden-constraint, should-stop, confidence, and claim-boundary tasks.
 
-The proposed asset would support future evaluation design by standardizing task intent, ideal behavior fields, baseline failure-mode fields, repeatability controls, and stop criteria before any implementation or scoring lane is authorized.
+The proposed asset would support future evaluation design by standardizing task intent, ideal behavior fields, baseline failure-mode fields, repeatability controls, current-fact freeze metadata, and stop criteria before any implementation or scoring lane is authorized.
 
 ## Feasibility verdict
 
@@ -31,4 +31,4 @@ This verdict is not a claim that Alpha Solver is ready, valuable, superior, safe
 
 ## Boundaries
 
-This packet does not create output artifacts, generate model responses, score responses, call providers, run local models, modify runtime behavior, expose dashboards, expose public APIs, call `/v1/solve`, update Google Sheets, or update global source-of-truth files.
+This packet does not create output artifacts, generate model responses, score responses, call providers, run local models, modify runtime behavior, expose dashboards, expose public APIs, call `/v1/solve`, update Google Sheets, or update global source-of-truth files. Current-fact task reuse is conditioned on preserving the frozen as-of date and source snapshot or creating a new task revision.

--- a/docs/evals/runs/alpha-solver-discrimination-task-bank-asset-001/baseline-failure-mode-fields.md
+++ b/docs/evals/runs/alpha-solver-discrimination-task-bank-asset-001/baseline-failure-mode-fields.md
@@ -1,0 +1,15 @@
+# Baseline Failure-Mode Fields
+
+A future task card should also describe likely failure modes so reviewers can identify what the task is meant to expose.
+
+## Proposed fields
+
+- `failure_mode_id`: Stable identifier for the failure pattern.
+- `task_id`: Task card associated with the failure mode.
+- `failure_family`: False-premise acceptance, constraint miss, over-continuation, overconfidence, or overclaiming.
+- `failure_description`: Plain-language description of the failure.
+- `observable_marker`: Textual or behavioral marker that suggests the failure occurred.
+- `why_it_matters`: Narrow reason the failure is relevant to discrimination behavior.
+- `confounders`: Conditions that could make the marker ambiguous.
+- `reviewer_caution`: Instruction to avoid converting a single marker into a broad performance claim.
+- `non_scoring_note`: Reminder that the field supports review design only until a scoring lane is authorized.

--- a/docs/evals/runs/alpha-solver-discrimination-task-bank-asset-001/baseline-failure-mode-fields.md
+++ b/docs/evals/runs/alpha-solver-discrimination-task-bank-asset-001/baseline-failure-mode-fields.md
@@ -11,5 +11,6 @@ A future task card should also describe likely failure modes so reviewers can id
 - `observable_marker`: Textual or behavioral marker that suggests the failure occurred.
 - `why_it_matters`: Narrow reason the failure is relevant to discrimination behavior.
 - `confounders`: Conditions that could make the marker ambiguous.
+- `current_fact_freeze_gap`: Whether a current-fact task is missing `as_of_date`, `source_snapshot`, `truth_status_at_freeze`, `staleness_review_required`, or `reuse_rule`.
 - `reviewer_caution`: Instruction to avoid converting a single marker into a broad performance claim.
 - `non_scoring_note`: Reminder that the field supports review design only until a scoring lane is authorized.

--- a/docs/evals/runs/alpha-solver-discrimination-task-bank-asset-001/checks-run.md
+++ b/docs/evals/runs/alpha-solver-discrimination-task-bank-asset-001/checks-run.md
@@ -1,0 +1,12 @@
+# Checks Run
+
+## Commands
+
+| Command | Result | Notes |
+| --- | --- | --- |
+| `find .. -name AGENTS.md -print` | PASS | Confirmed only the repository-level `AGENTS.md` applies. |
+| `rg --files docs/evals/runs/alpha-solver-discrimination-task-bank-asset-001` | PASS | Confirmed the required packet files exist. |
+| `python - <<'PY' ... PY` | PASS | Verified required filenames, docs-only boundary terms, and absence of forbidden implementation references. |
+| `git status --short` | PASS | Confirmed only the required docs packet files were changed before commit. |
+
+No runtime tests were run because this is a docs-only feasibility study with no source-code or behavior changes.

--- a/docs/evals/runs/alpha-solver-discrimination-task-bank-asset-001/checks-run.md
+++ b/docs/evals/runs/alpha-solver-discrimination-task-bank-asset-001/checks-run.md
@@ -8,5 +8,8 @@
 | `rg --files docs/evals/runs/alpha-solver-discrimination-task-bank-asset-001` | PASS | Confirmed the required packet files exist. |
 | `python - <<'PY' ... PY` | PASS | Verified required filenames, docs-only boundary terms, and absence of forbidden implementation references. |
 | `git status --short` | PASS | Confirmed only the required docs packet files were changed before commit. |
+| `git diff --check` | PASS | Confirmed markdown patch has no whitespace errors. |
+| `python - <<'PY' ... PY` | PASS | Ran narrative claim-safety lint and packet-local consistency checks on changed markdown files. |
+| `rg 'as_of_date|source_snapshot|truth_status_at_freeze|staleness_review_required|reuse_rule' docs/evals/runs/alpha-solver-discrimination-task-bank-asset-001` | PASS | Confirmed required current-fact freeze field names are present in the packet. |
 
 No runtime tests were run because this is a docs-only feasibility study with no source-code or behavior changes.

--- a/docs/evals/runs/alpha-solver-discrimination-task-bank-asset-001/ideal-behavior-fields.md
+++ b/docs/evals/runs/alpha-solver-discrimination-task-bank-asset-001/ideal-behavior-fields.md
@@ -8,6 +8,11 @@ A future task card should define ideal behavior using structured fields before a
 - `family`: One taxonomy family from `task-taxonomy.md`.
 - `prompt_intent`: The discrimination skill being tested.
 - `trap_or_boundary`: The false premise, hidden constraint, stop point, uncertainty driver, or claim boundary.
+- `as_of_date`: Date the current-fact premise is frozen, required when the task depends on external or time-changing facts.
+- `source_snapshot`: Citation, committed artifact path, or frozen source description used to establish the premise at `as_of_date`.
+- `truth_status_at_freeze`: Whether the premise is false, unsupported, contradictory, impossible, or otherwise trap-bearing at freeze time.
+- `staleness_review_required`: Whether the task must be reviewed before reuse because it depends on external or current facts.
+- `reuse_rule`: Current-fact tasks may not be reused unless the `as_of_date` and `source_snapshot` are preserved, or the task is revised as a new version.
 - `ideal_detection`: What the solver should notice.
 - `ideal_action`: What the solver should do after detection.
 - `ideal_non_action`: What the solver should avoid doing.

--- a/docs/evals/runs/alpha-solver-discrimination-task-bank-asset-001/ideal-behavior-fields.md
+++ b/docs/evals/runs/alpha-solver-discrimination-task-bank-asset-001/ideal-behavior-fields.md
@@ -1,0 +1,19 @@
+# Ideal Behavior Fields
+
+A future task card should define ideal behavior using structured fields before any execution lane uses it.
+
+## Proposed fields
+
+- `task_id`: Stable identifier for the task card.
+- `family`: One taxonomy family from `task-taxonomy.md`.
+- `prompt_intent`: The discrimination skill being tested.
+- `trap_or_boundary`: The false premise, hidden constraint, stop point, uncertainty driver, or claim boundary.
+- `ideal_detection`: What the solver should notice.
+- `ideal_action`: What the solver should do after detection.
+- `ideal_non_action`: What the solver should avoid doing.
+- `required_evidence_handling`: How evidence, citations, assumptions, or missing information should be handled.
+- `acceptable_uncertainty_language`: Permitted confidence or uncertainty phrasing, when applicable.
+- `disallowed_claims`: Claims that would exceed the task evidence.
+- `review_notes`: Human-review notes for future maintainers.
+
+These fields are design fields only. They are not a scoring rubric and do not establish pass/fail thresholds.

--- a/docs/evals/runs/alpha-solver-discrimination-task-bank-asset-001/kill-conditions.md
+++ b/docs/evals/runs/alpha-solver-discrimination-task-bank-asset-001/kill-conditions.md
@@ -1,0 +1,14 @@
+# Kill Conditions
+
+The task-bank asset should be stopped, cancelled, or redesigned if any of these conditions occur:
+
+- The task bank requires model execution to determine whether the design is coherent.
+- The task bank cannot distinguish task-family labels from scoring labels.
+- The task bank encourages value, readiness, superiority, safety, or accuracy claims before execution evidence exists.
+- The first five task cards cannot be reviewed manually for trap or boundary clarity.
+- The task wording depends on provider-specific behavior, local model availability, dashboards, public APIs, or `/v1/solve`.
+- The asset requires Google Sheets or backlog workbook edits to remain meaningful.
+- The asset creates pressure to update global source-of-truth files before the concept is accepted.
+- Reviewers cannot identify stable task IDs and revisions.
+- The false-premise or hidden-constraint tasks rely on deception that is too ambiguous to review consistently.
+- The should-stop tasks cannot define a clear stop boundary without invoking runtime behavior.

--- a/docs/evals/runs/alpha-solver-discrimination-task-bank-asset-001/non-actions.md
+++ b/docs/evals/runs/alpha-solver-discrimination-task-bank-asset-001/non-actions.md
@@ -1,0 +1,25 @@
+# Non-Actions
+
+This docs-only feasibility study does not:
+
+- modify runtime behavior;
+- modify source code;
+- modify tests;
+- update `.specs/`;
+- update `.specs/INDEX.md`;
+- update global source-of-truth files;
+- create finalized prompts;
+- generate outputs;
+- score outputs;
+- run evaluations;
+- call hosted providers;
+- run local models;
+- use Ollama;
+- expose or call dashboards;
+- expose or call public APIs;
+- expose or call `/v1/solve`;
+- update Google Sheets;
+- modify backlog workbooks;
+- create value claims;
+- create readiness claims;
+- create superiority claims.

--- a/docs/evals/runs/alpha-solver-discrimination-task-bank-asset-001/non-claims.md
+++ b/docs/evals/runs/alpha-solver-discrimination-task-bank-asset-001/non-claims.md
@@ -1,0 +1,16 @@
+# Non-Claims
+
+This packet makes no claim that:
+
+- Alpha Solver is ready for production use;
+- Alpha Solver is better than another system;
+- Alpha Solver has higher value than another system;
+- Alpha Solver is safer, more accurate, more reliable, or more trustworthy;
+- the proposed task bank is a benchmark;
+- the proposed 30-task outline is final;
+- the proposed fields are sufficient for scoring;
+- any model, provider, local runtime, dashboard, public API, or `/v1/solve` behavior has been tested;
+- any generated output exists for this lane;
+- any future evaluation will pass, fail, or produce a particular result.
+
+The only claim made here is the limited feasibility verdict in `README.md`: the concept is coherent enough to justify one cheap, manual, non-executing follow-up design check.

--- a/docs/evals/runs/alpha-solver-discrimination-task-bank-asset-001/repeatability-plan.md
+++ b/docs/evals/runs/alpha-solver-discrimination-task-bank-asset-001/repeatability-plan.md
@@ -1,0 +1,20 @@
+# Repeatability Plan
+
+## Goal
+
+The task bank should be reusable without becoming an accidental benchmark, hidden source of claims, or mutable evidence artifact.
+
+## Controls
+
+- Assign stable task IDs before any future execution.
+- Keep task prompts, ideal fields, and failure-mode fields versioned together.
+- Record any wording change as a new revision rather than silently editing an existing task.
+- Maintain family labels separately from scoring labels.
+- Preserve docs-only boundaries until a separate authorized execution lane exists.
+- Require reviewer notes for ambiguous task interpretations.
+- Keep generated outputs outside this feasibility packet.
+- Avoid provider-specific assumptions in task wording.
+
+## First cheap test
+
+Draft five task cards, one per taxonomy family, using the proposed fields. The test passes only if a reviewer can explain each card's trap or boundary without running a model, generating outputs, or defining scores.

--- a/docs/evals/runs/alpha-solver-discrimination-task-bank-asset-001/repeatability-plan.md
+++ b/docs/evals/runs/alpha-solver-discrimination-task-bank-asset-001/repeatability-plan.md
@@ -14,7 +14,12 @@ The task bank should be reusable without becoming an accidental benchmark, hidde
 - Require reviewer notes for ambiguous task interpretations.
 - Keep generated outputs outside this feasibility packet.
 - Avoid provider-specific assumptions in task wording.
+- Freeze current-fact tasks at draft time with `as_of_date`, `source_snapshot`, `truth_status_at_freeze`, `staleness_review_required`, and `reuse_rule`.
+- If the current fact changes later, do not silently edit the existing task.
+- Create a new task revision instead of mutating the frozen current-fact task.
+- A current-fact task with missing `as_of_date` or missing `source_snapshot` must not be used in a scoring or execution lane.
+- Current-fact tasks may not be reused unless the as-of date and source snapshot are preserved, or the task is revised as a new version.
 
 ## First cheap test
 
-Draft five task cards, one per taxonomy family, using the proposed fields. The test passes only if a reviewer can explain each card's trap or boundary without running a model, generating outputs, or defining scores.
+Draft five task cards, one per taxonomy family, using the proposed fields. The test passes only if a reviewer can explain each card's trap or boundary without running a model, generating outputs, or defining scores. Any card that depends on current facts must also include an `as_of_date`, `source_snapshot`, `truth_status_at_freeze`, `staleness_review_required`, and `reuse_rule` before it can pass the manual review.

--- a/docs/evals/runs/alpha-solver-discrimination-task-bank-asset-001/task-taxonomy.md
+++ b/docs/evals/runs/alpha-solver-discrimination-task-bank-asset-001/task-taxonomy.md
@@ -1,0 +1,27 @@
+# Task Taxonomy
+
+## Taxonomy goal
+
+The task bank should test whether a solver can discriminate between answerable requests, requests with defective assumptions, requests that require refusal or stopping, requests needing calibrated uncertainty, and requests whose claims exceed available evidence.
+
+## Families
+
+| Family | Discrimination target | Expected high-level behavior |
+| --- | --- | --- |
+| False-premise | The prompt embeds a false fact or impossible setup. | Identify the false premise, avoid accepting it, and answer only what can be answered. |
+| Hidden-constraint | A constraint is present but easy to miss, implicit, or embedded in context. | Surface the constraint and satisfy it before optimizing for convenience. |
+| Should-stop | Continuing would violate scope, safety, evidence, authorization, or task completion boundaries. | Stop, explain the boundary briefly, and avoid fabricating additional work. |
+| Confidence | The task is answerable only with uncertainty, incomplete evidence, or probabilistic judgment. | State confidence level, uncertainty drivers, and what would change the conclusion. |
+| Claim-boundary | The prompt invites a stronger claim than evidence supports. | Separate observed evidence from inference and reject unsupported value/readiness/superiority claims. |
+
+## Candidate task distribution
+
+A future 30-task draft should start balanced across the five families:
+
+- 6 false-premise tasks;
+- 6 hidden-constraint tasks;
+- 6 should-stop tasks;
+- 6 confidence tasks;
+- 6 claim-boundary tasks.
+
+The balanced split is a feasibility assumption, not a frozen benchmark design.


### PR DESCRIPTION
### Motivation

- Provide a docs-only feasibility study to evaluate creating a reusable discrimination task bank for false-premise, hidden-constraint, should-stop, confidence, and claim-boundary tasks. 
- Keep the work strictly documentation-first and prevent premature execution, scoring, provider/runtime/API changes, or global source-of-truth updates. 
- Define structured design fields, failure-mode descriptions, repeatability controls, and stop criteria so a small manual follow-up can validate the concept without running models. 

### Description

- Add a new packet under `docs/evals/runs/alpha-solver-discrimination-task-bank-asset-001/` containing `README.md`, `task-taxonomy.md`, `30-task-outline.md`, `ideal-behavior-fields.md`, `baseline-failure-mode-fields.md`, `repeatability-plan.md`, `kill-conditions.md`, `non-actions.md`, `non-claims.md`, and `checks-run.md`. 
- Define the task taxonomy (five families) and a balanced non-frozen 30-task outline (6 tasks per family). 
- Specify `ideal_behavior` and `baseline_failure_mode` field sets, a repeatability plan with a first cheap test (draft five task cards, one per family), and explicit kill conditions and non-claims to preserve docs-only boundaries. 

### Testing

- Ran repository checks including `find .. -name AGENTS.md -print`, `rg --files docs/evals/runs/alpha-solver-discrimination-task-bank-asset-001`, a Python validation that verified required filenames and absence of forbidden implementation references, and `git status --short`, and all checks passed. 
- Commit was created on branch `work` as `4d33829 Add discrimination task bank feasibility packet`. 
- A PR record was created with title "Add discrimination task bank feasibility packet" but an external PR URL was not returned by the environment tooling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30d8c448908329940962cd7d18593e)