### PR TITLE
Post-652 capture preflight and lift honesty boundary

### DIFF
--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -82,6 +82,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `PROVIDER-OPENAI-001.md` | PROVIDER-OPENAI-001 · Real OpenAI Provider Execution | ✅ `SPEC_OK` |
 | `PROVIDER-SAFEOUT-001.md` | PROVIDER-SAFEOUT-001 · Structured Provider SAFE-OUT Responses | ✅ `SPEC_OK` |
 | `POST-551-NO-ECHO-WIRING-FIX-001.md` | POST-551-NO-ECHO-WIRING-FIX-001 · Local Alpha No-Echo Wiring Fix | ✅ `SPEC_OK` |
+| `POST652-CAPTURE-PREFLIGHT-AND-LIFT-HONESTY-BOUNDARY-001.md` | POST652-CAPTURE-PREFLIGHT-AND-LIFT-HONESTY-BOUNDARY-001 · Capture Preflight and Lift Honesty Boundary | ✅ `SPEC_OK` |
 | `RES-03.md` | CODE SPEC — RES-03 · Decision Rules & Scoring (RES) | ✅ `SPEC_RECONSTRUCTED_FROM_SOURCE` |
 | `RES-04.md` | CODE SPEC — RES-04 · Confidence & Budget Gates (RES) | ✅ `SPEC_RECONSTRUCTED_FROM_SOURCE` |
 | `RES-05.md` | CODE SPEC — RES-05 · Tool Adapters (Playwright, GSheets) — MVP stubs (RES) | ✅ `SPEC_RECONSTRUCTED_FROM_SOURCE` |

--- a/.specs/POST652-CAPTURE-PREFLIGHT-AND-LIFT-HONESTY-BOUNDARY-001.md
+++ b/.specs/POST652-CAPTURE-PREFLIGHT-AND-LIFT-HONESTY-BOUNDARY-001.md
@@ -1,0 +1,41 @@
+# POST652-CAPTURE-PREFLIGHT-AND-LIFT-HONESTY-BOUNDARY-001 · Capture Preflight and Lift Honesty Boundary
+
+## Purpose
+
+Add the smallest post-#652 follow-up that improves qualitative capture hygiene
+and locks the local honesty boundary between unsupported deterministic SAFE-OUT
+and Substantive Lift shape.
+
+## Scope
+
+- Document a Substantive Lift capture preflight in `docs/OPERATOR_RUN_CAPTURE.md`.
+- Preserve prompt/context parity, raw export provenance when available, and
+  explicit high-headroom prompt anchors before reviewing PR646/post-652
+  qualitative capture packets.
+- Keep `route_metadata` limited to route and provenance facts, not quality
+  judgments.
+- Repeat that score, rank, winner, blind label, source map, identity map, A/B
+  identity key, readiness, benchmark, and superiority fields remain disallowed.
+- Add one regression proving unsupported local synthesis SAFE-OUT is not
+  allowed to become fabricated Substantive Lift output, even when a prompt
+  contains explicit anchors.
+
+## Boundaries and non-claims
+
+- No provider, hosted-model, local-model, or external model calls.
+- No `/v1/solve` wiring, dashboard/API changes, route/persona activation,
+  model-backed synthesis, broad evaluation, or scoring.
+- No changes to low-headroom precedence, SAFE-OUT semantics, or SolverEnvelope
+  shape.
+- `check_substantive_lift(solution, prompt=prompt)` is a non-scoring structural
+  preflight only. Passing it is not answer quality, benchmark validation,
+  readiness, production suitability, or superiority evidence.
+- Post-#652 rerun results are qualitative operator signal only; this lane makes
+  no claim that PR #652 improved answer quality.
+
+## Validation
+
+- Run focused local runtime honesty tests.
+- Run Substantive Lift contract tests.
+- Run narrative claim-safety on changed docs/spec when practical.
+- Run ruff on touched Python files.

--- a/docs/OPERATOR_RUN_CAPTURE.md
+++ b/docs/OPERATOR_RUN_CAPTURE.md
@@ -57,6 +57,32 @@ all outputs; the harness only scaffolds, validates, and exports.
    canonical body) so replay or review lanes can detect any post-export edit.
    Re-exporting the same capture yields byte-identical output.
 
+## Substantive Lift capture preflight
+
+Before reviewing a PR646/post-652 qualitative capture packet, operators should
+confirm the packet preserves the evidence needed to evaluate the run without
+turning the harness into a scorer:
+
+- Preserve prompt/context parity between baseline and Alpha threads, including
+  the same task wording, constraints, and any operator-provided context used to
+  generate each pasted output.
+- Preserve raw export provenance when available, such as the raw exported
+  transcript or capture artifact that the pasted fields came from.
+- Preserve explicit high-headroom prompt anchors when the prompt expects
+  case-specific reasoning, including files, PR numbers, issue numbers, named
+  artifacts, implementation lanes, or other concrete task objects.
+- Keep `route_metadata` limited to route and provenance facts. It is not a
+  place for quality judgments, comparative conclusions, or reviewer scoring.
+- Do not add score, rank, winner, blind label, source map, identity map, A/B
+  identity key, readiness, benchmark, or superiority fields to the capture,
+  export, `route_metadata`, or surrounding packet notes.
+
+`check_substantive_lift(solution, prompt=prompt)` may be used only as a
+non-scoring structural preflight for the Substantive Lift wording contract. A
+passing result must not be described as answer quality, benchmark validation,
+readiness, production suitability, or Alpha superiority; it only means the
+checked text satisfied the local structural wording rules for that prompt.
+
 ## Packet contents
 
 Every exported packet embeds a `harness_boundaries` block recording, as

--- a/tests/test_alpha_local_runtime_honesty.py
+++ b/tests/test_alpha_local_runtime_honesty.py
@@ -330,3 +330,51 @@ def test_portable_diagnostics_tot_matches_safeout_honesty_adjustment():
         == envelope.safe_out_state["confidence_adjustment_reason"]
     )
     assert diagnostics_tot["artifact_kind"] in {"prompt_echo", "template_branch"}
+
+
+def test_unsupported_local_safeout_is_not_lift_cosplay_for_anchored_prompt():
+    prompt = (
+        "For alpha_solver_portable.py after PR #652, decide whether "
+        "ALPHA-SOLVER-SUBSTANTIVE-LIFT-CASE-ANCHOR-HARDENING-001 proves "
+        "local deterministic synthesis can produce a case-anchored Substantive "
+        "Lift answer. Include concrete file and PR anchors."
+    )
+
+    envelope = portable.PortableAlphaSolver(seed=7).solve(prompt)
+
+    assert envelope.solution.startswith("SAFE-OUT:"), envelope.solution
+    assert envelope.confidence == 0.20
+    assert envelope.safe_out_state["answer_kind"] == "local_unsupported_safeout"
+    assert envelope.safe_out_state["synthesis_available"] is False
+    assert (
+        envelope.safe_out_state["confidence_adjustment_reason"]
+        == "confidence_adjusted_due_to_unsupported_local_synthesis"
+    )
+    assert envelope.diagnostics.tot["answer_kind"] == "local_unsupported_safeout"
+    assert envelope.diagnostics.tot["synthesis_available"] is False
+    assert _normalized(envelope.solution) != _normalized(prompt)
+    for prefix in BLOCKED_TEMPLATE_PREFIXES + COT_ARTIFACT_PREFIXES:
+        assert not envelope.solution.lower().startswith(prefix.lower())
+    for label in LIFT_LABELS:
+        assert not envelope.solution.startswith(label)
+    assert "Recommendation:" not in envelope.solution
+    assert "Fails if:" not in envelope.solution
+    assert "Next:" not in envelope.solution
+
+    generic_lift_block = "\n".join(
+        [
+            "Intent: Address the request with a thoughtful approach.",
+            "Assumes: The team wants a robust solution for the situation.",
+            "Tradeoff: Balance quality against speed for the best outcome.",
+            "Recommendation: Use best practices and carefully consider options.",
+            "Fails if: Various stakeholders disagree with the approach.",
+            "Next: Consider the available choices and decide how to proceed.",
+        ]
+    )
+    lift_check = portable.check_substantive_lift(generic_lift_block, prompt=prompt)
+
+    assert lift_check["ok"] is False
+    assert lift_check["unanchored_lift"] is True
+    assert lift_check["weak_anchor_distribution"] is True
+    assert lift_check["filler_flags"]
+    assert lift_check["weak_next_action"] is True


### PR DESCRIPTION
### Motivation

- Provide a minimal post-#652 follow-up that improves operator evidence hygiene for Substantive Lift capture and locks the honesty boundary so unsupported local SAFE-OUT cannot masquerade as a case-anchored Substantive Lift.
- Keep the change narrow and non-invasive: operator guidance, a focused spec, and a single regression test to prevent cross-contract contamination, without runtime or routing changes.

### Description

- Issue: `#650` and lane: `POST652-CAPTURE-PREFLIGHT-AND-LIFT-HONESTY-BOUNDARY-001`. 
- Added a narrow lane spec at `.specs/POST652-CAPTURE-PREFLIGHT-AND-LIFT-HONESTY-BOUNDARY-001.md` and registered it in `.specs/INDEX.md` to document scope, boundaries, and validation expectations. 
- Added a `Substantive Lift capture preflight` section to `docs/OPERATOR_RUN_CAPTURE.md` covering prompt/context parity, raw export provenance, explicit high-headroom anchors, `route_metadata` provenance-only guidance, and the non-scoring role of `check_substantive_lift(solution, prompt=prompt)`. 
- Added one regression test `test_unsupported_local_safeout_is_not_lift_cosplay_for_anchored_prompt` to `tests/test_alpha_local_runtime_honesty.py` that proves an anchored unsupported prompt yields a bounded `SAFE-OUT:` low-confidence response and that a generic six-line lift block fails prompt-aware `check_substantive_lift` anchoring checks; no runtime behavior or API wiring was changed.

### Testing

- Live-state verification: local repo history contains merged PR commits for #646, #647, #648, #649, #651, and #652 and required files (`docs/evals/runs/pr646-substantive-lift-manual-eval/OBSERVATION_MEMO.md` and `.specs/ALPHA-SOLVER-SUBSTANTIVE-LIFT-CASE-ANCHOR-HARDENING-001.md`) were found locally; GitHub `gh` CLI was not available in the environment so remote PR/issue live-state could not be queried. 
- Ran focused tests and linters with the following results: `python -m pytest tests/test_alpha_local_runtime_honesty.py -q` → passed, `python -m pytest tests/test_alpha_substantive_lift_contract.py -q` → passed, `python -m pytest tests/test_operator_run_capture.py tests/test_pr646_substantive_lift_eval_prep.py -q` → passed, `python scripts/check_narrative_claim_safety.py docs/OPERATOR_RUN_CAPTURE.md .specs/POST652-CAPTURE-PREFLIGHT-AND-LIFT-HONESTY-BOUNDARY-001.md` → passed (2 files scanned), and `python -m ruff check tests/test_alpha_local_runtime_honesty.py` → passed. 
- Explicit non-claims: this PR makes no provider/hosted/local-model calls, does not wire `/v1/solve` or change routes/personas, performs no scoring/ranking/blinding, does not change SAFE-OUT precedence or SolverEnvelope shape, and does not claim PR #652 improved answer quality. 
- Remaining risks: remote GitHub PR/issue open-state could not be validated due to missing `gh` in the environment, and the new docs guidance is operator-facing only (not enforced beyond existing validation/lint coverage). Behavior changed: docs/specs/tests only; no runtime behavior changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bf2457a34832985ac4c87899ffd43)