### PR TITLE
alpha: expand model catalog metadata

### DIFF
--- a/alpha/model_catalog.py
+++ b/alpha/model_catalog.py
@@ -12,6 +12,8 @@ from pathlib import Path
 from typing import Any, Iterable, Literal
 
 Mode = Literal["local", "openai"]
+Tier = Literal["low", "medium", "high", "unknown"]
+ReviewStatus = Literal["operator_metadata", "smoke_only"]
 
 DEFAULT_CATALOG_PATH = Path(__file__).resolve().parents[1] / "configs" / "model_catalog.json"
 DEFAULT_EVIDENCE_BOUNDARY: dict[str, bool] = {
@@ -29,32 +31,97 @@ class ModelCatalogEntry:
     mode: Mode
     model_id: str
     display_name: str
-    enabled_default: bool
+    enabled_by_default: bool
+    routing_roles: tuple[str, ...]
+    task_families: tuple[str, ...]
+    capability_tags: tuple[str, ...]
+    cost_tier: Tier
+    latency_tier: Tier
+    context_tier: Tier
+    privacy_tier: str
+    supports_json: bool
+    supports_tools: bool
+    supports_vision: bool
     smoke_eligible: bool
-    notes: str
-    quality_claim: bool = False
+    requires_network: bool
+    requires_credentials: bool
+    evidence_boundary: dict[str, bool]
+    quality_claim: bool
+    last_reviewed: str
+    review_status: ReviewStatus
+    operator_notes: str
 
     @classmethod
     def from_mapping(cls, raw: dict[str, Any]) -> "ModelCatalogEntry":
-        required = ("provider", "mode", "model_id", "display_name", "enabled_default", "smoke_eligible", "notes")
+        required = (
+            "provider",
+            "mode",
+            "model_id",
+            "display_name",
+            "enabled_by_default",
+            "routing_roles",
+            "task_families",
+            "capability_tags",
+            "cost_tier",
+            "latency_tier",
+            "context_tier",
+            "privacy_tier",
+            "supports_json",
+            "supports_tools",
+            "supports_vision",
+            "smoke_eligible",
+            "requires_network",
+            "requires_credentials",
+            "evidence_boundary",
+            "quality_claim",
+            "last_reviewed",
+            "review_status",
+            "operator_notes",
+        )
         missing = [field for field in required if field not in raw]
         if missing:
             raise ValueError(f"model catalog entry missing required fields: {', '.join(missing)}")
         mode = str(raw["mode"])
         if mode not in {"local", "openai"}:
             raise ValueError(f"unsupported model catalog mode: {mode}")
-        quality_claim = bool(raw.get("quality_claim", False))
+        quality_claim = bool(raw["quality_claim"])
         if quality_claim:
             raise ValueError("model catalog entries must not carry quality claims")
+        boundary = dict(DEFAULT_EVIDENCE_BOUNDARY)
+        boundary.update({key: bool(value) for key, value in raw["evidence_boundary"].items()})
+        if any(boundary.values()):
+            raise ValueError("model catalog entries must not imply validation evidence")
+        review_status = str(raw["review_status"])
+        if review_status not in {"operator_metadata", "smoke_only"}:
+            raise ValueError(f"unsupported model catalog review_status: {review_status}")
+        tiers = {"low", "medium", "high", "unknown"}
+        for tier_field in ("cost_tier", "latency_tier", "context_tier"):
+            if str(raw[tier_field]) not in tiers:
+                raise ValueError(f"unsupported {tier_field}: {raw[tier_field]}")
         return cls(
             provider=str(raw["provider"]),
             mode=mode,  # type: ignore[arg-type]
             model_id=str(raw["model_id"]),
             display_name=str(raw["display_name"]),
-            enabled_default=bool(raw["enabled_default"]),
+            enabled_by_default=bool(raw["enabled_by_default"]),
+            routing_roles=tuple(str(item) for item in raw["routing_roles"]),
+            task_families=tuple(str(item) for item in raw["task_families"]),
+            capability_tags=tuple(str(item) for item in raw["capability_tags"]),
+            cost_tier=str(raw["cost_tier"]),  # type: ignore[arg-type]
+            latency_tier=str(raw["latency_tier"]),  # type: ignore[arg-type]
+            context_tier=str(raw["context_tier"]),  # type: ignore[arg-type]
+            privacy_tier=str(raw["privacy_tier"]),
+            supports_json=bool(raw["supports_json"]),
+            supports_tools=bool(raw["supports_tools"]),
+            supports_vision=bool(raw["supports_vision"]),
             smoke_eligible=bool(raw["smoke_eligible"]),
-            notes=str(raw["notes"]),
+            requires_network=bool(raw["requires_network"]),
+            requires_credentials=bool(raw["requires_credentials"]),
+            evidence_boundary=boundary,
             quality_claim=quality_claim,
+            last_reviewed=str(raw["last_reviewed"]),
+            review_status=review_status,  # type: ignore[arg-type]
+            operator_notes=str(raw["operator_notes"]),
         )
 
     def as_dict(self) -> dict[str, Any]:
@@ -63,10 +130,25 @@ class ModelCatalogEntry:
             "mode": self.mode,
             "model_id": self.model_id,
             "display_name": self.display_name,
-            "enabled_default": self.enabled_default,
+            "enabled_by_default": self.enabled_by_default,
+            "routing_roles": list(self.routing_roles),
+            "task_families": list(self.task_families),
+            "capability_tags": list(self.capability_tags),
+            "cost_tier": self.cost_tier,
+            "latency_tier": self.latency_tier,
+            "context_tier": self.context_tier,
+            "privacy_tier": self.privacy_tier,
+            "supports_json": self.supports_json,
+            "supports_tools": self.supports_tools,
+            "supports_vision": self.supports_vision,
             "smoke_eligible": self.smoke_eligible,
-            "notes": self.notes,
+            "requires_network": self.requires_network,
+            "requires_credentials": self.requires_credentials,
+            "evidence_boundary": dict(self.evidence_boundary),
             "quality_claim": self.quality_claim,
+            "last_reviewed": self.last_reviewed,
+            "review_status": self.review_status,
+            "operator_notes": self.operator_notes,
         }
 
 
@@ -90,7 +172,7 @@ class ModelCatalog:
         return cls(version=str(data.get("version", "unversioned")), models=models, evidence_boundary=boundary)
 
     def enabled(self) -> tuple[ModelCatalogEntry, ...]:
-        return tuple(model for model in self.models if model.enabled_default)
+        return tuple(model for model in self.models if model.enabled_by_default)
 
     def by_model_id(self, model_id: str) -> ModelCatalogEntry | None:
         return next((model for model in self.models if model.model_id == model_id), None)

--- a/alpha/model_router.py
+++ b/alpha/model_router.py
@@ -35,6 +35,8 @@ class RoutingPreviewRequest:
     task_profile: str | None = None
     cost_preference: str | None = None
     latency_preference: str | None = None
+    required_capability: str | None = None
+    local_only: bool = False
 
 
 @dataclass(frozen=True)
@@ -46,6 +48,7 @@ class RoutingPreview:
     reasons: tuple[str, ...]
     evidence_boundary: dict[str, bool] = field(default_factory=lambda: dict(DEFAULT_EVIDENCE_BOUNDARY))
     warnings: tuple[str, ...] = ()
+    provider_or_local_execution_authorized: bool = False
 
     def as_dict(self) -> dict[str, Any]:
         return {
@@ -56,6 +59,7 @@ class RoutingPreview:
             "reasons": list(self.reasons),
             "evidence_boundary": dict(self.evidence_boundary),
             "warnings": list(self.warnings),
+            "provider_or_local_execution_authorized": self.provider_or_local_execution_authorized,
         }
 
 
@@ -65,7 +69,22 @@ def preview_route(request: RoutingPreviewRequest | None = None, catalog: ModelCa
     reasons: list[str] = ["routing_preview_only", "no_provider_or_local_model_calls"]
     warnings: list[str] = []
 
+    if req.local_only and req.allow_hosted_providers:
+        warnings.append("local_only_request_suppresses_hosted_recommendations")
+        req = RoutingPreviewRequest(
+            requested_mode=req.requested_mode or "local",
+            requested_model=req.requested_model,
+            allow_hosted_providers=False,
+            allow_local=req.allow_local,
+            prompt_length=req.prompt_length,
+            task_profile=req.task_profile,
+            cost_preference=req.cost_preference,
+            latency_preference=req.latency_preference,
+            required_capability=req.required_capability,
+            local_only=req.local_only,
+        )
     if req.prompt_length > MAX_PROMPT_CHARS:
+        warnings.append("prompt_length_exceeds_preview_smoke_boundary")
         return _failed("prompt_too_long_for_smoke_runner", cat, req, reasons, warnings)
     if not req.allow_hosted_providers and not req.allow_local:
         return _failed("no_modes_allowed", cat, req, reasons, warnings)
@@ -78,6 +97,8 @@ def preview_route(request: RoutingPreviewRequest | None = None, catalog: ModelCa
         reasons.append("cost_preference_recorded_no_pricing_selection")
     if req.latency_preference:
         reasons.append("latency_preference_recorded_no_latency_claim")
+    if req.required_capability:
+        reasons.append("required_capability_matched_as_metadata_only")
 
     selected: ModelCatalogEntry | None = None
     if req.requested_model:
@@ -85,9 +106,12 @@ def preview_route(request: RoutingPreviewRequest | None = None, catalog: ModelCa
         if selected is None:
             return _failed("requested_model_not_in_catalog", cat, req, reasons, warnings)
         reasons.append("model_available_in_catalog")
-        if not selected.enabled_default:
+        if not selected.enabled_by_default:
             return _failed("requested_model_disabled", cat, req, reasons, warnings)
+        if req.required_capability and req.required_capability not in selected.capability_tags:
+            return _failed("requested_model_missing_required_capability", cat, req, reasons, warnings)
         if selected.mode == "openai" and not req.allow_hosted_providers:
+            warnings.append("local_fallback_available" if cat.by_mode("local") and req.allow_local else "hosted_execution_disabled")
             return _failed("hosted_provider_not_allowed", cat, req, reasons, warnings)
         if selected.mode == "local" and not req.allow_local:
             return _failed("local_model_not_allowed", cat, req, reasons, warnings)
@@ -109,22 +133,40 @@ def preview_route(request: RoutingPreviewRequest | None = None, catalog: ModelCa
         recommended_model=selected.model_id,
         fallbacks=_fallbacks(cat, exclude=selected.model_id, request=req),
         reasons=tuple(reasons),
+        evidence_boundary=dict(selected.evidence_boundary),
         warnings=tuple(warnings),
     )
 
 
 def _default_for_request(cat: ModelCatalog, req: RoutingPreviewRequest, reasons: list[str]) -> ModelCatalogEntry | None:
-    if req.allow_hosted_providers and (req.requested_mode in (None, "openai") or not req.allow_local):
-        options = cat.by_mode("openai")
+    mode_order: tuple[Mode, ...]
+    if req.requested_mode == "openai" or not req.allow_local:
+        mode_order = ("openai", "local")
+    else:
+        mode_order = ("local", "openai")
+    for mode in mode_order:
+        if mode == "openai" and not req.allow_hosted_providers:
+            continue
+        if mode == "local" and not req.allow_local:
+            continue
+        options = _metadata_filtered(cat.by_mode(mode), req)
         if options:
-            reasons.append("openai_allowed_default_selected")
-            return options[0]
-    if req.allow_local and (req.requested_mode in (None, "local") or not req.allow_hosted_providers):
-        options = cat.by_mode("local")
-        if options:
-            reasons.append("local_allowed_default_selected")
+            reasons.append(f"{mode}_metadata_default_selected")
             return options[0]
     return None
+
+
+def _metadata_filtered(options: tuple[ModelCatalogEntry, ...], req: RoutingPreviewRequest) -> tuple[ModelCatalogEntry, ...]:
+    filtered = options
+    if req.required_capability:
+        filtered = tuple(model for model in filtered if req.required_capability in model.capability_tags)
+    if req.cost_preference:
+        filtered = tuple(model for model in filtered if model.cost_tier == req.cost_preference) or filtered
+    if req.latency_preference:
+        filtered = tuple(model for model in filtered if model.latency_tier == req.latency_preference) or filtered
+    if req.task_profile:
+        filtered = tuple(model for model in filtered if req.task_profile in model.task_families or req.task_profile in model.routing_roles) or filtered
+    return filtered
 
 
 def _fallbacks(cat: ModelCatalog, *, exclude: str | None, request: RoutingPreviewRequest) -> tuple[RouteFallback, ...]:
@@ -133,7 +175,11 @@ def _fallbacks(cat: ModelCatalog, *, exclude: str | None, request: RoutingPrevie
         allowed_modes.add("openai")
     if request.allow_local:
         allowed_modes.add("local")
-    fallbacks = [RouteFallback(model.mode, model.model_id) for model in cat.enabled() if model.model_id != exclude and model.mode in allowed_modes]
+    fallbacks = [
+        RouteFallback(model.mode, model.model_id)
+        for model in _metadata_filtered(cat.enabled(), request)
+        if model.model_id != exclude and model.mode in allowed_modes
+    ]
     return tuple(fallbacks[:3])
 
 

--- a/configs/model_catalog.json
+++ b/configs/model_catalog.json
@@ -1,5 +1,5 @@
 {
-  "version": "2026-06-16.model-catalog-routing-preview-001",
+  "version": "2026-06-17.model-catalog-expansion-cost-tiers-001",
   "evidence_boundary": {
     "runs_provider": false,
     "runs_local_model": false,
@@ -13,70 +13,278 @@
       "mode": "local",
       "model_id": "qwen2.5:3b",
       "display_name": "Qwen 2.5 3B via Ollama",
-      "enabled_default": true,
+      "enabled_by_default": true,
+      "routing_roles": [
+        "local_preview",
+        "offline_candidate"
+      ],
+      "task_families": [
+        "general",
+        "structured_reasoning_preview"
+      ],
+      "capability_tags": [
+        "local_runtime",
+        "small_context_candidate"
+      ],
+      "cost_tier": "low",
+      "latency_tier": "medium",
+      "context_tier": "low",
+      "privacy_tier": "local_operator_machine",
+      "supports_json": true,
+      "supports_tools": false,
+      "supports_vision": false,
       "smoke_eligible": true,
+      "requires_network": false,
+      "requires_credentials": false,
+      "evidence_boundary": {
+        "runs_provider": false,
+        "runs_local_model": false,
+        "quality_evidence": false,
+        "readiness_evidence": false,
+        "benchmark_evidence": false
+      },
       "quality_claim": false,
-      "notes": "Operator-relevant local/Ollama catalog default. Catalog inclusion is not a quality claim."
+      "last_reviewed": "2026-06-17",
+      "review_status": "smoke_only",
+      "operator_notes": "Catalog inclusion is operator-maintained metadata only; it is not validation, ranking, readiness, or a quality claim."
     },
     {
       "provider": "ollama",
       "mode": "local",
       "model_id": "gemma3:4b",
       "display_name": "Gemma 3 4B via Ollama",
-      "enabled_default": true,
+      "enabled_by_default": true,
+      "routing_roles": [
+        "local_preview",
+        "offline_candidate"
+      ],
+      "task_families": [
+        "general"
+      ],
+      "capability_tags": [
+        "local_runtime",
+        "small_context_candidate"
+      ],
+      "cost_tier": "low",
+      "latency_tier": "medium",
+      "context_tier": "low",
+      "privacy_tier": "local_operator_machine",
+      "supports_json": true,
+      "supports_tools": false,
+      "supports_vision": false,
       "smoke_eligible": true,
+      "requires_network": false,
+      "requires_credentials": false,
+      "evidence_boundary": {
+        "runs_provider": false,
+        "runs_local_model": false,
+        "quality_evidence": false,
+        "readiness_evidence": false,
+        "benchmark_evidence": false
+      },
       "quality_claim": false,
-      "notes": "Operator-relevant local/Ollama catalog default. Catalog inclusion is not a quality claim."
+      "last_reviewed": "2026-06-17",
+      "review_status": "smoke_only",
+      "operator_notes": "Catalog inclusion is operator-maintained metadata only; it is not validation, ranking, readiness, or a quality claim."
     },
     {
       "provider": "ollama",
       "mode": "local",
       "model_id": "llama3.2:1b",
       "display_name": "Llama 3.2 1B via Ollama",
-      "enabled_default": true,
+      "enabled_by_default": true,
+      "routing_roles": [
+        "local_preview",
+        "offline_candidate"
+      ],
+      "task_families": [
+        "general"
+      ],
+      "capability_tags": [
+        "local_runtime",
+        "small_context_candidate"
+      ],
+      "cost_tier": "low",
+      "latency_tier": "low",
+      "context_tier": "low",
+      "privacy_tier": "local_operator_machine",
+      "supports_json": true,
+      "supports_tools": false,
+      "supports_vision": false,
       "smoke_eligible": true,
+      "requires_network": false,
+      "requires_credentials": false,
+      "evidence_boundary": {
+        "runs_provider": false,
+        "runs_local_model": false,
+        "quality_evidence": false,
+        "readiness_evidence": false,
+        "benchmark_evidence": false
+      },
       "quality_claim": false,
-      "notes": "Operator-relevant local/Ollama catalog default. Catalog inclusion is not a quality claim."
+      "last_reviewed": "2026-06-17",
+      "review_status": "smoke_only",
+      "operator_notes": "Catalog inclusion is operator-maintained metadata only; it is not validation, ranking, readiness, or a quality claim."
     },
     {
       "provider": "ollama",
       "mode": "local",
       "model_id": "llama3.2:latest",
       "display_name": "Llama 3.2 latest via Ollama",
-      "enabled_default": true,
+      "enabled_by_default": true,
+      "routing_roles": [
+        "local_preview",
+        "offline_candidate"
+      ],
+      "task_families": [
+        "general"
+      ],
+      "capability_tags": [
+        "local_runtime",
+        "small_context_candidate"
+      ],
+      "cost_tier": "low",
+      "latency_tier": "medium",
+      "context_tier": "low",
+      "privacy_tier": "local_operator_machine",
+      "supports_json": true,
+      "supports_tools": false,
+      "supports_vision": false,
       "smoke_eligible": true,
+      "requires_network": false,
+      "requires_credentials": false,
+      "evidence_boundary": {
+        "runs_provider": false,
+        "runs_local_model": false,
+        "quality_evidence": false,
+        "readiness_evidence": false,
+        "benchmark_evidence": false
+      },
       "quality_claim": false,
-      "notes": "Operator-relevant local/Ollama catalog default. Catalog inclusion is not a quality claim."
+      "last_reviewed": "2026-06-17",
+      "review_status": "smoke_only",
+      "operator_notes": "Catalog inclusion is operator-maintained metadata only; it is not validation, ranking, readiness, or a quality claim."
     },
     {
       "provider": "openai",
       "mode": "openai",
       "model_id": "gpt-4.1-mini",
       "display_name": "GPT-4.1 mini",
-      "enabled_default": true,
+      "enabled_by_default": true,
+      "routing_roles": [
+        "hosted_preview",
+        "json_candidate"
+      ],
+      "task_families": [
+        "general",
+        "structured_output_preview"
+      ],
+      "capability_tags": [
+        "hosted_provider",
+        "json_capable"
+      ],
+      "cost_tier": "medium",
+      "latency_tier": "medium",
+      "context_tier": "high",
+      "privacy_tier": "hosted_provider_boundary",
+      "supports_json": true,
+      "supports_tools": true,
+      "supports_vision": false,
       "smoke_eligible": true,
+      "requires_network": true,
+      "requires_credentials": true,
+      "evidence_boundary": {
+        "runs_provider": false,
+        "runs_local_model": false,
+        "quality_evidence": false,
+        "readiness_evidence": false,
+        "benchmark_evidence": false
+      },
       "quality_claim": false,
-      "notes": "Conservative OpenAI catalog default for operator routing preview. Catalog inclusion is not model validation."
+      "last_reviewed": "2026-06-17",
+      "review_status": "smoke_only",
+      "operator_notes": "Catalog inclusion is operator-maintained metadata only; it is not validation, ranking, readiness, or a quality claim."
     },
     {
       "provider": "openai",
       "mode": "openai",
       "model_id": "gpt-4.1",
       "display_name": "GPT-4.1",
-      "enabled_default": true,
+      "enabled_by_default": true,
+      "routing_roles": [
+        "hosted_preview",
+        "json_candidate"
+      ],
+      "task_families": [
+        "general",
+        "structured_output_preview"
+      ],
+      "capability_tags": [
+        "hosted_provider",
+        "json_capable"
+      ],
+      "cost_tier": "high",
+      "latency_tier": "medium",
+      "context_tier": "high",
+      "privacy_tier": "hosted_provider_boundary",
+      "supports_json": true,
+      "supports_tools": true,
+      "supports_vision": false,
       "smoke_eligible": true,
+      "requires_network": true,
+      "requires_credentials": true,
+      "evidence_boundary": {
+        "runs_provider": false,
+        "runs_local_model": false,
+        "quality_evidence": false,
+        "readiness_evidence": false,
+        "benchmark_evidence": false
+      },
       "quality_claim": false,
-      "notes": "Conservative OpenAI catalog default for operator routing preview. Catalog inclusion is not model validation."
+      "last_reviewed": "2026-06-17",
+      "review_status": "operator_metadata",
+      "operator_notes": "Catalog inclusion is operator-maintained metadata only; it is not validation, ranking, readiness, or a quality claim."
     },
     {
       "provider": "openai",
       "mode": "openai",
       "model_id": "gpt-4o-mini",
       "display_name": "GPT-4o mini",
-      "enabled_default": true,
+      "enabled_by_default": true,
+      "routing_roles": [
+        "hosted_preview",
+        "vision_candidate"
+      ],
+      "task_families": [
+        "general",
+        "vision_preview"
+      ],
+      "capability_tags": [
+        "hosted_provider",
+        "json_capable",
+        "vision_capable"
+      ],
+      "cost_tier": "medium",
+      "latency_tier": "medium",
+      "context_tier": "medium",
+      "privacy_tier": "hosted_provider_boundary",
+      "supports_json": true,
+      "supports_tools": true,
+      "supports_vision": true,
       "smoke_eligible": true,
+      "requires_network": true,
+      "requires_credentials": true,
+      "evidence_boundary": {
+        "runs_provider": false,
+        "runs_local_model": false,
+        "quality_evidence": false,
+        "readiness_evidence": false,
+        "benchmark_evidence": false
+      },
       "quality_claim": false,
-      "notes": "Conservative OpenAI catalog default for operator routing preview. Catalog inclusion is not model validation."
+      "last_reviewed": "2026-06-17",
+      "review_status": "operator_metadata",
+      "operator_notes": "Catalog inclusion is operator-maintained metadata only; it is not validation, ranking, readiness, or a quality claim."
     }
   ]
 }

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -5,7 +5,7 @@
 
 ## Current verified phase
 
-**Tool catalog routing registry completed: the selected next state is review-only operator review after metadata-only tool recommendation preview support.**
+**Model catalog expansion cost tiers completed: the selected next state is review-only operator review after metadata-only model catalog expansion and routing preview support.**
 
 The merged #569–#574 wave updated the repository from the post-#568 blocked Value Read state to a broader documentation-and-boundary posture. PR #576 was superseded by PR #577 and should be closed unmerged. PR #577 completes `ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001` as a docs-only Alpha-native local operator harness design note.
 
@@ -17,12 +17,12 @@ These are docs, gate, helper, static/research, blocked-attempt, scoring-only, se
 
 | Field | Value |
 |-------|-------|
-| Latest verified completed lane in this wave | **`ALPHA-SOLVER-TOOL-CATALOG-ROUTING-REGISTRY-001`** |
-| Source-of-truth sync | Current docs record the completed metadata-only tool catalog routing registry and a review-only selected next state |
+| Latest verified completed lane in this wave | **`ALPHA-SOLVER-MODEL-CATALOG-EXPANSION-COST-TIERS-001`** |
+| Source-of-truth sync | Current docs record the completed metadata-only model catalog expansion cost tiers lane and a review-only selected next state |
 | Closed-unmerged superseded PR | **#561** - superseded by merged PR #562 |
-| Current controlling posture | Operator review required after tool catalog routing registry |
-| Selected next state | **`OPERATOR_REVIEW_REQUIRED_AFTER_TOOL_CATALOG_ROUTING_REGISTRY_001`** |
-| Strategic boundary | This review-only state records metadata-only tool catalog and deterministic tool recommendation preview support; it does not execute tools, browse, call providers, call GitHub from runtime code, expose `/v1/solve`, mutate Google Sheets, generate scores, run CI provider calls, run local models, or support tool/model/provider/local-model quality, readiness, benchmark, production/public, security/privacy, partnership/Pi.dev integration, or Alpha-superiority claims |
+| Current controlling posture | Operator review required after model catalog expansion cost tiers |
+| Selected next state | **`OPERATOR_REVIEW_REQUIRED_AFTER_MODEL_CATALOG_EXPANSION_COST_TIERS_001`** |
+| Strategic boundary | This review-only state records metadata-only model catalog expansion and deterministic routing preview support; it does not call providers, run local models, pull models, expose `/v1/solve`, mutate Google Sheets, generate scores, add dependencies, benchmark models, or support model/provider/local-model quality, readiness, benchmark, production/public, security/privacy, partnership/Pi.dev integration, or Alpha-superiority claims |
 
 ## Completed post-552 / post-565 / post-568 infrastructure lanes
 
@@ -71,9 +71,9 @@ See [`EVIDENCE_INDEX.md`](EVIDENCE_INDEX.md) for the PR status ledger and [`LANE
 
 ## Selected next state
 
-**`OPERATOR_REVIEW_REQUIRED_AFTER_TOOL_CATALOG_ROUTING_REGISTRY_001`** is the current global selected next state.
+**`OPERATOR_REVIEW_REQUIRED_AFTER_MODEL_CATALOG_EXPANSION_COST_TIERS_001`** is the current global selected next state.
 
-This is a review-only state after `ALPHA-SOLVER-TOOL-CATALOG-ROUTING-REGISTRY-001`. It means the metadata-only tool catalog and deterministic recommendation preview exist for operator review.
+This is a review-only state after `ALPHA-SOLVER-MODEL-CATALOG-EXPANSION-COST-TIERS-001`. It means the metadata-only model catalog expansion and deterministic routing preview exist for operator review.
 
 This state authorizes no production/public exposure, no task execution outside explicit local Operator submission, no output generation for evals, scoring, score change, source-map work, unblinding, raw Alpha output inspection, raw baseline output inspection, `/v1/solve` exposure, dashboard/public API exposure, Google Sheets mutation, benchmark work, release behavior, readiness claim, broad value claim, provider claim, local-model claim, security/privacy claim, production/public claim, partnership/Pi.dev integration claim, demo external-use approval, discrimination-task execution/scoring, or Alpha-superiority claim.
 
@@ -137,5 +137,13 @@ This phase does **not** support claims of broad value, OpenAI validation, provid
 - Packet: `docs/evals/runs/alpha-solver-tool-catalog-routing-registry-001/`
 - Evidence type: metadata-only tool catalog and deterministic recommendation preview only.
 - Tool execution status: not run by this lane.
-- Selected next state: `OPERATOR_REVIEW_REQUIRED_AFTER_TOOL_CATALOG_ROUTING_REGISTRY_001`.
+- Selected next state: `OPERATOR_REVIEW_REQUIRED_AFTER_MODEL_CATALOG_EXPANSION_COST_TIERS_001`.
 - Boundary: recommendations such as Python/computation, web/current research, or GitHub/code are metadata-only preview outputs, not execution, browsing, provider calls, GitHub runtime calls, file mutation, readiness evidence, tool-quality evidence, or Alpha-superiority evidence.
+
+
+## ALPHA-SOLVER-MODEL-CATALOG-EXPANSION-COST-TIERS-001
+
+- Status: completed backend metadata implementation / review-only selected next.
+- Evidence packet: `docs/evals/runs/alpha-solver-model-catalog-expansion-cost-tiers-001/`.
+- Selected next state: `OPERATOR_REVIEW_REQUIRED_AFTER_MODEL_CATALOG_EXPANSION_COST_TIERS_001`.
+- Boundary: metadata-only routing preview; no provider or local model execution, no quality/readiness/benchmark claim, no public API or dashboard behavior, no `/v1/solve`, and no Google Sheets mutation.

--- a/docs/EVIDENCE_INDEX.md
+++ b/docs/EVIDENCE_INDEX.md
@@ -54,11 +54,11 @@ The entries below are design, documentation, gate, helper, static-checking, meth
 
 ## Current selected next state
 
-`OPERATOR_REVIEW_REQUIRED_AFTER_TOOL_CATALOG_ROUTING_REGISTRY_001` is the selected next state. This is a review-only state after metadata-only tool catalog and deterministic recommendation-preview support, not production/public readiness authorization.
+`OPERATOR_REVIEW_REQUIRED_AFTER_MODEL_CATALOG_EXPANSION_COST_TIERS_001` is the selected next state. This is a review-only state after metadata-only model catalog expansion and deterministic routing-preview support, not production/public readiness authorization.
 
 `ALPHA-SOLVER-GATE-SUBSTANTIVE-DERIVATION-CHECK-001` was completed by merged PR #591 as a docs-first gate packet. It defines criteria, fixture planning, heuristic review aids, stop conditions, non-actions, and non-claims for operator review. `ALPHA-SOLVER-DISCRIMINATION-TASK-BANK-FIRST-CHEAP-TEST-001` was completed by merged PR #595 as a docs-only cheap-test packet grounded in that gate and the discrimination task-bank asset.
 
-The selected state records metadata-only tool catalog and recommendation-preview implementation only and authorizes no score change, source-map work, raw Alpha output inspection, raw baseline output inspection, dashboard or public API work, `/v1/solve` exposure, Google Sheets mutation, provider/local-model execution, council behavior, benchmark work, release behavior, readiness claim, broad value claim, provider claim, local-model claim, security/privacy claim, production/public claim, demo external-use approval, discrimination-task execution/scoring, partnership/Pi.dev integration claim, or Alpha-superiority claim.
+The selected state records metadata-only model catalog expansion and routing-preview implementation only and authorizes no score change, source-map work, raw Alpha output inspection, raw baseline output inspection, dashboard or public API work, `/v1/solve` exposure, Google Sheets mutation, provider/local-model execution, council behavior, benchmark work, release behavior, readiness claim, broad value claim, provider claim, local-model claim, security/privacy claim, production/public claim, demo external-use approval, discrimination-task execution/scoring, partnership/Pi.dev integration claim, or Alpha-superiority claim.
 
 ## Evidence boundary
 
@@ -123,5 +123,13 @@ This entry records Operator-provided, redacted smoke-only evidence. It does not 
 - Artifact: `alpha/tool_catalog.py`, `alpha/tool_router.py`, and `configs/tool_catalog.json`
 - Packet: `docs/evals/runs/alpha-solver-tool-catalog-routing-registry-001/`
 - Purpose: add metadata-only tool catalog and deterministic recommendation preview for Python/computation, web/current research, GitHub/code, docs/files, spreadsheets, PDF/file parsing, browser/computer use, specialized math tools, and future provider-specific tools.
-- Selected next state: `OPERATOR_REVIEW_REQUIRED_AFTER_TOOL_CATALOG_ROUTING_REGISTRY_001`.
+- Selected next state: `OPERATOR_REVIEW_REQUIRED_AFTER_MODEL_CATALOG_EXPANSION_COST_TIERS_001`.
 - Evidence boundary: recommendation preview only, no tool execution, no browsing, no provider/local-model calls, no runtime GitHub calls, no file or Sheet mutation, no readiness/quality/security/privacy/production/public/provider/local-model/tool-quality/Alpha-superiority claim.
+
+
+## ALPHA-SOLVER-MODEL-CATALOG-EXPANSION-COST-TIERS-001
+
+- Status: completed backend metadata implementation / review-only selected next.
+- Changed files: `alpha/model_catalog.py`; `alpha/model_router.py`; `configs/model_catalog.json`; `tests/test_model_catalog.py`; `tests/test_model_router.py`; `docs/evals/runs/alpha-solver-model-catalog-expansion-cost-tiers-001/`; `docs/CURRENT_STATE.md`; `docs/LANE_REGISTRY.md`; `docs/EVIDENCE_INDEX.md`.
+- Evidence value: expands metadata-only model catalog fields and deterministic routing preview warnings/fallbacks.
+- Boundary: does not call providers, run local models, pull models, add dependencies, expose `/v1/solve`, mutate Sheets, benchmark, validate model quality, or make readiness/quality/provider/local-model/Alpha-superiority claims.

--- a/docs/LANE_REGISTRY.md
+++ b/docs/LANE_REGISTRY.md
@@ -11,13 +11,13 @@
 
 | Lane | State | Evidence |
 |------|-------|----------|
-| Operator review after tool catalog routing registry | **current control posture** | `ALPHA-SOLVER-TOOL-CATALOG-ROUTING-REGISTRY-001` adds metadata-only tool catalog and deterministic recommendation preview. Selected next state is `OPERATOR_REVIEW_REQUIRED_AFTER_TOOL_CATALOG_ROUTING_REGISTRY_001`. |
+| Operator review after model catalog expansion cost tiers | **current control posture** | `ALPHA-SOLVER-MODEL-CATALOG-EXPANSION-COST-TIERS-001` expands metadata-only model catalog fields and deterministic routing preview. Selected next state is `OPERATOR_REVIEW_REQUIRED_AFTER_MODEL_CATALOG_EXPANSION_COST_TIERS_001`. |
 
 ## Next ready / current selected state
 
 | State | Lifecycle | Notes |
 |-------|-----------|-------|
-| **`OPERATOR_REVIEW_REQUIRED_AFTER_TOOL_CATALOG_ROUTING_REGISTRY_001`** | **review-only selected next state** | Operator review is required after metadata-only tool catalog and deterministic recommendation-preview support. The evidence is metadata-only routing preview. No tool execution, browsing, provider/local-model execution, runtime GitHub call, quality claim, readiness claim, benchmark claim, production/public claim, security/privacy completion claim, or Alpha-superiority claim is created by this lane. |
+| **`OPERATOR_REVIEW_REQUIRED_AFTER_MODEL_CATALOG_EXPANSION_COST_TIERS_001`** | **review-only selected next state** | Operator review is required after metadata-only model catalog expansion and deterministic routing-preview support. The evidence is metadata-only. No provider/local-model execution, quality claim, readiness claim, benchmark claim, production/public claim, security/privacy completion claim, or Alpha-superiority claim is created by this lane. |
 
 ## Completed (kept as evidence)
 
@@ -87,7 +87,7 @@
 
 - PR #561 lane as a standalone needs-human protocol PR - closed unmerged and superseded by PR #562.
 - Any merged packet lane verbatim - packets are immutable evidence; create a new lane id instead.
-- Any selected-next pointer that conflicts with `OPERATOR_REVIEW_REQUIRED_AFTER_TOOL_CATALOG_ROUTING_REGISTRY_001`. Earlier selected-next pointers, including `OPERATOR_REVIEW_REQUIRED_AFTER_LOCAL_OPENAI_TEST_CONSOLE_001`, `OPERATOR_REVIEW_REQUIRED_AFTER_LOCAL_OPENAI_SMOKE_RESULTS_IMPORT_001`, `OPERATOR_REVIEW_REQUIRED_AFTER_LOCAL_OPENAI_SMOKE_RUNNER_001`, and `OPERATOR_REVIEW_REQUIRED_AFTER_DISCRIMINATION_TASK_BANK_FIRST_CHEAP_TEST_001`, are prior review states and must not be treated as current.
+- Any selected-next pointer that conflicts with `OPERATOR_REVIEW_REQUIRED_AFTER_MODEL_CATALOG_EXPANSION_COST_TIERS_001`. Earlier selected-next pointers, including `OPERATOR_REVIEW_REQUIRED_AFTER_LOCAL_OPENAI_TEST_CONSOLE_001`, `OPERATOR_REVIEW_REQUIRED_AFTER_LOCAL_OPENAI_SMOKE_RESULTS_IMPORT_001`, `OPERATOR_REVIEW_REQUIRED_AFTER_LOCAL_OPENAI_SMOKE_RUNNER_001`, and `OPERATOR_REVIEW_REQUIRED_AFTER_DISCRIMINATION_TASK_BANK_FIRST_CHEAP_TEST_001`, are prior review states and must not be treated as current.
 - Direct Pi.dev integration from PR #574's research lane - the recorded verdict is patterns-only/no-integration.
 
 ## Forward path (single track)
@@ -184,7 +184,7 @@ OPERATOR_REVIEW_REQUIRED_AFTER_MODEL_CATALOG_ROUTING_PREVIEW_001 ← prior revie
         ↓
 ALPHA-SOLVER-TOOL-CATALOG-ROUTING-REGISTRY-001 ← metadata-only tool catalog and recommendation preview completed
         ↓
-OPERATOR_REVIEW_REQUIRED_AFTER_TOOL_CATALOG_ROUTING_REGISTRY_001 ← current review-only selected next state
+OPERATOR_REVIEW_REQUIRED_AFTER_MODEL_CATALOG_EXPANSION_COST_TIERS_001 ← current review-only selected next state
 ```
 
 This registry does not authorize production/public UI exposure, dashboard readiness, public provider exposure, local model validation claims, task execution, output generation, scoring, score change, unblinding, source-map work, raw output inspection, Pi.dev install/run/integration, runtime endpoint exposure, public API exposure, `/v1/solve` exposure, Google Sheets mutation, benchmark, dependency addition, release implementation lane, or readiness/broad-value/security/privacy/provider/local-Ollama/Alpha-superiority claim.
@@ -203,7 +203,7 @@ Prior selected next state after test console UX/redaction refinement: `OPERATOR_
 
 Prior selected next state after model catalog routing preview: `OPERATOR_REVIEW_REQUIRED_AFTER_MODEL_CATALOG_ROUTING_PREVIEW_001`.
 
-Current selected next state after tool catalog routing registry: `OPERATOR_REVIEW_REQUIRED_AFTER_TOOL_CATALOG_ROUTING_REGISTRY_001`.
+Current selected next state after model catalog expansion cost tiers: `OPERATOR_REVIEW_REQUIRED_AFTER_MODEL_CATALOG_EXPANSION_COST_TIERS_001`.
 
 Boundary: no provider quality, local model quality, readiness, benchmark success, production readiness, public readiness, security/privacy completion, UI authorization, or Alpha-superiority claim is created.
 
@@ -245,5 +245,15 @@ Boundary: no provider quality, local model quality, readiness, benchmark success
 - Artifact: `alpha/tool_catalog.py`, `alpha/tool_router.py`, and `configs/tool_catalog.json`
 - Packet: `docs/evals/runs/alpha-solver-tool-catalog-routing-registry-001/`
 - Purpose: add metadata-only tool catalog and deterministic recommendation preview.
-- Selected next state: `OPERATOR_REVIEW_REQUIRED_AFTER_TOOL_CATALOG_ROUTING_REGISTRY_001`.
+- Selected next state: `OPERATOR_REVIEW_REQUIRED_AFTER_MODEL_CATALOG_EXPANSION_COST_TIERS_001`.
 - Evidence boundary: recommendation preview only, no tool execution, no browsing, no provider/local-model calls, no runtime GitHub calls, no quality/readiness/benchmark/production/public/security/privacy/Alpha-superiority claim.
+
+
+## ALPHA-SOLVER-MODEL-CATALOG-EXPANSION-COST-TIERS-001
+
+| Field | Value |
+| --- | --- |
+| Status | completed backend metadata implementation / review-only selected next |
+| Evidence packet | `docs/evals/runs/alpha-solver-model-catalog-expansion-cost-tiers-001/` |
+| Selected next state | `OPERATOR_REVIEW_REQUIRED_AFTER_MODEL_CATALOG_EXPANSION_COST_TIERS_001` |
+| Boundary | Metadata-only model catalog and routing preview; no provider/local model execution and no quality/readiness/benchmark claim. |

--- a/docs/evals/runs/alpha-solver-model-catalog-expansion-cost-tiers-001/README.md
+++ b/docs/evals/runs/alpha-solver-model-catalog-expansion-cost-tiers-001/README.md
@@ -1,0 +1,23 @@
+# ALPHA-SOLVER-MODEL-CATALOG-EXPANSION-COST-TIERS-001
+
+## Verdict
+
+Completed metadata-only backend model catalog expansion and deterministic routing preview update.
+
+## Metadata added
+
+The model catalog now records operator-maintained metadata fields for provider, model identity, display name, mode, enabled-by-default state, routing roles, task families, capability tags, cost tier, latency tier, context tier, privacy tier, JSON/tool/vision support flags, smoke eligibility, network and credential requirements, evidence boundary, quality-claim guard, last-reviewed date, review status, and operator notes.
+
+## Routing preview behavior changed
+
+The router remains preview-only. It can recommend a local or hosted catalog path using metadata filters such as requested capability, task profile, cost preference, latency preference, local-only posture, and hosted/local allow flags. It returns recommended mode, recommended model, fallback paths, reasons, warnings, evidence boundary, and `provider_or_local_execution_authorized=false`.
+
+## Evidence boundary
+
+No provider was called. No local model was run. No model was pulled. No SDK, dependency, API key, credential, billing path, runtime execution route, dashboard behavior, public API behavior, `/v1/solve`, tool catalog backend, benchmark, source-map work, scoring, unblinding, raw output inspection, or Google Sheets mutation was added.
+
+Catalog inclusion is not validation. The lane makes no quality, readiness, benchmark, provider, local-model, production, public, security/privacy, Alpha-superiority, or best-model claim.
+
+## Selected next state
+
+`OPERATOR_REVIEW_REQUIRED_AFTER_MODEL_CATALOG_EXPANSION_COST_TIERS_001`

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -1,8 +1,38 @@
-from alpha.model_catalog import ModelCatalog
+import copy
+import json
+
+import pytest
+
+from alpha.model_catalog import DEFAULT_EVIDENCE_BOUNDARY, ModelCatalog, ModelCatalogEntry
 
 
 EXPECTED_LOCAL_MODELS = {"qwen2.5:3b", "gemma3:4b", "llama3.2:1b", "llama3.2:latest"}
 EXPECTED_OPENAI_MODELS = {"gpt-4.1-mini", "gpt-4.1", "gpt-4o-mini"}
+REQUIRED_METADATA_FIELDS = {
+    "provider",
+    "model_id",
+    "display_name",
+    "mode",
+    "enabled_by_default",
+    "routing_roles",
+    "task_families",
+    "capability_tags",
+    "cost_tier",
+    "latency_tier",
+    "context_tier",
+    "privacy_tier",
+    "supports_json",
+    "supports_tools",
+    "supports_vision",
+    "smoke_eligible",
+    "requires_network",
+    "requires_credentials",
+    "evidence_boundary",
+    "quality_claim",
+    "last_reviewed",
+    "review_status",
+    "operator_notes",
+}
 
 
 def test_catalog_loads_successfully():
@@ -10,13 +40,7 @@ def test_catalog_loads_successfully():
 
     assert catalog.version
     assert catalog.models
-    assert catalog.evidence_boundary == {
-        "runs_provider": False,
-        "runs_local_model": False,
-        "quality_evidence": False,
-        "readiness_evidence": False,
-        "benchmark_evidence": False,
-    }
+    assert catalog.evidence_boundary == DEFAULT_EVIDENCE_BOUNDARY
 
 
 def test_catalog_includes_expected_local_models():
@@ -35,9 +59,60 @@ def test_each_model_entry_has_required_no_quality_claim_metadata():
     catalog = ModelCatalog.load()
 
     for model in catalog.models:
+        data = model.as_dict()
+        assert REQUIRED_METADATA_FIELDS <= set(data)
         assert model.provider
         assert model.mode in {"local", "openai"}
         assert model.model_id
+        assert model.routing_roles
+        assert model.task_families
+        assert model.capability_tags
+        assert model.cost_tier in {"low", "medium", "high", "unknown"}
+        assert model.latency_tier in {"low", "medium", "high", "unknown"}
+        assert model.context_tier in {"low", "medium", "high", "unknown"}
         assert isinstance(model.smoke_eligible, bool)
         assert model.quality_claim is False
-        assert "not" in model.notes.lower()
+        assert model.evidence_boundary == DEFAULT_EVIDENCE_BOUNDARY
+        assert model.review_status in {"operator_metadata", "smoke_only"}
+        assert "not" in model.operator_notes.lower()
+
+
+def test_missing_required_metadata_field_is_rejected():
+    raw = ModelCatalog.load().models[0].as_dict()
+    raw.pop("cost_tier")
+
+    with pytest.raises(ValueError, match="missing required fields"):
+        ModelCatalogEntry.from_mapping(raw)
+
+
+def test_quality_claim_true_is_rejected():
+    raw = ModelCatalog.load().models[0].as_dict()
+    raw["quality_claim"] = True
+
+    with pytest.raises(ValueError, match="must not carry quality claims"):
+        ModelCatalogEntry.from_mapping(raw)
+
+
+def test_catalog_entries_do_not_imply_validation_evidence():
+    catalog = ModelCatalog.load()
+
+    assert all(model.quality_claim is False for model in catalog.models)
+    assert all(not any(model.evidence_boundary.values()) for model in catalog.models)
+    assert all("validation" not in model.review_status for model in catalog.models)
+
+
+def test_entry_evidence_boundary_true_is_rejected():
+    raw = copy.deepcopy(ModelCatalog.load().models[0].as_dict())
+    raw["evidence_boundary"]["quality_evidence"] = True
+
+    with pytest.raises(ValueError, match="must not imply validation evidence"):
+        ModelCatalogEntry.from_mapping(raw)
+
+
+def test_catalog_json_uses_required_metadata_names():
+    data = json.loads(open("configs/model_catalog.json", encoding="utf-8").read())
+
+    for raw in data["models"]:
+        assert REQUIRED_METADATA_FIELDS <= set(raw)
+        assert "enabled_default" not in raw
+        assert "notes" not in raw

--- a/tests/test_model_router.py
+++ b/tests/test_model_router.py
@@ -1,5 +1,3 @@
-import pytest
-
 from alpha.model_router import RoutingPreviewRequest, preview_route
 from tools.operator_smoke_runner import MAX_PROMPT_CHARS
 
@@ -12,6 +10,7 @@ def test_router_selects_requested_enabled_openai_model_when_hosted_allowed():
     assert preview.recommended_model == "gpt-4.1-mini"
     assert "model_available_in_catalog" in preview.reasons
     assert "smoke_eligible" in preview.reasons
+    assert preview.provider_or_local_execution_authorized is False
 
 
 def test_router_selects_requested_enabled_local_model_when_local_allowed():
@@ -22,12 +21,24 @@ def test_router_selects_requested_enabled_local_model_when_local_allowed():
     assert preview.recommended_model == "qwen2.5:3b"
 
 
-def test_router_rejects_hosted_model_when_hosted_not_allowed():
+def test_local_only_request_avoids_hosted_recommendations_unless_fallback_is_stated():
+    preview = preview_route(RoutingPreviewRequest(local_only=True, allow_local=True, allow_hosted_providers=True))
+
+    assert preview.status == "preview_only"
+    assert preview.recommended_mode == "local"
+    assert all(fallback.mode == "local" for fallback in preview.fallbacks)
+    assert "local_only_request_suppresses_hosted_recommendations" in preview.warnings
+
+
+def test_hosted_disabled_request_for_hosted_model_fails_closed_with_local_fallback():
     preview = preview_route(RoutingPreviewRequest(requested_model="gpt-4.1-mini", allow_hosted_providers=False, allow_local=True))
 
     assert preview.status == "failed_closed"
     assert preview.recommended_model is None
     assert "hosted_provider_not_allowed" in preview.reasons
+    assert "local_fallback_available" in preview.warnings
+    assert preview.fallbacks
+    assert all(fallback.mode == "local" for fallback in preview.fallbacks)
 
 
 def test_router_rejects_local_model_when_local_not_allowed():
@@ -46,19 +57,22 @@ def test_router_returns_failed_closed_preview_for_unknown_model():
     assert "requested_model_not_in_catalog" in preview.reasons
 
 
-def test_router_returns_failed_closed_preview_for_prompt_above_smoke_limit():
+def test_router_returns_failed_closed_preview_for_prompt_above_smoke_limit_with_warning():
     preview = preview_route(RoutingPreviewRequest(prompt_length=MAX_PROMPT_CHARS + 1))
 
     assert preview.status == "failed_closed"
     assert "prompt_too_long_for_smoke_runner" in preview.reasons
+    assert "prompt_length_exceeds_preview_smoke_boundary" in preview.warnings
 
 
-def test_router_includes_reasons():
-    preview = preview_route(RoutingPreviewRequest(requested_mode="openai", requested_model="gpt-4.1-mini"))
+def test_router_includes_metadata_reasons_without_validation_claims():
+    preview = preview_route(RoutingPreviewRequest(requested_mode="openai", requested_model="gpt-4.1-mini", required_capability="json_capable"))
 
     assert preview.reasons
     assert "routing_preview_only" in preview.reasons
     assert "openai_requested_by_operator" in preview.reasons
+    assert "required_capability_matched_as_metadata_only" in preview.reasons
+    assert preview.evidence_boundary["quality_evidence"] is False
 
 
 def test_router_includes_preview_only_evidence_boundary_flags():
@@ -71,6 +85,7 @@ def test_router_includes_preview_only_evidence_boundary_flags():
         "readiness_evidence": False,
         "benchmark_evidence": False,
     }
+    assert preview.provider_or_local_execution_authorized is False
 
 
 def test_router_does_not_require_api_keys(monkeypatch):
@@ -108,6 +123,43 @@ def test_router_does_not_call_ollama_or_local_runtime(monkeypatch):
     assert preview.status == "preview_only"
 
 
+def test_metadata_preferences_keep_routing_deterministic():
+    req = RoutingPreviewRequest(cost_preference="low", latency_preference="medium", task_profile="general")
+
+    previews = [preview_route(req).as_dict() for _ in range(3)]
+
+    assert previews[0] == previews[1] == previews[2]
+    assert previews[0]["recommended_mode"] == "local"
+
+
+def test_required_capability_filters_recommendations_metadata_only():
+    preview = preview_route(RoutingPreviewRequest(required_capability="vision_capable", allow_local=True, allow_hosted_providers=True))
+
+    assert preview.status == "preview_only"
+    assert preview.recommended_model == "gpt-4o-mini"
+    assert preview.provider_or_local_execution_authorized is False
+
+
+def test_requested_model_missing_required_capability_fails_closed():
+    preview = preview_route(RoutingPreviewRequest(requested_model="qwen2.5:3b", required_capability="vision_capable"))
+
+    assert preview.status == "failed_closed"
+    assert "requested_model_missing_required_capability" in preview.reasons
+
+
+def test_prior_smoke_only_evidence_boundaries_are_preserved():
+    preview = preview_route(RoutingPreviewRequest(requested_model="qwen2.5:3b"))
+
+    assert preview.status == "preview_only"
+    assert preview.evidence_boundary == {
+        "runs_provider": False,
+        "runs_local_model": False,
+        "quality_evidence": False,
+        "readiness_evidence": False,
+        "benchmark_evidence": False,
+    }
+
+
 def test_preview_as_dict_is_structured():
     data = preview_route(RoutingPreviewRequest(requested_model="gpt-4.1-mini")).as_dict()
 
@@ -116,3 +168,4 @@ def test_preview_as_dict_is_structured():
     assert isinstance(data["fallbacks"], list)
     assert isinstance(data["reasons"], list)
     assert data["evidence_boundary"]["runs_provider"] is False
+    assert data["provider_or_local_execution_authorized"] is False


### PR DESCRIPTION
### Motivation

- Allow the backend to reason about model roles, cost/latency/context tiers, capability tags, and local-vs-hosted suitability without contacting providers or running local models.  
- Keep catalog entries operator-maintained metadata-only (no validation/quality/readiness claims) and make routing decisions preview-only.  
- Preserve existing local/Ollama and OpenAI entries while switching to role-based, metadata-driven recommendations and explicit evidence boundaries.

### Description

- Extended the model catalog schema in `alpha/model_catalog.py` and `configs/model_catalog.json` to add fields including `provider`, `model_id`, `display_name`, `mode`, `enabled_by_default`, `routing_roles`, `task_families`, `capability_tags`, `cost_tier`, `latency_tier`, `context_tier`, `privacy_tier`, `supports_json`, `supports_tools`, `supports_vision`, `smoke_eligible`, `requires_network`, `requires_credentials`, `evidence_boundary`, `quality_claim` (guarded/rejected when true), `last_reviewed`, `review_status`, and `operator_notes`.  
- Updated the deterministic routing preview in `alpha/model_router.py` to remain metadata-only and preview-only by adding request filters (`required_capability`, `local_only`), metadata-based filtering defaults, explicit warnings/fallbacks for local-only and hosted-disabled postures, prompt-too-long preview fail-closed behavior, and returning `recommended_mode`, `recommended_model`, `fallbacks`, `reasons`, `warnings`, `evidence_boundary`, and `provider_or_local_execution_authorized=false`.  
- Preserved and extended existing local (Ollama) and hosted (OpenAI) catalog entries in `configs/model_catalog.json` as operator-maintained metadata only (no quality/readiness assertions).  
- Added and updated focused tests `tests/test_model_catalog.py` and `tests/test_model_router.py` that validate required metadata fields, reject `quality_claim=true`, ensure catalog entries do not imply validation evidence, exercise local-only/hosted-disabled behavior and prompt-too-long warnings, assert deterministic routing, and assert that no provider/local runtime clients are called; added docs packet and source-of-truth updates under `docs/evals/runs/alpha-solver-model-catalog-expansion-cost-tiers-001/` and updated `docs/CURRENT_STATE.md`, `docs/LANE_REGISTRY.md`, and `docs/EVIDENCE_INDEX.md`.

### Testing

- Focused tests: ran `python -m pytest -q tests/test_model_catalog.py tests/test_model_router.py` and the updated catalog/router tests passed.  
- Full test run: ran `python -m pytest -q` and the test suite completed with expected skips; no new failures introduced.  
- Safety & checks: ran `git diff --check`, the changed-line secret-safety check, and the narrative claim-safety linter on changed Markdown files (all passed), and a source-of-truth consistency check which confirmed selected-next state `OPERATOR_REVIEW_REQUIRED_AFTER_MODEL_CATALOG_EXPANSION_COST_TIERS_001`.  
- Determinism & non-execution guarantees: tests include monkeypatches that would fail if provider clients or local runtimes were invoked, and those tests passed, confirming the preview did not call providers or run local models.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31f8a65fd083298fc28994fbc7d125)