### PR TITLE
Clarify operator capture route_metadata boundary (post-merge hotfix for PR #643)

### DIFF
--- a/.specs/ALPHA-SOLVER-OPERATOR-RUN-CAPTURE-HARNESS-MVP-001.md
+++ b/.specs/ALPHA-SOLVER-OPERATOR-RUN-CAPTURE-HARNESS-MVP-001.md
@@ -27,9 +27,14 @@ validator, blind-scoring bridge) needs that substrate first.
   (routed Alpha), `route_metadata` (non-empty object), `validation_status`
   (`pending` / `captured` / `excluded`, with `exclusion_reason` required for
   excluded cases).
-- Strict validation before export: unknown fields are rejected at every level,
-  so score, rank, winner, blind-label, or identity-map fields cannot enter a
-  packet; export additionally requires no pending cases and at least one
+- Strict validation before export: unknown schema-level fields are rejected in
+  the case-packet and capture structures, so score, rank, winner, blind-label,
+  source-map, or identity-map fields are invalid as schema fields. The
+  `route_metadata` field intentionally remains a schema-light non-empty object
+  for MVP route facts and is exported verbatim; it must not be interpreted as
+  scoring, ranking, blinding, unblinding, source-map, identity-map, winner,
+  benchmark, readiness, quality, production, public-MVP, or Alpha-superiority
+  evidence. Export additionally requires no pending cases and at least one
   captured case.
 - Deterministic export: keys sorted, cases ordered by `task_id`, LF endings,
   no timestamps, byte-identical re-export, and a `content_digest` (SHA-256

--- a/docs/OPERATOR_RUN_CAPTURE.md
+++ b/docs/OPERATOR_RUN_CAPTURE.md
@@ -31,8 +31,12 @@ all outputs; the harness only scaffolds, validates, and exports.
    - `validation_status` — `captured`, or `excluded` with a non-empty
      `exclusion_reason` when a task is dropped
 
-   Task IDs and prompts are preserved from the case packet; unknown fields are
-   rejected, so score, rank, winner, or blind-label fields cannot be added.
+   Task IDs and prompts are preserved from the case packet. Unknown keys are
+   rejected on the case-packet and capture schema fields, so schema-level
+   score, rank, winner, blind-label, source-map, or identity-map fields are
+   invalid. `route_metadata` is intentionally schema-light in this MVP: it is
+   accepted as a non-empty JSON object and exported verbatim, and operators
+   must use it only for route facts they observed.
 
 4. **Validate** at any time (structural), or with `--for-export`
    (completeness: no `pending` cases, at least one `captured`):
@@ -69,6 +73,10 @@ own docs.
   `/v1/solve`, dashboards, or any external service.
 - No scoring, ranking, blinding, or unblinding. Blind scoring is a separate
   lane; no source map or A/B identity key is ever written by this harness.
+- `route_metadata` remains schema-light for this MVP. Its keys are route-fact
+  notes only and must not be interpreted as scoring, ranking, winner,
+  blinding, unblinding, source-map, identity-map, benchmark, readiness,
+  quality, production, public-MVP, or Alpha-superiority evidence.
 - A passing validation means only that the configured structural rules held
   for that capture file. It does not claim readiness, benchmark results,
   provider or local-model quality, or that routed output is better than the

--- a/tests/test_operator_run_capture.py
+++ b/tests/test_operator_run_capture.py
@@ -124,6 +124,29 @@ class TestCaptureValidation:
             "unknown keys" in error and "blind_label" in error for error in errors
         )
 
+    def test_schema_level_unknown_boundary_keys_rejected(self):
+        capture = _filled_capture()
+        capture["rank"] = 1
+        capture["cases"][0]["source_map"] = {"A": "baseline"}
+        errors = orc.validate_capture(capture)
+        assert any("unknown keys" in error and "rank" in error for error in errors)
+        assert any(
+            "unknown keys" in error and "source_map" in error for error in errors
+        )
+
+    def test_route_metadata_remains_schema_light_for_route_facts(self):
+        capture = _filled_capture()
+        capture["cases"][0]["route_metadata"] = {
+            "selected_route": "portable",
+            "fallbacks_observed": [],
+            "operator_note": "route facts recorded during manual capture",
+        }
+        assert orc.validate_capture(capture, for_export=True) == []
+        packet = orc.build_evidence_packet(capture)
+        exported_metadata = packet["cases"][0]["route_metadata"]
+        assert exported_metadata["selected_route"] == "portable"
+        assert exported_metadata["fallbacks_observed"] == []
+
     def test_wrong_schema_version_rejected(self):
         capture = _filled_capture()
         capture["schema_version"] = "operator_run_capture/v0"


### PR DESCRIPTION
### Motivation
- The merged capture harness claimed that unknown fields are rejected “at every level,” but the implementation intentionally accepts a schema-light `route_metadata` object and exports it verbatim, creating an overbroad boundary claim. 
- Narrow the textual boundary to avoid implying that scoring/ranking/blinding/identity/source-map data cannot be nested inside `route_metadata` while preserving the MVP decision to keep `route_metadata` schema-light.

### Description
- Update `docs/OPERATOR_RUN_CAPTURE.md` to state that unknown-key rejection applies to the case-packet and capture schema fields and to document that `route_metadata` intentionally remains schema-light for MVP route facts only. 
- Update `.specs/ALPHA-SOLVER-OPERATOR-RUN-CAPTURE-HARNESS-MVP-001.md` to replace the overbroad “unknown fields rejected at every level” language with precise schema-level rejection and a `route_metadata` schema-light boundary note. 
- Add two focused tests to `tests/test_operator_run_capture.py` that assert schema-level unknown keys are rejected and that arbitrary route-fact keys remain valid inside `route_metadata`; no behavior/code changes were made to `alpha/eval/operator_run_capture.py`. 
- Explicitly record that this is a post-merge claim-boundary clarification for PR #643 and that this change does not add scoring, ranking, blinding/unblinding, source maps, identity maps, provider/local-model calls, benchmark/readiness/production/public-MVP/Alpha-superiority claims.

### Testing
- Ran `python -m pytest tests/test_operator_run_capture.py -q` and the test file passed (new tests included) with all assertions green. 
- Ran `python scripts/check_narrative_claim_safety.py docs/OPERATOR_RUN_CAPTURE.md` and `python scripts/check_narrative_claim_safety.py .specs/ALPHA-SOLVER-OPERATOR-RUN-CAPTURE-HARNESS-MVP-001.md` and both linter checks passed. 
- Ran full `python -m pytest -q` and the test suite completed successfully with the repository's expected skips and deprecation warnings; no failures introduced by this clarification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b14db4d74832983e00bead7c1dc53)