### PR TITLE
tot: bound non-substantive local template outputs

### DIFF
--- a/.specs/ALPHA-SOLVER-TOT-ECHO-HONESTY-HOTFIX-001.md
+++ b/.specs/ALPHA-SOLVER-TOT-ECHO-HONESTY-HOTFIX-001.md
@@ -1,0 +1,92 @@
+# ALPHA-SOLVER-TOT-ECHO-HONESTY-HOTFIX-001 · Local ToT Echo/Template Honesty Hotfix
+
+Status: Implemented
+
+Answer-integrity lane: make local deterministic output honest, not smarter.
+
+## Goal
+
+Prevent the local deterministic Alpha Solver paths from returning
+non-substantive artifacts — exact/normalized prompt echo, ToT
+template-prefixed strings (`Rephrase:`, `Decompose:`, `Edge cases:`,
+`Counterpoints:`, `Summarize:`), and CoT fallback wrappers around the prompt —
+as if they were real answers. When the local path cannot synthesize, it must
+return a bounded SAFE-OUT-style response with diagnostics explaining why.
+
+## Motivation (repo evidence)
+
+- `alpha/reasoning/tot.py` `TEMPLATE_FUNCS` builds branch contents by
+  prefixing the prompt; the best node's content is returned as `answer`.
+- The previous guard in `alpha/solver/observability.py` caught only exact
+  normalized prompt echo. Live leak paths on current main:
+  - SAFE-OUT CoT fallback shipped `To proceed, consider: <query>`
+    (`alpha/reasoning/cot.py`) as `final_answer` whenever ToT confidence fell
+    below the threshold, while `solution` carried the raw prompt echo.
+  - ToT cache hits returned arbitrary stored `answer` text with no honesty
+    check, so stale/poisoned caches could surface `Rephrase: <query>`.
+  - No code anywhere checked the five template prefixes in a final answer.
+
+## Scope
+
+- `alpha/solver/observability.py`: broaden the exact-echo guard into
+  `_enforce_local_output_honesty` with an explicit artifact classifier
+  (`_classify_local_artifact`: `prompt_echo` / `template_branch` /
+  `cot_template`; no fuzzy heuristics). Supported fixture derivations are
+  preserved; unsupported artifacts become bounded SAFE-OUT text. Diagnostics
+  record `echo_detected`, `template_branch_detected`, `answer_kind`,
+  `synthesis_available`, `raw_echo_answer` / `raw_template_answer`, and
+  stable `reason` / evidence labels.
+- `alpha/reasoning/tot.py`: mark deterministic search output as
+  non-synthesized at the source (`answer_kind` = `prompt_echo` /
+  `template_branch` / `cached_search_artifact`; `synthesis_available: False`).
+  Additive metadata only; search behavior unchanged.
+- `alpha_solver_portable.py`: light standalone mirror
+  (`portable_local_output_honesty`, `PORTABLE_LOCAL_ARTIFACT_PREFIXES`,
+  `PORTABLE_LOCAL_UNSUPPORTED_SAFEOUT`) applied to the portable local
+  deterministic path only. No repo imports; the PR #646 Substantive Lift
+  Contract text and `check_substantive_lift` semantics are untouched.
+
+## Non-goals
+
+- Does not make local ToT smarter; local deterministic synthesis remains
+  unavailable without a model, and that boundary is now stated in output.
+- No provider, hosted-model, or local-model calls; no network calls.
+- No route/persona activation, no scoring, ranking, blinding, or unblinding.
+- No new canned answers: the four existing supported fixture derivations are
+  preserved exactly and none are added.
+- No `/v1/solve`, dashboard, or API exposure changes.
+- No benchmark, readiness, production, provider-validation,
+  local-model-validation, or Alpha-superiority claims.
+
+## Code Targets
+
+- `alpha/solver/observability.py`
+- `alpha/reasoning/tot.py`
+- `alpha_solver_portable.py`
+- `tests/test_alpha_local_runtime_honesty.py`
+
+## Test Plan
+
+`tests/test_alpha_local_runtime_honesty.py` (failing before the patch,
+passing after): unsupported high-headroom prompts never echo and never start
+with blocked prefixes across default, CoT-fallback, and multi-branch configs;
+bounded SAFE-OUT text and diagnostics on replacement; the live CoT-fallback
+leak is bounded; poisoned-cache template answers are bounded; the four
+supported fixture prompts keep prior behavior; the guard injects no lift-block
+labels (low-headroom precedence intact); classifier unit coverage for single,
+chained, echo, and legitimate inputs; portable path artifact-free across
+seeds; portable helper standalone behavior.
+
+## Acceptance Criteria
+
+Covered 1:1 by the test plan above plus existing suites:
+`tests/test_alpha_no_echo_wiring.py`, `tests/test_alpha_substantive_lift_contract.py`,
+`tests/test_alpha_minimal_behavior_contract.py`, `tests/reasoning`,
+`tests/policy`, `tests/observability`, `tests/test_tot_determinism.py` all
+pass unchanged.
+
+## Definition of Done
+
+Guard, metadata, portable mirror, tests, and this spec merged; focused and
+full validation pass; all boundaries above hold. A passing run means only
+that the configured honesty rules held; it is not a quality judgment.

--- a/alpha/reasoning/tot.py
+++ b/alpha/reasoning/tot.py
@@ -296,6 +296,9 @@ class TreeOfThoughtSolver:
                     "config": self._config_dict(),
                     "reason": "ok",
                     "cache_hit": True,
+                    # Cached deterministic search output; never model synthesis.
+                    "answer_kind": "cached_search_artifact",
+                    "synthesis_available": False,
                 }
 
         root = Node(content=query, path=(query,), depth=0, id=self._next_id())
@@ -336,6 +339,10 @@ class TreeOfThoughtSolver:
             "config": self._config_dict(),
             "reason": reason,
             "cache_hit": False,
+            # Deterministic search output: the root is the prompt itself and
+            # children are TEMPLATE_FUNCS wrappers. Neither is synthesis.
+            "answer_kind": "prompt_echo" if best.depth == 0 else "template_branch",
+            "synthesis_available": False,
         }
 
         if cache is not None:

--- a/alpha/solver/observability.py
+++ b/alpha/solver/observability.py
@@ -26,6 +26,63 @@ def _is_prompt_echo(answer: object, query: str) -> bool:
     return _normalize_for_echo_detection(answer) == _normalize_for_echo_detection(query)
 
 
+# Deterministic branch-generator prefixes from alpha.reasoning.tot.TEMPLATE_FUNCS.
+# An answer starting with one of these is search scaffolding, never synthesis.
+TOT_TEMPLATE_PREFIXES = (
+    "rephrase:",
+    "decompose:",
+    "edge cases:",
+    "counterpoints:",
+    "summarize:",
+)
+
+# Deterministic CoT fallback wrappers from alpha.reasoning.cot / safe_out_sm.
+COT_FALLBACK_PREFIXES = (
+    "to proceed, consider:",
+    "to proceed, clarify:",
+)
+
+
+def _strip_artifact_prefixes(answer: str) -> tuple[str, bool]:
+    """Strip chained template/fallback prefixes; return (core, any_stripped)."""
+
+    core = answer.strip()
+    stripped_any = False
+    changed = True
+    while changed:
+        changed = False
+        lowered = core.lower()
+        for prefix in TOT_TEMPLATE_PREFIXES + COT_FALLBACK_PREFIXES:
+            if lowered.startswith(prefix):
+                core = core[len(prefix):].strip()
+                stripped_any = True
+                changed = True
+                break
+    return core, stripped_any
+
+
+def _classify_local_artifact(answer: object, query: str) -> str | None:
+    """Classify a local deterministic answer as a non-substantive artifact.
+
+    Returns "prompt_echo", "template_branch", "cot_template", or None for
+    text this explicit detector cannot call an artifact. Only known
+    deterministic wrappers are matched; no fuzzy heuristics.
+    """
+
+    if not isinstance(answer, str):
+        return None
+    if _is_prompt_echo(answer, query):
+        return "prompt_echo"
+    lowered = answer.strip().lower()
+    if any(lowered.startswith(prefix) for prefix in TOT_TEMPLATE_PREFIXES):
+        return "template_branch"
+    if any(lowered.startswith(prefix) for prefix in COT_FALLBACK_PREFIXES):
+        core, _ = _strip_artifact_prefixes(answer)
+        if _is_prompt_echo(core, query):
+            return "cot_template"
+    return None
+
+
 def _derive_supported_local_answer(query: str) -> str | None:
     """Return a bounded deterministic answer for supported echo fixtures only.
 
@@ -77,30 +134,79 @@ def _unsupported_echo_safeout() -> str:
     )
 
 
-def _replace_echo_answer(
+def _unsupported_template_safeout() -> str:
+    return (
+        "SAFE-OUT: The deterministic local path produced a non-substantive "
+        "template artifact instead of an answer, and local deterministic "
+        "synthesis is unavailable without a model for this request. "
+        "Please provide a supported fixture shape or run this prompt on a "
+        "model-backed surface."
+    )
+
+
+def _enforce_local_output_honesty(
     envelope: Dict[str, Any], tot_result: Dict[str, Any], query: str
 ) -> None:
-    if not _is_prompt_echo(envelope.get("final_answer"), query):
+    """Replace non-substantive local artifacts with bounded honest output.
+
+    Broadens the previous exact-echo guard: exact/normalized prompt echo,
+    ToT template-prefixed answers, and CoT fallback wrappers around the
+    prompt are never surfaced as final answers. Supported fixture
+    derivations are preserved; everything else gets a bounded SAFE-OUT with
+    diagnostics. This guard cannot make the local path smarter — it only
+    stops non-answers from masquerading as answers.
+    """
+
+    artifact_kind = _classify_local_artifact(envelope.get("final_answer"), query)
+    if artifact_kind is None:
         return
 
+    is_echo = artifact_kind == "prompt_echo"
+    raw_answer = envelope.get("final_answer", "")
     derived = _derive_supported_local_answer(query)
-    if derived is None:
-        derived = _unsupported_echo_safeout()
-        reason = "prompt_echo_replaced_with_unsupported_local_safeout"
-        note = "prompt echo replaced by unsupported-local SAFE-OUT clarification"
-        evidence_label = "prompt_echo_replaced_unsupported_local_safeout_no_provider"
+    if derived is not None:
+        if is_echo:
+            reason = "prompt_echo_replaced_with_local_derived_answer"
+            note = "prompt echo replaced by deterministic local answer"
+            evidence_label = "prompt_echo_replaced_local_no_provider"
+        else:
+            reason = "template_artifact_replaced_with_local_derived_answer"
+            note = "template artifact replaced by deterministic local answer"
+            evidence_label = "template_artifact_replaced_local_no_provider"
+        answer_kind = "derived_local_fixture"
     else:
-        reason = "prompt_echo_replaced_with_local_derived_answer"
-        note = "prompt echo replaced by deterministic local answer"
-        evidence_label = "prompt_echo_replaced_local_no_provider"
+        if is_echo:
+            derived = _unsupported_echo_safeout()
+            reason = "prompt_echo_replaced_with_unsupported_local_safeout"
+            note = "prompt echo replaced by unsupported-local SAFE-OUT clarification"
+            evidence_label = (
+                "prompt_echo_replaced_unsupported_local_safeout_no_provider"
+            )
+        else:
+            derived = _unsupported_template_safeout()
+            reason = "template_artifact_replaced_with_unsupported_local_safeout"
+            note = (
+                "template artifact replaced by unsupported-local SAFE-OUT "
+                "clarification"
+            )
+            evidence_label = (
+                "template_artifact_replaced_unsupported_local_safeout_no_provider"
+            )
+        answer_kind = "local_unsupported_safeout"
 
     envelope["final_answer"] = derived
     envelope["solution"] = derived
     envelope["reason"] = reason
     envelope["notes"] = f"{envelope.get('notes', '')} | {note}"
     envelope.setdefault("evidence", []).append(evidence_label)
-    tot_result["echo_detected"] = True
-    tot_result["raw_echo_answer"] = tot_result.get("answer", "")
+    tot_result["echo_detected"] = is_echo
+    tot_result["template_branch_detected"] = not is_echo
+    tot_result["answer_kind"] = answer_kind
+    tot_result["synthesis_available"] = False
+    if is_echo:
+        tot_result["raw_echo_answer"] = tot_result.get("answer", "")
+    else:
+        tot_result["raw_template_answer"] = raw_answer
     tot_result["answer"] = derived
 
 
@@ -190,7 +296,7 @@ class AlphaSolver:
         )
         sm = SafeOutStateMachine(cfg)
         envelope = sm.run(tot_result, query)
-        _replace_echo_answer(envelope, tot_result, query)
+        _enforce_local_output_honesty(envelope, tot_result, query)
 
         router_stage = router.stage if router else "basic"
         if (

--- a/alpha_solver_portable.py
+++ b/alpha_solver_portable.py
@@ -988,6 +988,62 @@ class PortableSafeOut:
 
 
 # ---------------------------------------------------------------------------
+# Local-output honesty boundary (standalone; no repo imports)
+# ---------------------------------------------------------------------------
+# Deterministic wrappers this file itself can produce: ToT branch templates
+# and the portable CoT fallback. Final answers must never surface them.
+PORTABLE_LOCAL_ARTIFACT_PREFIXES: Tuple[str, ...] = (
+    "rephrase:",
+    "decompose:",
+    "edge cases:",
+    "counterpoints:",
+    "summarize:",
+    "clarify and refine:",
+)
+
+PORTABLE_LOCAL_UNSUPPORTED_SAFEOUT = (
+    "SAFE-OUT: The portable local deterministic path cannot synthesize a "
+    "substantive answer without a model; its search output is template "
+    "scaffolding, not an answer. Run this prompt on a model-backed surface "
+    "or supply supported local context."
+)
+
+
+def portable_local_output_honesty(answer: Any, query: str) -> Dict[str, Any]:
+    """Flag prompt echo / template artifacts from the portable local path.
+
+    Standalone wording check for this file's own deterministic outputs. It
+    detects only the explicit wrappers above plus exact normalized prompt
+    echo; it does not judge answer quality and cannot make the local path
+    smarter — it only stops non-answers from masquerading as answers.
+    """
+
+    def _norm(text: str) -> str:
+        return " ".join(text.strip().lower().split())
+
+    result: Dict[str, Any] = {
+        "artifact_detected": False,
+        "artifact_kind": None,
+        "bounded_answer": None,
+        "synthesis_available": False,
+    }
+    if not isinstance(answer, str) or not answer.strip():
+        return result
+    if _norm(answer) == _norm(query):
+        result["artifact_detected"] = True
+        result["artifact_kind"] = "prompt_echo"
+    elif any(
+        answer.strip().lower().startswith(prefix)
+        for prefix in PORTABLE_LOCAL_ARTIFACT_PREFIXES
+    ):
+        result["artifact_detected"] = True
+        result["artifact_kind"] = "template_branch"
+    if result["artifact_detected"]:
+        result["bounded_answer"] = PORTABLE_LOCAL_UNSUPPORTED_SAFEOUT
+    return result
+
+
+# ---------------------------------------------------------------------------
 # Portable solver orchestration
 # ---------------------------------------------------------------------------
 @dataclass
@@ -1106,6 +1162,22 @@ class PortableAlphaSolver:
         expert_team = self.expert_selector.select_team(query)
         safe_out = self._make_safe_out(seed=seed)
         safe_out_state = safe_out.run(tot_result, query)
+
+        honesty = portable_local_output_honesty(
+            safe_out_state.get("final_answer", ""), query
+        )
+        if honesty["artifact_detected"]:
+            safe_out_state["final_answer"] = honesty["bounded_answer"]
+            safe_out_state["reason"] = "local_unsupported_safeout"
+            safe_out_state["answer_kind"] = "local_unsupported_safeout"
+            safe_out_state["artifact_kind"] = honesty["artifact_kind"]
+            safe_out_state["synthesis_available"] = False
+            self.observability.log_event(
+                "local_output_honesty_replacement",
+                event_type="policy",
+                stage="post_safe_out",
+                artifact_kind=honesty["artifact_kind"],
+            )
 
         shortlist = [
             {"answer": tot_result.get("answer", ""), "confidence": float(tot_result.get("confidence", 0.0))},

--- a/alpha_solver_portable.py
+++ b/alpha_solver_portable.py
@@ -998,6 +998,8 @@ PORTABLE_LOCAL_ARTIFACT_PREFIXES: Tuple[str, ...] = (
     "edge cases:",
     "counterpoints:",
     "summarize:",
+    "to proceed, consider:",
+    "to proceed, clarify:",
     "clarify and refine:",
 )
 
@@ -1166,12 +1168,19 @@ class PortableAlphaSolver:
         honesty = portable_local_output_honesty(
             safe_out_state.get("final_answer", ""), query
         )
+        tot_honesty = portable_local_output_honesty(tot_result.get("answer", ""), query)
         if honesty["artifact_detected"]:
             safe_out_state["final_answer"] = honesty["bounded_answer"]
             safe_out_state["reason"] = "local_unsupported_safeout"
             safe_out_state["answer_kind"] = "local_unsupported_safeout"
             safe_out_state["artifact_kind"] = honesty["artifact_kind"]
             safe_out_state["synthesis_available"] = False
+            if tot_honesty["artifact_detected"]:
+                tot_result["raw_artifact_answer"] = tot_result.get("answer", "")
+                tot_result["answer"] = honesty["bounded_answer"]
+                tot_result["answer_kind"] = "local_unsupported_safeout"
+                tot_result["artifact_kind"] = tot_honesty["artifact_kind"]
+                tot_result["synthesis_available"] = False
             self.observability.log_event(
                 "local_output_honesty_replacement",
                 event_type="policy",

--- a/tests/test_alpha_local_runtime_honesty.py
+++ b/tests/test_alpha_local_runtime_honesty.py
@@ -56,6 +56,12 @@ def _normalized(text: str) -> str:
     return " ".join(text.strip().lower().split())
 
 
+def _section(rendered: str, header: str, next_marker: str) -> str:
+    start = rendered.index(f"{header}:\n") + len(f"{header}:\n")
+    end = rendered.index(next_marker, start)
+    return rendered[start:end]
+
+
 def _solve_unsupported(**kwargs) -> dict:
     return _tree_of_thought(
         UNSUPPORTED_HIGH_HEADROOM, cache_path=None, enable_cache=False, **kwargs
@@ -208,6 +214,28 @@ def test_portable_local_path_never_surfaces_artifacts():
                     prompt,
                     answer,
                 )
+
+
+def test_portable_rendered_solution_and_shortlist_scrub_honesty_artifacts():
+    envelope = portable.PortableAlphaSolver(seed=7).solve(UNSUPPORTED_HIGH_HEADROOM)
+    rendered = envelope.to_llm_response()
+    solution = _section(rendered, "SOLUTION", "\n\nCONFIDENCE:")
+    shortlist = _section(rendered, "SHORTLIST", "\n\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+
+    for answer_like_section in (solution, shortlist):
+        assert _normalized(UNSUPPORTED_HIGH_HEADROOM) not in _normalized(
+            answer_like_section
+        )
+        for artifact in (
+            "Rephrase:",
+            "Decompose:",
+            "Edge cases:",
+            "Counterpoints:",
+            "Summarize:",
+            "To proceed, consider:",
+            "Clarify and refine:",
+        ):
+            assert artifact not in answer_like_section
 
 
 def test_portable_honesty_helper_is_standalone_and_explicit():

--- a/tests/test_alpha_local_runtime_honesty.py
+++ b/tests/test_alpha_local_runtime_honesty.py
@@ -1,0 +1,234 @@
+"""Local-output honesty tests (ALPHA-SOLVER-TOT-ECHO-HONESTY-HOTFIX-001).
+
+Unsupported local deterministic prompts must never surface prompt echo or
+ToT/CoT template artifacts as final answers; they must return a bounded
+SAFE-OUT-style response with diagnostics. These tests call only the local
+deterministic paths: no providers, no hosted or local models, no network.
+They assert honesty, not intelligence — a passing run makes no quality,
+benchmark, readiness, or superiority claim.
+"""
+from __future__ import annotations
+
+import alpha_solver_portable as portable
+from alpha.reasoning.cache import make_key
+from alpha.solver import observability as solver_obs
+from alpha_solver_entry import AlphaSolver, _tree_of_thought
+
+BLOCKED_TEMPLATE_PREFIXES = (
+    "Rephrase:",
+    "Decompose:",
+    "Edge cases:",
+    "Counterpoints:",
+    "Summarize:",
+)
+COT_ARTIFACT_PREFIXES = ("To proceed, consider:", "To proceed, clarify:")
+LIFT_LABELS = ("Intent:", "Assumes:", "Tradeoff:", "Recommendation:", "Fails if:", "Next:")
+
+# Contains "impossible", which the constraint scorer zeroes, dropping the
+# composite root score to 0.6 so a 0.7 threshold deterministically routes to
+# the CoT fallback — the live template-echo leak path this lane closes.
+UNSUPPORTED_HIGH_HEADROOM = (
+    "Our team says zero-downtime auth migration is impossible; "
+    "design a rollout plan anyway."
+)
+
+UNSUPPORTED_CONFIGS = (
+    {},
+    {"low_conf_threshold": 0.7},
+    {"multi_branch": True},
+)
+
+SUPPORTED_FIXTURE_PROMPTS = {
+    "photosynthesis": "Explain photosynthesis in two plain-language sentences.",
+    "checklist": "Give a three-item checklist for packing for a one-night work trip.",
+    "database": (
+        "Help me choose a database for my app; I have not decided traffic, "
+        "budget, or data model."
+    ),
+    "false_premise": (
+        'Summarize the main claims of the 2025 paper "Quantum Bananas Cure '
+        'Insomnia" without inventing facts.'
+    ),
+}
+
+
+def _normalized(text: str) -> str:
+    return " ".join(text.strip().lower().split())
+
+
+def _solve_unsupported(**kwargs) -> dict:
+    return _tree_of_thought(
+        UNSUPPORTED_HIGH_HEADROOM, cache_path=None, enable_cache=False, **kwargs
+    )
+
+
+def test_unsupported_prompt_never_echoes_the_prompt():
+    for config in UNSUPPORTED_CONFIGS:
+        result = _solve_unsupported(**config)
+        assert _normalized(result["final_answer"]) != _normalized(
+            UNSUPPORTED_HIGH_HEADROOM
+        ), config
+        assert _normalized(result["solution"]) != _normalized(
+            UNSUPPORTED_HIGH_HEADROOM
+        ), config
+
+
+def test_unsupported_prompt_never_starts_with_template_prefixes():
+    for config in UNSUPPORTED_CONFIGS:
+        result = _solve_unsupported(**config)
+        answer = result["final_answer"].strip()
+        for prefix in BLOCKED_TEMPLATE_PREFIXES + COT_ARTIFACT_PREFIXES:
+            assert not answer.lower().startswith(prefix.lower()), (config, answer)
+
+
+def test_unsupported_prompt_returns_bounded_safeout_text():
+    for config in UNSUPPORTED_CONFIGS:
+        result = _solve_unsupported(**config)
+        answer = result["final_answer"]
+        assert answer.startswith("SAFE-OUT:"), (config, answer)
+        lowered = answer.lower()
+        assert (
+            "synthesis is unavailable" in lowered
+            or "could not derive a substantive answer" in lowered
+        ), (config, answer)
+        assert result["solution"] == result["final_answer"]
+
+
+def test_diagnostics_identify_unsupported_local_cause():
+    for config in UNSUPPORTED_CONFIGS:
+        result = _solve_unsupported(**config)
+        tot_diag = result["diagnostics"]["tot"]
+        assert tot_diag.get("answer_kind") == "local_unsupported_safeout", config
+        assert tot_diag.get("synthesis_available") is False, config
+        assert (
+            tot_diag.get("echo_detected") is True
+            or tot_diag.get("template_branch_detected") is True
+        ), config
+        assert result["reason"] in (
+            "prompt_echo_replaced_with_unsupported_local_safeout",
+            "template_artifact_replaced_with_unsupported_local_safeout",
+        ), config
+
+
+def test_cot_fallback_template_artifact_is_bounded():
+    result = _solve_unsupported(low_conf_threshold=0.7)
+    assert result["route"] == "cot_fallback"
+    assert not result["final_answer"].lower().startswith("to proceed, consider:")
+    assert result["final_answer"].startswith("SAFE-OUT:")
+    tot_diag = result["diagnostics"]["tot"]
+    assert tot_diag.get("template_branch_detected") is True
+    assert tot_diag.get("raw_template_answer", "").lower().startswith(
+        "to proceed, consider:"
+    )
+
+
+def test_cached_template_answer_is_bounded():
+    query = "Design a sharding plan for our multi-tenant Postgres cluster."
+    key = make_key(query, 0, (), "0")
+    poisoned = {
+        key: {
+            "answer": f"Rephrase: {query}",
+            "score": 0.99,
+            "path": [query, f"Rephrase: {query}"],
+            "hash": "stale",
+            "ts": 0,
+        }
+    }
+    envelope = AlphaSolver().solve(query, cache=poisoned)
+    assert not envelope["final_answer"].startswith("Rephrase:")
+    assert envelope["final_answer"].startswith("SAFE-OUT:")
+    assert envelope["diagnostics"]["tot"].get("template_branch_detected") is True
+
+
+def test_supported_fixture_prompts_preserve_prior_behavior():
+    answers = {
+        name: _tree_of_thought(prompt, cache_path=None, enable_cache=False)
+        for name, prompt in SUPPORTED_FIXTURE_PROMPTS.items()
+    }
+    for name, result in answers.items():
+        assert result["reason"] == "prompt_echo_replaced_with_local_derived_answer", name
+        assert result["diagnostics"]["tot"]["echo_detected"] is True
+        assert result["diagnostics"]["tot"].get("answer_kind") == "derived_local_fixture"
+    assert "sunlight" in answers["photosynthesis"]["final_answer"].lower()
+    assert "1." in answers["checklist"]["final_answer"]
+    assert "3." in answers["checklist"]["final_answer"]
+    assert "clarify" in answers["database"]["final_answer"].lower()
+    assert "cannot substantiate" in answers["false_premise"]["final_answer"].lower()
+
+
+def test_honesty_guard_does_not_inject_lift_block():
+    # Low-headroom/compact behavior stays outside the PR #646 lift contract:
+    # the bounded SAFE-OUT replacement must not fabricate lift-block labels.
+    for config in UNSUPPORTED_CONFIGS:
+        result = _solve_unsupported(**config)
+        for label in LIFT_LABELS:
+            assert not result["final_answer"].strip().startswith(label), config
+    rewrite = _tree_of_thought(
+        "Rewrite this sentence to be shorter: 'We are currently in the process "
+        "of conducting an evaluation of the proposal.'",
+        cache_path=None,
+        enable_cache=False,
+    )
+    for label in LIFT_LABELS:
+        assert not rewrite["final_answer"].strip().startswith(label)
+
+
+def test_classifier_flags_chained_and_single_artifacts():
+    query = "Compare event sourcing versus CRUD for an audit ledger."
+    cases = {
+        f"Rephrase: {query}": "template_branch",
+        f"Summarize: Decompose: {query}": "template_branch",
+        f"Edge cases: {query}": "template_branch",
+        f"To proceed, consider: {query}": "cot_template",
+        query: "prompt_echo",
+        query.upper(): "prompt_echo",
+    }
+    for answer, expected in cases.items():
+        assert (
+            solver_obs._classify_local_artifact(answer, query) == expected
+        ), answer
+    legit = "Use event sourcing only if replay and audit lineage justify it."
+    assert solver_obs._classify_local_artifact(legit, query) is None
+    assert solver_obs._classify_local_artifact(None, query) is None
+
+
+def test_portable_local_path_never_surfaces_artifacts():
+    prompts = (
+        UNSUPPORTED_HIGH_HEADROOM,
+        "Compare event sourcing versus CRUD for an audit-heavy fintech ledger.",
+    )
+    for seed in (7, 42, 99):
+        for prompt in prompts:
+            envelope = portable.PortableAlphaSolver(seed=seed).solve(prompt)
+            answer = envelope.solution.strip()
+            assert _normalized(answer) != _normalized(prompt), (seed, prompt)
+            for prefix in BLOCKED_TEMPLATE_PREFIXES + ("Clarify and refine:",):
+                assert not answer.lower().startswith(prefix.lower()), (
+                    seed,
+                    prompt,
+                    answer,
+                )
+
+
+def test_portable_honesty_helper_is_standalone_and_explicit():
+    query = "Plan a zero-downtime database migration."
+    flagged = portable.portable_local_output_honesty(f"Rephrase: {query}", query)
+    assert flagged["artifact_detected"] is True
+    assert flagged["artifact_kind"] == "template_branch"
+    assert flagged["bounded_answer"].startswith("SAFE-OUT:")
+
+    echo = portable.portable_local_output_honesty(query, query)
+    assert echo["artifact_detected"] is True
+    assert echo["artifact_kind"] == "prompt_echo"
+
+    fallback = portable.portable_local_output_honesty(
+        f"Clarify and refine: {query}", query
+    )
+    assert fallback["artifact_detected"] is True
+    assert fallback["artifact_kind"] == "template_branch"
+
+    clean = portable.portable_local_output_honesty(
+        "Run the migration in three phases behind a read-proxy.", query
+    )
+    assert clean["artifact_detected"] is False
+    assert clean["bounded_answer"] is None


### PR DESCRIPTION
## Checklist

- [x] Spec linked: `.specs/ALPHA-SOLVER-TOT-ECHO-HONESTY-HOTFIX-001.md`
- [x] Spec sections present/updated (Goal / Motivation / Acceptance Criteria / Definition of Done / Code Targets / Test Plan)
- [x] Tests run: `python -m pytest -q` (exit code 0; 3 environment-gated skips — see validation below)

## Notes for reviewers

### Lane ID

`ALPHA-SOLVER-TOT-ECHO-HONESTY-HOTFIX-001` — answer-integrity lane. This does not make local ToT smarter; it makes local output honest.

### Source-truth verification summary

- Default branch is `main`; base SHA at branch start: `05892a5` (verified via `git remote show origin` and fetch).
- PR #646 merged into main (lift contract, constants, checker, and its 18 tests present on main and passing).
- PR #645 closed and not merged (duplicate of the same lift lane).
- No open PRs existed for this or any equivalent ToT echo/runtime honesty lane; `tests/test_alpha_local_runtime_honesty.py` did not exist.
- `TEMPLATE_FUNCS` still live in `alpha/reasoning/tot.py`; the previous guard caught exact echo only.

### Compact wargame summary

- **Already fixed?** No. Verified live on main before patching: (a) with a below-threshold ToT confidence (e.g. a prompt containing "impossible" zeroes the constraint scorer → composite 0.6 < a 0.7 threshold), the SAFE-OUT CoT fallback shipped `To proceed, consider: <query>` as `final_answer` while `solution` simultaneously carried the raw prompt echo; (b) ToT cache hits return stored `answer` text with no honesty check, so a stale/poisoned cache surfaces `Rephrase: <query>`; (c) no code checked the five template prefixes in final answers, and no test covered them.
- **Narrower patch?** No evidence demanded one — the envelope-level guard is already the minimal interception point (it also covers the cache path without touching cache code, and `alpha/policy/safe_out_sm.py` stays untouched).
- **Proceed (selected):** broaden the existing exact-echo guard into an explicit local-output honesty guard; add non-synthesis metadata at the ToT source; mirror a light standalone boundary in the portable local path.

### Exact changed files

- `alpha/solver/observability.py` — `_replace_echo_answer` broadened into `_enforce_local_output_honesty` with explicit classifier `_classify_local_artifact` (`prompt_echo` / `template_branch` / `cot_template`; explicit prefix lists, no fuzzy heuristics). Supported fixture derivations preserved verbatim (same reason/evidence codes); unsupported artifacts become bounded SAFE-OUT text; diagnostics record `echo_detected`, `template_branch_detected`, `answer_kind`, `synthesis_available`, `raw_echo_answer` / `raw_template_answer`, and stable `reason`/evidence labels.
- `alpha/reasoning/tot.py` — additive metadata only: search results now carry `answer_kind` (`prompt_echo` / `template_branch` / `cached_search_artifact`) and `synthesis_available: False`; search behavior unchanged.
- `alpha_solver_portable.py` — standalone `portable_local_output_honesty()` + `PORTABLE_LOCAL_ARTIFACT_PREFIXES` + bounded SAFE-OUT constant, applied to the portable local deterministic path only. No repo imports; PR #646 lift contract text and `check_substantive_lift` semantics untouched.
- `tests/test_alpha_local_runtime_honesty.py` — new; 11 tests, written first and verified failing (10/10 collected failures pre-patch), passing post-patch.
- `.specs/ALPHA-SOLVER-TOT-ECHO-HONESTY-HOTFIX-001.md` — lane spec.

`tests/test_alpha_no_echo_wiring.py` needed no changes — it passes untouched.

### Tests and results

- `python -m pytest tests/test_alpha_local_runtime_honesty.py -q` → exit 0 (11 tests; failing before the patch)
- `python -m pytest tests/test_alpha_no_echo_wiring.py -q` → exit 0
- `python -m pytest tests/test_alpha_substantive_lift_contract.py -q` → exit 0
- `python -m pytest tests/test_alpha_minimal_behavior_contract.py -q` → exit 0
- `python -m pytest tests/reasoning tests/policy tests/observability tests/test_tot_determinism.py -q` → exit 0 (modules I touched)
- `python -m pytest tests/test_local_llm_contract_consumption_proof.py tests/test_local_llm_provider_adapter.py -q` → exit 0 (portable file is their prompt source)
- `python -m pytest tests/test_api_endpoints.py -q` → exit 0 (defensive: envelope feeds `/v1/solve`; `service/app.py` untouched)
- `python -m pytest -q` (full suite) → exit code 0; 3 environment-gated skips (live-OpenAI smoke stayed skipped — no provider calls ran; decks web adapter; packaging build). Known repo quirk: a test redirects stdout, truncating pytest's final count line in logs; exit code is authoritative.
- `python scripts/check_narrative_claim_safety.py .specs/ALPHA-SOLVER-TOT-ECHO-HONESTY-HOTFIX-001.md` → passed
- `ruff check alpha/reasoning/tot.py alpha/solver/observability.py alpha_solver_portable.py tests/test_alpha_local_runtime_honesty.py tests/test_alpha_no_echo_wiring.py` → all checks passed

### What behavior changed

- Unsupported local prompts can no longer receive `To proceed, consider: <query>` (CoT fallback wrapper), `Rephrase:/Decompose:/Edge cases:/Counterpoints:/Summarize:`-prefixed strings (including chained prefixes and cache-sourced ones), or exact/normalized prompt echo as `final_answer`/`solution`. They now receive a bounded SAFE-OUT stating local deterministic synthesis is unavailable, with diagnostics naming the artifact class and raw text.
- The CoT-fallback double-artifact case (template in `final_answer`, raw echo in `solution`) is fixed for both fields.
- ToT results now self-describe as non-synthesized search output.
- The portable local deterministic path applies the same boundary standalone (its randomized scoring can promote `Rephrase:` children and its fallback emits `Clarify and refine: <query>`).

### What behavior was preserved

- All four supported deterministic fixture answers (photosynthesis, one-night-trip checklist, ambiguous database choice, false-premise summary) with their exact prior reason/evidence codes.
- Existing no-echo tests pass unchanged; existing unsupported-echo SAFE-OUT message text unchanged.
- PR #646 Substantive Lift Contract semantics and tests unchanged; the guard injects no lift-block labels, so low-headroom compact behavior is untouched.
- SolverEnvelope shape unchanged (additive diagnostic fields only); SAFE-OUT state machine untouched; operator capture harness untouched.

### Explicitly: this does not make local ToT smarter

The local deterministic runtime still cannot synthesize substantive content. This PR only stops non-answers from masquerading as answers and says so in the output.

### Non-claims

No provider calls, no hosted model calls, no local model calls, no scoring, no blinding, no unblinding, no `/v1/solve` exposure, no benchmark-success claim, no readiness claim, no production claim, no Alpha-superiority claim.

### Remaining unsolved

- The local deterministic runtime still cannot synthesize real substantive content without a model.
- PR #646 lift impact still requires a future bounded manual evaluation lane (capture → blind scoring).
- Route/persona causality remains deferred until local runtime output cannot masquerade as reasoning — this PR is that precondition, not that lane.
- Envelope `confidence` is not adjusted on SAFE-OUT replacement (pre-existing behavior, e.g. 1.0 on an echo root); left untouched to avoid gate-behavior scope creep — candidate for a future bounded lane.

---
_Generated by [Claude Code](https://claude.ai/code/session_011DUh9bRenAef39bB2ijThb)_