### PR TITLE
Harden portable Substantive Lift case anchoring

### DIFF
--- a/.specs/ALPHA-SOLVER-SUBSTANTIVE-LIFT-CASE-ANCHOR-HARDENING-001.md
+++ b/.specs/ALPHA-SOLVER-SUBSTANTIVE-LIFT-CASE-ANCHOR-HARDENING-001.md
@@ -1,0 +1,69 @@
+# ALPHA-SOLVER-SUBSTANTIVE-LIFT-CASE-ANCHOR-HARDENING-001
+
+## Goal
+
+Harden the portable Substantive Lift wording contract so prompt-aware checks can reject structurally valid but generic lift blocks that could be reused under unrelated prompts.
+
+## Motivation
+
+The manual evaluation lane showed that a six-line lift block can satisfy label order, length, anti-hedge wording, and executable-next checks while still avoiding the concrete objects in the task. This spec narrows that gap on the portable surface by adding deterministic case-anchoring checks when prompt anchors are available.
+
+## Scope
+
+- Add case-anchoring contract wording to `alpha_solver_portable.py`.
+- Add conservative deterministic prompt-anchor extraction for files, paths, PR references, issue references, backticked spans, uppercase lane IDs, and number-bearing identifier tokens.
+- Extend `check_substantive_lift(solution_text, prompt=None)` with prompt-aware result fields while preserving prompt-omitted compatibility.
+- Add fixtures and tests for generic cosplay blocks, anchored counterparts, anchor extraction, vacuous anchor-free prompts, intent-restatement checks, filler checks, and summary/spec indexing.
+
+## Non-goals
+
+- No `/v1/solve` changes.
+- No dashboard or API changes.
+- No routing, persona, SAFE-OUT, SolverEnvelope, budget, determinism, replay, observability, scoring, ranking, winner-field, source-map, identity-map, or benchmark changes.
+- No provider calls, hosted model calls, or local model calls.
+- No answer-quality, readiness, production, provider-validation, local-model-validation, model-superiority, or Alpha-superiority claims.
+
+## Code targets
+
+- `alpha_solver_portable.py`
+- `tests/fixtures/alpha_substantive_lift_cases.json`
+- `tests/test_alpha_substantive_lift_contract.py`
+- `.specs/ALPHA-SOLVER-SUBSTANTIVE-LIFT-CASE-ANCHOR-HARDENING-001.md`
+- `.specs/INDEX.md`
+
+## Test plan
+
+Run the focused and regression checks requested for this lane:
+
+```bash
+python -m pytest tests/test_alpha_substantive_lift_contract.py -q
+python -m pytest tests/test_alpha_minimal_behavior_contract.py -q
+python -m pytest tests/test_alpha_local_runtime_honesty.py -q
+python -m pytest tests/test_alpha_no_echo_wiring.py -q
+python -m pytest -q
+python scripts/check_narrative_claim_safety.py .specs/ALPHA-SOLVER-SUBSTANTIVE-LIFT-CASE-ANCHOR-HARDENING-001.md
+ruff check alpha_solver_portable.py tests/test_alpha_substantive_lift_contract.py
+```
+
+## Acceptance criteria
+
+- The contract summary includes the case-anchoring rules, including the required non-compliance sentence.
+- A structurally valid generic lift block passes the prompt-omitted checker path, proving the old shape-only gap remains representable in tests.
+- The same generic lift block fails when prompt anchors are provided.
+- Anchored counterpart examples pass when prompt anchors are provided.
+- Anchor-free prompts do not create an unanchored failure.
+- Intent restatement is flagged only for narrow obvious restatement patterns.
+- Filler detection uses explicit word-boundary regexes only.
+- The spec is indexed.
+
+## Definition of done
+
+- The implementation is limited to the scoped portable files.
+- The checker remains deterministic and uses explicit regexes only.
+- Back-compat for `check_substantive_lift(solution_text)` callers is preserved.
+- Validation results are reported with exact commands.
+- The PR description includes live-state verification, the pre-patch cosplay proof, changed files, implementation summary, validation results, explicit non-claims, and remaining risks.
+
+## Explicit non-claims
+
+A passing checker means only that the configured structural wording, anti-generic, and case-anchoring checks held for the supplied text and optional prompt. This lane does not claim improved answer quality, benchmark performance, production readiness, provider validation, local-model validation, model superiority, or Alpha superiority.

--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -101,3 +101,4 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `UI-KEYS-001.md` | UI-KEYS-001 · Dashboard: API Keys Management | ✅ `SPEC_OK` |
 | `UI-REQ-001.md` | UI-REQ-001 · Dashboard Request Submission UI | ✅ `SPEC_OK` |
 | `UI-RUN-001.md` | UI-RUN-001 · Dashboard One-click Demo Run | ✅ `SPEC_OK` |
+| `ALPHA-SOLVER-SUBSTANTIVE-LIFT-CASE-ANCHOR-HARDENING-001.md` | ALPHA-SOLVER-SUBSTANTIVE-LIFT-CASE-ANCHOR-HARDENING-001 · Substantive Lift Case Anchor Hardening | ✅ `SPEC_OK` |

--- a/alpha_solver_portable.py
+++ b/alpha_solver_portable.py
@@ -140,6 +140,19 @@ six labeled lines, one line each, before any supporting detail:
 Supporting analysis follows the block and must go deep on the controlling
 constraint rather than shallowly enumerating every consideration.
 
+CASE-ANCHORING RULES (apply when prompt context contains case objects):
+1. A lift block must be written for this case, not reusable under any prompt.
+2. Reference case-specific objects from the task when such objects exist: files,
+   PR numbers, issue numbers, metrics, constraints, artifacts, named options,
+   or explicit implementation lanes.
+3. Intent must identify the decision beneath the question, not merely repeat the
+   user's wording.
+4. Recommendation must commit to one concrete path.
+5. Fails if must name an observable condition, event, threshold, or repo fact
+   that would invalidate the recommendation.
+6. Next must name a concrete object or action in the task context.
+A lift block that could be pasted under a different question unchanged is non-compliant.
+
 ANTI-GENERIC RULES (apply to the whole SOLUTION on applicable tasks):
 1. Commit: exactly one primary recommendation. Rank alternatives against it
    in SHORTLIST instead of presenting an unranked menu inside SOLUTION.
@@ -460,6 +473,69 @@ SUBSTANTIVE_LIFT_ANTI_GENERIC_RULES: Tuple[str, ...] = (
     "instead of touching every dimension superficially.",
 )
 
+SUBSTANTIVE_LIFT_CASE_ANCHOR_RULES: Tuple[str, ...] = (
+    "A lift block must be written for this case, not reusable under any prompt.",
+    "Reference case-specific objects from the task when such objects exist: "
+    "files, PR numbers, issue numbers, metrics, constraints, artifacts, named "
+    "options, or explicit implementation lanes.",
+    "Intent must identify the decision beneath the question, not merely repeat "
+    "the user's wording.",
+    "Recommendation must commit to one concrete path.",
+    "Fails if must name an observable condition, event, threshold, or repo fact "
+    "that would invalidate the recommendation.",
+    "Next must name a concrete object or action in the task context.",
+    "A lift block that could be pasted under a different question unchanged is non-compliant.",
+)
+
+GENERIC_LIFT_FILLER_PATTERNS: Tuple[str, ...] = (
+    r"\bbest practices\b",
+    r"\bholistic approach\b",
+    r"\bcarefully consider\b",
+    r"\bvarious stakeholders\b",
+    r"\bleverage synergies\b",
+    r"\brobust solution\b",
+    r"\bthoughtful approach\b",
+)
+
+
+def _extract_case_anchors(prompt: str) -> Tuple[str, ...]:
+    """Extract explicit case objects from a prompt with conservative regexes."""
+
+    if not prompt:
+        return ()
+    patterns = (
+        r"`([^`\n]{2,120})`",
+        r"\b(?:PR|pr)\s*#\d+\b",
+        r"\b(?:issue|Issue)\s*#\d+\b",
+        r"(?<![\w/.-])#\d+\b",
+        r"\b[A-Z][A-Z0-9]+(?:-[A-Z0-9]+){2,}\b",
+        r"\b(?:[A-Za-z0-9_.-]+/)+[A-Za-z0-9_.-]+\.[A-Za-z0-9]+\b",
+        r"\b[A-Za-z0-9_-]+\.(?:py|md|json|yaml|yml|toml|txt|csv|xlsx)\b",
+        r"\b[A-Za-z][A-Za-z0-9_-]*\d+[A-Za-z0-9_-]*\b",
+    )
+    anchors: List[str] = []
+    seen: set[str] = set()
+    for pattern in patterns:
+        for match in re.finditer(pattern, prompt):
+            anchor = match.group(1) if match.groups() else match.group(0)
+            anchor = anchor.strip("`.,;:()[]{}<>")
+            if not anchor:
+                continue
+            key = anchor.lower()
+            if key not in seen:
+                anchors.append(anchor)
+                seen.add(key)
+    return tuple(anchors)
+
+
+def _line_contains_anchor(text: str, anchors: Sequence[str]) -> bool:
+    lowered = text.lower()
+    return any(anchor.lower() in lowered for anchor in anchors)
+
+
+def _normalize_lift_text(text: str) -> str:
+    return re.sub(r"[^a-z0-9]+", " ", text.lower()).strip()
+
 
 def substantive_lift_contract_summary() -> str:
     """Return the portable prompt/protocol wording for the substantive lift contract.
@@ -488,10 +564,14 @@ def substantive_lift_contract_summary() -> str:
     )
     lines.append("Anti-generic rules:")
     lines.extend(f"  - {rule}" for rule in SUBSTANTIVE_LIFT_ANTI_GENERIC_RULES)
+    lines.append("Case-anchoring rules:")
+    lines.extend(f"  - {rule}" for rule in SUBSTANTIVE_LIFT_CASE_ANCHOR_RULES)
     return "\n".join(lines)
 
 
-def check_substantive_lift(solution_text: str) -> Dict[str, Any]:
+def check_substantive_lift(
+    solution_text: str, prompt: Optional[str] = None
+) -> Dict[str, Any]:
     """Deterministically check a SOLUTION's wording against the lift contract.
 
     This is a structural wording check only: it verifies the six-move lift
@@ -535,6 +615,66 @@ def check_substantive_lift(solution_text: str) -> Dict[str, Any]:
             next_content.startswith(opener) for opener in WEAK_NEXT_ACTION_OPENERS
         )
 
+    filler_flags = [
+        pattern
+        for pattern in GENERIC_LIFT_FILLER_PATTERNS
+        if re.search(pattern, lowered)
+    ]
+
+    case_anchors: Tuple[str, ...] = ()
+    anchored_lift_lines: Dict[str, List[str]] = {}
+    unanchored_lift = False
+    weak_anchor_distribution = False
+    intent_restates_prompt = False
+    if prompt is not None:
+        case_anchors = _extract_case_anchors(prompt)
+        anchored_lift_lines = {
+            label: [
+                anchor
+                for anchor in case_anchors
+                if label in found and anchor.lower() in found[label].lower()
+            ]
+            for label in labels
+        }
+        if case_anchors:
+            anchored_labels = [
+                label for label, anchors in anchored_lift_lines.items() if anchors
+            ]
+            key_labels = ("Recommendation:", "Fails if:", "Next:")
+            key_line_anchored = any(
+                anchored_lift_lines.get(label) for label in key_labels
+            )
+            unanchored_lift = not anchored_labels
+            weak_anchor_distribution = not (
+                len(anchored_labels) >= 2 or key_line_anchored
+            )
+
+        intent_content = found.get("Intent:", "")
+        normalized_intent = _normalize_lift_text(intent_content)
+        normalized_prompt = _normalize_lift_text(prompt)
+        generic_restatements = {
+            "answer the question",
+            "decide what to do",
+            "decide how to proceed",
+            "address the request",
+            "handle the task",
+        }
+        intent_has_anchor = _line_contains_anchor(intent_content, case_anchors)
+        restatement_prefix = re.match(
+            r"^(?:answer|address|respond to|handle|decide about)\s+"
+            r"(?:the|this)\s+(?:question|request|prompt|task)\b",
+            intent_content.strip(),
+            flags=re.IGNORECASE,
+        )
+        intent_restates_prompt = bool(
+            normalized_intent
+            and (
+                normalized_intent == normalized_prompt
+                or normalized_intent in generic_restatements
+                or (restatement_prefix and not intent_has_anchor)
+            )
+        )
+
     has_lift_block = not missing_moves
     ok = (
         has_lift_block
@@ -543,6 +683,10 @@ def check_substantive_lift(solution_text: str) -> Dict[str, Any]:
         and opens_with_intent
         and not generic_flags
         and not weak_next_action
+        and not (prompt is not None and filler_flags)
+        and not unanchored_lift
+        and not weak_anchor_distribution
+        and not intent_restates_prompt
     )
     return {
         "ok": ok,
@@ -553,6 +697,12 @@ def check_substantive_lift(solution_text: str) -> Dict[str, Any]:
         "opens_with_intent": opens_with_intent,
         "generic_flags": generic_flags,
         "weak_next_action": weak_next_action,
+        "case_anchors": list(case_anchors),
+        "anchored_lift_lines": anchored_lift_lines,
+        "unanchored_lift": unanchored_lift,
+        "weak_anchor_distribution": weak_anchor_distribution,
+        "intent_restates_prompt": intent_restates_prompt,
+        "filler_flags": filler_flags,
         "lane": SUBSTANTIVE_LIFT_LANE,
     }
 

--- a/tests/fixtures/alpha_substantive_lift_cases.json
+++ b/tests/fixtures/alpha_substantive_lift_cases.json
@@ -37,6 +37,24 @@
       "compliant_solution": "We are evaluating the proposal.",
       "non_compliant_solution": "Intent: Shorten a sentence while preserving meaning.\nAssumes: Formal register should be kept.\nTradeoff: Brevity versus completeness.\nRecommendation: Use 'We are evaluating the proposal.'\nFails if: The original legal phrasing was required verbatim.\nNext: Replace the sentence in the source document.\n\nWe are evaluating the proposal.",
       "non_compliant_reason": "lift block forced onto a low-headroom task; restraint rules take precedence and require the direct rewrite first with no scaffolding"
+    },
+    {
+      "case_id": "LIFT-COSPLAY-PR651-001",
+      "task_family": "implementation lane hardening",
+      "lift_required": true,
+      "prompt": "For lane ALPHA-SOLVER-SUBSTANTIVE-LIFT-CASE-ANCHOR-HARDENING-001, update alpha_solver_portable.py and tests/test_alpha_substantive_lift_contract.py after PR #651 so generic lift blocks are rejected.",
+      "compliant_solution": "Intent: Decide how to harden ALPHA-SOLVER-SUBSTANTIVE-LIFT-CASE-ANCHOR-HARDENING-001 without changing non-portable behavior.\nAssumes: PR #651 is already present on main and the allowed code target is alpha_solver_portable.py.\nTradeoff: Catching reusable lift scaffolding versus avoiding a rule that forces every line to repeat file names.\nRecommendation: Add prompt-aware anchor extraction in alpha_solver_portable.py and require anchors in multiple key lift lines only when the prompt yields anchors.\nFails if: tests/test_alpha_substantive_lift_contract.py shows prompt=None behavior changed or PR #651 diagnostics parity is no longer present.\nNext: Add the cosplay fixture to tests/fixtures/alpha_substantive_lift_cases.json and assert it fails only with the lane prompt.\n",
+      "non_compliant_solution": "Intent: Decide the underlying approach for the request.\nAssumes: The main constraint is to avoid unnecessary complexity.\nTradeoff: Speed of action versus confidence from additional analysis.\nRecommendation: Use the simplest concrete path that satisfies the constraints.\nFails if: A required constraint makes the simple path invalid.\nNext: Draft the first implementation step and review it today.\n",
+      "non_compliant_reason": "structurally valid lift block with no prompt anchors; reusable under a different implementation request unchanged"
+    },
+    {
+      "case_id": "LIFT-COSPLAY-ISSUE650-001",
+      "task_family": "planning under repo constraints",
+      "lift_required": true,
+      "prompt": "Plan the bounded follow-up for issue #650 using docs/evals/runbooks/PR646_SUBSTANTIVE_LIFT_MANUAL_EVAL.md and tests/fixtures/operator_run_capture/pr646_substantive_lift_case_packet.json without making quality claims.",
+      "compliant_solution": "Intent: Decide the bounded follow-up for issue #650 using the PR646 manual-eval artifacts without claiming answer quality.\nAssumes: docs/evals/runbooks/PR646_SUBSTANTIVE_LIFT_MANUAL_EVAL.md and tests/fixtures/operator_run_capture/pr646_substantive_lift_case_packet.json remain the source artifacts.\nTradeoff: Improving wording checks versus accidentally turning the runbook into a benchmark claim.\nRecommendation: Keep the follow-up limited to portable contract checks tied to issue #650 and the PR646 fixture packet.\nFails if: The change requires provider capture data beyond tests/fixtures/operator_run_capture/pr646_substantive_lift_case_packet.json.\nNext: Cross-check docs/evals/runbooks/PR646_SUBSTANTIVE_LIFT_MANUAL_EVAL.md against the new spec before editing code.\n",
+      "non_compliant_solution": "Intent: Decide what to do.\nAssumes: The task needs a thoughtful approach with clear constraints.\nTradeoff: Acting quickly versus preserving flexibility for future changes.\nRecommendation: Apply best practices and choose a robust solution for the situation.\nFails if: Important facts change in a way that invalidates the direction.\nNext: Create an action item and complete it today.\n",
+      "non_compliant_reason": "generic filler and no concrete case anchors despite a prompt with issue, file, and fixture anchors"
     }
   ]
 }

--- a/tests/test_alpha_substantive_lift_contract.py
+++ b/tests/test_alpha_substantive_lift_contract.py
@@ -17,6 +17,10 @@ import alpha_solver_portable as portable
 FIXTURE = Path("tests/fixtures/alpha_substantive_lift_cases.json")
 PORTABLE_CONTRACT = Path("alpha_solver_portable.py")
 SPEC = Path(".specs/ALPHA-SOLVER-SUBSTANTIVE-LIFT-ANSWER-CONTRACT-001.md")
+ANCHOR_SPEC = Path(
+    ".specs/ALPHA-SOLVER-SUBSTANTIVE-LIFT-CASE-ANCHOR-HARDENING-001.md"
+)
+SPEC_INDEX = Path(".specs/INDEX.md")
 
 EXPECTED_LABELS = [
     "Intent:",
@@ -96,7 +100,10 @@ class TestContractConstants:
             assert label in summary
         for rule in portable.SUBSTANTIVE_LIFT_ANTI_GENERIC_RULES:
             assert rule in summary
+        for rule in portable.SUBSTANTIVE_LIFT_CASE_ANCHOR_RULES:
+            assert rule in summary
         assert "SOLUTION wording requirements only" in summary
+        assert "A lift block that could be pasted under a different question unchanged is non-compliant." in summary
 
 
 class TestChecker:
@@ -115,9 +122,129 @@ class TestChecker:
         for case in _cases():
             if not case["lift_required"]:
                 continue
-            result = portable.check_substantive_lift(case["non_compliant_solution"])
+            result = portable.check_substantive_lift(
+                case["non_compliant_solution"], prompt=case["prompt"]
+            )
             assert not result["ok"], (case["case_id"], result)
-            assert result["missing_moves"], case["case_id"]
+            assert (
+                result["missing_moves"]
+                or result["generic_flags"]
+                or result["unanchored_lift"]
+                or result["weak_anchor_distribution"]
+                or result["filler_flags"]
+                or result["intent_restates_prompt"]
+            ), case["case_id"]
+
+    def test_generic_cosplay_fixture_proves_old_shape_only_gap(self):
+        case = next(c for c in _cases() if c["case_id"] == "LIFT-COSPLAY-PR651-001")
+        result = portable.check_substantive_lift(case["non_compliant_solution"])
+        assert result["ok"], result
+        assert result["case_anchors"] == []
+        assert not result["unanchored_lift"]
+
+    def test_prompt_aware_checker_rejects_generic_cosplay_fixture(self):
+        case = next(c for c in _cases() if c["case_id"] == "LIFT-COSPLAY-PR651-001")
+        result = portable.check_substantive_lift(
+            case["non_compliant_solution"], prompt=case["prompt"]
+        )
+        assert not result["ok"], result
+        assert "alpha_solver_portable.py" in result["case_anchors"]
+        assert "PR #651" in result["case_anchors"]
+        assert result["unanchored_lift"]
+
+    def test_prompt_aware_checker_accepts_anchored_counterpart(self):
+        case = next(c for c in _cases() if c["case_id"] == "LIFT-COSPLAY-PR651-001")
+        result = portable.check_substantive_lift(
+            case["compliant_solution"], prompt=case["prompt"]
+        )
+        assert result["ok"], result
+        assert result["anchored_lift_lines"]["Recommendation:"]
+        assert not result["unanchored_lift"]
+
+    def test_prompt_none_preserves_shape_only_compatibility_for_cosplay(self):
+        case = next(c for c in _cases() if c["case_id"] == "LIFT-COSPLAY-PR651-001")
+        result = portable.check_substantive_lift(case["non_compliant_solution"])
+        assert result["ok"], result
+        assert result["case_anchors"] == []
+        assert result["anchored_lift_lines"] == {}
+
+    def test_anchor_extraction_covers_explicit_case_objects(self):
+        prompt = (
+            "Use `alpha_solver_portable.py`, docs/OPERATING_GUIDE.md, PR #646, "
+            "#651, issue #650, ALPHA-SOLVER-SUBSTANTIVE-LIFT-CASE-ANCHOR-HARDENING-001, "
+            "and run2_packet.json."
+        )
+        anchors = portable._extract_case_anchors(prompt)
+        assert "alpha_solver_portable.py" in anchors
+        assert "docs/OPERATING_GUIDE.md" in anchors
+        assert "PR #646" in anchors
+        assert "#651" in anchors
+        assert "issue #650" in anchors
+        assert "ALPHA-SOLVER-SUBSTANTIVE-LIFT-CASE-ANCHOR-HARDENING-001" in anchors
+        assert "run2_packet.json" in anchors
+        assert "2" not in anchors
+
+    def test_anchor_free_prompt_is_vacuous(self):
+        text = (
+            "Intent: Decide the safest rollout path for the requested change.\n"
+            "Assumes: The main risk is disrupting existing behavior.\n"
+            "Tradeoff: Faster delivery versus more regression confidence.\n"
+            "Recommendation: Ship the smallest reversible patch first.\n"
+            "Fails if: Review finds a required behavior outside the patch scope.\n"
+            "Next: Write the focused regression test before changing code.\n"
+        )
+        result = portable.check_substantive_lift(text, prompt="How should we proceed?")
+        assert result["ok"], result
+        assert result["case_anchors"] == []
+        assert not result["unanchored_lift"]
+
+    def test_intent_restatement_flag(self):
+        text = (
+            "Intent: Decide what to do.\n"
+            "Assumes: The repo change should stay narrow.\n"
+            "Tradeoff: Simplicity versus coverage for future cases.\n"
+            "Recommendation: Update alpha_solver_portable.py with the smallest checker change.\n"
+            "Fails if: PR #651 behavior changes unexpectedly.\n"
+            "Next: Run tests/test_alpha_substantive_lift_contract.py today.\n"
+        )
+        result = portable.check_substantive_lift(
+            text,
+            prompt="Update alpha_solver_portable.py after PR #651.",
+        )
+        assert not result["ok"]
+        assert result["intent_restates_prompt"]
+
+    def test_intent_restatement_false_positive_guard(self):
+        text = (
+            "Intent: Decide whether alpha_solver_portable.py should add prompt-aware anchors without touching /v1/solve.\n"
+            "Assumes: PR #651 is already present on main.\n"
+            "Tradeoff: Rejecting reusable lift scaffolds versus avoiding name-dropping on every line.\n"
+            "Recommendation: Add the anchor rule in alpha_solver_portable.py only.\n"
+            "Fails if: PR #651 diagnostics parity changes.\n"
+            "Next: Run tests/test_alpha_substantive_lift_contract.py.\n"
+        )
+        result = portable.check_substantive_lift(
+            text,
+            prompt="Update alpha_solver_portable.py after PR #651.",
+        )
+        assert result["ok"], result
+        assert not result["intent_restates_prompt"]
+
+    def test_filler_word_boundary_false_positive_guard(self):
+        text = (
+            "Intent: Decide whether robust_solution_notes.md belongs in the portable docs update.\n"
+            "Assumes: robust_solution_notes.md is a filename, not filler wording.\n"
+            "Tradeoff: Documenting the file versus widening the implementation surface.\n"
+            "Recommendation: Leave robust_solution_notes.md untouched and update alpha_solver_portable.py only.\n"
+            "Fails if: robust_solution_notes.md is named by the accepted spec.\n"
+            "Next: Check alpha_solver_portable.py before editing robust_solution_notes.md.\n"
+        )
+        result = portable.check_substantive_lift(
+            text,
+            prompt="Decide whether robust_solution_notes.md affects alpha_solver_portable.py.",
+        )
+        assert result["ok"], result
+        assert result["filler_flags"] == []
 
     def test_hedge_phrasing_is_flagged_even_with_lift_block(self):
         text = (
@@ -206,3 +333,10 @@ class TestFixtureShape:
         text = _read(SPEC)
         assert "ALPHA-ANSWER-STRUCTURE-V2-001" in text
         assert "ALPHA-SOLVER-SUBSTANTIVE-LIFT-ANSWER-CONTRACT-001" in text
+
+    def test_anchor_hardening_spec_exists_and_is_indexed(self):
+        text = _read(ANCHOR_SPEC)
+        index = _read(SPEC_INDEX)
+        assert "ALPHA-SOLVER-SUBSTANTIVE-LIFT-CASE-ANCHOR-HARDENING-001" in text
+        assert "Explicit non-claims" in text
+        assert ANCHOR_SPEC.name in index


### PR DESCRIPTION
### Motivation

- Address a gap where structurally valid six-line lift blocks (label-compliant, hedge-free, non-weak Next) could be reused unchanged under different prompts and still pass the portable checker.  
- Require practical case-anchoring on the portable Substantive Lift surface so lift blocks refer to task-specific objects when the prompt contains extractable anchors while preserving prompt-omitted backwards compatibility.  
- Preserve deterministic, regex-only heuristics and avoid forcing mechanical name-dropping on every line; keep the rule vacuous when a prompt has no extractable anchors.  
- Verified local repository state and required artifacts exist before changes: local history shows the merge commits for PRs #646, #647, #648, #649, #651 and presence of `docs/evals/.../OBSERVATION_MEMO.md`, `docs/evals/runbooks/PR646_SUBSTANTIVE_LIFT_MANUAL_EVAL.md`, and `tests/fixtures/operator_run_capture/pr646_substantive_lift_case_packet.json`.

### Description

- Added CASE-ANCHORING RULES wording to the portable contract and included the required sentence verbatim: "A lift block that could be pasted under a different question unchanged is non-compliant."  
- Introduced constants `SUBSTANTIVE_LIFT_CASE_ANCHOR_RULES` and `GENERIC_LIFT_FILLER_PATTERNS`, conservative word-boundary filler regexes, and summary propagation via `substantive_lift_contract_summary()`.  
- Implemented deterministic anchor extraction `_extract_case_anchors(prompt: str) -> tuple[str, ...]` and helpers (`_line_contains_anchor`, `_normalize_lift_text`) that detect backticked spans, file/path tokens, PR/issue refs, uppercase lane IDs, and meaningful identifier tokens only.  
- Extended `check_substantive_lift(solution_text, prompt: Optional[str] = None)` to accept an optional `prompt`, return new result fields (`case_anchors`, `anchored_lift_lines`, `unanchored_lift`, `weak_anchor_distribution`, `intent_restates_prompt`, `filler_flags`), enforce a minimum anchor distribution (at least two distinct anchored lift lines or one of Recommendation/Fails if/Next anchored), flag obvious intent-restatement and filler patterns, and remain fully compatible with `prompt=None` callers.  
- Added fixtures and tests and a spec: changed files are `.specs/ALPHA-SOLVER-SUBSTANTIVE-LIFT-CASE-ANCHOR-HARDENING-001.md`, `.specs/INDEX.md`, `alpha_solver_portable.py`, `tests/fixtures/alpha_substantive_lift_cases.json`, and `tests/test_alpha_substantive_lift_contract.py`.

### Testing

- Pre-patch gap proof preserved: a structurally valid generic cosplay lift block still returns `ok: True` from `check_substantive_lift(text)` when `prompt=None`, proving shape-only behavior is still representable in tests.  
- Ran focused unit tests and linters with the following commands and results: `python -m pytest tests/test_alpha_substantive_lift_contract.py -q` (PASS), `python -m pytest tests/test_alpha_minimal_behavior_contract.py -q` (PASS), `python -m pytest tests/test_alpha_local_runtime_honesty.py -q` (PASS), `python -m pytest tests/test_alpha_no_echo_wiring.py -q` (PASS), `python -m pytest -q` (PASS with a small set of existing skips noted), `python scripts/check_narrative_claim_safety.py .specs/ALPHA-SOLVER-SUBSTANTIVE-LIFT-CASE-ANCHOR-HARDENING-001.md` (PASS), and `ruff check alpha_solver_portable.py tests/test_alpha_substantive_lift_contract.py` (PASS).  
- Focused tests added and passing cover: cosplay/generic fixtures that prove the old checker gap, prompt-aware rejection of cosplay fixtures, anchored counterparts passing when prompt anchors are provided, anchor extraction behavior, anchor-free prompt vacuity, intent-restatement flagging and false-positive guards, filler word-boundary guards, summary inclusion of case-anchoring rules, and spec indexing.

Notes and explicit non-claims: this change is limited to portable wording checks and deterministic regex heuristics only, makes no answer-quality, benchmark, readiness, provider, or model superiority claims, and preserves `check_substantive_lift(solution_text)` backward compatibility when `prompt` is omitted.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4be668ca848329948840fc67b594a6)