### PR TITLE
Add PR646 observation memo and portable diagnostic parity

### DIFF
--- a/alpha_solver_portable.py
+++ b/alpha_solver_portable.py
@@ -1230,7 +1230,17 @@ class PortableAlphaSolver:
         diagnostics = SolverDiagnostics(
             router={"stage": route_decision.stage, "rationale": route_decision.rationale, "escalations": route_decision.escalations},
             safe_out={"config": asdict(getattr(safe_out, "config", PortableSOConfig()))},
-            tot={"steps": tot_result.get("steps", []), "best_path": tot_result.get("best_path", []), "timed_out": tot_result.get("timed_out", False)},
+            tot={
+                "steps": tot_result.get("steps", []),
+                "best_path": tot_result.get("best_path", []),
+                "timed_out": tot_result.get("timed_out", False),
+                "answer_kind": tot_result.get("answer_kind"),
+                "artifact_kind": tot_result.get("artifact_kind"),
+                "synthesis_available": tot_result.get("synthesis_available"),
+                "confidence": tot_result.get("confidence"),
+                "confidence_before_adjustment": tot_result.get("confidence_before_adjustment"),
+                "confidence_adjustment_reason": tot_result.get("confidence_adjustment_reason"),
+            },
             expert_selection={"lead": expert_team.lead["id"], "team_size": 5, "synergy": expert_team.synergy_score, "domains": expert_team.domain_classification},
             observability_events=self.observability.export(),
         )

--- a/docs/evals/runs/pr646-substantive-lift-manual-eval/OBSERVATION_MEMO.md
+++ b/docs/evals/runs/pr646-substantive-lift-manual-eval/OBSERVATION_MEMO.md
@@ -1,0 +1,61 @@
+# PR646 Substantive Lift Manual Eval Observation Memo
+
+Lane: `PR646-SUBSTANTIVE-LIFT-MANUAL-EVAL-PREP-001`
+
+## Source and merge-state note
+
+Local repository history shows the prerequisite PR commits present on this branch:
+
+- PR #646: `portable: add substantive lift answer contract`.
+- PR #647: `tot: bound non-substantive local template outputs`.
+- PR #648: `Cap unsupported SAFE-OUT confidence`.
+- PR #649: `eval: add PR646 manual substantive-lift eval prep packet and runbook`.
+
+This memo is based on the operator-provided issue-comment summary of two final
+ChatGPT ghost-chat exports. The raw ghost-chat export files are not present in
+this repository, so this memo does not claim direct access to raw exports.
+
+## Observation boundary
+
+This is a qualitative observation memo only. It does not score the outputs,
+rank the outputs, pick a winner, claim Alpha superiority, claim benchmark
+status, claim readiness, or treat the ghost-chat test as proof.
+
+The test has a material caveat: the Alpha `.py` thread appeared more repo-aware
+than the baseline thread. That makes the result operator signal from an
+as-run ghost-chat comparison, not a clean controlled proof of the PR #646 answer
+contract or of Alpha Solver superiority.
+
+## Qualitative operator signal
+
+The issue-comment summary indicates the Alpha-thread output more consistently
+presented the answer as an operator-actionable memo: it made the intent of the
+question explicit, called out hidden assumptions, named a dominant tradeoff,
+committed to a bounded recommendation, and preserved a concrete failure
+condition or next action.
+
+The same summary indicates the baseline-thread output was usable as general
+analysis, but appeared less anchored to the repo-specific contract and less
+consistent about separating observation, caveat, and next diagnostic action.
+Because the baseline thread may have had less effective repo context, this is
+not interpretable as a controlled treatment effect.
+
+## Diagnostic follow-up from the run
+
+The operator signal raised a possible diagnostic-surface parity issue in
+`alpha_solver_portable.py`: user-visible portable SAFE-OUT honesty fields were
+being adjusted, while the exported `diagnostics.tot` surface did not expose the
+same confidence and unsupported-synthesis markers. That issue is narrow and
+mechanical rather than an answer-quality claim.
+
+The follow-up implementation should therefore stay limited to parity of
+portable diagnostic fields and a focused regression test. It should not broaden
+runtime behavior, route/persona behavior, provider execution, scoring, or eval
+claims.
+
+## Allowed use
+
+This memo may be cited only as preservation of operator-observed qualitative
+signal and as justification for the narrow diagnostic-surface parity check. It
+must not be cited as benchmark evidence, production-readiness evidence, a clean
+A/B comparison, or proof that Alpha Solver outperforms a baseline.

--- a/tests/test_alpha_local_runtime_honesty.py
+++ b/tests/test_alpha_local_runtime_honesty.py
@@ -311,3 +311,22 @@ def test_portable_honesty_helper_is_standalone_and_explicit():
     )
     assert clean["artifact_detected"] is False
     assert clean["bounded_answer"] is None
+
+
+def test_portable_diagnostics_tot_matches_safeout_honesty_adjustment():
+    envelope = portable.PortableAlphaSolver(seed=7).solve(UNSUPPORTED_HIGH_HEADROOM)
+    diagnostics_tot = envelope.diagnostics.tot
+
+    assert envelope.solution.startswith("SAFE-OUT:")
+    assert diagnostics_tot["answer_kind"] == "local_unsupported_safeout"
+    assert diagnostics_tot["synthesis_available"] is False
+    assert diagnostics_tot["confidence"] == envelope.safe_out_state["confidence"]
+    assert (
+        diagnostics_tot["confidence_before_adjustment"]
+        == envelope.safe_out_state["confidence_before_adjustment"]
+    )
+    assert (
+        diagnostics_tot["confidence_adjustment_reason"]
+        == envelope.safe_out_state["confidence_adjustment_reason"]
+    )
+    assert diagnostics_tot["artifact_kind"] in {"prompt_echo", "template_branch"}


### PR DESCRIPTION
### Motivation
- Preserve operator qualitative signal from the PR #646 manual ghost-chat run as a non-claim observation memo while documenting the repo-awareness caveat that prevents treating the run as a controlled proof.
- Verify and resolve a narrow diagnostic-surface parity issue where SAFE-OUT honesty adjustments were reflected in user-visible state but not exposed on the exported `diagnostics.tot` surface.

### Description
- Add a qualitative-only observation memo at `docs/evals/runs/pr646-substantive-lift-manual-eval/OBSERVATION_MEMO.md` that records merge-state notes, non-claim boundaries, and the repo-awareness caveat. 
- Expose unsupported-local-synthesis and confidence-adjustment markers on the portable `diagnostics.tot` dict in `alpha_solver_portable.py` so the exported diagnostics match the SAFE-OUT state. 
- Add a focused regression test `test_portable_diagnostics_tot_matches_safeout_honesty_adjustment` to `tests/test_alpha_local_runtime_honesty.py` that asserts parity between `diagnostics.tot` and `safe_out_state` for the unsupported local SAFE-OUT case.

### Testing
- Ran `python -m pytest tests/test_alpha_local_runtime_honesty.py -q` and the test suite including the new regression test passed. 
- Ran `python scripts/check_narrative_claim_safety.py docs/evals/runs/pr646-substantive-lift-manual-eval/OBSERVATION_MEMO.md` and the narrative-claim linter passed. 
- Ran `python -m pytest tests/test_pr646_substantive_lift_eval_prep.py -q` and those prep-run tests passed, and `git diff --check` reported no whitespace/errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bd8aec0ec832983e00a76662d0044)