### PR TITLE
docs: add MVP cutover review

### DIFF
--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -1,11 +1,11 @@
 # Alpha Solver - Current State
 
-> Source-of-truth navigation doc. Last verified **2026-06-17** for routed-vs-plain pilot packet creation.
-> This lane creates a docs-only routed-vs-plain pilot packet for later operator review. It does not run the pilot, call providers, run hosted or local models, execute tools, browse, generate outputs, score outputs, mutate Sheets, expose `/v1/solve`, or make readiness/benchmark/Alpha-superiority claims.
+> Source-of-truth navigation doc. Last verified **2026-06-17** for MVP cutover review.
+> This lane records a docs-only STOP / go-no-go review for local operator MVP candidate manual review. It does not run providers, run hosted or local models, execute tools, browse, execute the routed-vs-plain pilot, generate outputs, score outputs, mutate Sheets, expose `/v1/solve`, deploy, or make production/public/benchmark/provider/local-model/tool/security/privacy/autonomous-readiness/Alpha-superiority claims.
 
 ## Current verified phase
 
-**Routed-vs-plain pilot packet completed: the selected next state is review-only operator review after creating the static routed-vs-plain pilot packet.**
+**MVP cutover review completed: the selected next state is review-only operator manual review after the local operator MVP candidate check.**
 
 The merged #569–#574 wave updated the repository from the post-#568 blocked Value Read state to a broader documentation-and-boundary posture. PR #576 was superseded by PR #577 and should be closed unmerged. PR #577 completes `ALPHA-SOLVER-LOCAL-OPERATOR-HARNESS-DESIGN-NOTE-001` as a docs-only Alpha-native local operator harness design note.
 
@@ -17,12 +17,12 @@ These are docs, gate, helper, static/research, blocked-attempt, scoring-only, se
 
 | Field | Value |
 |-------|-------|
-| Latest verified completed lane in this wave | **`ALPHA-SOLVER-ROUTED-VS-PLAIN-PILOT-PACKET-001`** |
-| Source-of-truth sync | Current docs record the completed routed-vs-plain pilot packet lane and a review-only selected next state |
+| Latest verified completed lane in this wave | **`ALPHA-SOLVER-MVP-CUTOVER-REVIEW-001`** |
+| Source-of-truth sync | Current docs record the completed MVP cutover review lane and a review-only selected next state |
 | Closed-unmerged superseded PR | **#561** - superseded by merged PR #562 |
-| Current controlling posture | Operator review required after routed-vs-plain pilot packet |
-| Selected next state | **`OPERATOR_REVIEW_REQUIRED_AFTER_ROUTED_VS_PLAIN_PILOT_PACKET_001`** |
-| Strategic boundary | This review-only state records a static routed-vs-plain pilot packet; it does not authorize pilot execution, provider/local-model execution, hosted model execution, tool execution, browsing, output generation, scoring, score changes, unblinding, raw output inspection, source-map work, `/v1/solve` exposure, Google Sheets mutation, dependency addition, dashboard/public API behavior, or readiness/benchmark/production/public/security/privacy/provider/local-model/tool-quality/Alpha-superiority claims |
+| Current controlling posture | Operator review required after MVP cutover review |
+| Selected next state | **`OPERATOR_REVIEW_REQUIRED_AFTER_MVP_CUTOVER_REVIEW_001`** |
+| Strategic boundary | This review-only state records a docs-only local operator MVP candidate cutover review; it does not authorize pilot execution, provider/local-model execution, hosted model execution, tool execution, browsing, output generation, scoring, score changes, unblinding, raw output inspection, source-map work, `/v1/solve` exposure, Google Sheets mutation, dependency addition, dashboard/public API behavior, deployment, or readiness/benchmark/production/public/security/privacy/provider/local-model/tool-quality/autonomous-readiness/Alpha-superiority claims |
 
 ## Completed post-552 / post-565 / post-568 infrastructure lanes
 
@@ -70,14 +70,17 @@ These are docs, gate, helper, static/research, blocked-attempt, scoring-only, se
 | test-console-ui-polish lane | `ALPHA-SOLVER-LOCAL-OPENAI-TEST-CONSOLE-UI-POLISH-001` | Polishes the local-only console UI with mode and model dropdowns, a prompt counter and 500-character limit warning, a friendly result display, and a copyable sanitized JSON panel; modifies no model catalog or tool catalog logic and proves no behavior quality, provider quality, local-model quality, readiness, benchmark success, production/public readiness, security/privacy completion, or Alpha superiority. |
 | test-console-routing-preview lane | `ALPHA-SOLVER-TEST-CONSOLE-ROUTING-PREVIEW-INTEGRATION-001` | Wires the local-only Operator console to metadata-only model/tool route preview before separate smoke execution; proves no provider/local-model/tool quality, readiness, benchmark, production/public, security/privacy, or Alpha superiority. |
 | routed-vs-plain pilot packet lane | `ALPHA-SOLVER-ROUTED-VS-PLAIN-PILOT-PACKET-001` | Creates a docs-only routed-vs-plain pilot packet with task cards, rubric, comparison protocol, blank result template, runbook, stop conditions, non-actions, and non-claims; runs no pilot and generates no outputs or scores. |
+| MVP cutover review lane | `ALPHA-SOLVER-MVP-CUTOVER-REVIEW-001` | Records a STOP / go-no-go review with verdict `LOCAL_OPERATOR_MVP_CANDIDATE_READY_FOR_MANUAL_REVIEW`; creates no provider/local-model/tool/pilot execution, output generation, scoring, readiness, benchmark, production/public, security/privacy completion, tool-quality, autonomous-readiness, or Alpha-superiority evidence. |
 
 See [`EVIDENCE_INDEX.md`](EVIDENCE_INDEX.md) for the PR status ledger and [`LANE_REGISTRY.md`](LANE_REGISTRY.md) for lifecycle classification.
 
 ## Selected next state
 
-**`OPERATOR_REVIEW_REQUIRED_AFTER_ROUTED_VS_PLAIN_PILOT_PACKET_001`** is the current global selected next state.
+**`OPERATOR_REVIEW_REQUIRED_AFTER_MVP_CUTOVER_REVIEW_001`** is the current global selected next state.
 
-This is a review-only state after `ALPHA-SOLVER-ROUTED-VS-PLAIN-PILOT-PACKET-001`. The prior selected next state was `OPERATOR_REVIEW_REQUIRED_AFTER_TEST_CONSOLE_ROUTING_PREVIEW_INTEGRATION_001`. It means the repository now contains a static routed-vs-plain pilot packet for future operator review only: the pilot was not executed; no provider or local-model calls occurred; no tools were executed; no browsing occurred; no Alpha outputs or baseline outputs were generated; no scoring, unblinding, raw output inspection, or source-map work occurred; no Google Sheets mutation occurred; and `/v1/solve` was not exposed or invoked. The state makes no readiness, benchmark, production/public, provider, local-model, tool-quality, security/privacy, or Alpha-superiority claims. The prior selected next state after UI polish was `OPERATOR_REVIEW_REQUIRED_AFTER_LOCAL_OPENAI_TEST_CONSOLE_UI_POLISH_001`.
+This is a review-only state after `ALPHA-SOLVER-MVP-CUTOVER-REVIEW-001`. The prior selected next state was `OPERATOR_REVIEW_REQUIRED_AFTER_ROUTED_VS_PLAIN_PILOT_PACKET_001`. The review verdict is `LOCAL_OPERATOR_MVP_CANDIDATE_READY_FOR_MANUAL_REVIEW` for local operator manual review only. It does not run providers, hosted models, local models, tools, the routed-vs-plain pilot, output generation, scoring, unblinding, raw output inspection, source-map work, dependency installation, Google Sheets mutation, `/v1/solve`, dashboard/public API behavior, or deployment, and it creates no production/public readiness, benchmark, provider/local-model/tool-quality, security/privacy completion, autonomous-readiness, or Alpha-superiority claim.
+
+The prior state was a review-only state after `ALPHA-SOLVER-ROUTED-VS-PLAIN-PILOT-PACKET-001`. The prior selected next state was `OPERATOR_REVIEW_REQUIRED_AFTER_TEST_CONSOLE_ROUTING_PREVIEW_INTEGRATION_001`. It means the repository now contains a static routed-vs-plain pilot packet for future operator review only: the pilot was not executed; no provider or local-model calls occurred; no tools were executed; no browsing occurred; no Alpha outputs or baseline outputs were generated; no scoring, unblinding, raw output inspection, or source-map work occurred; no Google Sheets mutation occurred; and `/v1/solve` was not exposed or invoked. The state makes no readiness, benchmark, production/public, provider, local-model, tool-quality, security/privacy, or Alpha-superiority claims. The prior selected next state after UI polish was `OPERATOR_REVIEW_REQUIRED_AFTER_LOCAL_OPENAI_TEST_CONSOLE_UI_POLISH_001`.
 
 This state authorizes no production/public exposure, no task execution outside explicit local Operator submission, no output generation for evals, scoring, score change, source-map work, unblinding, raw Alpha output inspection, raw baseline output inspection, `/v1/solve` exposure, dashboard/public API exposure, Google Sheets mutation, benchmark work, release behavior, readiness claim, broad value claim, provider claim, local-model claim, security/privacy claim, production/public claim, partnership/Pi.dev integration claim, demo external-use approval, discrimination-task execution/scoring, or Alpha-superiority claim.
 
@@ -98,6 +101,16 @@ This state authorizes no production/public exposure, no task execution outside e
 ## What must not be claimed
 
 This phase does **not** support claims of broad value, OpenAI validation, provider validation, local Ollama validation, Pi.dev integration, runtime readiness, production readiness, public MVP readiness, security/privacy completion, DEF-002 resolved, DEF-003 resolved, benchmark validation, benchmark superiority, broad-user readiness, autonomous readiness, `/v1/solve` readiness, dashboard readiness, Google Sheets synchronization, or Alpha superiority.
+
+
+## ALPHA-SOLVER-MVP-CUTOVER-REVIEW-001
+
+- Packet: `docs/evals/runs/alpha-solver-mvp-cutover-review-001/`
+- Evidence type: docs-only STOP / go-no-go local operator MVP candidate cutover review.
+- Verdict: `LOCAL_OPERATOR_MVP_CANDIDATE_READY_FOR_MANUAL_REVIEW`.
+- Prior selected next state: `OPERATOR_REVIEW_REQUIRED_AFTER_ROUTED_VS_PLAIN_PILOT_PACKET_001`.
+- Selected next state: `OPERATOR_REVIEW_REQUIRED_AFTER_MVP_CUTOVER_REVIEW_001`.
+- Boundary: manual-review candidate only; no provider/local-model/tool/pilot execution, output generation, scoring, unblinding, source-map work, dependency addition, `/v1/solve` exposure, dashboard/public API exposure, deployment, production/public readiness, benchmark, provider/local-model/tool-quality, security/privacy completion, autonomous-readiness, or Alpha-superiority evidence.
 
 ## ALPHA-SOLVER-LOCAL-OPENAI-SMOKE-RESULTS-IMPORT-001
 

--- a/docs/EVIDENCE_INDEX.md
+++ b/docs/EVIDENCE_INDEX.md
@@ -54,7 +54,7 @@ The entries below are design, documentation, gate, helper, static-checking, meth
 
 ## Current selected next state
 
-`OPERATOR_REVIEW_REQUIRED_AFTER_ROUTED_VS_PLAIN_PILOT_PACKET_001` is the selected next state. The prior selected next state was `OPERATOR_REVIEW_REQUIRED_AFTER_TEST_CONSOLE_ROUTING_PREVIEW_INTEGRATION_001`. This is a review-only state after the static routed-vs-plain pilot packet lane `ALPHA-SOLVER-ROUTED-VS-PLAIN-PILOT-PACKET-001`: the pilot was not executed; no provider or local-model calls occurred; no tool execution or browsing occurred; no Alpha outputs or baseline outputs were generated; no scoring, unblinding, raw output inspection, or source-map work occurred; no Google Sheets mutation occurred; and `/v1/solve` was not exposed or invoked. The state makes no readiness, benchmark, production/public, provider, local-model, tool-quality, security/privacy, or Alpha-superiority claims. The prior selected next state after UI polish was `OPERATOR_REVIEW_REQUIRED_AFTER_LOCAL_OPENAI_TEST_CONSOLE_UI_POLISH_001`.
+`OPERATOR_REVIEW_REQUIRED_AFTER_MVP_CUTOVER_REVIEW_001` is the selected next state. The prior selected next state was `OPERATOR_REVIEW_REQUIRED_AFTER_ROUTED_VS_PLAIN_PILOT_PACKET_001`. This is a review-only state after the MVP cutover review lane `ALPHA-SOLVER-MVP-CUTOVER-REVIEW-001` with verdict `LOCAL_OPERATOR_MVP_CANDIDATE_READY_FOR_MANUAL_REVIEW`: the pilot was not executed; no provider or local-model calls occurred; no tool execution or browsing occurred; no Alpha outputs or baseline outputs were generated; no scoring, unblinding, raw output inspection, or source-map work occurred; no Google Sheets mutation occurred; and `/v1/solve` was not exposed or invoked. The state makes no readiness, benchmark, production/public, provider, local-model, tool-quality, security/privacy, or Alpha-superiority claims. The prior selected next state after UI polish was `OPERATOR_REVIEW_REQUIRED_AFTER_LOCAL_OPENAI_TEST_CONSOLE_UI_POLISH_001`.
 
 `ALPHA-SOLVER-GATE-SUBSTANTIVE-DERIVATION-CHECK-001` was completed by merged PR #591 as a docs-first gate packet. It defines criteria, fixture planning, heuristic review aids, stop conditions, non-actions, and non-claims for operator review. `ALPHA-SOLVER-DISCRIMINATION-TASK-BANK-FIRST-CHEAP-TEST-001` was completed by merged PR #595 as a docs-only cheap-test packet grounded in that gate and the discrimination task-bank asset.
 
@@ -168,3 +168,15 @@ This entry records Operator-provided, redacted smoke-only evidence. It does not 
 | Selected next state | `OPERATOR_REVIEW_REQUIRED_AFTER_ROUTED_VS_PLAIN_PILOT_PACKET_001` |
 | Evidence value | Provides static task cards, route-value rubric, plain-model comparison protocol, blank result capture template, operator runbook, stop conditions, non-actions, and non-claims for later operator review. |
 | Boundary | Does not execute the pilot, call providers, run hosted models, run local models, execute tools, browse, generate Alpha outputs, generate baseline outputs, score outputs, change scores, unblind, inspect raw Alpha or baseline outputs, perform source-map work, mutate Google Sheets, add dependencies, expose `/v1/solve`, expose dashboard/public API behavior, or make readiness, benchmark, production, public, security/privacy, provider, local-model, tool-quality, or Alpha-superiority claims. |
+
+
+## ALPHA-SOLVER-MVP-CUTOVER-REVIEW-001
+
+| Field | Value |
+|-------|-------|
+| Status | completed docs-only STOP / go-no-go review |
+| Packet | `docs/evals/runs/alpha-solver-mvp-cutover-review-001/` |
+| Verdict | `LOCAL_OPERATOR_MVP_CANDIDATE_READY_FOR_MANUAL_REVIEW` |
+| Prior selected next state | `OPERATOR_REVIEW_REQUIRED_AFTER_ROUTED_VS_PLAIN_PILOT_PACKET_001` |
+| Selected next state | `OPERATOR_REVIEW_REQUIRED_AFTER_MVP_CUTOVER_REVIEW_001` |
+| Boundary | Local operator manual-review candidate only; no provider/local-model/tool/pilot execution, output generation, scoring, unblinding, raw-output inspection, source-map work, dependency addition, Google Sheets mutation, `/v1/solve` exposure, dashboard/public API exposure, deployment, production/public readiness, benchmark, provider/local-model/tool-quality, security/privacy completion, autonomous-readiness, or Alpha-superiority claim. |

--- a/docs/LANE_REGISTRY.md
+++ b/docs/LANE_REGISTRY.md
@@ -1,7 +1,7 @@
 # Lane Registry
 
 > Source-of-truth lane lifecycle registry. Verification date **2026-06-17** for
-> the routed-vs-plain pilot packet.
+> MVP cutover review.
 
 ## Lifecycle classes
 
@@ -11,13 +11,14 @@
 
 | Lane | State | Evidence |
 |------|-------|----------|
-| Operator review after routed-vs-plain pilot packet | **current control posture** | `ALPHA-SOLVER-ROUTED-VS-PLAIN-PILOT-PACKET-001` creates a static routed-vs-plain pilot packet for future operator review only. Selected next state is `OPERATOR_REVIEW_REQUIRED_AFTER_ROUTED_VS_PLAIN_PILOT_PACKET_001`. |
+| Operator review after MVP cutover review | **current control posture** | `ALPHA-SOLVER-MVP-CUTOVER-REVIEW-001` records verdict `LOCAL_OPERATOR_MVP_CANDIDATE_READY_FOR_MANUAL_REVIEW` for local operator manual review only. Selected next state is `OPERATOR_REVIEW_REQUIRED_AFTER_MVP_CUTOVER_REVIEW_001`. |
 
 ## Next ready / current selected state
 
 | State | Lifecycle | Notes |
 |-------|-----------|-------|
-| **`OPERATOR_REVIEW_REQUIRED_AFTER_ROUTED_VS_PLAIN_PILOT_PACKET_001`** | **review-only selected next state** | Operator review is required after the static routed-vs-plain pilot packet. The pilot was not executed; no provider/local-model calls, tool execution, browsing, Alpha output generation, baseline output generation, scoring, unblinding, raw output inspection, source-map work, Google Sheets mutation, or `/v1/solve` exposure/invocation occurred. No readiness, benchmark, production/public, provider, local-model, tool-quality, security/privacy, or Alpha-superiority claim is created by this lane. The prior selected next state was `OPERATOR_REVIEW_REQUIRED_AFTER_TEST_CONSOLE_ROUTING_PREVIEW_INTEGRATION_001`. |
+| **`OPERATOR_REVIEW_REQUIRED_AFTER_MVP_CUTOVER_REVIEW_001`** | **review-only selected next state** | Operator manual review is required after `ALPHA-SOLVER-MVP-CUTOVER-REVIEW-001`; verdict is `LOCAL_OPERATOR_MVP_CANDIDATE_READY_FOR_MANUAL_REVIEW`. No provider/local-model/tool/pilot execution, output generation, scoring, unblinding, raw-output inspection, source-map work, Google Sheets mutation, dependency addition, `/v1/solve` exposure, dashboard/public API exposure, deployment, production/public readiness, benchmark, provider/local-model/tool-quality, security/privacy completion, autonomous-readiness, or Alpha-superiority claim is authorized. Prior selected next state was `OPERATOR_REVIEW_REQUIRED_AFTER_ROUTED_VS_PLAIN_PILOT_PACKET_001`. |
+| `OPERATOR_REVIEW_REQUIRED_AFTER_ROUTED_VS_PLAIN_PILOT_PACKET_001` | prior review-only selected next state | Operator review was required after the static routed-vs-plain pilot packet. The pilot was not executed; no provider/local-model calls, tool execution, browsing, Alpha output generation, baseline output generation, scoring, unblinding, raw output inspection, source-map work, Google Sheets mutation, or `/v1/solve` exposure/invocation occurred. No readiness, benchmark, production/public, provider, local-model, tool-quality, security/privacy, or Alpha-superiority claim is created by this lane. The prior selected next state was `OPERATOR_REVIEW_REQUIRED_AFTER_TEST_CONSOLE_ROUTING_PREVIEW_INTEGRATION_001`. |
 
 ## Completed (kept as evidence)
 
@@ -89,7 +90,7 @@
 
 - PR #561 lane as a standalone needs-human protocol PR - closed unmerged and superseded by PR #562.
 - Any merged packet lane verbatim - packets are immutable evidence; create a new lane id instead.
-- Any selected-next pointer that conflicts with `OPERATOR_REVIEW_REQUIRED_AFTER_ROUTED_VS_PLAIN_PILOT_PACKET_001`. Earlier selected-next pointers, including `OPERATOR_REVIEW_REQUIRED_AFTER_LOCAL_OPENAI_TEST_CONSOLE_001`, `OPERATOR_REVIEW_REQUIRED_AFTER_LOCAL_OPENAI_SMOKE_RESULTS_IMPORT_001`, `OPERATOR_REVIEW_REQUIRED_AFTER_LOCAL_OPENAI_SMOKE_RUNNER_001`, `OPERATOR_REVIEW_REQUIRED_AFTER_DISCRIMINATION_TASK_BANK_FIRST_CHEAP_TEST_001`, `OPERATOR_REVIEW_REQUIRED_AFTER_TOOL_CATALOG_ROUTING_REGISTRY_001`, and `OPERATOR_REVIEW_REQUIRED_AFTER_MODEL_CATALOG_EXPANSION_COST_TIERS_001`, are prior review states and must not be treated as current.
+- Any selected-next pointer that conflicts with `OPERATOR_REVIEW_REQUIRED_AFTER_MVP_CUTOVER_REVIEW_001`. Earlier selected-next pointers, including `OPERATOR_REVIEW_REQUIRED_AFTER_LOCAL_OPENAI_TEST_CONSOLE_001`, `OPERATOR_REVIEW_REQUIRED_AFTER_LOCAL_OPENAI_SMOKE_RESULTS_IMPORT_001`, `OPERATOR_REVIEW_REQUIRED_AFTER_LOCAL_OPENAI_SMOKE_RUNNER_001`, `OPERATOR_REVIEW_REQUIRED_AFTER_DISCRIMINATION_TASK_BANK_FIRST_CHEAP_TEST_001`, `OPERATOR_REVIEW_REQUIRED_AFTER_TOOL_CATALOG_ROUTING_REGISTRY_001`, and `OPERATOR_REVIEW_REQUIRED_AFTER_MODEL_CATALOG_EXPANSION_COST_TIERS_001`, are prior review states and must not be treated as current.
 - Direct Pi.dev integration from PR #574's research lane - the recorded verdict is patterns-only/no-integration.
 
 ## Forward path (single track)
@@ -206,7 +207,9 @@ OPERATOR_REVIEW_REQUIRED_AFTER_TEST_CONSOLE_ROUTING_PREVIEW_INTEGRATION_001 ← 
 ALPHA-SOLVER-ROUTED-VS-PLAIN-PILOT-PACKET-001 ← docs-only routed-vs-plain pilot packet completed
         │
         ▼
-OPERATOR_REVIEW_REQUIRED_AFTER_ROUTED_VS_PLAIN_PILOT_PACKET_001 ← current review-only selected next state
+OPERATOR_REVIEW_REQUIRED_AFTER_ROUTED_VS_PLAIN_PILOT_PACKET_001 ← prior review-only selected next state
+ALPHA-SOLVER-MVP-CUTOVER-REVIEW-001 ← docs-only MVP cutover review completed
+OPERATOR_REVIEW_REQUIRED_AFTER_MVP_CUTOVER_REVIEW_001 ← current review-only selected next state
 ```
 
 This registry does not authorize production/public UI exposure, dashboard readiness, public provider exposure, local model validation claims, task execution, output generation, scoring, score change, unblinding, source-map work, raw output inspection, Pi.dev install/run/integration, runtime endpoint exposure, public API exposure, `/v1/solve` exposure, Google Sheets mutation, benchmark, dependency addition, release implementation lane, or readiness/broad-value/security/privacy/provider/local-Ollama/Alpha-superiority claim.
@@ -229,7 +232,7 @@ Prior selected next state after model catalog expansion cost tiers: `OPERATOR_RE
 
 Prior selected next state after test console routing preview integration: `OPERATOR_REVIEW_REQUIRED_AFTER_TEST_CONSOLE_ROUTING_PREVIEW_INTEGRATION_001`.
 
-Current selected next state after routed-vs-plain pilot packet: `OPERATOR_REVIEW_REQUIRED_AFTER_ROUTED_VS_PLAIN_PILOT_PACKET_001`.
+Current selected next state after MVP cutover review: `OPERATOR_REVIEW_REQUIRED_AFTER_MVP_CUTOVER_REVIEW_001`.
 
 Boundary: no provider quality, local model quality, readiness, benchmark success, production readiness, public readiness, security/privacy completion, UI authorization, or Alpha-superiority claim is created.
 
@@ -316,3 +319,15 @@ Boundary: no provider quality, local model quality, readiness, benchmark success
 | Prior selected next state | `OPERATOR_REVIEW_REQUIRED_AFTER_TEST_CONSOLE_ROUTING_PREVIEW_INTEGRATION_001` |
 | Selected next state | `OPERATOR_REVIEW_REQUIRED_AFTER_ROUTED_VS_PLAIN_PILOT_PACKET_001` |
 | Boundary | packet only; no pilot execution, provider/local/hosted model execution, tool execution, browsing, output generation, scoring, score change, unblinding, raw output inspection, source-map work, Google Sheets mutation, dependency addition, `/v1/solve` exposure, dashboard/public API behavior, or readiness/benchmark/production/public/security/privacy/provider/local-model/tool-quality/Alpha-superiority claim |
+
+
+## ALPHA-SOLVER-MVP-CUTOVER-REVIEW-001
+
+| Field | Value |
+|-------|-------|
+| Status | completed docs-only review |
+| Packet | `docs/evals/runs/alpha-solver-mvp-cutover-review-001/` |
+| Verdict | `LOCAL_OPERATOR_MVP_CANDIDATE_READY_FOR_MANUAL_REVIEW` |
+| Prior selected next state | `OPERATOR_REVIEW_REQUIRED_AFTER_ROUTED_VS_PLAIN_PILOT_PACKET_001` |
+| Selected next state | `OPERATOR_REVIEW_REQUIRED_AFTER_MVP_CUTOVER_REVIEW_001` |
+| Boundary | No provider/local-model/tool/pilot execution, output generation, scoring, unblinding, raw-output inspection, source-map work, dependency addition, Google Sheets mutation, `/v1/solve` exposure, dashboard/public API exposure, deployment, production/public readiness, benchmark, provider/local-model/tool-quality, security/privacy completion, autonomous-readiness, or Alpha-superiority claim. |

--- a/docs/evals/runs/alpha-solver-mvp-cutover-review-001/README.md
+++ b/docs/evals/runs/alpha-solver-mvp-cutover-review-001/README.md
@@ -1,0 +1,26 @@
+# ALPHA-SOLVER-MVP-CUTOVER-REVIEW-001
+
+Verdict: `LOCAL_OPERATOR_MVP_CANDIDATE_READY_FOR_MANUAL_REVIEW`.
+
+This packet records a STOP / go-no-go review for local operator MVP candidate review after the local operator console, metadata-only model/tool routing preview, and routed-vs-plain pilot packet lanes.
+
+The review inspected committed repository files only. It did not execute providers, hosted models, local models, tools, the routed-vs-plain pilot, output generation, scoring, unblinding, raw output inspection, source-map work, dependency installation, Google Sheets mutation, `/v1/solve`, dashboard behavior, public API behavior, or deployment.
+
+## Source-of-truth result
+
+- Completed lane: `ALPHA-SOLVER-MVP-CUTOVER-REVIEW-001`.
+- Prior selected next state: `OPERATOR_REVIEW_REQUIRED_AFTER_ROUTED_VS_PLAIN_PILOT_PACKET_001`.
+- Selected next state: `OPERATOR_REVIEW_REQUIRED_AFTER_MVP_CUTOVER_REVIEW_001`.
+- No production/public readiness, benchmark readiness, provider readiness, local-model readiness, security/privacy completion, tool-quality validation, autonomous execution readiness, or Alpha-superiority claim is created.
+
+## Packet files
+
+- `live-verification.md`
+- `mvp-candidate-checklist.md`
+- `blocking-gaps.md`
+- `manual-review-plan.md`
+- `non-actions.md`
+- `non-claims.md`
+- `checks-run.md`
+- `selected-next-state.md`
+- `selected-next-action.md`

--- a/docs/evals/runs/alpha-solver-mvp-cutover-review-001/blocking-gaps.md
+++ b/docs/evals/runs/alpha-solver-mvp-cutover-review-001/blocking-gaps.md
@@ -1,0 +1,16 @@
+# Blocking gaps
+
+Verdict blocker status: no blockers for `LOCAL_OPERATOR_MVP_CANDIDATE_READY_FOR_MANUAL_REVIEW`.
+
+No blocker was found against the narrow MVP definition for local operator manual review:
+
+1. local-only console exists;
+2. metadata-only model/tool routing preview exists;
+3. route reasons, warnings, fallback, evidence boundary, and false execution authorization flags are visible through the preview path;
+4. preview and smoke execution remain separate;
+5. sanitized JSON and scoped copy behavior exist;
+6. routed-vs-plain pilot packet exists for later separate authorization.
+
+## Explicitly not evaluated
+
+This review did not evaluate provider quality, local-model quality, tool quality, benchmark quality, security/privacy completion, production readiness, public readiness, autonomous execution readiness, or Alpha superiority.

--- a/docs/evals/runs/alpha-solver-mvp-cutover-review-001/checks-run.md
+++ b/docs/evals/runs/alpha-solver-mvp-cutover-review-001/checks-run.md
@@ -1,0 +1,11 @@
+# Checks run
+
+All checks were run locally on 2026-06-17 after creating this packet and updating source-of-truth docs.
+
+| Check | Command | Exact result |
+|-------|---------|--------------|
+| Whitespace / patch check | `git diff --check` | Passed with no output. |
+| Narrative claim-safety lint on changed Markdown files | `CHANGED_MD=$( { git diff --name-only -- '*.md'; git ls-files --others --exclude-standard -- '*.md'; } | sort -u ); python scripts/check_narrative_claim_safety.py $CHANGED_MD` | `ALPHA-SOLVER-NARRATIVE-CLAIM-SAFETY-LINTER-001 passed (13 files scanned). This is not a completeness claim.` |
+| Source-of-truth consistency check | Inline Python assertion for `ALPHA-SOLVER-MVP-CUTOVER-REVIEW-001` and `OPERATOR_REVIEW_REQUIRED_AFTER_MVP_CUTOVER_REVIEW_001` in `docs/CURRENT_STATE.md`, `docs/LANE_REGISTRY.md`, and `docs/EVIDENCE_INDEX.md` | `source-of-truth consistency check passed for OPERATOR_REVIEW_REQUIRED_AFTER_MVP_CUTOVER_REVIEW_001` |
+| Changed-line secret-safety check | Inline Python regex scan of `git diff --unified=0` for common API key / private-key patterns | `changed-line secret-safety check passed` |
+| Packet completeness check | Inline Python assertion for required files under `docs/evals/runs/alpha-solver-mvp-cutover-review-001/` | `packet completeness check passed: README.md, live-verification.md, mvp-candidate-checklist.md, blocking-gaps.md, manual-review-plan.md, non-actions.md, non-claims.md, checks-run.md, selected-next-state.md, selected-next-action.md` |

--- a/docs/evals/runs/alpha-solver-mvp-cutover-review-001/live-verification.md
+++ b/docs/evals/runs/alpha-solver-mvp-cutover-review-001/live-verification.md
@@ -1,0 +1,36 @@
+# Live verification
+
+Result: baseline clean for this review.
+
+## PR state verification
+
+Verified on 2026-06-17 using GitHub PR API responses:
+
+| PR | Required state | Observed state |
+|----|----------------|----------------|
+| #603 | merged | closed, merged at 2026-06-17T01:28:12Z |
+| #605 | merged | closed, merged at 2026-06-17T02:45:35Z |
+| #606 | merged | closed, merged at 2026-06-17T03:27:09Z |
+| #607 | merged | closed, merged at 2026-06-17T03:57:26Z |
+| #608 | merged | closed, merged at 2026-06-17T14:11:57Z |
+| #604 | closed without merge | closed, `merged_at=None` |
+
+## Open PR overlap verification
+
+No open PR was found editing any watched path:
+
+- `docs/CURRENT_STATE.md`
+- `docs/LANE_REGISTRY.md`
+- `docs/EVIDENCE_INDEX.md`
+- `tools/operator_test_console.py`
+- `alpha/model_router.py`
+- `alpha/tool_router.py`
+- `configs/model_catalog.json`
+- `configs/tool_catalog.json`
+
+## Baseline source-of-truth verification before edits
+
+Before this packet, `docs/CURRENT_STATE.md`, `docs/LANE_REGISTRY.md`, and `docs/EVIDENCE_INDEX.md` agreed that:
+
+- latest completed lane was `ALPHA-SOLVER-ROUTED-VS-PLAIN-PILOT-PACKET-001`;
+- selected next state was `OPERATOR_REVIEW_REQUIRED_AFTER_ROUTED_VS_PLAIN_PILOT_PACKET_001`.

--- a/docs/evals/runs/alpha-solver-mvp-cutover-review-001/manual-review-plan.md
+++ b/docs/evals/runs/alpha-solver-mvp-cutover-review-001/manual-review-plan.md
@@ -1,0 +1,16 @@
+# Manual review plan
+
+This plan is for a local operator reviewing the MVP candidate manually.
+
+1. Open the local console with the documented local console command, for example `python tools/operator_test_console.py` from the repository root.
+2. Click or use the route preview path first; do not submit smoke execution first.
+3. Enter a non-sensitive test task and request route preview without running smoke.
+4. Verify that the preview displays a recommended model path and recommended tool path.
+5. Verify that route reasons, warnings, fallback path, and evidence boundary are visible.
+6. Verify that execution authorization flags remain false for provider execution, local-model execution, and tool execution in the preview metadata.
+7. Verify prompt-too-long behavior by exceeding the documented prompt limit and confirming the console fails closed rather than running smoke.
+8. Verify sanitized JSON copy behavior by copying only from the sanitized JSON panel and confirming raw secrets or sensitive content are not copied.
+9. Stop immediately if sensitive content appears in preview, result, logs, copied JSON, terminal output, browser UI, or recorded notes.
+10. Record only bounded evidence: screenshots or notes showing the local console exists, preview metadata appears, execution flags are false, smoke execution is separate, prompt-too-long fails closed, and sanitized JSON copy is scoped.
+11. Do not claim provider quality, local-model quality, tool quality, security/privacy completion, benchmark success, production/public readiness, autonomous execution readiness, or Alpha superiority.
+12. Do not execute the routed-vs-plain pilot unless a later separate authorization explicitly permits it.

--- a/docs/evals/runs/alpha-solver-mvp-cutover-review-001/manual-review-plan.md
+++ b/docs/evals/runs/alpha-solver-mvp-cutover-review-001/manual-review-plan.md
@@ -2,7 +2,7 @@
 
 This plan is for a local operator reviewing the MVP candidate manually.
 
-1. Open the local console with the documented local console command, for example `python tools/operator_test_console.py` from the repository root.
+1. Open the local console from the repository root with `python -m uvicorn tools.operator_test_console:app --host 127.0.0.1 --port 8765`. Run this from an environment where project dependencies are installed, for example after activating `.venv` and installing project dependencies.
 2. Click or use the route preview path first; do not submit smoke execution first.
 3. Enter a non-sensitive test task and request route preview without running smoke.
 4. Verify that the preview displays a recommended model path and recommended tool path.

--- a/docs/evals/runs/alpha-solver-mvp-cutover-review-001/mvp-candidate-checklist.md
+++ b/docs/evals/runs/alpha-solver-mvp-cutover-review-001/mvp-candidate-checklist.md
@@ -1,0 +1,30 @@
+# MVP candidate checklist
+
+Verdict: `LOCAL_OPERATOR_MVP_CANDIDATE_READY_FOR_MANUAL_REVIEW`.
+
+| # | Criterion | Status | Evidence inspected |
+|---|-----------|--------|--------------------|
+| 1 | local console exists | Pass | `tools/operator_test_console.py`; `tests/test_operator_test_console.py` |
+| 2 | route preview exists | Pass | console routing preview integration; `alpha/model_router.py`; `alpha/tool_router.py` |
+| 3 | route preview is metadata-only | Pass | model/tool catalog and router boundaries state no provider, local-model, or tool execution |
+| 4 | model recommendation appears | Pass | route preview exposes recommended model path metadata |
+| 5 | tool recommendation appears | Pass | route preview exposes recommended tool path metadata |
+| 6 | reasons appear | Pass | model and tool routers return reasons |
+| 7 | warnings appear | Pass | model and tool routers return warnings |
+| 8 | fallback appears | Pass | model router fallback path metadata exists |
+| 9 | evidence boundary appears | Pass | model/tool catalog and preview metadata expose evidence boundary |
+| 10 | execution authorization flags are false | Pass | catalog/router metadata keeps execution authorization false |
+| 11 | preview does not execute providers | Pass | preview uses metadata-only router/catalog paths |
+| 12 | preview does not execute local models | Pass | preview uses metadata-only router/catalog paths |
+| 13 | preview does not execute tools | Pass | tool routing is metadata-only and execution-disabled |
+| 14 | smoke execution remains separate | Pass | console separates preview from explicit smoke submit path |
+| 15 | sanitized JSON exists | Pass | console has sanitized JSON output panel |
+| 16 | copy behavior is scoped to sanitized JSON | Pass | console copy behavior is scoped to sanitized JSON |
+| 17 | prompt-too-long behavior is fail-closed | Pass | console prompt length limit behavior is tested and blocks smoke execution |
+| 18 | model/tool catalog metadata exists | Pass | `configs/model_catalog.json`; `configs/tool_catalog.json` |
+| 19 | routed-vs-plain pilot packet exists | Pass | `docs/evals/runs/alpha-solver-routed-vs-plain-pilot-packet-001/` |
+| 20 | source-of-truth docs agree | Pass | `docs/CURRENT_STATE.md`; `docs/LANE_REGISTRY.md`; `docs/EVIDENCE_INDEX.md` |
+
+## Boundary
+
+This checklist supports only local operator manual review readiness for the candidate console workflow. It does not create production readiness, public readiness, benchmark readiness, provider readiness, local-model readiness, security/privacy completion, tool-quality validation, autonomous execution readiness, or Alpha-superiority evidence.

--- a/docs/evals/runs/alpha-solver-mvp-cutover-review-001/non-actions.md
+++ b/docs/evals/runs/alpha-solver-mvp-cutover-review-001/non-actions.md
@@ -1,0 +1,29 @@
+# Non-actions
+
+This review does not:
+
+- run providers;
+- run hosted models;
+- run local models;
+- execute tools;
+- browse the web;
+- execute the routed-vs-plain pilot;
+- generate Alpha outputs;
+- generate baseline outputs;
+- score outputs;
+- change scores;
+- unblind;
+- inspect raw Alpha outputs;
+- inspect raw baseline outputs;
+- perform source-map work;
+- mutate Google Sheets;
+- add dependencies;
+- expose `/v1/solve`;
+- expose dashboard or public API behavior;
+- deploy anything;
+- create production/public readiness evidence;
+- create benchmark evidence;
+- create provider/local-model quality evidence;
+- create tool-quality evidence;
+- create security/privacy completion evidence;
+- create Alpha-superiority evidence.

--- a/docs/evals/runs/alpha-solver-mvp-cutover-review-001/non-claims.md
+++ b/docs/evals/runs/alpha-solver-mvp-cutover-review-001/non-claims.md
@@ -1,0 +1,20 @@
+# Non-claims
+
+This packet claims only that the committed repository is ready for local operator manual review of the MVP candidate workflow under the narrow checklist.
+
+It does not claim:
+
+- production readiness;
+- public readiness;
+- benchmark readiness or benchmark success;
+- provider readiness or provider quality;
+- local-model readiness or local-model quality;
+- tool execution readiness or tool quality;
+- autonomous execution readiness;
+- security/privacy completion;
+- `/v1/solve` readiness;
+- dashboard readiness;
+- public API readiness;
+- Alpha superiority;
+- that the routed-vs-plain pilot has been executed;
+- that Alpha outputs or baseline outputs have been generated or scored.

--- a/docs/evals/runs/alpha-solver-mvp-cutover-review-001/selected-next-action.md
+++ b/docs/evals/runs/alpha-solver-mvp-cutover-review-001/selected-next-action.md
@@ -1,0 +1,7 @@
+# Selected next action
+
+Recommended next action: operator performs manual review of the local MVP candidate using `manual-review-plan.md`.
+
+The operator should start with route preview only, verify that preview metadata is visible and execution flags are false, verify prompt-too-long fail-closed behavior, verify sanitized JSON copy scope, and stop if sensitive content appears.
+
+The operator should not execute the routed-vs-plain pilot, run scoring, unblind, inspect raw Alpha/baseline outputs, expose `/v1/solve`, expose dashboard/public API behavior, deploy, add dependencies, mutate Google Sheets, or claim production/public/benchmark/provider/local-model/tool/security/privacy/autonomous readiness or Alpha superiority.

--- a/docs/evals/runs/alpha-solver-mvp-cutover-review-001/selected-next-state.md
+++ b/docs/evals/runs/alpha-solver-mvp-cutover-review-001/selected-next-state.md
@@ -1,0 +1,11 @@
+# Selected next state
+
+Prior selected next state: `OPERATOR_REVIEW_REQUIRED_AFTER_ROUTED_VS_PLAIN_PILOT_PACKET_001`.
+
+Completed lane: `ALPHA-SOLVER-MVP-CUTOVER-REVIEW-001`.
+
+Verdict: `LOCAL_OPERATOR_MVP_CANDIDATE_READY_FOR_MANUAL_REVIEW`.
+
+Selected next state: `OPERATOR_REVIEW_REQUIRED_AFTER_MVP_CUTOVER_REVIEW_001`.
+
+This selected next state requires operator manual review of the local MVP candidate. It authorizes no provider execution, hosted model execution, local model execution, tool execution, pilot execution, output generation, scoring, unblinding, source-map work, Google Sheets mutation, dependency addition, `/v1/solve` exposure, dashboard/public API exposure, deployment, production/public readiness claim, benchmark claim, provider/local-model/tool-quality claim, security/privacy completion claim, autonomous execution readiness claim, or Alpha-superiority claim.


### PR DESCRIPTION
### Motivation

- Record a STOP / go-no-go review for the local-operator MVP candidate so the repo can be reviewed manually without executing providers, local models, tools, or the routed-vs-plain pilot. 
- Capture a narrowly-scoped verdict (`LOCAL_OPERATOR_MVP_CANDIDATE_READY_FOR_MANUAL_REVIEW`) and update the source-of-truth to advance the selected next state to `OPERATOR_REVIEW_REQUIRED_AFTER_MVP_CUTOVER_REVIEW_001`.
- Preserve the evidence boundary and operator-only manual-review workflow while avoiding any runtime, provider, or model execution during the review.

### Description

- Add a review packet at `docs/evals/runs/alpha-solver-mvp-cutover-review-001/` containing `README.md`, `live-verification.md`, `mvp-candidate-checklist.md`, `blocking-gaps.md`, `manual-review-plan.md`, `non-actions.md`, `non-claims.md`, `checks-run.md`, `selected-next-state.md`, and `selected-next-action.md` to document the cutover review and operator next steps. 
- Update `docs/CURRENT_STATE.md`, `docs/LANE_REGISTRY.md`, and `docs/EVIDENCE_INDEX.md` to record completed lane `ALPHA-SOLVER-MVP-CUTOVER-REVIEW-001` and set `OPERATOR_REVIEW_REQUIRED_AFTER_MVP_CUTOVER_REVIEW_001` as the selected next state. 
- Make only documentation changes and keep all runtime, router, console, config, and test code untouched so the packet remains metadata-only and review-safe. 

### Testing

- Verified prerequisite PR states and open-PR overlap: PRs `#603`, `#605`, `#606`, `#607`, and `#608` were merged and `#604` was closed without merge, with no open PR touching watched files. 
- Ran `git diff --check` which produced no output, and ran the narrative claim-safety linter which reported `ALPHA-SOLVER-NARRATIVE-CLAIM-SAFETY-LINTER-001 passed (13 files scanned)`. 
- Performed an inline source-of-truth consistency assertion confirming `ALPHA-SOLVER-MVP-CUTOVER-REVIEW-001` and `OPERATOR_REVIEW_REQUIRED_AFTER_MVP_CUTOVER_REVIEW_001` appear in `docs/CURRENT_STATE.md`, `docs/LANE_REGISTRY.md`, and `docs/EVIDENCE_INDEX.md`, and ran a changed-line secret-safety regex scan which passed. 
- Executed a packet completeness check confirming all required packet files were created, and committed the changes as `docs: add MVP cutover review`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32ad80ee78832993ef15e2e2b8485f)