### PR TITLE
eval: add local-only operator run capture harness (MVP)

### DIFF
--- a/.specs/ALPHA-SOLVER-OPERATOR-RUN-CAPTURE-HARNESS-MVP-001.md
+++ b/.specs/ALPHA-SOLVER-OPERATOR-RUN-CAPTURE-HARNESS-MVP-001.md
@@ -1,0 +1,85 @@
+# ALPHA-SOLVER-OPERATOR-RUN-CAPTURE-HARNESS-MVP-001 · Operator Run Capture Harness (MVP)
+
+## Goal
+
+Give the operator a local, deterministic harness that turns manually generated
+routed-vs-plain runs into a normalized, machine-validated JSON evidence packet,
+replacing hand-assembled per-run markdown files as the capture substrate for
+later (separately authorized) blind scoring, replay, and audit lanes.
+
+## Motivation
+
+Operator evidence currently lives in loose markdown files per run directory
+(for example `raw/baseline/<task>.md` and `raw/alpha/<task>.md`), with
+consistency enforced only by regex documentation checkers. There is no
+machine-readable capture format, no required-field validation before an
+evidence packet exists, and no byte-stable export a replay or scoring lane can
+digest. Every downstream evidence lane (packet normalizer, scorer packet
+validator, blind-scoring bridge) needs that substrate first.
+
+## Scope
+
+- Case packet ingestion: `packet_id`, optional `description`, cases with
+  unique non-empty `task_id`, `prompt`, optional `notes`.
+- Capture scaffolding with one empty slot per task; task IDs and prompts are
+  preserved verbatim.
+- Operator-filled fields per case: `baseline_output` (plain), `routed_output`
+  (routed Alpha), `route_metadata` (non-empty object), `validation_status`
+  (`pending` / `captured` / `excluded`, with `exclusion_reason` required for
+  excluded cases).
+- Strict validation before export: unknown fields are rejected at every level,
+  so score, rank, winner, blind-label, or identity-map fields cannot enter a
+  packet; export additionally requires no pending cases and at least one
+  captured case.
+- Deterministic export: keys sorted, cases ordered by `task_id`, LF endings,
+  no timestamps, byte-identical re-export, and a `content_digest` (SHA-256
+  over the canonical body) for tamper detection.
+- Embedded `harness_boundaries` attestation block covering only what the
+  harness itself did (no provider/model/tool calls, no network, no scoring,
+  no blinding or unblinding).
+
+## Non-goals
+
+- Do not call providers, hosted models, or local models.
+- Do not execute tools or use the network.
+- Do not touch `/v1/solve`, dashboards, or any external service.
+- Do not score, rank, blind, or unblind outputs.
+- Do not write any source map or A/B identity key.
+- Do not claim readiness, benchmark results, provider or local-model quality,
+  or that routed output is better than baseline; comparative interpretation is
+  out of scope for this lane.
+
+## Code Targets
+
+- `alpha/eval/operator_run_capture.py` — validation, scaffolding, packet
+  build, digest, deterministic rendering.
+- `scripts/operator_run_capture.py` — `init` / `validate` / `export` CLI with
+  distinct exit codes (0 ok, 1 validation failure, 2 usage/IO) and overwrite
+  protection.
+- `tests/fixtures/operator_run_capture/` — synthetic case packet and filled
+  capture fixtures (all content invented; no provider or model output).
+- `docs/OPERATOR_RUN_CAPTURE.md` — process doc with explicit non-claims.
+
+## Test Plan
+
+`tests/test_operator_run_capture.py` covers: case-packet validation (missing
+keys, duplicates, unknown keys, empty case lists), scaffolding preservation,
+capture validation (output/metadata requirements, exclusion reasons, schema
+version, export completeness), packet structure and counts, task-ID ordering,
+byte-identical deterministic export, digest verification and tamper detection,
+and CLI roundtrip plus exit codes via subprocess.
+
+## Acceptance Criteria
+
+- `python -m pytest tests/test_operator_run_capture.py -q` passes.
+- `python scripts/check_narrative_claim_safety.py docs/OPERATOR_RUN_CAPTURE.md`
+  passes.
+- Re-exporting an unchanged capture produces byte-identical packet files.
+- A validation pass means only that the configured structural rules held for
+  that capture file; it does not claim readiness or output quality.
+
+## Definition of Done
+
+Module, CLI, fixtures, tests, and process doc merged; all listed checks pass;
+boundaries above hold with no provider/model/tool/network usage anywhere in
+the lane.

--- a/alpha/eval/operator_run_capture.py
+++ b/alpha/eval/operator_run_capture.py
@@ -1,0 +1,312 @@
+"""Local-only operator run capture harness (ALPHA-SOLVER-OPERATOR-RUN-CAPTURE-HARNESS-MVP-001).
+
+This module turns manually generated routed-vs-plain operator runs into a
+normalized, machine-validated evidence packet. It is a lab notebook, not a
+runner:
+
+- It performs no provider calls, no hosted or local model calls, no tool
+  execution, and no network access.
+- It does not score, rank, blind, or unblind outputs, and it rejects unknown
+  fields so scoring or identity-map data cannot be smuggled into a packet.
+- A produced packet records what an operator captured for specific task IDs;
+  it does not claim readiness, benchmark results, or output quality.
+
+Workflow: scaffold a capture file from a case packet, let the operator paste
+plain-baseline output, routed Alpha output, and route metadata per task, then
+validate and export a byte-stable JSON evidence packet suitable for later
+(separately authorized) blind scoring or replay lanes.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+LANE_ID = "ALPHA-SOLVER-OPERATOR-RUN-CAPTURE-HARNESS-MVP-001"
+CAPTURE_SCHEMA_VERSION = "operator_run_capture/v1"
+PACKET_SCHEMA_VERSION = "operator_run_capture_packet/v1"
+CAPTURE_MODE = "operator_manual"
+
+VALIDATION_STATUSES = ("pending", "captured", "excluded")
+
+CASE_PACKET_REQUIRED_KEYS = frozenset({"packet_id", "cases"})
+CASE_PACKET_ALLOWED_KEYS = CASE_PACKET_REQUIRED_KEYS | {"description"}
+CASE_REQUIRED_KEYS = frozenset({"task_id", "prompt"})
+CASE_ALLOWED_KEYS = CASE_REQUIRED_KEYS | {"notes"}
+
+CAPTURE_REQUIRED_KEYS = frozenset(
+    {"schema_version", "packet_id", "capture_mode", "cases"}
+)
+CAPTURE_ALLOWED_KEYS = CAPTURE_REQUIRED_KEYS | {"description"}
+CAPTURE_CASE_REQUIRED_KEYS = frozenset(
+    {
+        "task_id",
+        "prompt",
+        "baseline_output",
+        "routed_output",
+        "route_metadata",
+        "validation_status",
+    }
+)
+CAPTURE_CASE_ALLOWED_KEYS = CAPTURE_CASE_REQUIRED_KEYS | {"notes", "exclusion_reason"}
+
+# Boundary attestation embedded in every exported packet. These statements
+# cover only what this harness itself did during capture and export.
+HARNESS_BOUNDARIES = {
+    "provider_calls_made_by_harness": False,
+    "hosted_model_calls_made_by_harness": False,
+    "local_model_calls_made_by_harness": False,
+    "tool_execution_performed_by_harness": False,
+    "network_access_used_by_harness": False,
+    "scoring_performed": False,
+    "blinding_or_unblinding_performed": False,
+    "readiness_or_quality_claims_made": False,
+}
+
+
+def _is_nonempty_str(value: Any) -> bool:
+    return isinstance(value, str) and value.strip() != ""
+
+
+def load_json(path: Path) -> Any:
+    with Path(path).open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def validate_case_packet(packet: Any) -> List[str]:
+    """Validate an operator-authored case packet. Returns a list of errors."""
+    errors: List[str] = []
+    if not isinstance(packet, dict):
+        return ["case packet: top level must be a JSON object"]
+    unknown = sorted(set(packet) - CASE_PACKET_ALLOWED_KEYS)
+    if unknown:
+        errors.append(f"case packet: unknown keys not allowed: {unknown}")
+    missing = sorted(CASE_PACKET_REQUIRED_KEYS - set(packet))
+    if missing:
+        errors.append(f"case packet: missing required keys: {missing}")
+    if "packet_id" in packet and not _is_nonempty_str(packet["packet_id"]):
+        errors.append("case packet: packet_id must be a non-empty string")
+    cases = packet.get("cases")
+    if "cases" in packet:
+        if not isinstance(cases, list) or not cases:
+            errors.append("case packet: cases must be a non-empty list")
+        else:
+            seen: set = set()
+            for index, case in enumerate(cases):
+                label = f"case packet: cases[{index}]"
+                if not isinstance(case, dict):
+                    errors.append(f"{label}: must be a JSON object")
+                    continue
+                unknown = sorted(set(case) - CASE_ALLOWED_KEYS)
+                if unknown:
+                    errors.append(f"{label}: unknown keys not allowed: {unknown}")
+                missing = sorted(CASE_REQUIRED_KEYS - set(case))
+                if missing:
+                    errors.append(f"{label}: missing required keys: {missing}")
+                task_id = case.get("task_id")
+                if "task_id" in case:
+                    if not _is_nonempty_str(task_id):
+                        errors.append(f"{label}: task_id must be a non-empty string")
+                    elif task_id in seen:
+                        errors.append(f"{label}: duplicate task_id {task_id!r}")
+                    else:
+                        seen.add(task_id)
+                if "prompt" in case and not _is_nonempty_str(case.get("prompt")):
+                    errors.append(f"{label}: prompt must be a non-empty string")
+    return errors
+
+
+def scaffold_capture(case_packet: Dict[str, Any]) -> Dict[str, Any]:
+    """Build an empty capture structure from a validated case packet."""
+    errors = validate_case_packet(case_packet)
+    if errors:
+        raise ValueError("invalid case packet: " + "; ".join(errors))
+    capture: Dict[str, Any] = {
+        "schema_version": CAPTURE_SCHEMA_VERSION,
+        "packet_id": case_packet["packet_id"],
+        "capture_mode": CAPTURE_MODE,
+        "cases": [],
+    }
+    if _is_nonempty_str(case_packet.get("description")):
+        capture["description"] = case_packet["description"]
+    for case in case_packet["cases"]:
+        entry: Dict[str, Any] = {
+            "task_id": case["task_id"],
+            "prompt": case["prompt"],
+            "baseline_output": "",
+            "routed_output": "",
+            "route_metadata": {},
+            "validation_status": "pending",
+        }
+        if _is_nonempty_str(case.get("notes")):
+            entry["notes"] = case["notes"]
+        capture["cases"].append(entry)
+    return capture
+
+
+def _validate_capture_case(case: Any, index: int) -> List[str]:
+    label = f"cases[{index}]"
+    if not isinstance(case, dict):
+        return [f"{label}: must be a JSON object"]
+    errors: List[str] = []
+    unknown = sorted(set(case) - CAPTURE_CASE_ALLOWED_KEYS)
+    if unknown:
+        errors.append(f"{label}: unknown keys not allowed: {unknown}")
+    missing = sorted(CAPTURE_CASE_REQUIRED_KEYS - set(case))
+    if missing:
+        errors.append(f"{label}: missing required keys: {missing}")
+    if "task_id" in case and not _is_nonempty_str(case.get("task_id")):
+        errors.append(f"{label}: task_id must be a non-empty string")
+    if "prompt" in case and not _is_nonempty_str(case.get("prompt")):
+        errors.append(f"{label}: prompt must be a non-empty string")
+    status = case.get("validation_status")
+    if "validation_status" in case and status not in VALIDATION_STATUSES:
+        errors.append(
+            f"{label}: validation_status must be one of {list(VALIDATION_STATUSES)}"
+        )
+        return errors
+    if status == "captured":
+        if not _is_nonempty_str(case.get("baseline_output")):
+            errors.append(
+                f"{label}: captured case requires non-empty baseline_output"
+            )
+        if not _is_nonempty_str(case.get("routed_output")):
+            errors.append(f"{label}: captured case requires non-empty routed_output")
+        metadata = case.get("route_metadata")
+        if not isinstance(metadata, dict) or not metadata:
+            errors.append(
+                f"{label}: captured case requires route_metadata as a non-empty object"
+            )
+    elif status == "excluded":
+        if not _is_nonempty_str(case.get("exclusion_reason")):
+            errors.append(
+                f"{label}: excluded case requires non-empty exclusion_reason"
+            )
+    return errors
+
+
+def validate_capture(capture: Any, for_export: bool = False) -> List[str]:
+    """Validate a capture file. With for_export=True, also require completion."""
+    if not isinstance(capture, dict):
+        return ["capture: top level must be a JSON object"]
+    errors: List[str] = []
+    unknown = sorted(set(capture) - CAPTURE_ALLOWED_KEYS)
+    if unknown:
+        errors.append(f"capture: unknown keys not allowed: {unknown}")
+    missing = sorted(CAPTURE_REQUIRED_KEYS - set(capture))
+    if missing:
+        errors.append(f"capture: missing required keys: {missing}")
+    if (
+        "schema_version" in capture
+        and capture["schema_version"] != CAPTURE_SCHEMA_VERSION
+    ):
+        errors.append(
+            f"capture: schema_version must be {CAPTURE_SCHEMA_VERSION!r}, "
+            f"got {capture['schema_version']!r}"
+        )
+    if "packet_id" in capture and not _is_nonempty_str(capture["packet_id"]):
+        errors.append("capture: packet_id must be a non-empty string")
+    if "capture_mode" in capture and capture["capture_mode"] != CAPTURE_MODE:
+        errors.append(
+            f"capture: capture_mode must be {CAPTURE_MODE!r}, "
+            f"got {capture['capture_mode']!r}"
+        )
+    cases = capture.get("cases")
+    if "cases" in capture:
+        if not isinstance(cases, list) or not cases:
+            errors.append("capture: cases must be a non-empty list")
+            cases = []
+    else:
+        cases = []
+    seen: set = set()
+    statuses: List[Any] = []
+    for index, case in enumerate(cases):
+        errors.extend(_validate_capture_case(case, index))
+        if isinstance(case, dict):
+            task_id = case.get("task_id")
+            if _is_nonempty_str(task_id):
+                if task_id in seen:
+                    errors.append(f"cases[{index}]: duplicate task_id {task_id!r}")
+                seen.add(task_id)
+            statuses.append(case.get("validation_status"))
+    if for_export and not errors:
+        pending = [
+            case.get("task_id")
+            for case in cases
+            if case.get("validation_status") == "pending"
+        ]
+        if pending:
+            errors.append(
+                "export: all cases must be captured or excluded; "
+                f"still pending: {pending}"
+            )
+        if not any(status == "captured" for status in statuses):
+            errors.append("export: at least one case must have status 'captured'")
+    return errors
+
+
+def build_evidence_packet(capture: Dict[str, Any]) -> Dict[str, Any]:
+    """Build the normalized evidence packet from a validated capture."""
+    errors = validate_capture(capture, for_export=True)
+    if errors:
+        raise ValueError("invalid capture: " + "; ".join(errors))
+    cases = sorted(capture["cases"], key=lambda case: case["task_id"])
+    normalized_cases: List[Dict[str, Any]] = []
+    for case in cases:
+        entry: Dict[str, Any] = {
+            "task_id": case["task_id"],
+            "prompt": case["prompt"],
+            "validation_status": case["validation_status"],
+            "baseline_output": case["baseline_output"],
+            "routed_output": case["routed_output"],
+            "route_metadata": case["route_metadata"],
+        }
+        if _is_nonempty_str(case.get("notes")):
+            entry["notes"] = case["notes"]
+        if case["validation_status"] == "excluded":
+            entry["exclusion_reason"] = case["exclusion_reason"]
+        normalized_cases.append(entry)
+    captured = sum(
+        1 for case in normalized_cases if case["validation_status"] == "captured"
+    )
+    excluded = len(normalized_cases) - captured
+    packet: Dict[str, Any] = {
+        "schema_version": PACKET_SCHEMA_VERSION,
+        "lane_id": LANE_ID,
+        "packet_id": capture["packet_id"],
+        "capture_mode": capture["capture_mode"],
+        "harness_boundaries": dict(HARNESS_BOUNDARIES),
+        "counts": {
+            "captured": captured,
+            "excluded": excluded,
+            "total": len(normalized_cases),
+        },
+        "cases": normalized_cases,
+    }
+    if _is_nonempty_str(capture.get("description")):
+        packet["description"] = capture["description"]
+    packet["content_digest"] = "sha256:" + _digest(packet)
+    return packet
+
+
+def _digest(packet: Dict[str, Any]) -> str:
+    body = {key: value for key, value in packet.items() if key != "content_digest"}
+    canonical = json.dumps(
+        body, ensure_ascii=True, sort_keys=True, separators=(",", ":")
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def verify_packet_digest(packet: Dict[str, Any]) -> bool:
+    """Recompute the packet digest; True when it matches the recorded value."""
+    recorded = packet.get("content_digest")
+    if not _is_nonempty_str(recorded):
+        return False
+    return recorded == "sha256:" + _digest(packet)
+
+
+def render_json_bytes(payload: Dict[str, Any]) -> bytes:
+    """Render a payload as byte-stable, replay-friendly JSON."""
+    text = json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True)
+    return (text + "\n").encode("utf-8")

--- a/docs/OPERATOR_RUN_CAPTURE.md
+++ b/docs/OPERATOR_RUN_CAPTURE.md
@@ -1,0 +1,75 @@
+# Operator Run Capture Harness
+
+Lane: `ALPHA-SOLVER-OPERATOR-RUN-CAPTURE-HARNESS-MVP-001`
+
+A local-only harness that turns manually generated routed-vs-plain operator
+runs into a normalized, machine-validated, byte-stable JSON evidence packet.
+It replaces hand-assembled per-run markdown files with a format that later
+(separately authorized) blind-scoring, replay, and audit lanes can consume.
+
+The harness is a lab notebook, not a runner: the operator generates and pastes
+all outputs; the harness only scaffolds, validates, and exports.
+
+## Workflow
+
+1. **Author a case packet** (JSON) listing the tasks to capture. See
+   `tests/fixtures/operator_run_capture/case_packet.json` for the shape:
+   `packet_id`, optional `description`, and `cases` with unique `task_id`,
+   `prompt`, optional `notes`.
+
+2. **Scaffold a capture file** with one empty slot per task:
+
+   ```bash
+   python scripts/operator_run_capture.py init \
+     --case-packet my_cases.json --out my_capture.json
+   ```
+
+3. **Fill in each case by hand.** For every task the operator pastes:
+   - `baseline_output` — the plain (non-routed) output they collected
+   - `routed_output` — the routed Alpha output they collected
+   - `route_metadata` — a non-empty JSON object of route facts they observed
+   - `validation_status` — `captured`, or `excluded` with a non-empty
+     `exclusion_reason` when a task is dropped
+
+   Task IDs and prompts are preserved from the case packet; unknown fields are
+   rejected, so score, rank, winner, or blind-label fields cannot be added.
+
+4. **Validate** at any time (structural), or with `--for-export`
+   (completeness: no `pending` cases, at least one `captured`):
+
+   ```bash
+   python scripts/operator_run_capture.py validate --capture my_capture.json --for-export
+   ```
+
+5. **Export the evidence packet**:
+
+   ```bash
+   python scripts/operator_run_capture.py export \
+     --capture my_capture.json --out my_packet.json
+   ```
+
+   The export is deterministic: keys sorted, cases ordered by `task_id`, LF
+   line endings, no timestamps, and a `content_digest` (SHA-256 over the
+   canonical body) so replay or review lanes can detect any post-export edit.
+   Re-exporting the same capture yields byte-identical output.
+
+## Packet contents
+
+Every exported packet embeds a `harness_boundaries` block recording, as
+machine-readable booleans, that the harness itself made no provider calls, no
+hosted or local model calls, executed no tools, used no network access,
+performed no scoring, and performed no blinding or unblinding. These
+statements cover only what the harness did; they say nothing about how the
+operator produced the pasted outputs — record that provenance in the run's
+own docs.
+
+## Non-claims and boundaries
+
+- Local files only. Nothing here calls providers, models, or tools, touches
+  `/v1/solve`, dashboards, or any external service.
+- No scoring, ranking, blinding, or unblinding. Blind scoring is a separate
+  lane; no source map or A/B identity key is ever written by this harness.
+- A passing validation means only that the configured structural rules held
+  for that capture file. It does not claim readiness, benchmark results,
+  provider or local-model quality, or that routed output is better than the
+  baseline. Comparative interpretation is out of scope for this lane.

--- a/scripts/operator_run_capture.py
+++ b/scripts/operator_run_capture.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Local-only CLI for the operator run capture harness.
+
+Subcommands:
+  init      Scaffold a capture file from an operator-authored case packet.
+  validate  Check a capture file (add --for-export for export completeness).
+  export    Validate and write the normalized evidence packet.
+
+This CLI reads and writes local JSON files only. It performs no provider,
+hosted-model, or local-model calls, no tool execution, and no network access,
+and it does not score, blind, or unblind outputs.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from alpha.eval import operator_run_capture as orc  # noqa: E402
+
+EXIT_OK = 0
+EXIT_VALIDATION = 1
+EXIT_USAGE = 2
+
+
+def _read_json(path: Path, label: str):
+    try:
+        return orc.load_json(path)
+    except FileNotFoundError:
+        print(f"error: {label} not found: {path}", file=sys.stderr)
+        raise SystemExit(EXIT_USAGE)
+    except ValueError as exc:
+        print(f"error: {label} is not valid JSON: {path}: {exc}", file=sys.stderr)
+        raise SystemExit(EXIT_USAGE)
+
+
+def _write_bytes(path: Path, payload: bytes, force: bool) -> None:
+    if path.exists() and not force:
+        print(
+            f"error: refusing to overwrite existing file without --force: {path}",
+            file=sys.stderr,
+        )
+        raise SystemExit(EXIT_USAGE)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(payload)
+
+
+def _report_errors(errors: list) -> None:
+    for error in errors:
+        print(f"FAIL {error}")
+
+
+def cmd_init(args: argparse.Namespace) -> int:
+    case_packet = _read_json(Path(args.case_packet), "case packet")
+    errors = orc.validate_case_packet(case_packet)
+    if errors:
+        _report_errors(errors)
+        return EXIT_VALIDATION
+    capture = orc.scaffold_capture(case_packet)
+    _write_bytes(Path(args.out), orc.render_json_bytes(capture), args.force)
+    print(
+        f"OK scaffolded capture for packet {capture['packet_id']!r} "
+        f"({len(capture['cases'])} cases) -> {args.out}"
+    )
+    return EXIT_OK
+
+
+def cmd_validate(args: argparse.Namespace) -> int:
+    capture = _read_json(Path(args.capture), "capture file")
+    errors = orc.validate_capture(capture, for_export=args.for_export)
+    if errors:
+        _report_errors(errors)
+        return EXIT_VALIDATION
+    mode = "export-ready" if args.for_export else "structurally valid"
+    print(f"OK capture is {mode}: {args.capture}")
+    return EXIT_OK
+
+
+def cmd_export(args: argparse.Namespace) -> int:
+    capture = _read_json(Path(args.capture), "capture file")
+    errors = orc.validate_capture(capture, for_export=True)
+    if errors:
+        _report_errors(errors)
+        return EXIT_VALIDATION
+    packet = orc.build_evidence_packet(capture)
+    _write_bytes(Path(args.out), orc.render_json_bytes(packet), args.force)
+    counts = packet["counts"]
+    print(
+        f"OK exported evidence packet {packet['packet_id']!r} "
+        f"(captured={counts['captured']} excluded={counts['excluded']}) -> {args.out}"
+    )
+    print(f"content_digest: {packet['content_digest']}")
+    return EXIT_OK
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="operator_run_capture",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    init_parser = sub.add_parser("init", help="scaffold a capture file")
+    init_parser.add_argument("--case-packet", required=True)
+    init_parser.add_argument("--out", required=True)
+    init_parser.add_argument("--force", action="store_true")
+    init_parser.set_defaults(func=cmd_init)
+
+    validate_parser = sub.add_parser("validate", help="validate a capture file")
+    validate_parser.add_argument("--capture", required=True)
+    validate_parser.add_argument("--for-export", action="store_true")
+    validate_parser.set_defaults(func=cmd_validate)
+
+    export_parser = sub.add_parser("export", help="export the evidence packet")
+    export_parser.add_argument("--capture", required=True)
+    export_parser.add_argument("--out", required=True)
+    export_parser.add_argument("--force", action="store_true")
+    export_parser.set_defaults(func=cmd_export)
+    return parser
+
+
+def main(argv: list | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/operator_run_capture/case_packet.json
+++ b/tests/fixtures/operator_run_capture/case_packet.json
@@ -1,0 +1,19 @@
+{
+  "packet_id": "ORC-FIXTURE-001",
+  "description": "Synthetic fixture case packet for the operator run capture harness tests. All content is invented; no provider or model output is included.",
+  "cases": [
+    {
+      "task_id": "ORC-SIM-001",
+      "prompt": "A dashboard shows zero provider calls but a transcript mentions live provider output. What should the operator check before drawing any conclusion?",
+      "notes": "Synthetic evidence-reconciliation case."
+    },
+    {
+      "task_id": "ORC-SIM-002",
+      "prompt": "An evidence packet is missing route metadata for one task. How should the gap be recorded without overclaiming?"
+    },
+    {
+      "task_id": "ORC-SIM-003",
+      "prompt": "Two capture files disagree on a task ID. Describe a deterministic way to detect and report the mismatch."
+    }
+  ]
+}

--- a/tests/fixtures/operator_run_capture/filled_capture.json
+++ b/tests/fixtures/operator_run_capture/filled_capture.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": "operator_run_capture/v1",
+  "packet_id": "ORC-FIXTURE-001",
+  "capture_mode": "operator_manual",
+  "description": "Synthetic fixture case packet for the operator run capture harness tests. All content is invented; no provider or model output is included.",
+  "cases": [
+    {
+      "task_id": "ORC-SIM-001",
+      "prompt": "A dashboard shows zero provider calls but a transcript mentions live provider output. What should the operator check before drawing any conclusion?",
+      "notes": "Synthetic evidence-reconciliation case.",
+      "baseline_output": "Synthetic operator-typed baseline text: reconcile timestamps and run IDs before concluding anything.",
+      "routed_output": "Synthetic operator-typed routed text: reconcile timestamps, run IDs, and log sources; record the gap explicitly if unresolved.",
+      "route_metadata": {
+        "route_label": "synthetic-route-a",
+        "gate_status": "synthetic-pass",
+        "notes": "Fixture metadata only; not produced by any router run."
+      },
+      "validation_status": "captured"
+    },
+    {
+      "task_id": "ORC-SIM-002",
+      "prompt": "An evidence packet is missing route metadata for one task. How should the gap be recorded without overclaiming?",
+      "baseline_output": "Synthetic baseline: record the missing field and mark the task incomplete.",
+      "routed_output": "Synthetic routed: record the missing field, mark the task incomplete, and exclude it from any downstream comparison.",
+      "route_metadata": {
+        "route_label": "synthetic-route-b"
+      },
+      "validation_status": "captured"
+    },
+    {
+      "task_id": "ORC-SIM-003",
+      "prompt": "Two capture files disagree on a task ID. Describe a deterministic way to detect and report the mismatch.",
+      "baseline_output": "",
+      "routed_output": "",
+      "route_metadata": {},
+      "validation_status": "excluded",
+      "exclusion_reason": "Fixture demonstrates the excluded path; no outputs were captured for this task."
+    }
+  ]
+}

--- a/tests/test_operator_run_capture.py
+++ b/tests/test_operator_run_capture.py
@@ -1,0 +1,221 @@
+"""Tests for the local-only operator run capture harness."""
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from alpha.eval import operator_run_capture as orc
+
+FIXTURES = Path(__file__).parent / "fixtures" / "operator_run_capture"
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "operator_run_capture.py"
+
+
+def _case_packet() -> dict:
+    return json.loads((FIXTURES / "case_packet.json").read_text(encoding="utf-8"))
+
+
+def _filled_capture() -> dict:
+    return json.loads((FIXTURES / "filled_capture.json").read_text(encoding="utf-8"))
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        cwd=str(SCRIPT.parents[1]),
+    )
+
+
+class TestCasePacketValidation:
+    def test_fixture_packet_is_valid(self):
+        assert orc.validate_case_packet(_case_packet()) == []
+
+    def test_missing_packet_id(self):
+        packet = _case_packet()
+        del packet["packet_id"]
+        errors = orc.validate_case_packet(packet)
+        assert any("missing required keys" in error for error in errors)
+
+    def test_duplicate_task_ids_rejected(self):
+        packet = _case_packet()
+        packet["cases"][1]["task_id"] = packet["cases"][0]["task_id"]
+        errors = orc.validate_case_packet(packet)
+        assert any("duplicate task_id" in error for error in errors)
+
+    def test_unknown_keys_rejected(self):
+        packet = _case_packet()
+        packet["score"] = 5
+        packet["cases"][0]["winner"] = "alpha"
+        errors = orc.validate_case_packet(packet)
+        assert any("unknown keys" in error and "score" in error for error in errors)
+        assert any("unknown keys" in error and "winner" in error for error in errors)
+
+    def test_empty_cases_rejected(self):
+        packet = _case_packet()
+        packet["cases"] = []
+        errors = orc.validate_case_packet(packet)
+        assert any("non-empty list" in error for error in errors)
+
+
+class TestScaffold:
+    def test_scaffold_preserves_task_ids_and_prompts(self):
+        packet = _case_packet()
+        capture = orc.scaffold_capture(packet)
+        assert capture["schema_version"] == orc.CAPTURE_SCHEMA_VERSION
+        assert capture["packet_id"] == packet["packet_id"]
+        assert capture["capture_mode"] == orc.CAPTURE_MODE
+        assert [case["task_id"] for case in capture["cases"]] == [
+            case["task_id"] for case in packet["cases"]
+        ]
+        for entry in capture["cases"]:
+            assert entry["baseline_output"] == ""
+            assert entry["routed_output"] == ""
+            assert entry["route_metadata"] == {}
+            assert entry["validation_status"] == "pending"
+
+    def test_scaffold_rejects_invalid_packet(self):
+        with pytest.raises(ValueError, match="invalid case packet"):
+            orc.scaffold_capture({"cases": []})
+
+
+class TestCaptureValidation:
+    def test_filled_fixture_is_export_ready(self):
+        assert orc.validate_capture(_filled_capture(), for_export=True) == []
+
+    def test_scaffold_is_valid_but_not_export_ready(self):
+        capture = orc.scaffold_capture(_case_packet())
+        assert orc.validate_capture(capture) == []
+        errors = orc.validate_capture(capture, for_export=True)
+        assert any("still pending" in error for error in errors)
+
+    def test_captured_case_requires_outputs_and_metadata(self):
+        capture = _filled_capture()
+        capture["cases"][0]["baseline_output"] = "   "
+        capture["cases"][0]["route_metadata"] = {}
+        errors = orc.validate_capture(capture)
+        assert any("non-empty baseline_output" in error for error in errors)
+        assert any("route_metadata as a non-empty object" in error for error in errors)
+
+    def test_excluded_case_requires_reason(self):
+        capture = _filled_capture()
+        del capture["cases"][2]["exclusion_reason"]
+        errors = orc.validate_capture(capture)
+        assert any("non-empty exclusion_reason" in error for error in errors)
+
+    def test_export_requires_at_least_one_captured_case(self):
+        capture = _filled_capture()
+        for case in capture["cases"]:
+            case["validation_status"] = "excluded"
+            case["exclusion_reason"] = "all excluded for the test"
+        errors = orc.validate_capture(capture, for_export=True)
+        assert any("at least one case" in error for error in errors)
+
+    def test_unknown_case_keys_rejected(self):
+        capture = _filled_capture()
+        capture["cases"][0]["blind_label"] = "A"
+        errors = orc.validate_capture(capture)
+        assert any(
+            "unknown keys" in error and "blind_label" in error for error in errors
+        )
+
+    def test_wrong_schema_version_rejected(self):
+        capture = _filled_capture()
+        capture["schema_version"] = "operator_run_capture/v0"
+        errors = orc.validate_capture(capture)
+        assert any("schema_version" in error for error in errors)
+
+
+class TestEvidencePacket:
+    def test_packet_structure_and_counts(self):
+        packet = orc.build_evidence_packet(_filled_capture())
+        assert packet["schema_version"] == orc.PACKET_SCHEMA_VERSION
+        assert packet["lane_id"] == orc.LANE_ID
+        assert packet["packet_id"] == "ORC-FIXTURE-001"
+        assert packet["counts"] == {"captured": 2, "excluded": 1, "total": 3}
+        assert packet["harness_boundaries"] == orc.HARNESS_BOUNDARIES
+        assert all(value is False for value in packet["harness_boundaries"].values())
+
+    def test_cases_sorted_by_task_id(self):
+        capture = _filled_capture()
+        capture["cases"].reverse()
+        packet = orc.build_evidence_packet(capture)
+        task_ids = [case["task_id"] for case in packet["cases"]]
+        assert task_ids == sorted(task_ids)
+
+    def test_export_bytes_are_deterministic(self):
+        first = orc.render_json_bytes(orc.build_evidence_packet(_filled_capture()))
+        shuffled = _filled_capture()
+        shuffled["cases"].reverse()
+        second = orc.render_json_bytes(orc.build_evidence_packet(shuffled))
+        assert first == second
+        assert first.endswith(b"\n")
+
+    def test_digest_verifies_and_detects_tampering(self):
+        packet = orc.build_evidence_packet(_filled_capture())
+        assert orc.verify_packet_digest(packet)
+        tampered = copy.deepcopy(packet)
+        tampered["cases"][0]["routed_output"] = "edited after export"
+        assert not orc.verify_packet_digest(tampered)
+
+    def test_build_rejects_incomplete_capture(self):
+        with pytest.raises(ValueError, match="invalid capture"):
+            orc.build_evidence_packet(orc.scaffold_capture(_case_packet()))
+
+
+class TestCli:
+    def test_init_validate_export_roundtrip(self, tmp_path: Path):
+        capture_path = tmp_path / "capture.json"
+        packet_path = tmp_path / "packet.json"
+
+        result = _run_cli(
+            "init",
+            "--case-packet",
+            str(FIXTURES / "case_packet.json"),
+            "--out",
+            str(capture_path),
+        )
+        assert result.returncode == 0, result.stderr
+        assert "OK scaffolded capture" in result.stdout
+
+        result = _run_cli("validate", "--capture", str(capture_path))
+        assert result.returncode == 0, result.stderr
+
+        result = _run_cli("validate", "--capture", str(capture_path), "--for-export")
+        assert result.returncode == 1
+        assert "still pending" in result.stdout
+
+        filled_path = tmp_path / "filled.json"
+        filled_path.write_text(
+            json.dumps(_filled_capture()), encoding="utf-8"
+        )
+        result = _run_cli(
+            "export", "--capture", str(filled_path), "--out", str(packet_path)
+        )
+        assert result.returncode == 0, result.stderr
+        assert "content_digest: sha256:" in result.stdout
+
+        exported = json.loads(packet_path.read_text(encoding="utf-8"))
+        assert orc.verify_packet_digest(exported)
+
+    def test_export_refuses_overwrite_without_force(self, tmp_path: Path):
+        filled_path = tmp_path / "filled.json"
+        filled_path.write_text(json.dumps(_filled_capture()), encoding="utf-8")
+        packet_path = tmp_path / "packet.json"
+        packet_path.write_text("existing", encoding="utf-8")
+        result = _run_cli(
+            "export", "--capture", str(filled_path), "--out", str(packet_path)
+        )
+        assert result.returncode == 2
+        assert "refusing to overwrite" in result.stderr
+        assert packet_path.read_text(encoding="utf-8") == "existing"
+
+    def test_missing_input_file_is_usage_error(self, tmp_path: Path):
+        result = _run_cli("validate", "--capture", str(tmp_path / "missing.json"))
+        assert result.returncode == 2
+        assert "not found" in result.stderr


### PR DESCRIPTION
## Checklist

- [x] Spec linked: `.specs/ALPHA-SOLVER-OPERATOR-RUN-CAPTURE-HARNESS-MVP-001.md`
- [x] Spec sections present/updated (Goal / Motivation / Acceptance Criteria / Definition of Done / Code Targets / Test Plan)
- [x] Tests run: `python -m pytest -q` (exit code 0; 3 environment-gated skips, incl. the live-OpenAI smoke test — see validation below)

## Notes for reviewers

### Selected target and lane ID

`ALPHA-SOLVER-OPERATOR-RUN-CAPTURE-HARNESS-MVP-001` — a local-only, deterministic operator run capture harness that turns manually generated routed-vs-plain runs into a normalized, machine-validated JSON evidence packet.

### Wargame summary

Candidates considered:

1. **Operator run capture harness (selected).** Repo inspection showed operator evidence lives in hand-assembled markdown per run directory (e.g. `docs/evals/runs/.../raw/baseline/VR-SIM-012.md` vs `raw/alpha/VR-SIM-012.md`), policed only by regex doc-linters (`check_local_llm_packet_consistency.py`, `check_narrative_claim_safety.py`). There was no machine-readable capture format, no required-field validation before an evidence packet exists, and no byte-stable export. This is the substrate every other candidate needs.
2. **Routed-vs-plain pilot capture bridge** — subsumed: the harness's per-case slots are exactly plain-baseline vs routed capture.
3. **Replay/evidence packet normalizer** — dependent: there is no normalized packet format to normalize until this PR defines one.
4. **Test-console-to-evidence-export bridge** — touches the console/webapp surface, larger scope and exposure risk; not one focused PR.
5. **Scorer packet validator** — a validator without a machine-readable capture format has nothing solid to validate; this harness ships strict validation as its core step, giving a future validator lane a real substrate.
6. **Repo-native alternative (replace regex doc-checkers)** — would be broad cleanup, out of bounds.

### Exact changed files

- `alpha/eval/operator_run_capture.py` — new module: case-packet validation, capture scaffolding, strict capture validation, normalized packet build, SHA-256 content digest, deterministic JSON rendering
- `scripts/operator_run_capture.py` — new CLI: `init` / `validate [--for-export]` / `export`, exit codes 0/1/2, overwrite protection
- `tests/test_operator_run_capture.py` — 22 new tests (validation rules, byte-identical export, digest tamper detection, CLI roundtrip via subprocess)
- `tests/fixtures/operator_run_capture/case_packet.json` — synthetic fixture (all content invented)
- `tests/fixtures/operator_run_capture/filled_capture.json` — synthetic filled capture fixture
- `docs/OPERATOR_RUN_CAPTURE.md` — short process doc with explicit non-claims
- `.specs/ALPHA-SOLVER-OPERATOR-RUN-CAPTURE-HARNESS-MVP-001.md` — lane spec

No existing files were modified.

### Validation commands and results

- `python -m pytest tests/test_operator_run_capture.py -q` → 22 passed
- `python -m pytest -q` (full suite) → exit code 0; 3 skips, all environment-gated (`test_openai_live_smoke` requires `ALPHA_LIVE_OPENAI=1`+key and stayed skipped, `test_decks_smoke` web adapter disabled, `test_packaging_build` build module absent). Note: a test in the suite redirects stdout, so pytest's final count line is truncated in captured logs; the exit code is the authoritative result.
- `python -m pytest tests/test_self_operator_forbidden_behavior_static.py tests/test_self_operator_static_guardrails.py tests/test_self_operator_closeout_guardrails.py tests/test_local_llm_evidence_boundaries.py -q` → 47 passed
- `python scripts/check_narrative_claim_safety.py docs/OPERATOR_RUN_CAPTURE.md` → passed
- `python scripts/check_narrative_claim_safety.py .specs/ALPHA-SOLVER-OPERATOR-RUN-CAPTURE-HARNESS-MVP-001.md` → passed
- `python scripts/check_local_llm_packet_consistency.py` → passed (184 packet directories scanned)
- `ruff check` on the three new Python files → all checks passed (CI's `ruff check alpha` scope included)

### Boundary preservation

- Local JSON files only: no provider calls, no hosted/local model calls, no tool execution, no network access anywhere in the new code paths.
- No `/v1/solve`, dashboard, or public API/dashboard exposure; nothing is mounted or served.
- No scoring, ranking, blinding, or unblinding; strict allowed-key validation rejects unknown fields at every level, so score/winner/blind-label/identity-map data cannot be smuggled into a packet. No source map or A/B identity key is written.
- Every exported packet embeds a `harness_boundaries` attestation block scoped to what the harness itself did; operator-supplied output provenance is explicitly out of the harness's attestation scope.
- Fixtures are fully synthetic; no provider or model output is committed.
- No Google Docs/Sheets/Drive interaction; no web research performed.

### Risks / blockers

- The harness records operator-pasted text verbatim; it cannot verify how the operator produced the outputs. Provenance stays an operator responsibility, documented in the process doc.
- `route_metadata` is intentionally schema-light (any non-empty object) to avoid coupling to the evolving route-metadata shape; a future lane can tighten it once consumers exist.
- The capture format is v1 (`operator_run_capture/v1`); downstream lanes (packet normalizer, scorer packet validator, blind-scoring bridge) should pin on `schema_version` before extending.

### Explicit non-claims

This PR does not prove readiness, provider or local-model quality, benchmark success, production or public readiness, or Alpha superiority. A passing validation means only that the configured structural rules held for a given capture file; comparative interpretation, scoring, and blinding remain separate, unauthorized-here lanes.

---
_Generated by [Claude Code](https://claude.ai/code/session_011DUh9bRenAef39bB2ijThb)_