### PR TITLE
docs: clarify literal values in token-smoke retry evidence commands

### DIFF
--- a/docs/evals/runs/local-openai-token-smoke-capture-retry-001/commands-run.md
+++ b/docs/evals/runs/local-openai-token-smoke-capture-retry-001/commands-run.md
@@ -34,7 +34,7 @@ git branch --show-current; git log --oneline -5
 
 Exit code: `0`
 
-Purpose: Verify live GitHub PR state for PRs #502-#508 without secrets.
+Purpose: Verify live GitHub PR state for the literal PR range #502 through #508 without secrets.
 
 ```bash
 for n in 502 503 504 505 506 507 508; do echo "--- PR #$n"; curl -fsSL https://api.github.com/repos/adonisdv23/Alpha-Solver/pulls/$n | python -c 'import sys,json; d=json.load(sys.stdin); print("state",d.get("state")); print("merged_at",d.get("merged_at")); print("title",d.get("title")); print("merge_commit_sha",d.get("merge_commit_sha"))'; done
@@ -44,7 +44,7 @@ for n in 502 503 504 505 506 507 508; do echo "--- PR #$n"; curl -fsSL https://a
 
 Exit code: `0`
 
-Purpose: Verify required packet directories exist locally.
+Purpose: Verify the literal required packet directory list exists locally.
 
 ```bash
 paths=(docs/evals/runs/alpha-solver-openai-free-token-eval-smoke-harness-plan-001 docs/evals/runs/alpha-solver-post-level-3-level-14-self-operator-def-002-def-003-evidence-boundary-001 docs/evals/runs/openai-data-sharing-operator-verification-001 docs/evals/runs/local-openai-token-smoke-capture-001 docs/evals/runs/openai-synthetic-smoke-prompt-fixture-001 docs/evals/runs/openai-data-sharing-operator-attestation-001 docs/evals/runs/openai-packet-checker-scope-001); for p in "${paths[@]}"; do [ -d "$p" ] && echo "OK $p" || echo "MISSING $p"; done


### PR DESCRIPTION
### Motivation
- Remove ambiguous placeholder language from an evidence record so the commands are auditable and the exact PR range and packet directories are explicit.

### Description
- Update `docs/evals/runs/local-openai-token-smoke-capture-retry-001/commands-run.md` to state that Command 4 verifies the literal PR range `#502` through `#508` and that Command 5 verifies the literal required packet directory list.

### Testing
- Ran `rg -n '<PR_NUMBER>|<required_packet_dirs>' docs/evals/runs/local-openai-token-smoke-capture-retry-001/commands-run.md` and `python scripts/check_local_llm_packet_consistency.py`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31112869dc8329871082c3e9e6be5e)