### PR TITLE
alpha: add model catalog routing preview

### DIFF
--- a/alpha/model_catalog.py
+++ b/alpha/model_catalog.py
@@ -1,0 +1,100 @@
+"""Configurable model catalog for backend routing previews.
+
+This module is deliberately metadata-only. Loading the catalog does not contact
+hosted providers, Ollama, or any local model runtime.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Any, Iterable, Literal
+
+Mode = Literal["local", "openai"]
+
+DEFAULT_CATALOG_PATH = Path(__file__).resolve().parents[1] / "configs" / "model_catalog.json"
+DEFAULT_EVIDENCE_BOUNDARY: dict[str, bool] = {
+    "runs_provider": False,
+    "runs_local_model": False,
+    "quality_evidence": False,
+    "readiness_evidence": False,
+    "benchmark_evidence": False,
+}
+
+
+@dataclass(frozen=True)
+class ModelCatalogEntry:
+    provider: str
+    mode: Mode
+    model_id: str
+    display_name: str
+    enabled_default: bool
+    smoke_eligible: bool
+    notes: str
+    quality_claim: bool = False
+
+    @classmethod
+    def from_mapping(cls, raw: dict[str, Any]) -> "ModelCatalogEntry":
+        required = ("provider", "mode", "model_id", "display_name", "enabled_default", "smoke_eligible", "notes")
+        missing = [field for field in required if field not in raw]
+        if missing:
+            raise ValueError(f"model catalog entry missing required fields: {', '.join(missing)}")
+        mode = str(raw["mode"])
+        if mode not in {"local", "openai"}:
+            raise ValueError(f"unsupported model catalog mode: {mode}")
+        quality_claim = bool(raw.get("quality_claim", False))
+        if quality_claim:
+            raise ValueError("model catalog entries must not carry quality claims")
+        return cls(
+            provider=str(raw["provider"]),
+            mode=mode,  # type: ignore[arg-type]
+            model_id=str(raw["model_id"]),
+            display_name=str(raw["display_name"]),
+            enabled_default=bool(raw["enabled_default"]),
+            smoke_eligible=bool(raw["smoke_eligible"]),
+            notes=str(raw["notes"]),
+            quality_claim=quality_claim,
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "provider": self.provider,
+            "mode": self.mode,
+            "model_id": self.model_id,
+            "display_name": self.display_name,
+            "enabled_default": self.enabled_default,
+            "smoke_eligible": self.smoke_eligible,
+            "notes": self.notes,
+            "quality_claim": self.quality_claim,
+        }
+
+
+@dataclass(frozen=True)
+class ModelCatalog:
+    version: str
+    models: tuple[ModelCatalogEntry, ...]
+    evidence_boundary: dict[str, bool]
+
+    @classmethod
+    def load(cls, path: str | Path = DEFAULT_CATALOG_PATH) -> "ModelCatalog":
+        catalog_path = Path(path)
+        data = json.loads(catalog_path.read_text(encoding="utf-8"))
+        models = tuple(ModelCatalogEntry.from_mapping(item) for item in data.get("models", []))
+        if not models:
+            raise ValueError("model catalog must contain at least one model")
+        boundary = dict(DEFAULT_EVIDENCE_BOUNDARY)
+        boundary.update({key: bool(value) for key, value in data.get("evidence_boundary", {}).items()})
+        if any(boundary.values()):
+            raise ValueError("model catalog evidence boundary must remain preview-only")
+        return cls(version=str(data.get("version", "unversioned")), models=models, evidence_boundary=boundary)
+
+    def enabled(self) -> tuple[ModelCatalogEntry, ...]:
+        return tuple(model for model in self.models if model.enabled_default)
+
+    def by_model_id(self, model_id: str) -> ModelCatalogEntry | None:
+        return next((model for model in self.models if model.model_id == model_id), None)
+
+    def by_mode(self, mode: Mode, *, enabled_only: bool = True) -> tuple[ModelCatalogEntry, ...]:
+        source: Iterable[ModelCatalogEntry] = self.enabled() if enabled_only else self.models
+        return tuple(model for model in source if model.mode == mode)

--- a/alpha/model_router.py
+++ b/alpha/model_router.py
@@ -1,0 +1,149 @@
+"""Deterministic routing preview over the model catalog.
+
+The preview returns route metadata only. It never calls hosted providers, Ollama,
+or any local model runtime.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from tools.operator_smoke_runner import MAX_PROMPT_CHARS
+
+from .model_catalog import DEFAULT_EVIDENCE_BOUNDARY, ModelCatalog, ModelCatalogEntry, Mode
+
+Status = Literal["preview_only", "failed_closed"]
+
+
+@dataclass(frozen=True)
+class RouteFallback:
+    mode: Mode
+    model: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {"mode": self.mode, "model": self.model}
+
+
+@dataclass(frozen=True)
+class RoutingPreviewRequest:
+    requested_mode: Mode | None = None
+    requested_model: str | None = None
+    allow_hosted_providers: bool = True
+    allow_local: bool = True
+    prompt_length: int = 0
+    task_profile: str | None = None
+    cost_preference: str | None = None
+    latency_preference: str | None = None
+
+
+@dataclass(frozen=True)
+class RoutingPreview:
+    status: Status
+    recommended_mode: Mode | None
+    recommended_model: str | None
+    fallbacks: tuple[RouteFallback, ...]
+    reasons: tuple[str, ...]
+    evidence_boundary: dict[str, bool] = field(default_factory=lambda: dict(DEFAULT_EVIDENCE_BOUNDARY))
+    warnings: tuple[str, ...] = ()
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "recommended_mode": self.recommended_mode,
+            "recommended_model": self.recommended_model,
+            "fallbacks": [fallback.as_dict() for fallback in self.fallbacks],
+            "reasons": list(self.reasons),
+            "evidence_boundary": dict(self.evidence_boundary),
+            "warnings": list(self.warnings),
+        }
+
+
+def preview_route(request: RoutingPreviewRequest | None = None, catalog: ModelCatalog | None = None) -> RoutingPreview:
+    req = request or RoutingPreviewRequest()
+    cat = catalog or ModelCatalog.load()
+    reasons: list[str] = ["routing_preview_only", "no_provider_or_local_model_calls"]
+    warnings: list[str] = []
+
+    if req.prompt_length > MAX_PROMPT_CHARS:
+        return _failed("prompt_too_long_for_smoke_runner", cat, req, reasons, warnings)
+    if not req.allow_hosted_providers and not req.allow_local:
+        return _failed("no_modes_allowed", cat, req, reasons, warnings)
+
+    if req.requested_mode:
+        reasons.append(f"{req.requested_mode}_requested_by_operator")
+    if req.task_profile:
+        reasons.append("task_profile_recorded_no_quality_selection")
+    if req.cost_preference:
+        reasons.append("cost_preference_recorded_no_pricing_selection")
+    if req.latency_preference:
+        reasons.append("latency_preference_recorded_no_latency_claim")
+
+    selected: ModelCatalogEntry | None = None
+    if req.requested_model:
+        selected = cat.by_model_id(req.requested_model)
+        if selected is None:
+            return _failed("requested_model_not_in_catalog", cat, req, reasons, warnings)
+        reasons.append("model_available_in_catalog")
+        if not selected.enabled_default:
+            return _failed("requested_model_disabled", cat, req, reasons, warnings)
+        if selected.mode == "openai" and not req.allow_hosted_providers:
+            return _failed("hosted_provider_not_allowed", cat, req, reasons, warnings)
+        if selected.mode == "local" and not req.allow_local:
+            return _failed("local_model_not_allowed", cat, req, reasons, warnings)
+        if req.requested_mode and selected.mode != req.requested_mode:
+            return _failed("requested_mode_model_mismatch", cat, req, reasons, warnings)
+    else:
+        selected = _default_for_request(cat, req, reasons)
+        if selected is None:
+            return _failed("no_eligible_model", cat, req, reasons, warnings)
+
+    if selected.smoke_eligible:
+        reasons.append("smoke_eligible")
+    else:
+        warnings.append("selected_model_not_smoke_eligible")
+
+    return RoutingPreview(
+        status="preview_only",
+        recommended_mode=selected.mode,
+        recommended_model=selected.model_id,
+        fallbacks=_fallbacks(cat, exclude=selected.model_id, request=req),
+        reasons=tuple(reasons),
+        warnings=tuple(warnings),
+    )
+
+
+def _default_for_request(cat: ModelCatalog, req: RoutingPreviewRequest, reasons: list[str]) -> ModelCatalogEntry | None:
+    if req.allow_hosted_providers and (req.requested_mode in (None, "openai") or not req.allow_local):
+        options = cat.by_mode("openai")
+        if options:
+            reasons.append("openai_allowed_default_selected")
+            return options[0]
+    if req.allow_local and (req.requested_mode in (None, "local") or not req.allow_hosted_providers):
+        options = cat.by_mode("local")
+        if options:
+            reasons.append("local_allowed_default_selected")
+            return options[0]
+    return None
+
+
+def _fallbacks(cat: ModelCatalog, *, exclude: str | None, request: RoutingPreviewRequest) -> tuple[RouteFallback, ...]:
+    allowed_modes = set()
+    if request.allow_hosted_providers:
+        allowed_modes.add("openai")
+    if request.allow_local:
+        allowed_modes.add("local")
+    fallbacks = [RouteFallback(model.mode, model.model_id) for model in cat.enabled() if model.model_id != exclude and model.mode in allowed_modes]
+    return tuple(fallbacks[:3])
+
+
+def _failed(reason: str, cat: ModelCatalog, req: RoutingPreviewRequest, reasons: list[str], warnings: list[str]) -> RoutingPreview:
+    reasons.append(reason)
+    return RoutingPreview(
+        status="failed_closed",
+        recommended_mode=None,
+        recommended_model=None,
+        fallbacks=_fallbacks(cat, exclude=None, request=req),
+        reasons=tuple(reasons),
+        warnings=tuple(warnings),
+    )

--- a/configs/model_catalog.json
+++ b/configs/model_catalog.json
@@ -1,0 +1,82 @@
+{
+  "version": "2026-06-16.model-catalog-routing-preview-001",
+  "evidence_boundary": {
+    "runs_provider": false,
+    "runs_local_model": false,
+    "quality_evidence": false,
+    "readiness_evidence": false,
+    "benchmark_evidence": false
+  },
+  "models": [
+    {
+      "provider": "ollama",
+      "mode": "local",
+      "model_id": "qwen2.5:3b",
+      "display_name": "Qwen 2.5 3B via Ollama",
+      "enabled_default": true,
+      "smoke_eligible": true,
+      "quality_claim": false,
+      "notes": "Operator-relevant local/Ollama catalog default. Catalog inclusion is not a quality claim."
+    },
+    {
+      "provider": "ollama",
+      "mode": "local",
+      "model_id": "gemma3:4b",
+      "display_name": "Gemma 3 4B via Ollama",
+      "enabled_default": true,
+      "smoke_eligible": true,
+      "quality_claim": false,
+      "notes": "Operator-relevant local/Ollama catalog default. Catalog inclusion is not a quality claim."
+    },
+    {
+      "provider": "ollama",
+      "mode": "local",
+      "model_id": "llama3.2:1b",
+      "display_name": "Llama 3.2 1B via Ollama",
+      "enabled_default": true,
+      "smoke_eligible": true,
+      "quality_claim": false,
+      "notes": "Operator-relevant local/Ollama catalog default. Catalog inclusion is not a quality claim."
+    },
+    {
+      "provider": "ollama",
+      "mode": "local",
+      "model_id": "llama3.2:latest",
+      "display_name": "Llama 3.2 latest via Ollama",
+      "enabled_default": true,
+      "smoke_eligible": true,
+      "quality_claim": false,
+      "notes": "Operator-relevant local/Ollama catalog default. Catalog inclusion is not a quality claim."
+    },
+    {
+      "provider": "openai",
+      "mode": "openai",
+      "model_id": "gpt-4.1-mini",
+      "display_name": "GPT-4.1 mini",
+      "enabled_default": true,
+      "smoke_eligible": true,
+      "quality_claim": false,
+      "notes": "Conservative OpenAI catalog default for operator routing preview. Catalog inclusion is not model validation."
+    },
+    {
+      "provider": "openai",
+      "mode": "openai",
+      "model_id": "gpt-4.1",
+      "display_name": "GPT-4.1",
+      "enabled_default": true,
+      "smoke_eligible": true,
+      "quality_claim": false,
+      "notes": "Conservative OpenAI catalog default for operator routing preview. Catalog inclusion is not model validation."
+    },
+    {
+      "provider": "openai",
+      "mode": "openai",
+      "model_id": "gpt-4o-mini",
+      "display_name": "GPT-4o mini",
+      "enabled_default": true,
+      "smoke_eligible": true,
+      "quality_claim": false,
+      "notes": "Conservative OpenAI catalog default for operator routing preview. Catalog inclusion is not model validation."
+    }
+  ]
+}

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -1,11 +1,11 @@
 # Alpha Solver - Current State
 
-> Source-of-truth navigation doc. Last verified **2026-06-16** for local/OpenAI test console UX redaction refinement.
-> This lane preserves submitted console form state and avoids over-redacting safe numeric usage token counts for bounded local/Ollama and OpenAI smoke checks. The console evidence is smoke-only and makes no provider/runtime quality or readiness claims.
+> Source-of-truth navigation doc. Last verified **2026-06-16** for model catalog routing preview.
+> This lane adds a configurable backend model catalog and deterministic routing preview. It makes no provider/local-model calls and creates no quality, readiness, benchmark, production/public, security/privacy, or Alpha-superiority claim.
 
 ## Current verified phase
 
-**Local/OpenAI test console UX redaction refinement completed: the selected next state is review-only operator review after the UX/redaction refinement.**
+**Model catalog routing preview completed: the selected next state is review-only operator review after backend catalog and routing-preview support.**
 
 The merged #569–#574 wave updated the repository from the post-#568 blocked Value Read state to a broader documentation-and-boundary posture. PR #576 was superseded by PR #577 and should be closed unmerged. PR #577 completes `ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001` as a docs-only Alpha-native local operator harness design note.
 
@@ -17,12 +17,12 @@ These are docs, gate, helper, static/research, blocked-attempt, scoring-only, se
 
 | Field | Value |
 |-------|-------|
-| Latest verified completed lane in this wave | **`ALPHA-SOLVER-LOCAL-OPENAI-TEST-CONSOLE-UX-REDUCTION-001`** |
-| Source-of-truth sync | Current docs record the completed local-only test console UX/redaction refinement and a review-only selected next state |
+| Latest verified completed lane in this wave | **`ALPHA-SOLVER-MODEL-CATALOG-ROUTING-PREVIEW-001`** |
+| Source-of-truth sync | Current docs record the completed backend model catalog routing preview and a review-only selected next state |
 | Closed-unmerged superseded PR | **#561** - superseded by merged PR #562 |
-| Current controlling posture | Operator review required after local/OpenAI test console UX/redaction refinement |
-| Selected next state | **`OPERATOR_REVIEW_REQUIRED_AFTER_LOCAL_OPENAI_TEST_CONSOLE_UX_REDUCTION_001`** |
-| Strategic boundary | This review-only state records a local-only Operator smoke test console UX/redaction refinement; it does not expose `/v1/solve`, mutate Google Sheets, generate scores, run CI provider calls, or support provider/local-model quality, readiness, benchmark, production/public, security/privacy, partnership/Pi.dev integration, or Alpha-superiority claims |
+| Current controlling posture | Operator review required after model catalog routing preview |
+| Selected next state | **`OPERATOR_REVIEW_REQUIRED_AFTER_MODEL_CATALOG_ROUTING_PREVIEW_001`** |
+| Strategic boundary | This review-only state records backend-only model catalog and deterministic routing-preview support; it does not expose `/v1/solve`, mutate Google Sheets, generate scores, run CI provider calls, run local models, or support provider/local-model quality, readiness, benchmark, production/public, security/privacy, partnership/Pi.dev integration, or Alpha-superiority claims |
 
 ## Completed post-552 / post-565 / post-568 infrastructure lanes
 
@@ -64,14 +64,15 @@ These are docs, gate, helper, static/research, blocked-attempt, scoring-only, se
 | smoke-results-import lane | `ALPHA-SOLVER-LOCAL-OPENAI-SMOKE-RESULTS-IMPORT-001` | Imports Operator-provided, redacted smoke-only results showing local/Ollama passed using `qwen2.5:3b` and OpenAI passed using `gpt-4.1-mini-2025-04-14`; proves no behavior quality, provider quality, local-model quality, readiness, benchmark success, production/public readiness, or Alpha superiority. |
 | test-console lane | `ALPHA-SOLVER-LOCAL-OPENAI-TEST-CONSOLE-001` | Adds a local-only Operator console for bounded local/Ollama and OpenAI smoke checks through the existing smoke runner path; proves no behavior quality, provider quality, local-model quality, readiness, benchmark success, production/public readiness, security/privacy completion, or Alpha superiority. |
 | test-console-ux-redaction lane | `ALPHA-SOLVER-LOCAL-OPENAI-TEST-CONSOLE-UX-REDUCTION-001` | Preserves submitted form state after console runs and avoids over-redacting safe numeric usage token counts; proves no behavior quality, provider quality, local-model quality, readiness, benchmark success, production/public readiness, security/privacy completion, or Alpha superiority. |
+| model-catalog-routing-preview lane | `ALPHA-SOLVER-MODEL-CATALOG-ROUTING-PREVIEW-001` | Adds configurable backend model catalog metadata and deterministic routing preview; performs no provider/local-model calls and proves no quality, readiness, benchmark, production/public, security/privacy, or Alpha-superiority claim. |
 
 See [`EVIDENCE_INDEX.md`](EVIDENCE_INDEX.md) for the PR status ledger and [`LANE_REGISTRY.md`](LANE_REGISTRY.md) for lifecycle classification.
 
 ## Selected next state
 
-**`OPERATOR_REVIEW_REQUIRED_AFTER_LOCAL_OPENAI_TEST_CONSOLE_UX_REDUCTION_001`** is the current global selected next state.
+**`OPERATOR_REVIEW_REQUIRED_AFTER_MODEL_CATALOG_ROUTING_PREVIEW_001`** is the current global selected next state.
 
-This is a review-only state after `ALPHA-SOLVER-LOCAL-OPENAI-TEST-CONSOLE-UX-REDUCTION-001`. It means the local-only Operator console preserves submitted form state after runs and preserves safe numeric usage token counts while redacting secret-like values.
+This is a review-only state after `ALPHA-SOLVER-MODEL-CATALOG-ROUTING-PREVIEW-001`. It means the backend catalog and deterministic routing preview exist for metadata-only review.
 
 This state authorizes no production/public exposure, no task execution outside explicit local Operator submission, no output generation for evals, scoring, score change, source-map work, unblinding, raw Alpha output inspection, raw baseline output inspection, `/v1/solve` exposure, dashboard/public API exposure, Google Sheets mutation, benchmark work, release behavior, readiness claim, broad value claim, provider claim, local-model claim, security/privacy claim, production/public claim, partnership/Pi.dev integration claim, demo external-use approval, discrimination-task execution/scoring, or Alpha-superiority claim.
 
@@ -119,3 +120,12 @@ This phase does **not** support claims of broad value, OpenAI validation, provid
 - Purpose: preserve submitted form state after console runs and avoid over-redacting safe usage token counts.
 - Selected next state: `OPERATOR_REVIEW_REQUIRED_AFTER_LOCAL_OPENAI_TEST_CONSOLE_UX_REDUCTION_001`.
 - Boundary: UX/redaction refinement only, no quality/readiness/benchmark/public/production/security/privacy/Alpha-superiority claim.
+
+## ALPHA-SOLVER-MODEL-CATALOG-ROUTING-PREVIEW-001
+
+- Artifact: `alpha/model_catalog.py`, `alpha/model_router.py`, and `configs/model_catalog.json`
+- Packet: `docs/evals/runs/alpha-solver-model-catalog-routing-preview-001/`
+- Evidence type: backend metadata and deterministic routing preview only.
+- Provider/local execution status: not run by this lane.
+- Selected next state: `OPERATOR_REVIEW_REQUIRED_AFTER_MODEL_CATALOG_ROUTING_PREVIEW_001`.
+- Boundary: does not prove provider quality, local model quality, readiness, benchmark success, production readiness, public readiness, security/privacy completion, buyer validation, traction, partnership/Pi.dev integration, or Alpha superiority.

--- a/docs/EVIDENCE_INDEX.md
+++ b/docs/EVIDENCE_INDEX.md
@@ -49,13 +49,15 @@ The entries below are design, documentation, gate, helper, static-checking, meth
 | this PR | tools: add local OpenAI test console | source-of-truth sync in this PR | `tools/operator_test_console.py`; `tests/test_operator_test_console.py`; `docs/evals/runs/alpha-solver-local-openai-test-console-001/`; `docs/CURRENT_STATE.md`; `docs/LANE_REGISTRY.md`; `docs/EVIDENCE_INDEX.md` | Adds a local-only Operator smoke test console that reuses the existing smoke runner path for local/Ollama and OpenAI smoke checks. | Does not create behavior evidence, quality evidence, readiness evidence, benchmark evidence, production/public evidence, security/privacy completion evidence, provider-quality evidence, local-model-quality evidence, or Alpha-superiority evidence. | completed console implementation / review-only selected next |
 | this PR | docs: import local and OpenAI smoke results | source-of-truth sync in this PR | `docs/evals/runs/alpha-solver-local-openai-smoke-results-import-001/`; `docs/CURRENT_STATE.md`; `docs/LANE_REGISTRY.md`; `docs/EVIDENCE_INDEX.md` | Imports Operator-provided, redacted smoke-only results: local/Ollama passed using `qwen2.5:3b`, and OpenAI passed using `gpt-4.1-mini-2025-04-14`. | Does not create behavior evidence, quality evidence, readiness evidence, benchmark evidence, production/public evidence, provider-quality evidence, local-model-quality evidence, or Alpha-superiority evidence. | completed evidence import / review-only selected next |
 
+| this PR | alpha: add model catalog routing preview | source-of-truth sync in this PR | `alpha/model_catalog.py`; `alpha/model_router.py`; `configs/model_catalog.json`; `tests/test_model_catalog.py`; `tests/test_model_router.py`; `docs/evals/runs/alpha-solver-model-catalog-routing-preview-001/`; `docs/CURRENT_STATE.md`; `docs/LANE_REGISTRY.md`; `docs/EVIDENCE_INDEX.md` | Adds configurable backend model catalog metadata and deterministic routing preview. | Does not call providers, run local models, expose `/v1/solve`, mutate Sheets, generate eval outputs, score outputs, unblind, add dependencies, build UI, or make quality/readiness/benchmark/production/public/security/privacy/Alpha-superiority claims. | completed backend implementation / review-only selected next |
+
 ## Current selected next state
 
-`OPERATOR_REVIEW_REQUIRED_AFTER_LOCAL_OPENAI_TEST_CONSOLE_UX_REDUCTION_001` is the selected next state. This is a review-only state after the local-only Operator smoke test console implementation, not production/public readiness authorization.
+`OPERATOR_REVIEW_REQUIRED_AFTER_MODEL_CATALOG_ROUTING_PREVIEW_001` is the selected next state. This is a review-only state after backend model catalog and deterministic routing-preview support, not production/public readiness authorization.
 
 `ALPHA-SOLVER-GATE-SUBSTANTIVE-DERIVATION-CHECK-001` was completed by merged PR #591 as a docs-first gate packet. It defines criteria, fixture planning, heuristic review aids, stop conditions, non-actions, and non-claims for operator review. `ALPHA-SOLVER-DISCRIMINATION-TASK-BANK-FIRST-CHEAP-TEST-001` was completed by merged PR #595 as a docs-only cheap-test packet grounded in that gate and the discrimination task-bank asset.
 
-The selected state records console implementation only and authorizes no score change, source-map work, raw Alpha output inspection, raw baseline output inspection, dashboard or public API work, `/v1/solve` exposure, Google Sheets mutation, routing behavior, council behavior, benchmark work, release behavior, readiness claim, broad value claim, provider claim, local-model claim, security/privacy claim, production/public claim, demo external-use approval, discrimination-task execution/scoring, partnership/Pi.dev integration claim, or Alpha-superiority claim.
+The selected state records backend catalog and routing-preview implementation only and authorizes no score change, source-map work, raw Alpha output inspection, raw baseline output inspection, dashboard or public API work, `/v1/solve` exposure, Google Sheets mutation, provider/local-model execution, council behavior, benchmark work, release behavior, readiness claim, broad value claim, provider claim, local-model claim, security/privacy claim, production/public claim, demo external-use approval, discrimination-task execution/scoring, partnership/Pi.dev integration claim, or Alpha-superiority claim.
 
 ## Evidence boundary
 
@@ -106,3 +108,11 @@ This entry records Operator-provided, redacted smoke-only evidence. It does not 
 | Packet | `docs/evals/runs/alpha-solver-local-openai-test-console-ux-reduction-001/` |
 | Selected next state | `OPERATOR_REVIEW_REQUIRED_AFTER_LOCAL_OPENAI_TEST_CONSOLE_UX_REDUCTION_001` |
 | Evidence boundary | UX/redaction refinement only, no quality/readiness/benchmark/public/production/security/privacy/Alpha-superiority claim |
+
+## ALPHA-SOLVER-MODEL-CATALOG-ROUTING-PREVIEW-001
+
+- Artifact: `alpha/model_catalog.py`, `alpha/model_router.py`, and `configs/model_catalog.json`
+- Packet: `docs/evals/runs/alpha-solver-model-catalog-routing-preview-001/`
+- Purpose: add configurable model catalog and deterministic routing preview backend.
+- Selected next state: `OPERATOR_REVIEW_REQUIRED_AFTER_MODEL_CATALOG_ROUTING_PREVIEW_001`.
+- Evidence boundary: routing preview only, no provider/local-model calls, no quality/readiness/benchmark/production/public/security/privacy/Alpha-superiority claim.

--- a/docs/LANE_REGISTRY.md
+++ b/docs/LANE_REGISTRY.md
@@ -81,7 +81,7 @@
 
 - PR #561 lane as a standalone needs-human protocol PR - closed unmerged and superseded by PR #562.
 - Any merged packet lane verbatim - packets are immutable evidence; create a new lane id instead.
-- Any selected-next pointer that conflicts with `OPERATOR_REVIEW_REQUIRED_AFTER_LOCAL_OPENAI_TEST_CONSOLE_UX_REDUCTION_001`. Earlier selected-next pointers, including `OPERATOR_REVIEW_REQUIRED_AFTER_LOCAL_OPENAI_TEST_CONSOLE_001`, `OPERATOR_REVIEW_REQUIRED_AFTER_LOCAL_OPENAI_SMOKE_RESULTS_IMPORT_001`, `OPERATOR_REVIEW_REQUIRED_AFTER_LOCAL_OPENAI_SMOKE_RUNNER_001`, and `OPERATOR_REVIEW_REQUIRED_AFTER_DISCRIMINATION_TASK_BANK_FIRST_CHEAP_TEST_001`, are prior review states and must not be treated as current.
+- Any selected-next pointer that conflicts with `OPERATOR_REVIEW_REQUIRED_AFTER_MODEL_CATALOG_ROUTING_PREVIEW_001`. Earlier selected-next pointers, including `OPERATOR_REVIEW_REQUIRED_AFTER_LOCAL_OPENAI_TEST_CONSOLE_001`, `OPERATOR_REVIEW_REQUIRED_AFTER_LOCAL_OPENAI_SMOKE_RESULTS_IMPORT_001`, `OPERATOR_REVIEW_REQUIRED_AFTER_LOCAL_OPENAI_SMOKE_RUNNER_001`, and `OPERATOR_REVIEW_REQUIRED_AFTER_DISCRIMINATION_TASK_BANK_FIRST_CHEAP_TEST_001`, are prior review states and must not be treated as current.
 - Direct Pi.dev integration from PR #574's research lane - the recorded verdict is patterns-only/no-integration.
 
 ## Forward path (single track)
@@ -211,3 +211,13 @@ Boundary: no provider quality, local model quality, readiness, benchmark success
 - Evidence boundary: console implementation only, no quality/readiness/benchmark/public/production/security/privacy/Alpha-superiority claim.
 
 - `ALPHA-SOLVER-LOCAL-OPENAI-TEST-CONSOLE-UX-REDUCTION-001` (this PR) - local-only test console UX/redaction refinement. Purpose: preserve submitted form state after console runs and avoid over-redacting safe usage token counts. Selected next state: `OPERATOR_REVIEW_REQUIRED_AFTER_LOCAL_OPENAI_TEST_CONSOLE_UX_REDUCTION_001`. Boundary: no quality/readiness/benchmark/public/production/security/privacy/Alpha-superiority claim.
+
+## ALPHA-SOLVER-MODEL-CATALOG-ROUTING-PREVIEW-001
+
+| Field | Value |
+|-------|-------|
+| Status | completed backend implementation / review-only selected next |
+| Purpose | Add configurable model catalog metadata and deterministic routing preview backend. |
+| Packet | `docs/evals/runs/alpha-solver-model-catalog-routing-preview-001/` |
+| Selected next state | `OPERATOR_REVIEW_REQUIRED_AFTER_MODEL_CATALOG_ROUTING_PREVIEW_001` |
+| Evidence boundary | Routing preview only; no provider/local-model calls; no quality, readiness, benchmark, production/public, security/privacy, Alpha-superiority, partnership/Pi.dev integration, buyer-validation, or traction claim. |

--- a/docs/evals/runs/alpha-solver-model-catalog-routing-preview-001/README.md
+++ b/docs/evals/runs/alpha-solver-model-catalog-routing-preview-001/README.md
@@ -1,0 +1,27 @@
+# ALPHA-SOLVER-MODEL-CATALOG-ROUTING-PREVIEW-001
+
+## Objective
+
+Add backend-only support for a configurable model catalog and deterministic routing preview lane.
+
+## Scope
+
+This packet records metadata-only catalog and routing-preview work. The lane adds no UI and exposes no runtime endpoint.
+
+## Evidence boundary
+
+The lane is preview-only:
+
+- No OpenAI call.
+- No Ollama call.
+- No local model call.
+- No benchmark selection.
+- No quality evidence.
+- No readiness evidence.
+- No production or public readiness evidence.
+- No security or privacy completion claim.
+- No Alpha-superiority claim.
+
+## Selected next state
+
+`OPERATOR_REVIEW_REQUIRED_AFTER_MODEL_CATALOG_ROUTING_PREVIEW_001`

--- a/docs/evals/runs/alpha-solver-model-catalog-routing-preview-001/checks-run.md
+++ b/docs/evals/runs/alpha-solver-model-catalog-routing-preview-001/checks-run.md
@@ -1,0 +1,10 @@
+# Checks run
+
+- `python -m pytest -q tests/test_model_catalog.py tests/test_model_router.py` passed, 16 tests.
+- `python -m pytest -q tests/test_operator_smoke_runner.py` passed, 9 tests.
+- `python -m pytest -q` passed with expected skips and deprecation warnings.
+- `make check-local-llm-orchestration-guardrails` passed.
+- `git diff --check` passed.
+- `python scripts/check_narrative_claim_safety.py $(git diff --name-only -- '*.md')` passed for changed Markdown files.
+- Source-of-truth consistency check passed for `OPERATOR_REVIEW_REQUIRED_AFTER_MODEL_CATALOG_ROUTING_PREVIEW_001` in `docs/CURRENT_STATE.md`, `docs/LANE_REGISTRY.md`, `docs/EVIDENCE_INDEX.md`, and `selected-next-state.md`.
+- Secret-safety check passed on added lines for forbidden secret and runtime-transcript markers.

--- a/docs/evals/runs/alpha-solver-model-catalog-routing-preview-001/model-catalog.md
+++ b/docs/evals/runs/alpha-solver-model-catalog-routing-preview-001/model-catalog.md
@@ -1,0 +1,22 @@
+# Model catalog
+
+The backend catalog is loaded from `configs/model_catalog.json` through `alpha/model_catalog.py`.
+
+## Included local/Ollama defaults
+
+- `qwen2.5:3b`
+- `gemma3:4b`
+- `llama3.2:1b`
+- `llama3.2:latest`
+
+## Included OpenAI defaults
+
+- `gpt-4.1-mini`
+- `gpt-4.1`
+- `gpt-4o-mini`
+
+## Metadata fields
+
+Each entry records provider, mode, model id, display name, enabled default status, smoke eligibility, notes, and `quality_claim: false`.
+
+Catalog inclusion is not a claim that a provider currently offers a model to every account or that any model is validated for Alpha Solver quality.

--- a/docs/evals/runs/alpha-solver-model-catalog-routing-preview-001/non-actions.md
+++ b/docs/evals/runs/alpha-solver-model-catalog-routing-preview-001/non-actions.md
@@ -1,0 +1,19 @@
+# Non-actions
+
+This lane did not:
+
+- Run OpenAI.
+- Run Ollama.
+- Run local models.
+- Expose `/v1/solve`.
+- Deploy.
+- Mutate Google Sheets.
+- Generate eval outputs.
+- Score outputs.
+- Inspect raw prior eval outputs.
+- Unblind.
+- Perform source-map work.
+- Add dependencies.
+- Build UI.
+- Add external telemetry.
+- Add result persistence.

--- a/docs/evals/runs/alpha-solver-model-catalog-routing-preview-001/non-claims.md
+++ b/docs/evals/runs/alpha-solver-model-catalog-routing-preview-001/non-claims.md
@@ -1,0 +1,17 @@
+# Non-claims
+
+This lane does not claim:
+
+- Broad value.
+- Readiness.
+- Benchmark success.
+- Provider quality.
+- Local-model quality.
+- Security or privacy completion.
+- Production readiness.
+- Public readiness.
+- Partnership or Pi.dev integration.
+- Buyer validation or traction.
+- Alpha superiority.
+
+Catalog entries are configurable defaults and not permanent claims about provider availability.

--- a/docs/evals/runs/alpha-solver-model-catalog-routing-preview-001/routing-preview-rules.md
+++ b/docs/evals/runs/alpha-solver-model-catalog-routing-preview-001/routing-preview-rules.md
@@ -1,0 +1,19 @@
+# Routing preview rules
+
+The router in `alpha/model_router.py` is deterministic and metadata-only.
+
+## Rules
+
+- If the prompt length is above the smoke-runner limit, return `failed_closed`.
+- If no modes are allowed, return `failed_closed`.
+- If a requested model is not in the catalog, return `failed_closed`.
+- If a requested hosted model is present but hosted providers are not allowed, return `failed_closed`.
+- If a requested local model is present but local models are not allowed, return `failed_closed`.
+- If an enabled requested model is allowed, select it.
+- If no model is requested, select the first enabled OpenAI model when hosted providers are allowed, otherwise select the first enabled local model when local is allowed.
+- Return fallbacks from enabled catalog entries that are allowed by the request.
+- Always return reasons and preview-only evidence-boundary flags.
+
+## Non-empirical boundary
+
+The router does not choose the best model empirically. Task profile, cost preference, and latency preference are recorded only as reasons, without provider quality, pricing, latency, or benchmark claims.

--- a/docs/evals/runs/alpha-solver-model-catalog-routing-preview-001/selected-next-state.md
+++ b/docs/evals/runs/alpha-solver-model-catalog-routing-preview-001/selected-next-state.md
@@ -1,0 +1,5 @@
+# Selected next state
+
+`OPERATOR_REVIEW_REQUIRED_AFTER_MODEL_CATALOG_ROUTING_PREVIEW_001`
+
+This is a review-only selected next state after adding backend model catalog and deterministic routing preview support. It authorizes no provider calls, local model calls, UI work, endpoint exposure, scoring, unblinding, Google Sheets mutation, deployment, benchmark work, production readiness claim, public readiness claim, security/privacy claim, or Alpha-superiority claim.

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -1,0 +1,43 @@
+from alpha.model_catalog import ModelCatalog
+
+
+EXPECTED_LOCAL_MODELS = {"qwen2.5:3b", "gemma3:4b", "llama3.2:1b", "llama3.2:latest"}
+EXPECTED_OPENAI_MODELS = {"gpt-4.1-mini", "gpt-4.1", "gpt-4o-mini"}
+
+
+def test_catalog_loads_successfully():
+    catalog = ModelCatalog.load()
+
+    assert catalog.version
+    assert catalog.models
+    assert catalog.evidence_boundary == {
+        "runs_provider": False,
+        "runs_local_model": False,
+        "quality_evidence": False,
+        "readiness_evidence": False,
+        "benchmark_evidence": False,
+    }
+
+
+def test_catalog_includes_expected_local_models():
+    catalog = ModelCatalog.load()
+
+    assert EXPECTED_LOCAL_MODELS <= {model.model_id for model in catalog.by_mode("local", enabled_only=False)}
+
+
+def test_catalog_includes_expected_openai_models():
+    catalog = ModelCatalog.load()
+
+    assert EXPECTED_OPENAI_MODELS <= {model.model_id for model in catalog.by_mode("openai", enabled_only=False)}
+
+
+def test_each_model_entry_has_required_no_quality_claim_metadata():
+    catalog = ModelCatalog.load()
+
+    for model in catalog.models:
+        assert model.provider
+        assert model.mode in {"local", "openai"}
+        assert model.model_id
+        assert isinstance(model.smoke_eligible, bool)
+        assert model.quality_claim is False
+        assert "not" in model.notes.lower()

--- a/tests/test_model_router.py
+++ b/tests/test_model_router.py
@@ -1,0 +1,118 @@
+import pytest
+
+from alpha.model_router import RoutingPreviewRequest, preview_route
+from tools.operator_smoke_runner import MAX_PROMPT_CHARS
+
+
+def test_router_selects_requested_enabled_openai_model_when_hosted_allowed():
+    preview = preview_route(RoutingPreviewRequest(requested_mode="openai", requested_model="gpt-4.1-mini", allow_hosted_providers=True))
+
+    assert preview.status == "preview_only"
+    assert preview.recommended_mode == "openai"
+    assert preview.recommended_model == "gpt-4.1-mini"
+    assert "model_available_in_catalog" in preview.reasons
+    assert "smoke_eligible" in preview.reasons
+
+
+def test_router_selects_requested_enabled_local_model_when_local_allowed():
+    preview = preview_route(RoutingPreviewRequest(requested_mode="local", requested_model="qwen2.5:3b", allow_local=True))
+
+    assert preview.status == "preview_only"
+    assert preview.recommended_mode == "local"
+    assert preview.recommended_model == "qwen2.5:3b"
+
+
+def test_router_rejects_hosted_model_when_hosted_not_allowed():
+    preview = preview_route(RoutingPreviewRequest(requested_model="gpt-4.1-mini", allow_hosted_providers=False, allow_local=True))
+
+    assert preview.status == "failed_closed"
+    assert preview.recommended_model is None
+    assert "hosted_provider_not_allowed" in preview.reasons
+
+
+def test_router_rejects_local_model_when_local_not_allowed():
+    preview = preview_route(RoutingPreviewRequest(requested_model="qwen2.5:3b", allow_hosted_providers=True, allow_local=False))
+
+    assert preview.status == "failed_closed"
+    assert preview.recommended_model is None
+    assert "local_model_not_allowed" in preview.reasons
+
+
+def test_router_returns_failed_closed_preview_for_unknown_model():
+    preview = preview_route(RoutingPreviewRequest(requested_model="unknown-model"))
+
+    assert preview.status == "failed_closed"
+    assert preview.recommended_model is None
+    assert "requested_model_not_in_catalog" in preview.reasons
+
+
+def test_router_returns_failed_closed_preview_for_prompt_above_smoke_limit():
+    preview = preview_route(RoutingPreviewRequest(prompt_length=MAX_PROMPT_CHARS + 1))
+
+    assert preview.status == "failed_closed"
+    assert "prompt_too_long_for_smoke_runner" in preview.reasons
+
+
+def test_router_includes_reasons():
+    preview = preview_route(RoutingPreviewRequest(requested_mode="openai", requested_model="gpt-4.1-mini"))
+
+    assert preview.reasons
+    assert "routing_preview_only" in preview.reasons
+    assert "openai_requested_by_operator" in preview.reasons
+
+
+def test_router_includes_preview_only_evidence_boundary_flags():
+    preview = preview_route(RoutingPreviewRequest())
+
+    assert preview.evidence_boundary == {
+        "runs_provider": False,
+        "runs_local_model": False,
+        "quality_evidence": False,
+        "readiness_evidence": False,
+        "benchmark_evidence": False,
+    }
+
+
+def test_router_does_not_require_api_keys(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    preview = preview_route(RoutingPreviewRequest(requested_model="gpt-4.1-mini"))
+
+    assert preview.status == "preview_only"
+    assert preview.recommended_model == "gpt-4.1-mini"
+
+
+def test_router_does_not_call_provider_clients(monkeypatch):
+    import alpha.providers.openai as openai_provider
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("provider client must not be called by routing preview")
+
+    monkeypatch.setattr(openai_provider.OpenAIProviderClient, "execute", fail_if_called)
+
+    preview = preview_route(RoutingPreviewRequest(requested_model="gpt-4.1-mini"))
+
+    assert preview.status == "preview_only"
+
+
+def test_router_does_not_call_ollama_or_local_runtime(monkeypatch):
+    import alpha.local_llm.provider_adapter as provider_adapter
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("local runtime must not be called by routing preview")
+
+    monkeypatch.setattr(provider_adapter, "run_configured_local_llm_runtime", fail_if_called)
+
+    preview = preview_route(RoutingPreviewRequest(requested_model="qwen2.5:3b"))
+
+    assert preview.status == "preview_only"
+
+
+def test_preview_as_dict_is_structured():
+    data = preview_route(RoutingPreviewRequest(requested_model="gpt-4.1-mini")).as_dict()
+
+    assert data["status"] == "preview_only"
+    assert data["recommended_mode"] == "openai"
+    assert isinstance(data["fallbacks"], list)
+    assert isinstance(data["reasons"], list)
+    assert data["evidence_boundary"]["runs_provider"] is False


### PR DESCRIPTION
### Motivation

- Add a backend-only, configurable model catalog and a deterministic routing-preview lane to enable richer model choices and begin routing decision scaffolding without contacting providers or changing the UI.
- Keep firm evidence boundaries: routing preview only, no provider/local-model calls, and no quality/readiness/benchmark claims.
- Provide an operator-editable catalog and a repeatable deterministic router for safe operator review and subsequent UI/integration work.

### Description

- Added a JSON-configurable catalog at `configs/model_catalog.json` and a metadata-only loader `alpha/model_catalog.py` that validates required fields and rejects entries with `quality_claim: true`.
- Implemented a deterministic, metadata-only router `alpha/model_router.py` that returns structured preview objects (status, recommended_mode/model, fallbacks, reasons, warnings, evidence_boundary) and never calls providers or local runtimes. 
- Added tests `tests/test_model_catalog.py` and `tests/test_model_router.py`, and a docs packet under `docs/evals/runs/alpha-solver-model-catalog-routing-preview-001/`; updated source-of-truth files `docs/CURRENT_STATE.md`, `docs/LANE_REGISTRY.md`, and `docs/EVIDENCE_INDEX.md` to record lane `ALPHA-SOLVER-MODEL-CATALOG-ROUTING-PREVIEW-001` and selected next state `OPERATOR_REVIEW_REQUIRED_AFTER_MODEL_CATALOG_ROUTING_PREVIEW_001`.
- Files changed: `alpha/model_catalog.py`, `alpha/model_router.py`, `configs/model_catalog.json`, `tests/test_model_catalog.py`, `tests/test_model_router.py`, and the doc files noted above.

### Testing

- Ran `python -m pytest -q tests/test_model_catalog.py tests/test_model_router.py` and all tests passed (16 tests total).
- Ran `python -m pytest -q tests/test_operator_smoke_runner.py` and it passed (9 tests), and `python -m pytest -q` passed with expected skips and deprecation warnings.
- Ran `make check-local-llm-orchestration-guardrails`, `git diff --check`, narrative claim-safety, secret-safety checks on added lines, and a source-of-truth consistency check for `OPERATOR_REVIEW_REQUIRED_AFTER_MODEL_CATALOG_ROUTING_PREVIEW_001`, all of which passed.
- Static checks and guard scripts that verify evidence boundaries passed (local LLM evidence-boundary and packet consistency checks passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31b6575b5483299b7492c0f25a4bae)