### PR TITLE
Add claim-safe demo evidence feasibility packet

### DIFF
--- a/docs/evals/runs/alpha-solver-demo-evidence-packet-to-demo-001/README.md
+++ b/docs/evals/runs/alpha-solver-demo-evidence-packet-to-demo-001/README.md
@@ -1,0 +1,41 @@
+# Demo Evidence Packet to Demo Feasibility Study
+
+Lane: `ALPHA-SOLVER-DEMO-EVIDENCE-PACKET-TO-DEMO-001`
+
+## Objective
+
+Create a docs-only feasibility study for turning committed evidence packets into a claim-safe demo narrative without implying proof beyond the evidence.
+
+## Feasibility verdict
+
+`FEASIBLE_WITH_STRICT_EVIDENCE_BOUNDARIES`
+
+A claim-safe demo narrative is feasible if it is presented as an evidence inventory and narrative template, not as product proof, value proof, readiness proof, superiority proof, or runtime demonstration. The demo must quote or summarize only committed artifacts, preserve uncertainty, and stop when the available packet evidence does not support a requested claim.
+
+## Required demo shape
+
+The demo should be a narrated, docs-only walkthrough:
+
+1. Identify the committed evidence packet being used.
+2. State what the packet directly contains.
+3. State what the packet does not contain.
+4. Convert supported observations into cautious demo language.
+5. List forbidden claims and non-claims before any outward-facing summary.
+6. Ask a reviewer to verify every claim against the source packet.
+
+## Packet files
+
+- `source-evidence-inventory.md` records eligible and ineligible evidence sources.
+- `demo-one-pager-template.md` provides the claim-safe demo narrative template.
+- `forbidden-claims.md` lists claims blocked by this feasibility study.
+- `claim-safe-language.md` provides allowed wording patterns and replacement language.
+- `reviewer-checklist.md` defines review gates before any demo narrative is used.
+- `first-cheap-test.md` defines the smallest validation test.
+- `kill-conditions.md` defines stop conditions.
+- `non-actions.md` records actions not taken.
+- `non-claims.md` records claims this packet does not make.
+- `checks-run.md` records validation checks.
+
+## Evidence boundary
+
+This packet is docs-only. It does not modify global source-of-truth files, product UI, runtime behavior, dashboards, public APIs, `/v1/solve`, providers, local models, Google Sheets, or any implementation path. It does not make value, readiness, superiority, production, public, provider, local-model, dashboard, API, security, privacy, traction, or buyer-validation claims.

--- a/docs/evals/runs/alpha-solver-demo-evidence-packet-to-demo-001/checks-run.md
+++ b/docs/evals/runs/alpha-solver-demo-evidence-packet-to-demo-001/checks-run.md
@@ -1,0 +1,14 @@
+# Checks Run
+
+The required checks for this docs-only packet are recorded here after execution:
+
+- `git status --short`
+- `git diff --name-only`
+- `git diff --check`
+- `test "$(git diff --name-only | rg -v '^docs/evals/runs/alpha-solver-demo-evidence-packet-to-demo-001/' | wc -l)" -eq 0`
+- `find docs/evals/runs/alpha-solver-demo-evidence-packet-to-demo-001 -maxdepth 1 -type f | sort`
+- Required boundary phrase scan with `rg` against this packet directory.
+
+## Evidence boundary
+
+These checks are local documentation and static boundary checks only. They do not modify global source-of-truth files, product UI, runtime behavior, dashboards, public APIs, `/v1/solve`, providers, local models, Google Sheets, or implementation paths.

--- a/docs/evals/runs/alpha-solver-demo-evidence-packet-to-demo-001/claim-safe-language.md
+++ b/docs/evals/runs/alpha-solver-demo-evidence-packet-to-demo-001/claim-safe-language.md
@@ -1,0 +1,34 @@
+# Claim-Safe Language
+
+## Preferred wording
+
+Use language that ties every statement to committed evidence:
+
+- "The committed packet records..."
+- "This source supports the narrow observation that..."
+- "The evidence boundary says this does not show..."
+- "A fair internal demo can describe the artifact discipline, not product proof."
+- "The next evidence needed would be..."
+- "This remains a hypothesis until a future committed run shows..."
+
+## Replacement patterns
+
+| Unsafe wording | Claim-safe replacement |
+| --- | --- |
+| "Alpha Solver proves value." | "This packet preserves evidence for a narrow evaluation question; it does not prove value." |
+| "The demo shows the product works." | "The demo narrates committed evidence and its limits." |
+| "Ready for customers." | "Not customer-readiness evidence." |
+| "Better than providers." | "No superiority claim is supported by this packet." |
+| "The API is ready." | "This packet does not exercise or expose a public API." |
+| "The dashboard proves progress." | "No dashboard-readiness claim is made here." |
+
+## Required uncertainty markers
+
+Use at least one uncertainty marker when interpreting any packet:
+
+- "narrow"
+- "docs-only"
+- "committed evidence"
+- "does not establish"
+- "requires future evidence"
+- "internal review only"

--- a/docs/evals/runs/alpha-solver-demo-evidence-packet-to-demo-001/demo-one-pager-template.md
+++ b/docs/evals/runs/alpha-solver-demo-evidence-packet-to-demo-001/demo-one-pager-template.md
@@ -1,0 +1,46 @@
+# Demo One-Pager Template
+
+## Title
+
+Evidence-bound demo narrative for `[SOURCE_PACKET_OR_DOC]`
+
+## Audience
+
+Internal reviewer, founder narrative review, or tightly supervised operator walkthrough.
+
+## Opening boundary statement
+
+This is a docs-only narrative based on committed repository evidence. It is not a product demo, runtime demo, public API demo, dashboard demo, provider demo, local-model demo, readiness claim, value claim, or superiority claim.
+
+## What the evidence packet shows
+
+- `[Observation 1 directly supported by source path]`
+- `[Observation 2 directly supported by source path]`
+- `[Observation 3 directly supported by source path]`
+
+## What the evidence packet does not show
+
+- `[Missing artifact, run, or validation]`
+- `[Blocked scope or unsupported claim]`
+- `[Operational capability not exercised]`
+
+## Claim-safe narrative
+
+The committed evidence supports a narrow statement: `[insert cautious source-backed statement]`. The fair interpretation is that Alpha Solver has documented `[design/evaluation/governance behavior]` for this packet, while `[runtime/value/readiness/superiority]` remains unproven unless a future committed artifact directly supports it.
+
+## Demo flow
+
+1. Show the source packet name and path.
+2. Read the evidence boundary before interpreting the packet.
+3. Highlight two or three directly supported observations.
+4. Highlight missing evidence and blocked claims.
+5. Explain the next cheap test that would reduce uncertainty.
+6. Stop before suggesting production, public, provider, local-model, dashboard, API, or value readiness.
+
+## Reviewer signoff
+
+- Reviewer name:
+- Source packet reviewed:
+- Unsupported claims removed:
+- Missing evidence stated clearly:
+- Approved for internal docs-only use: yes/no

--- a/docs/evals/runs/alpha-solver-demo-evidence-packet-to-demo-001/first-cheap-test.md
+++ b/docs/evals/runs/alpha-solver-demo-evidence-packet-to-demo-001/first-cheap-test.md
@@ -1,0 +1,22 @@
+# First Cheap Test
+
+## Test
+
+Select one committed evidence packet and draft a one-page internal demo narrative using `demo-one-pager-template.md`. Then run a manual claim audit against `reviewer-checklist.md`, `forbidden-claims.md`, and `non-claims.md`.
+
+## Pass condition
+
+The test passes only if:
+
+- every positive statement maps to a committed source path;
+- every missing artifact or unsupported capability is disclosed;
+- no forbidden claim appears directly or by implication;
+- a reviewer can remove the source packet and immediately identify that the narrative would no longer be supported.
+
+## Fail condition
+
+The test fails if the one-pager can be read as proof of value, readiness, superiority, runtime capability, provider validation, local-model validation, dashboard readiness, public API readiness, `/v1/solve` readiness, or market/customer validation.
+
+## Output
+
+The output should be a redlined one-pager and a short reviewer note. No code, UI, runtime, model, provider, dashboard, API, or Google Sheets work is part of this test.

--- a/docs/evals/runs/alpha-solver-demo-evidence-packet-to-demo-001/forbidden-claims.md
+++ b/docs/evals/runs/alpha-solver-demo-evidence-packet-to-demo-001/forbidden-claims.md
@@ -1,0 +1,14 @@
+# Forbidden Claims
+
+The demo narrative must not claim or imply:
+
+- Alpha Solver proves value.
+- Alpha Solver is ready for MVP, public release, production, deployment, customers, pilots, or buyers.
+- Alpha Solver is superior to baseline models, plain providers, competitors, or prior systems.
+- A committed design/spec packet proves runtime behavior.
+- A stopped, blocked, docs-only, or planning packet proves product capability.
+- Provider integration, hosted-model validation, local-model validation, or orchestration validation.
+- `/v1/solve`, public API, dashboard, UI, security, privacy, tenancy, billing, or operational readiness.
+- Customer traction, design-partner validation, buyer validation, product-market fit, or willingness to pay.
+- Repeatability, statistical lift, benchmark success, or generalization unless the cited committed artifact directly establishes that exact claim.
+- Evidence exists when the artifact is missing, ignored, uncommitted, operator-reported only, or not cited.

--- a/docs/evals/runs/alpha-solver-demo-evidence-packet-to-demo-001/kill-conditions.md
+++ b/docs/evals/runs/alpha-solver-demo-evidence-packet-to-demo-001/kill-conditions.md
@@ -1,0 +1,13 @@
+# Kill Conditions
+
+Stop the demo narrative work if any condition occurs:
+
+- A claim cannot be traced to committed evidence.
+- The narrative needs uncommitted artifacts, missing archives, external spreadsheets, or operator memory.
+- The wording implies value, readiness, superiority, customer validation, provider validation, local-model validation, dashboard readiness, public API readiness, or `/v1/solve` readiness.
+- The reviewer cannot distinguish design/spec evidence from measured behavior.
+- The demo requires product UI, runtime/dashboard/public API work, providers, local models, Google Sheets, or source-of-truth updates.
+- The one-pager omits non-claims or forbidden claims.
+- A stakeholder asks to remove uncertainty markers or evidence boundaries.
+
+When a kill condition is hit, preserve the draft as blocked evidence and record the unsupported claim that caused the stop.

--- a/docs/evals/runs/alpha-solver-demo-evidence-packet-to-demo-001/non-actions.md
+++ b/docs/evals/runs/alpha-solver-demo-evidence-packet-to-demo-001/non-actions.md
@@ -1,0 +1,17 @@
+# Non-Actions
+
+This feasibility study did not:
+
+- update global source-of-truth files;
+- update `.specs/INDEX.md`;
+- modify product UI;
+- modify runtime behavior;
+- expose or test dashboards;
+- expose or test public APIs;
+- expose or test `/v1/solve`;
+- call providers;
+- run local models;
+- modify Google Sheets;
+- create a marketing page;
+- create a public demo;
+- create or change code, tests, configs, credentials, or deployment artifacts.

--- a/docs/evals/runs/alpha-solver-demo-evidence-packet-to-demo-001/non-claims.md
+++ b/docs/evals/runs/alpha-solver-demo-evidence-packet-to-demo-001/non-claims.md
@@ -1,0 +1,26 @@
+# Non-Claims
+
+This packet does not claim:
+
+- value validation;
+- MVP readiness;
+- public readiness;
+- production readiness;
+- runtime readiness;
+- dashboard readiness;
+- public API readiness;
+- `/v1/solve` readiness;
+- provider validation;
+- hosted-model validation;
+- local-model validation;
+- orchestration validation;
+- security or privacy completion;
+- customer traction;
+- buyer validation;
+- design-partner validation;
+- product-market fit;
+- benchmark success;
+- repeatable lift;
+- Alpha Solver superiority.
+
+The only claim made here is that a docs-only, internal, claim-safe demo narrative appears feasible when every statement is tied to committed evidence and all unsupported claims are explicitly blocked.

--- a/docs/evals/runs/alpha-solver-demo-evidence-packet-to-demo-001/reviewer-checklist.md
+++ b/docs/evals/runs/alpha-solver-demo-evidence-packet-to-demo-001/reviewer-checklist.md
@@ -1,0 +1,14 @@
+# Reviewer Checklist
+
+Before using any one-pager or demo narrative, the reviewer must confirm:
+
+- [ ] Every positive claim maps to a committed source path.
+- [ ] Missing artifacts and absent runs are stated plainly.
+- [ ] The narrative distinguishes design/spec evidence from measured behavior.
+- [ ] The narrative avoids value, readiness, superiority, provider, local-model, dashboard, public API, `/v1/solve`, customer, buyer, and product-market-fit claims.
+- [ ] The source packet's own non-claims are preserved.
+- [ ] The demo is labeled internal and docs-only unless a future packet explicitly authorizes broader use.
+- [ ] The first cheap test is identified instead of implying completion.
+- [ ] Kill conditions are checked before sharing.
+
+If any checkbox fails, the demo narrative is blocked until revised.

--- a/docs/evals/runs/alpha-solver-demo-evidence-packet-to-demo-001/source-evidence-inventory.md
+++ b/docs/evals/runs/alpha-solver-demo-evidence-packet-to-demo-001/source-evidence-inventory.md
@@ -1,0 +1,43 @@
+# Source Evidence Inventory
+
+## Eligible source evidence
+
+A demo narrative may use only evidence that is already committed in the repository and can be cited by path, commit, or packet name. Eligible material includes:
+
+- committed eval run packets under `docs/evals/runs/`;
+- committed eval interpretation documents under `docs/evals/`;
+- committed operator/demo evidence templates under `docs/`;
+- committed specs under `.specs/` when they are described as design contracts, not as measured behavior;
+- committed check logs or packet-local `checks-run.md` files when the claim is limited to the check that was actually run.
+
+## Ineligible source evidence
+
+A demo narrative must not rely on:
+
+- uncommitted local files;
+- operator memory or chat-only assertions;
+- external backlog spreadsheets;
+- missing artifact directories;
+- absent archives;
+- provider dashboards or billing pages;
+- Google Sheets;
+- runtime observations not captured in committed artifacts;
+- screenshots or recordings that are not committed evidence;
+- implied behavior from code paths that were not exercised by the packet.
+
+## Inventory fields for each demo source
+
+For every source packet used, record:
+
+| Field | Required content |
+| --- | --- |
+| Source path | Repository-relative path to the committed source. |
+| Evidence type | Design doc, eval packet, interpretation memo, check log, template, or spec. |
+| Directly supported observations | Facts directly visible in the source. |
+| Explicit non-claims | Claims the source blocks or refuses to support. |
+| Missing evidence | Artifacts or runs absent from the source. |
+| Demo-safe summary | One or two cautious sentences that preserve the boundary. |
+
+## Minimum source rule
+
+A one-pager may proceed only when each narrative claim maps to at least one committed source and the reviewer can identify the exact source before publication or live narration.


### PR DESCRIPTION
### Motivation

- Provide a docs-only feasibility study to turn committed evidence packets into a claim-safe demo narrative that does not imply proof beyond the evidence.
- Prevent overclaiming by codifying evidence boundaries, forbidden assertions, and required uncertainty markers for any demo narrative.
- Supply a reusable, reviewable process so internal demos can narrate committed artifacts without requiring runtime, provider, or product-surface work.

### Description

- Add a new packet at `docs/evals/runs/alpha-solver-demo-evidence-packet-to-demo-001/` containing `README.md` and ten artifacts: `source-evidence-inventory.md`, `demo-one-pager-template.md`, `forbidden-claims.md`, `claim-safe-language.md`, `reviewer-checklist.md`, `first-cheap-test.md`, `kill-conditions.md`, `non-actions.md`, `non-claims.md`, and `checks-run.md`.
- `demo-one-pager-template.md` and `source-evidence-inventory.md` define the demo flow, required inventory fields, eligible vs ineligible evidence, and the minimum-source rule that every claim must map to committed artifacts.
- `forbidden-claims.md`, `claim-safe-language.md`, `non-claims.md`, and `non-actions.md` enumerate disallowed claims and provide replacement phrasing to avoid implying value, readiness, superiority, provider/local-model/dashboard/API, or `/v1/solve` readiness.
- `reviewer-checklist.md`, `first-cheap-test.md`, `kill-conditions.md`, and `checks-run.md` add reviewer gates, a small manual audit test, explicit stop conditions, and a set of static checks to validate the packet remains docs-only.

### Testing

- Ran static validation commands: `git status --short`, `git diff --name-only`, and `git diff --check`, and no problems were reported.
- Verified scope containment with `test "$(git diff --name-only | rg -v '^docs/evals/runs/alpha-solver-demo-evidence-packet-to-demo-001/' | wc -l)" -eq 0`, which succeeded.
- Listed created files with `find docs/evals/runs/alpha-solver-demo-evidence-packet-to-demo-001 -maxdepth 1 -type f | sort` and ran a boundary phrase scan with `rg` for forbidden keywords, both of which succeeded.
- All checks were documentation-only static checks and did not perform any runtime, provider, deployment, or source-of-truth modification steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30d8cf00a88329bc22397b846933f9)