### PR TITLE
portable: add substantive lift answer contract (ANSWER-STRUCTURE-V2 runtime)

### DIFF
--- a/.specs/ALPHA-SOLVER-SUBSTANTIVE-LIFT-ANSWER-CONTRACT-001.md
+++ b/.specs/ALPHA-SOLVER-SUBSTANTIVE-LIFT-ANSWER-CONTRACT-001.md
@@ -1,0 +1,97 @@
+# ALPHA-SOLVER-SUBSTANTIVE-LIFT-ANSWER-CONTRACT-001 · Substantive Lift Answer Contract
+
+Status: Implemented (portable surface only)
+
+Runtime successor of the `ALPHA-ANSWER-STRUCTURE-V2-001` planning lane for the
+portable prompt surface (`alpha_solver_portable.py`).
+
+## Goal
+
+Make Alpha's answers on substantive tasks visibly and structurally different
+from a generic model response by requiring the SOLUTION itself to perform six
+compact reasoning moves — intent diagnosis, hidden-assumption surfacing,
+dominant-tradeoff identification, a committed recommendation, a named failure
+condition, and an executable next action — plus anti-generic wording rules.
+
+## Motivation
+
+The active answer surface operators use is the portable spec monolith loaded
+as a system prompt. Its existing contract contains envelope structure and ten
+restraint rules (brevity, format fit, claim safety) but no rule that forces
+sharper content inside SOLUTION. The committed Batch B planning evidence
+recorded that Alpha's limited-pilot lift clustered around substantive
+constraint, risk, evidence, and comparative-value behavior (+21 lift cluster)
+while its clearest weakness was brevity (-10), and `ALPHA-ANSWER-STRUCTURE-V2-001`
+proposed a prompt-aware answer architecture as planning only, with no runtime
+implementation. This lane implements that architecture's high-headroom half as
+an enforceable contract on the portable surface, leaving the existing
+low-headroom restraint rules in control of concise tasks.
+
+## Scope
+
+- New docstring section in `alpha_solver_portable.py`:
+  `SUBSTANTIVE LIFT CONTRACT (HIGH-HEADROOM TASKS)` with the six-move lift
+  block, applicability triggers, low-headroom exemptions with explicit
+  restraint precedence, five anti-generic rules, and a wording-only boundary.
+- Machine-readable constants mirroring the contract: `SUBSTANTIVE_LIFT_MOVES`,
+  `SUBSTANTIVE_LIFT_TRIGGERS`, `SUBSTANTIVE_LIFT_EXEMPT`,
+  `GENERIC_HEDGE_PATTERNS`, `WEAK_NEXT_ACTION_OPENERS`,
+  `SUBSTANTIVE_LIFT_ANTI_GENERIC_RULES`, plus
+  `substantive_lift_contract_summary()` for prompt-loading workflows.
+- Deterministic structural checker `check_substantive_lift(solution_text)`
+  verifying: all six labels present in order, `Intent:` first, non-empty move
+  content, no hedge phrasing (word-boundary matched), and an executable rather
+  than deliberative `Next:` line.
+- Updated `COMPLIANCE_EXAMPLES` (compliant lift-block example plus a new
+  `NON_COMPLIANT_GENERIC` example showing that envelope labels without
+  substantive content fail the protocol) and a lift-form
+  `ENVELOPE_OUTPUT_EXAMPLE`.
+- Fixtures with three realistic substantive prompts (decision, root-cause
+  diagnosis, constrained plan) carrying compliant and non-compliant answers,
+  plus one low-headroom case proving restraint precedence.
+
+## Non-goals
+
+- No provider, hosted-model, or local-model calls; no network calls.
+- No `/v1/solve`, routing, SAFE-OUT, or SolverEnvelope shape changes.
+- No scoring, ranking, blinding, or unblinding; no capture or rescoring.
+- No claim that the contract improves scores: whether these wording
+  requirements produce measurable lift is a separate, future evaluation lane.
+- No benchmark, readiness, production, public-MVP, provider-validation,
+  local-model-validation, or Alpha-superiority claims.
+- The deterministic local ToT path is out of scope: it cannot generate
+  substantive content without a model, which remains out of bounds here.
+
+## Code Targets
+
+- `alpha_solver_portable.py` — contract text, constants, summary helper,
+  checker, examples.
+- `tests/fixtures/alpha_substantive_lift_cases.json` — synthetic cases.
+- `tests/test_alpha_substantive_lift_contract.py` — structural enforcement.
+
+## Test Plan
+
+`tests/test_alpha_substantive_lift_contract.py` covers: contract section
+presence and placement after the restraint contract, explicit low-headroom
+precedence wording, wording-only boundary statements, constant/label
+consistency, summary completeness, checker pass on compliant fixtures, checker
+failure on non-compliant fixtures with named missing moves, hedge-phrase
+flagging (including a word-boundary false-positive guard), weak next-action
+flagging, out-of-order block rejection, low-headroom answers correctly carrying
+no lift block, fixture shape (three or more realistic substantive prompts),
+and compliance-example round-trips through the checker.
+
+## Acceptance Criteria
+
+- `python -m pytest tests/test_alpha_substantive_lift_contract.py -q` passes.
+- `python -m pytest tests/test_alpha_minimal_behavior_contract.py -q` still
+  passes (restraint contract and its precedence untouched).
+- `python scripts/check_narrative_claim_safety.py` passes on this spec.
+- A passing checker result means only that the configured wording structure
+  held for the given text; it is not a quality or correctness judgment.
+
+## Definition of Done
+
+Contract text, constants, checker, examples, fixtures, and tests merged; all
+listed checks pass; the low-headroom restraint contract retains precedence and
+all boundaries above hold.

--- a/alpha_solver_portable.py
+++ b/alpha_solver_portable.py
@@ -106,6 +106,61 @@ allows.
    provider payloads, or other source artifacts are missing or unavailable,
    start with "Stop:" and do not reconstruct, rescore, rerun capture, call live
    providers, update Sheets, or make proof/readiness claims.
+
+SUBSTANTIVE LIFT CONTRACT (HIGH-HEADROOM TASKS)
+-----------------------------------------------
+Runtime implementation of the ALPHA-ANSWER-STRUCTURE-V2-001 planning lane for
+this portable surface (lane: ALPHA-SOLVER-SUBSTANTIVE-LIFT-ANSWER-CONTRACT-001).
+
+Purpose: on substantive tasks the SOLUTION itself must contain Alpha-specific
+reasoning moves, not just envelope scaffolding. Envelope structure alone is
+not lift; these moves are what the answer must DO.
+
+Applies when the task is high-headroom: choosing between options; an
+architecture, design, or tooling decision; root-cause diagnosis; planning or
+prioritization under constraints; a strategy or approach question; or an
+ambiguous request where the real goal must be inferred before answering.
+
+Does NOT apply to low-headroom tasks (simple rewrites, formatting, direct
+extraction, short confirmations, reviewer-facing edits, one-step admin tasks,
+simple factual lookups). Precedence: the COMPACT-ENVELOPE EXCEPTION and
+low-headroom restraint rules override this contract; never force the lift
+block onto a task the restraint rules classify as low-headroom.
+
+On applicable tasks, the SOLUTION must OPEN with this compact lift block —
+six labeled lines, one line each, before any supporting detail:
+
+  Intent: <what the user is actually deciding beneath the literal question>
+  Assumes: <the strongest hidden assumption or missing constraint, made explicit>
+  Tradeoff: <the dominant tradeoff that controls this decision>
+  Recommendation: <one committed recommendation under the stated assumptions>
+  Fails if: <the concrete condition that would make the recommendation wrong>
+  Next: <one concrete action executable today, naming its object>
+
+Supporting analysis follows the block and must go deep on the controlling
+constraint rather than shallowly enumerating every consideration.
+
+ANTI-GENERIC RULES (apply to the whole SOLUTION on applicable tasks):
+1. Commit: exactly one primary recommendation. Rank alternatives against it
+   in SHORTLIST instead of presenting an unranked menu inside SOLUTION.
+2. No hedge phrasing: never write "it depends", "there are several factors",
+   "both options have pros and cons", "no one-size-fits-all", "the choice is
+   yours", or equivalents. State the controlling condition instead: "Under
+   <assumption>, do <X>."
+3. Caveats must name triggers: every caveat states the condition that
+   activates it ("Fails if p95 latency exceeds 400ms", never "there are risks").
+4. Executable next action: "Next:" names a specific object and is doable
+   within one day; "consider evaluating options" is non-compliant.
+5. Depth over coverage: analyze the one constraint that controls the outcome
+   instead of touching every dimension superficially.
+
+If you produce a SOLUTION for an applicable task without the lift block, or
+with hedge phrasing in place of a commitment, you have FAILED the protocol.
+
+Boundary: this contract constrains SOLUTION wording on this portable surface
+only. It does not change providers, models, routing, SAFE-OUT, the
+SolverEnvelope shape, or /v1/solve, and it makes no benchmark, readiness,
+production, or superiority claims.
 """
 
 from __future__ import annotations
@@ -114,6 +169,7 @@ import argparse
 import json
 import os
 import random
+import re
 import time
 from dataclasses import dataclass, field, asdict
 from datetime import datetime, timezone
@@ -159,7 +215,13 @@ Tree-of-Thought execution guidance for LLMs:
 """
 
 ENVELOPE_OUTPUT_EXAMPLE: str = """
-solution: Provide a concise comparison of carbon taxes vs cap-and-trade with pros/cons and real-world examples.
+solution: |
+  Intent: Choose a carbon-pricing instrument for a specific jurisdiction and audience.
+  Assumes: Policymaker audience; jurisdiction not yet specified.
+  Tradeoff: Price certainty (tax) versus emissions-quantity certainty (cap-and-trade).
+  Recommendation: Under an administrative-simplicity constraint, favor a carbon tax with border adjustments.
+  Fails if: Political durability is the binding constraint; allowance markets survive repeal pressure better.
+  Next: Confirm the target jurisdiction so revenue-recycling options can be compared concretely.
 confidence: 72%
 route: SAFE-OUT (applied CoT fallback)
 shortlist: [
@@ -322,6 +384,179 @@ def minimal_behavior_contract_summary() -> str:
     return "\n".join(lines)
 
 
+# ---------------------------------------------------------------------------
+# Substantive lift contract (ANSWER-STRUCTURE-V2 runtime for this surface)
+# ---------------------------------------------------------------------------
+SUBSTANTIVE_LIFT_LANE = "ALPHA-SOLVER-SUBSTANTIVE-LIFT-ANSWER-CONTRACT-001"
+
+# Ordered lift moves: (line label, what the line must contain). On applicable
+# high-headroom tasks the SOLUTION must open with these six lines in order.
+SUBSTANTIVE_LIFT_MOVES: Tuple[Tuple[str, str], ...] = (
+    ("Intent:", "what the user is actually deciding beneath the literal question"),
+    ("Assumes:", "the strongest hidden assumption or missing constraint, made explicit"),
+    ("Tradeoff:", "the dominant tradeoff that controls this decision"),
+    ("Recommendation:", "one committed recommendation under the stated assumptions"),
+    ("Fails if:", "the concrete condition that would make the recommendation wrong"),
+    ("Next:", "one concrete action executable today, naming its object"),
+)
+
+SUBSTANTIVE_LIFT_TRIGGERS: Tuple[str, ...] = (
+    "choosing between options",
+    "architecture, design, or tooling decision",
+    "root-cause diagnosis",
+    "planning or prioritization under constraints",
+    "strategy or approach question",
+    "ambiguous request where the real goal must be inferred",
+)
+
+# Low-headroom task families where the lift block must NOT be forced; the
+# COMPACT-ENVELOPE EXCEPTION and low-headroom restraint rules take precedence.
+SUBSTANTIVE_LIFT_EXEMPT: Tuple[str, ...] = (
+    "simple rewrites",
+    "formatting",
+    "direct extraction",
+    "short confirmations",
+    "reviewer-facing edits",
+    "one-step admin tasks",
+    "simple factual lookups",
+)
+
+# Hedge phrasings that mark a generic non-committal answer. Matched with word
+# boundaries, case-insensitively, after apostrophe normalization.
+GENERIC_HEDGE_PATTERNS: Tuple[str, ...] = (
+    r"\bit depends\b",
+    r"\bthere are (?:several|many|various) factors\b",
+    r"\bboth (?:options|approaches|choices) have (?:pros and cons|merit|merits)\b",
+    r"\bpros and cons of each\b",
+    r"\bno one-size-fits-all\b",
+    r"\bthe choice is yours\b",
+    r"\bit is up to you\b",
+    r"\bit's up to you\b",
+    r"\bultimately,? (?:the|your) (?:choice|decision)\b",
+)
+
+# A "Next:" line that starts with one of these verbs is deliberation, not an
+# executable action, and fails anti-generic rule 4.
+WEAK_NEXT_ACTION_OPENERS: Tuple[str, ...] = (
+    "consider",
+    "explore",
+    "think about",
+    "look into",
+    "reflect on",
+    "evaluate your options",
+    "weigh",
+)
+
+SUBSTANTIVE_LIFT_ANTI_GENERIC_RULES: Tuple[str, ...] = (
+    "Commit: exactly one primary recommendation; rank alternatives against it "
+    "in SHORTLIST instead of presenting an unranked menu inside SOLUTION.",
+    "No hedge phrasing: state the controlling condition ('Under <assumption>, "
+    "do <X>') instead of 'it depends' or equivalents.",
+    "Caveats must name triggers: every caveat states the condition that "
+    "activates it, never a vague 'there are risks'.",
+    "Executable next action: 'Next:' names a specific object and is doable "
+    "within one day.",
+    "Depth over coverage: analyze the one constraint that controls the outcome "
+    "instead of touching every dimension superficially.",
+)
+
+
+def substantive_lift_contract_summary() -> str:
+    """Return the portable prompt/protocol wording for the substantive lift contract.
+
+    Like :func:`minimal_behavior_contract_summary`, this exposes the active
+    contract for offline tests and prompt-loading workflows. It constrains
+    SOLUTION wording on this portable surface only; it does not alter provider,
+    model, routing, SAFE-OUT, envelope-shape, or /v1/solve behavior, and it
+    makes no benchmark, readiness, production, or superiority claims.
+    """
+
+    lines = [
+        f"Substantive lift contract ({SUBSTANTIVE_LIFT_LANE}):",
+        "Boundary: SOLUTION wording requirements only; does not alter provider, "
+        "model, routing, SAFE-OUT, envelope shape, or /v1/solve behavior.",
+        "Applies to high-headroom tasks:",
+    ]
+    lines.extend(f"  - {trigger}" for trigger in SUBSTANTIVE_LIFT_TRIGGERS)
+    lines.append(
+        "Does not apply to low-headroom tasks (restraint rules take precedence):"
+    )
+    lines.extend(f"  - {exempt}" for exempt in SUBSTANTIVE_LIFT_EXEMPT)
+    lines.append("SOLUTION must open with the lift block, in order:")
+    lines.extend(
+        f"  - {label} {requirement}" for label, requirement in SUBSTANTIVE_LIFT_MOVES
+    )
+    lines.append("Anti-generic rules:")
+    lines.extend(f"  - {rule}" for rule in SUBSTANTIVE_LIFT_ANTI_GENERIC_RULES)
+    return "\n".join(lines)
+
+
+def check_substantive_lift(solution_text: str) -> Dict[str, Any]:
+    """Deterministically check a SOLUTION's wording against the lift contract.
+
+    This is a structural wording check only: it verifies the six-move lift
+    block and the anti-generic wording rules. It cannot judge whether the
+    content is true or useful, and a passing result makes no quality,
+    benchmark, readiness, or superiority claim.
+    """
+
+    normalized = solution_text.replace("’", "'")
+    lines = [line.strip() for line in normalized.splitlines() if line.strip()]
+    labels = [label for label, _ in SUBSTANTIVE_LIFT_MOVES]
+
+    found: Dict[str, str] = {}
+    positions: Dict[str, int] = {}
+    for index, line in enumerate(lines):
+        for label in labels:
+            if label not in found and line.lower().startswith(label.lower()):
+                found[label] = line[len(label):].strip()
+                positions[label] = index
+
+    missing_moves = [label for label in labels if label not in found]
+    empty_moves = [
+        label for label in labels if label in found and len(found[label]) < 8
+    ]
+    order_ok = not missing_moves and [
+        positions[label] for label in labels
+    ] == sorted(positions[label] for label in labels)
+    opens_with_intent = bool(lines) and lines[0].lower().startswith("intent:")
+
+    lowered = normalized.lower()
+    generic_flags = [
+        pattern
+        for pattern in GENERIC_HEDGE_PATTERNS
+        if re.search(pattern, lowered)
+    ]
+
+    weak_next_action = False
+    next_content = found.get("Next:", "").lower()
+    if next_content:
+        weak_next_action = any(
+            next_content.startswith(opener) for opener in WEAK_NEXT_ACTION_OPENERS
+        )
+
+    has_lift_block = not missing_moves
+    ok = (
+        has_lift_block
+        and not empty_moves
+        and order_ok
+        and opens_with_intent
+        and not generic_flags
+        and not weak_next_action
+    )
+    return {
+        "ok": ok,
+        "has_lift_block": has_lift_block,
+        "missing_moves": missing_moves,
+        "empty_moves": empty_moves,
+        "order_ok": order_ok,
+        "opens_with_intent": opens_with_intent,
+        "generic_flags": generic_flags,
+        "weak_next_action": weak_next_action,
+        "lane": SUBSTANTIVE_LIFT_LANE,
+    }
+
+
 EXPERT_SELECTION_TEMPLATE: str = """
 Expert Selection Protocol:
 1. CLASSIFY the query into 1-3 primary domains
@@ -349,15 +584,37 @@ COMPLIANCE_EXAMPLES: Dict[str, str] = {
 
 Why it fails: No envelope structure, no confidence, no experts, no pipeline confirmation.
 """,
+    "NON_COMPLIANT_GENERIC": """
+❌ WRONG - envelope labels present, but the SOLUTION is generic:
+
+SOLUTION:
+It depends on your requirements. Microservices offer better scalability
+while monoliths are simpler. Option 1: stay on the monolith. Option 2:
+migrate to microservices. Consider evaluating your team's needs, budget,
+and timeline. Ultimately, the choice is yours.
+
+Why it fails the substantive lift contract: hedge opener, unranked option
+menu inside SOLUTION, no committed recommendation, no named failure
+condition, no executable next action. The envelope alone is not lift.
+""",
     "COMPLIANT": """
-✅ CORRECT - This follows the protocol:
+✅ CORRECT - This follows the protocol (high-headroom task, lift block first):
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 SOLVER ENVELOPE
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 SOLUTION:
-[Concise answer here]
+Intent: Decide whether to split the monolith now or defer until scale demands it.
+Assumes: One team of ~8 engineers and no measured scaling bottleneck today.
+Tradeoff: Operational overhead now versus refactoring cost after growth.
+Recommendation: Stay on the monolith; extract only the billing module, which ships on a different release cadence.
+Fails if: Deploy frequency is already blocked by merge contention across teams.
+Next: Pull deploy-queue wait times for the last 30 days and check for contention before any split decision.
+
+Supporting detail: the controlling constraint is team size, not traffic;
+a service split below ~3 teams adds coordination cost without removing
+any measured bottleneck.
 
 CONFIDENCE: 85%
 

--- a/tests/fixtures/alpha_substantive_lift_cases.json
+++ b/tests/fixtures/alpha_substantive_lift_cases.json
@@ -1,0 +1,42 @@
+{
+  "lane": "ALPHA-SOLVER-SUBSTANTIVE-LIFT-ANSWER-CONTRACT-001",
+  "description": "Synthetic fixture cases for the substantive lift answer contract. All prompts and answers are invented operator-authored examples for structural wording checks only; none are provider or model outputs, and none carry quality, benchmark, readiness, or superiority claims.",
+  "cases": [
+    {
+      "case_id": "LIFT-DECISION-001",
+      "task_family": "choosing between options",
+      "lift_required": true,
+      "prompt": "We're a 12-person startup heading into a Series B. Should we migrate our monolith to microservices before the raise, or after?",
+      "compliant_solution": "Intent: Decide whether an architecture migration belongs before or after the Series B raise.\nAssumes: The monolith is not currently failing under load and diligence is 4-6 months away.\nTradeoff: Engineering capacity spent on migration now versus feature velocity and diligence-ready metrics for the raise.\nRecommendation: Defer the migration until after the raise; carve out only the one module with a measured scaling problem, if any.\nFails if: A signed enterprise deal already requires isolation or compliance boundaries the monolith cannot provide.\nNext: List the three slowest endpoints from last month's traces and check whether any is a genuine architectural limit rather than a query or cache fix.\n\nSupporting detail: with 12 engineers, the controlling constraint is capacity, not architecture. A migration consumes roughly a quarter of team throughput for two quarters, which lands exactly in the diligence window when growth metrics matter most.",
+      "non_compliant_solution": "It depends on your specific situation. There are several factors to consider, including team size, timeline, and technical debt. Microservices offer better scalability and independent deployments, while monoliths are simpler to operate. Option 1: migrate now to get ahead of scale. Option 2: wait until after the raise. Both options have pros and cons, so you should weigh them carefully against your goals. Ultimately, the choice is yours.",
+      "non_compliant_reason": "hedge opener, unranked option menu, no committed recommendation, no failure condition, no executable next action"
+    },
+    {
+      "case_id": "LIFT-DIAGNOSIS-001",
+      "task_family": "root-cause diagnosis",
+      "lift_required": true,
+      "prompt": "Our p95 latency doubled right after we added a Redis cache in front of the primary database. What is going on?",
+      "compliant_solution": "Intent: Find why adding a cache made tail latency worse instead of better.\nAssumes: The doubling is measured at the same traffic level and the cache sits in the synchronous request path.\nTradeoff: Keeping the cache warm for hit-rate versus adding a serial network hop that every miss now pays twice.\nRecommendation: Instrument hit-rate first; a cold or low-hit cache turns every miss into cache-check plus database read, which alone explains a doubled p95.\nFails if: Hit-rate is above ~90 percent, in which case look at connection-pool exhaustion or synchronous cache writes on the hot path instead.\nNext: Log cache hit/miss per request for one hour and split p95 by hit versus miss before touching any configuration.\n\nSupporting detail: the controlling variable is the miss path, not Redis speed. A serial miss path costs cache RTT plus database RTT plus serialization; under 50 percent hit-rate that is strictly worse than no cache at the tail.",
+      "non_compliant_solution": "There are many factors that could cause increased latency after adding a cache. Caching is complex and performance can vary. You might have cache misses, network issues, serialization overhead, or configuration problems. Consider reviewing your cache configuration, monitoring your metrics, and evaluating whether Redis is set up correctly. It may also be worth exploring alternative caching strategies.",
+      "non_compliant_reason": "hedge phrasing, shallow enumeration with no controlling constraint, no committed diagnosis, deliberative next steps only"
+    },
+    {
+      "case_id": "LIFT-PLAN-001",
+      "task_family": "planning or prioritization under constraints",
+      "lift_required": true,
+      "prompt": "We have 2 engineers and 6 weeks to deliver SSO, audit logging, and RBAC for an enterprise deal. How should we sequence this?",
+      "compliant_solution": "Intent: Sequence three security features so the deal closes with two engineers in six weeks.\nAssumes: The buyer's security review gates the signature and accepts a documented roadmap for items in progress.\nTradeoff: Building all three shallowly versus landing the one contractual blocker completely and negotiating the rest.\nRecommendation: Ship SSO via an identity library in weeks 1-3, structured audit logging in weeks 3-5, and deliver coarse two-role RBAC plus a dated roadmap for fine-grained roles.\nFails if: The contract names fine-grained RBAC as an acceptance criterion rather than a roadmap item.\nNext: Ask the buyer's security contact today which of the three items are contractual blockers versus review checkboxes.\n\nSupporting detail: the controlling constraint is the security review, not engineering scope. SSO is usually the only hard gate; audit logging is a schema-plus-middleware task; RBAC granularity is the piece most often negotiable to a roadmap.",
+      "non_compliant_solution": "This is a challenging timeline, and there is no one-size-fits-all approach to sequencing security features. All three features are important for enterprise readiness. You could start with SSO since many enterprises require it, or begin with RBAC as a foundation. Audit logging is also valuable. Consider breaking each feature into smaller milestones and evaluating your options each week. Both parallel and serial approaches have merit.",
+      "non_compliant_reason": "no committed sequence, unranked alternatives, no failure condition, deliberative guidance instead of an executable next action"
+    },
+    {
+      "case_id": "LOW-HEADROOM-REWRITE-001",
+      "task_family": "simple rewrites",
+      "lift_required": false,
+      "prompt": "Rewrite this sentence to be shorter: 'We are currently in the process of conducting an evaluation of the proposal.'",
+      "compliant_solution": "We are evaluating the proposal.",
+      "non_compliant_solution": "Intent: Shorten a sentence while preserving meaning.\nAssumes: Formal register should be kept.\nTradeoff: Brevity versus completeness.\nRecommendation: Use 'We are evaluating the proposal.'\nFails if: The original legal phrasing was required verbatim.\nNext: Replace the sentence in the source document.\n\nWe are evaluating the proposal.",
+      "non_compliant_reason": "lift block forced onto a low-headroom task; restraint rules take precedence and require the direct rewrite first with no scaffolding"
+    }
+  ]
+}

--- a/tests/test_alpha_substantive_lift_contract.py
+++ b/tests/test_alpha_substantive_lift_contract.py
@@ -1,0 +1,208 @@
+"""Offline structural tests for the substantive lift answer contract.
+
+These checks validate the portable-surface contract text, its machine-readable
+constants, the deterministic wording checker, and committed fixture examples.
+They do not call providers or models, do not execute /v1/solve, and do not
+score, rank, or compare outputs; a passing run makes no quality, benchmark,
+readiness, or superiority claim.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import alpha_solver_portable as portable
+
+FIXTURE = Path("tests/fixtures/alpha_substantive_lift_cases.json")
+PORTABLE_CONTRACT = Path("alpha_solver_portable.py")
+SPEC = Path(".specs/ALPHA-SOLVER-SUBSTANTIVE-LIFT-ANSWER-CONTRACT-001.md")
+
+EXPECTED_LABELS = [
+    "Intent:",
+    "Assumes:",
+    "Tradeoff:",
+    "Recommendation:",
+    "Fails if:",
+    "Next:",
+]
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _normalize(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip().lower()
+
+
+def _cases() -> list[dict]:
+    return json.loads(_read(FIXTURE))["cases"]
+
+
+class TestContractText:
+    def test_portable_docstring_contains_lift_contract_section(self):
+        text = _read(PORTABLE_CONTRACT)
+        assert "SUBSTANTIVE LIFT CONTRACT (HIGH-HEADROOM TASKS)" in text
+        assert "ALPHA-SOLVER-SUBSTANTIVE-LIFT-ANSWER-CONTRACT-001" in text
+        assert "ANTI-GENERIC RULES" in text
+        for label in EXPECTED_LABELS:
+            assert label in text
+
+    def test_lift_section_comes_after_restraint_contract(self):
+        text = _read(PORTABLE_CONTRACT)
+        assert text.index("MINIMAL ALPHA BEHAVIOR CONTRACT") < text.index(
+            "SUBSTANTIVE LIFT CONTRACT (HIGH-HEADROOM TASKS)"
+        )
+
+    def test_low_headroom_precedence_is_explicit(self):
+        normalized = _normalize(_read(PORTABLE_CONTRACT))
+        assert (
+            "the compact-envelope exception and low-headroom restraint rules "
+            "override this contract" in normalized
+        )
+        assert "never force the lift block" in normalized
+
+    def test_contract_states_wording_only_boundary(self):
+        normalized = _normalize(_read(PORTABLE_CONTRACT))
+        assert (
+            "this contract constrains solution wording on this portable surface "
+            "only" in normalized
+        )
+        assert (
+            "makes no benchmark, readiness, production, or superiority claims"
+            in normalized
+        )
+
+
+class TestContractConstants:
+    def test_moves_match_documented_labels_in_order(self):
+        assert [label for label, _ in portable.SUBSTANTIVE_LIFT_MOVES] == (
+            EXPECTED_LABELS
+        )
+        for _, requirement in portable.SUBSTANTIVE_LIFT_MOVES:
+            assert requirement.strip()
+
+    def test_triggers_and_exemptions_are_disjoint_and_nonempty(self):
+        triggers = set(portable.SUBSTANTIVE_LIFT_TRIGGERS)
+        exempt = set(portable.SUBSTANTIVE_LIFT_EXEMPT)
+        assert triggers and exempt
+        assert not triggers & exempt
+
+    def test_summary_contains_moves_rules_and_boundary(self):
+        summary = portable.substantive_lift_contract_summary()
+        assert portable.SUBSTANTIVE_LIFT_LANE in summary
+        for label in EXPECTED_LABELS:
+            assert label in summary
+        for rule in portable.SUBSTANTIVE_LIFT_ANTI_GENERIC_RULES:
+            assert rule in summary
+        assert "SOLUTION wording requirements only" in summary
+
+
+class TestChecker:
+    def test_compliant_fixture_solutions_pass(self):
+        for case in _cases():
+            if not case["lift_required"]:
+                continue
+            result = portable.check_substantive_lift(case["compliant_solution"])
+            assert result["ok"], (case["case_id"], result)
+            assert result["has_lift_block"]
+            assert result["opens_with_intent"]
+            assert result["order_ok"]
+            assert result["generic_flags"] == []
+
+    def test_non_compliant_fixture_solutions_fail(self):
+        for case in _cases():
+            if not case["lift_required"]:
+                continue
+            result = portable.check_substantive_lift(case["non_compliant_solution"])
+            assert not result["ok"], (case["case_id"], result)
+            assert result["missing_moves"], case["case_id"]
+
+    def test_hedge_phrasing_is_flagged_even_with_lift_block(self):
+        text = (
+            "Intent: Decide between two databases for the new service.\n"
+            "Assumes: Read-heavy workload with modest write volume.\n"
+            "Tradeoff: Operational familiarity versus horizontal scale.\n"
+            "Recommendation: It depends on your team, but Postgres is common.\n"
+            "Fails if: Write volume exceeds a single primary's capacity.\n"
+            "Next: Load-test the top three queries against Postgres today.\n"
+        )
+        result = portable.check_substantive_lift(text)
+        assert not result["ok"]
+        assert result["generic_flags"]
+
+    def test_word_boundary_prevents_audit_depends_false_positive(self):
+        text = (
+            "Intent: Decide whether the audit depends on external counsel.\n"
+            "Assumes: The audit scope is already fixed by the contract.\n"
+            "Tradeoff: Internal speed versus external defensibility.\n"
+            "Recommendation: Run the audit internally with counsel reviewing only findings.\n"
+            "Fails if: The contract requires an independent third-party attestation.\n"
+            "Next: Read the audit clause in the signed contract this morning.\n"
+        )
+        result = portable.check_substantive_lift(text)
+        assert result["ok"], result
+
+    def test_weak_next_action_is_flagged(self):
+        text = (
+            "Intent: Choose a queue technology for background jobs.\n"
+            "Assumes: Throughput stays under 1k messages per second.\n"
+            "Tradeoff: Operational simplicity versus delivery guarantees.\n"
+            "Recommendation: Use the managed queue already in the platform account.\n"
+            "Fails if: Jobs require strict ordering across partitions.\n"
+            "Next: Consider evaluating several queue options with the team.\n"
+        )
+        result = portable.check_substantive_lift(text)
+        assert not result["ok"]
+        assert result["weak_next_action"]
+
+    def test_out_of_order_block_is_rejected(self):
+        text = (
+            "Recommendation: Ship the migration behind a feature flag.\n"
+            "Intent: Decide how to roll out the schema change safely.\n"
+            "Assumes: The table has under ten million rows.\n"
+            "Tradeoff: Rollout speed versus rollback safety.\n"
+            "Fails if: The migration locks the table longer than five seconds.\n"
+            "Next: Measure the migration lock time against a production-size copy.\n"
+        )
+        result = portable.check_substantive_lift(text)
+        assert not result["ok"]
+        assert not result["opens_with_intent"]
+        assert not result["order_ok"]
+
+    def test_low_headroom_answer_correctly_has_no_lift_block(self):
+        low = [case for case in _cases() if not case["lift_required"]]
+        assert low, "fixture must include a low-headroom precedence case"
+        for case in low:
+            result = portable.check_substantive_lift(case["compliant_solution"])
+            assert not result["has_lift_block"]
+
+
+class TestFixtureShape:
+    def test_at_least_three_realistic_substantive_prompts(self):
+        substantive = [case for case in _cases() if case["lift_required"]]
+        assert len(substantive) >= 3
+        for case in substantive:
+            assert len(case["prompt"]) > 40
+            assert case["non_compliant_reason"].strip()
+
+    def test_compliance_example_solution_passes_checker(self):
+        example = portable.COMPLIANCE_EXAMPLES["COMPLIANT"]
+        start = example.index("SOLUTION:") + len("SOLUTION:")
+        end = example.index("CONFIDENCE:")
+        result = portable.check_substantive_lift(example[start:end])
+        assert result["ok"], result
+
+    def test_generic_compliance_example_fails_checker(self):
+        example = portable.COMPLIANCE_EXAMPLES["NON_COMPLIANT_GENERIC"]
+        start = example.index("SOLUTION:") + len("SOLUTION:")
+        end = example.index("Why it fails")
+        result = portable.check_substantive_lift(example[start:end])
+        assert not result["ok"]
+        assert result["generic_flags"]
+
+    def test_spec_exists_and_names_planning_predecessor(self):
+        text = _read(SPEC)
+        assert "ALPHA-ANSWER-STRUCTURE-V2-001" in text
+        assert "ALPHA-SOLVER-SUBSTANTIVE-LIFT-ANSWER-CONTRACT-001" in text


### PR DESCRIPTION
## Checklist

- [x] Spec linked: `.specs/ALPHA-SOLVER-SUBSTANTIVE-LIFT-ANSWER-CONTRACT-001.md`
- [x] Spec sections present/updated (Goal / Motivation / Acceptance Criteria / Definition of Done / Code Targets / Test Plan)
- [x] Tests run: `python -m pytest -q` (exit code 0; 3 environment-gated skips — see validation below)

## Notes for reviewers

### Selected target and lane ID

`ALPHA-SOLVER-SUBSTANTIVE-LIFT-ANSWER-CONTRACT-001` — implement the runtime half of the `ALPHA-ANSWER-STRUCTURE-V2-001` planning lane on the portable prompt surface: a Substantive Lift Contract that forces high-headroom SOLUTIONs to contain Alpha-specific reasoning moves, structurally enforced by a deterministic checker and fixture-backed tests.

### Wargame summary: why Alpha does not feel smarter yet

1. The local deterministic runtime cannot generate content. `alpha/reasoning/tot.py` produces template-wrapped prompt echoes (`"Edge cases: Rephrase: <query>"`); `_replace_echo_answer` in `alpha/solver/observability.py` patches exact echoes with four hardcoded fixture answers or a SAFE-OUT string. No model calls are permitted, so this path cannot be made smarter honestly.
2. The answer path operators actually use is `alpha_solver_portable.py`, loaded as a system prompt into a web LLM chat. Its contract had envelope scaffolding plus `MINIMAL_BEHAVIOR_CONTRACT` — ten restraint rules (brevity, format fit, claim safety) and zero rules forcing sharper content. Scaffolding makes output look different; nothing made the SOLUTION better than a plain model answer.
3. The repo's own committed pilot planning evidence (`.specs/ALPHA-ANSWER-STRUCTURE-V2-001.md`) records that Alpha's Batch B limited-pilot lift clustered in substantive behavior (+21 lift cluster: constraints, risk, evidence, comparative judgment) while brevity lost (−10) — and the spec that would encode those lift moves was stamped "planning only, no runtime implementation." The lift behaviors were identified and never wired into the answer contract. This PR wires them in.

### Candidates considered and why this won

- **Answer Quality Synthesis Layer / Alpha Mode Response Contract (selected, merged):** smallest change that alters what every future Alpha answer must contain, on the surface operators actually load, enforceable with the repo's existing contract-testing conventions.
- **Expert/persona activation fix:** portable experts are display-only (`ExpertTeam.to_display`) one-liners; making them heavier adds scaffolding — the exact thing Batch B penalized — without a content source.
- **Draft-critique-upgrade pass:** its critique criteria (genericness, missing constraints, weak next actions, false certainty) are folded into this contract's anti-generic rules, enforced in one pass; multi-pass narration is already banned by the restraint rules.
- **Operator-visible demo harness:** more infrastructure; unnecessary because the portable path is a live answer surface.
- **Fix local ToT echo answers:** impossible honestly without a model (forbidden); expanding the canned-answer library would fake intelligence. Rejected.

### Exact changed files

- `alpha_solver_portable.py` — new `SUBSTANTIVE LIFT CONTRACT (HIGH-HEADROOM TASKS)` docstring section (six-move lift block, applicability triggers, low-headroom exemptions with explicit restraint precedence, five anti-generic rules, wording-only boundary); machine-readable constants (`SUBSTANTIVE_LIFT_MOVES`, `SUBSTANTIVE_LIFT_TRIGGERS`, `SUBSTANTIVE_LIFT_EXEMPT`, `GENERIC_HEDGE_PATTERNS`, `WEAK_NEXT_ACTION_OPENERS`, `SUBSTANTIVE_LIFT_ANTI_GENERIC_RULES`); `substantive_lift_contract_summary()`; deterministic `check_substantive_lift()`; upgraded `COMPLIANCE_EXAMPLES` (lift-block COMPLIANT example + new `NON_COMPLIANT_GENERIC` example) and lift-form `ENVELOPE_OUTPUT_EXAMPLE`
- `tests/fixtures/alpha_substantive_lift_cases.json` — 3 realistic substantive prompts (Series B monolith-vs-microservices decision; p95-latency-doubled-after-Redis diagnosis; 2-engineers/6-weeks SSO+audit+RBAC plan), each with compliant and non-compliant answers, plus 1 low-headroom rewrite case proving restraint precedence
- `tests/test_alpha_substantive_lift_contract.py` — 18 tests enforcing the contract structurally
- `.specs/ALPHA-SOLVER-SUBSTANTIVE-LIFT-ANSWER-CONTRACT-001.md` — lane spec

### Validation commands and results

- `python -m pytest tests/test_alpha_substantive_lift_contract.py -q` → exit 0 (18 tests)
- `python -m pytest tests/test_alpha_minimal_behavior_contract.py tests/test_local_llm_contract_consumption_proof.py tests/test_local_llm_provider_adapter.py -q` → exit 0 each (all existing portable-contract invariants preserved, including the STRICT/COMPACT/MINIMAL docstring section slicing)
- `python -m pytest -q` (full suite) → exit code 0; 3 environment-gated skips (live-OpenAI smoke stayed skipped — no provider calls ran; decks web adapter; packaging build). Known repo quirk: a test redirects stdout so pytest's final count line is truncated in logs; exit code is authoritative.
- `python scripts/check_narrative_claim_safety.py .specs/ALPHA-SOLVER-SUBSTANTIVE-LIFT-ANSWER-CONTRACT-001.md` → passed
- `ruff check alpha_solver_portable.py tests/test_alpha_substantive_lift_contract.py` → all checks passed
- Checker demo: a generic "It depends… both options have pros and cons…" answer fails with 6 missing moves and 2 hedge flags; a six-move lift answer passes.

### How this improves operator-visible answer quality

On any substantive task (decision, design, diagnosis, plan, strategy, ambiguous ask), an Alpha answer must now **open** with six compact labeled lines — `Intent:` (what the user is actually deciding), `Assumes:` (the strongest hidden assumption made explicit), `Tradeoff:` (the dominant tradeoff), `Recommendation:` (one committed recommendation, not a menu), `Fails if:` (the condition that would make it wrong), `Next:` (one action executable today) — followed by depth on the controlling constraint. Hedge phrasing ("it depends", "pros and cons of each", "the choice is yours") and deliberative next actions ("consider evaluating options") are protocol failures. An operator can put a routed answer next to a plain answer and point at the difference: committed recommendation with a named failure condition and a same-day action, versus a balanced essay. Low-headroom tasks are explicitly exempt, preserving the brevity/format-fit gains the restraint contract already won.

### What remains unsolved

- The local deterministic ToT path still cannot generate substantive content — it needs a model, which stays out of bounds; its echo-replacement band-aid is untouched.
- Whether this contract measurably lifts blind scores is a separate future evaluation lane (capture via the merged operator run capture harness, then blind scoring).
- The `/v1/solve` provider path and routing behavior are untouched by design.

### Explicit non-claims

This PR makes no readiness, benchmark-success, production/public-readiness, provider-validation, or local-model-validation claims, and it is not proof of Alpha superiority. A passing `check_substantive_lift` result means only that the configured wording structure held for the given text — it is not a quality or correctness judgment.

---
_Generated by [Claude Code](https://claude.ai/code/session_011DUh9bRenAef39bB2ijThb)_