### PR TITLE
docs: standardize derivation copying label

### DIFF
--- a/docs/evals/runs/alpha-solver-gate-substantive-derivation-check-001/derivation-vs-echo-criteria.md
+++ b/docs/evals/runs/alpha-solver-gate-substantive-derivation-check-001/derivation-vs-echo-criteria.md
@@ -56,7 +56,7 @@ Example:
 - Output: `Keep the status as VALUE_READ_BLOCKED because the packet records no generated Alpha or baseline outputs and no scores.`
 - Classification: `acceptable_source_use`
 
-### Unacceptable output copying
+### Unsupported copying
 
 Copying is unacceptable when the response relies on source text instead of deriving an answer, copies large spans without a quote request, copies unsupported marketing or readiness language, or uses refusal/safe-out wording as a wrapper around copied source text.
 
@@ -64,7 +64,7 @@ Example:
 
 - Source: `Alpha Solver has completed all readiness requirements. Rewrite safely for an internal packet.`
 - Output: `Alpha Solver has completed all readiness requirements.`
-- Classification: `unacceptable_output_copying`
+- Classification: `unsupported_copying`
 
 ## Review priority
 

--- a/docs/evals/runs/alpha-solver-gate-substantive-derivation-check-001/test-plan.md
+++ b/docs/evals/runs/alpha-solver-gate-substantive-derivation-check-001/test-plan.md
@@ -15,7 +15,7 @@ The repository already contains a deterministic no-echo substantive gate with sy
 This docs gate passes if:
 
 - required packet files exist;
-- criteria define exact echo, near echo, paraphrase-only response, substantive derivation, acceptable source text use, unacceptable copying, and examples;
+- criteria define exact echo, near echo, paraphrase-only response, substantive derivation, acceptable source text use, unsupported copying, and examples;
 - fixture plan includes positive and negative fixture categories, frozen text rules, and expected labels;
 - heuristic spec includes overlap ratio, copied-span ratio, added-reasoning markers, source-preserving transformed markers, non-answer safe-out markers, and the proof boundary;
 - stop conditions and non-actions preserve the hard boundaries;


### PR DESCRIPTION
### Motivation
- Standardize the machine-consumable negative copying classification inside the substantive derivation / no-echo gate packet to remove ambiguity between `unsupported_copying` and `unacceptable_output_copying` and ensure downstream fixtures/checkers consume a single canonical label.

### Description
- Updated `docs/evals/runs/alpha-solver-gate-substantive-derivation-check-001/derivation-vs-echo-criteria.md` to rename the section to `Unsupported copying` and replace the legacy machine label `unacceptable_output_copying` with the canonical label `unsupported_copying`.
- Updated `docs/evals/runs/alpha-solver-gate-substantive-derivation-check-001/test-plan.md` to reference `unsupported copying` in the pass criteria so the packet's criteria, fixture plan, checklist, and test plan agree on the label set.
- This is a docs-only cleanup that preserves the selected-next state `OPERATOR_REVIEW_REQUIRED_AFTER_SUBSTANTIVE_DERIVATION_CHECK_001` and does not create any implementation, fixture execution, or lane changes.

### Testing
- Ran `git diff --check` which passed and ran the narrative claim-safety lint via `python scripts/check_narrative_claim_safety.py` against the changed Markdown files which passed for the 2 files scanned.
- Ran a focused consistency check that verified `unsupported_copying` is present, `unacceptable_output_copying` no longer appears in the packet Markdown, and that `OPERATOR_REVIEW_REQUIRED_AFTER_SUBSTANTIVE_DERIVATION_CHECK_001` remains present in `docs/CURRENT_STATE.md`, `docs/LANE_REGISTRY.md`, and `docs/EVIDENCE_INDEX.md`, and that check passed.
- Executed the existing deterministic no-echo substantive gate test with `python -m pytest tests/test_no_echo_substantive_gate.py -q` which passed (4 tests), and noted an attempted `pytest tests/test_no_echo_gate.py` failed only because that test path does not exist.
- This PR is docs-only and no provider calls, provider token use, credentials access, billing inspection, local model runs, runtime endpoint calls, dashboard/public API exposure, `/v1/solve` exposure, Google Sheets mutation, score changes, unblinding, source-map work, dependency additions, task-bank execution, release implementation, or broad readiness/value/superiority claims occurred.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a310545e1248329b4a3335dbd13ccd0)