### PR TITLE
eval: add Substantive Lift preflight CLI for operator capture

### DIFF
--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -103,3 +103,4 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `UI-REQ-001.md` | UI-REQ-001 · Dashboard Request Submission UI | ✅ `SPEC_OK` |
 | `UI-RUN-001.md` | UI-RUN-001 · Dashboard One-click Demo Run | ✅ `SPEC_OK` |
 | `ALPHA-SOLVER-SUBSTANTIVE-LIFT-CASE-ANCHOR-HARDENING-001.md` | ALPHA-SOLVER-SUBSTANTIVE-LIFT-CASE-ANCHOR-HARDENING-001 · Substantive Lift Case Anchor Hardening | ✅ `SPEC_OK` |
+| `OPERATOR-RUN-CAPTURE-SUBSTANTIVE-LIFT-PREFLIGHT-CLI-001.md` | OPERATOR-RUN-CAPTURE-SUBSTANTIVE-LIFT-PREFLIGHT-CLI-001 · Substantive Lift Preflight CLI | ✅ `SPEC_OK` |

--- a/.specs/OPERATOR-RUN-CAPTURE-SUBSTANTIVE-LIFT-PREFLIGHT-CLI-001.md
+++ b/.specs/OPERATOR-RUN-CAPTURE-SUBSTANTIVE-LIFT-PREFLIGHT-CLI-001.md
@@ -1,0 +1,113 @@
+# OPERATOR-RUN-CAPTURE-SUBSTANTIVE-LIFT-PREFLIGHT-CLI-001 · Substantive Lift Preflight CLI
+
+Status: Implemented
+
+## Goal
+
+Turn the post-#654 Substantive Lift capture-preflight guidance in
+`docs/OPERATOR_RUN_CAPTURE.md` into an optional, local, read-only CLI path so
+the operator can catch structural lift/case-anchoring wording problems in a
+filled capture before qualitative review, without converting the capture
+harness into an evaluator.
+
+## Motivation
+
+PR #654 documented that `check_substantive_lift(solution, prompt=prompt)` may
+be used as a non-scoring structural preflight, but the operator had to wire
+that call up by hand for every case in a capture. This lane gives the existing
+operator run capture CLI a `lift-preflight` subcommand that performs exactly
+that documented, bounded use over an existing capture file. It automates
+already-approved guidance; it adds no new evaluation semantics.
+
+## Scope
+
+- `alpha/eval/operator_run_capture.py`: read-only preflight helpers —
+  `lift_preflight_capture(capture)` classifies each case into one of
+  `LIFT_PREFLIGHT_STATES` (`invalid_case`, `excluded_case`, `missing_prompt`,
+  `missing_routed_output`, `safe_out_not_applicable`, `structural_pass`,
+  `structural_fail`), calling
+  `check_substantive_lift(routed_output, prompt=prompt)` from
+  `alpha_solver_portable.py` only for cases that carry both texts;
+  `render_lift_preflight_text(report)` renders operator-readable console
+  output. Every report embeds `LIFT_PREFLIGHT_BOUNDARY`, the structural-only
+  boundary statement.
+- Bounded `SAFE-OUT:`-prefixed routed outputs are reported as
+  `safe_out_not_applicable`: the lift wording contract does not apply to
+  honest non-answers, mirroring the POST652 honesty boundary.
+- Anchor-free prompts are reported as vacuous for anchor-specific checks
+  (`anchor_checks_vacuous`), never as failures.
+- `scripts/operator_run_capture.py`: new `lift-preflight` subcommand with
+  `--capture`, optional `--report-out` (local JSON report, overwrite-guarded
+  behind `--force`), exit code 0 when no case needs attention and 1 when any
+  case is a structural fail, has missing text, or is malformed.
+- `docs/OPERATOR_RUN_CAPTURE.md`: CLI usage, state meanings, exit codes, and
+  boundary language under the existing Substantive Lift capture preflight
+  section.
+- Tests in `tests/test_operator_run_capture.py` covering pass, fail,
+  vacuous-anchor, excluded, missing-text, SAFE-OUT, non-mutation,
+  prohibited-field absence, report/overwrite behavior, and that the existing
+  init/validate/export flow is untouched.
+
+## Non-goals and boundaries
+
+- No provider, hosted-model, or local-model calls; no network access.
+- No `/v1/solve` wiring, dashboard/API changes, or route/persona activation.
+- No scoring, ranking, winner fields, blind labels, source maps, identity
+  maps, or A/B identity keys; the report structure carries none of these.
+- No change to the capture schema, the export packet schema, or the existing
+  `init` / `validate` / `export` semantics; the preflight report is a separate
+  local file with its own `operator_lift_preflight_report/v1` schema version
+  and is not an input to `export`.
+- The preflight never mutates the capture file.
+- No change to SAFE-OUT semantics, SolverEnvelope shape, or low-headroom
+  precedence; the portable checker itself is consumed, not modified.
+- No benchmark, readiness, production, provider-validation,
+  local-model-validation, model-superiority, or Alpha-superiority claims.
+- No claim that PR #646, #652, #654, or this lane improves answer quality.
+  A `structural_pass` means only that the configured local structural wording
+  checks held for the supplied routed output text and prompt; it is not an
+  answer-quality judgment, and comparative interpretation of baseline versus
+  routed outputs stays out of scope.
+
+## Code Targets
+
+- `alpha/eval/operator_run_capture.py`
+- `scripts/operator_run_capture.py`
+- `docs/OPERATOR_RUN_CAPTURE.md`
+- `tests/test_operator_run_capture.py`
+
+## Test Plan
+
+`tests/test_operator_run_capture.py` (`TestLiftPreflight`,
+`TestLiftPreflightCli`): anchored compliant routed output reaches
+`structural_pass`; a generic six-move block under an anchored prompt reaches
+`structural_fail` with `unanchored_lift` named; an anchor-free prompt yields a
+vacuous pass, not a false failure; excluded cases are skipped and never
+checked; missing prompt and missing routed output map to their own states;
+bounded `SAFE-OUT:` routed output maps to `safe_out_not_applicable`; the
+preflight never mutates the capture (in-memory and on-disk byte checks); the
+report and console output carry the structural-only boundary language and no
+score/rank/winner/blind/source-map/identity-map keys; `--report-out` refuses
+to overwrite without `--force`; invalid top-level shapes raise; non-dict cases
+are flagged, not crashed; the existing init/validate/export flow still passes
+unchanged.
+
+## Validation
+
+- `python -m pytest tests/test_operator_run_capture.py -q`
+- `python -m pytest tests/test_pr646_substantive_lift_eval_prep.py -q`
+- `python -m pytest tests/test_alpha_substantive_lift_contract.py -q`
+- `python -m pytest tests/test_alpha_local_runtime_honesty.py -q`
+- `python -m pytest -q`
+- `python scripts/check_narrative_claim_safety.py docs/OPERATOR_RUN_CAPTURE.md`
+- `python scripts/check_narrative_claim_safety.py .specs/OPERATOR-RUN-CAPTURE-SUBSTANTIVE-LIFT-PREFLIGHT-CLI-001.md`
+- `ruff check alpha/eval/operator_run_capture.py scripts/operator_run_capture.py tests/test_operator_run_capture.py`
+
+## Definition of Done
+
+Preflight helpers, CLI subcommand, docs, tests, and this spec merged; all
+validation commands pass; existing init/validate/export behavior and both
+capture/export schemas unchanged; all boundaries above hold. A passing
+preflight run means only that the configured structural rules held for the
+checked capture text; it is not a quality, benchmark, readiness, or
+superiority judgment.

--- a/alpha/eval/operator_run_capture.py
+++ b/alpha/eval/operator_run_capture.py
@@ -310,3 +310,219 @@ def render_json_bytes(payload: Dict[str, Any]) -> bytes:
     """Render a payload as byte-stable, replay-friendly JSON."""
     text = json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True)
     return (text + "\n").encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Substantive Lift preflight
+# (OPERATOR-RUN-CAPTURE-SUBSTANTIVE-LIFT-PREFLIGHT-CLI-001)
+#
+# Optional, read-only structural preflight over an existing capture file. For
+# each case that has both a prompt and a routed output, it runs the portable
+# Substantive Lift wording checker so the operator can catch lift/case-anchor
+# structure problems before qualitative review. It never mutates the capture,
+# never touches the export packet schema, and never scores, ranks, blinds, or
+# picks winners.
+# ---------------------------------------------------------------------------
+
+LIFT_PREFLIGHT_LANE_ID = "OPERATOR-RUN-CAPTURE-SUBSTANTIVE-LIFT-PREFLIGHT-CLI-001"
+LIFT_PREFLIGHT_REPORT_SCHEMA_VERSION = "operator_lift_preflight_report/v1"
+
+# Boundary statement repeated in every report and rendered output. A preflight
+# pass is a structural wording result only.
+LIFT_PREFLIGHT_BOUNDARY = (
+    "Structural wording preflight only: not answer quality, not benchmark "
+    "validation, not readiness, and not Alpha superiority. A pass means only "
+    "that the configured local structural checks held for the supplied "
+    "routed output text and prompt."
+)
+
+LIFT_PREFLIGHT_STATES = (
+    "invalid_case",
+    "excluded_case",
+    "missing_prompt",
+    "missing_routed_output",
+    "safe_out_not_applicable",
+    "structural_pass",
+    "structural_fail",
+)
+
+# States that mean the capture needs operator attention before qualitative
+# review; the CLI maps any of these to a non-zero exit code.
+LIFT_PREFLIGHT_ATTENTION_STATES = frozenset(
+    {"invalid_case", "missing_prompt", "missing_routed_output", "structural_fail"}
+)
+
+# Bounded SAFE-OUT responses are honest non-answers: the lift wording contract
+# does not apply to them, so the preflight reports them as not applicable
+# instead of failing them. Explicit prefix match only, mirroring the portable
+# honesty guard's explicit-prefix style.
+_LIFT_PREFLIGHT_SAFEOUT_PREFIX = "safe-out:"
+
+
+def _lift_structural_flags(checker_result: Dict[str, Any]) -> List[str]:
+    """Name the structural checks that did not hold, for operator display."""
+    flags: List[str] = []
+    if checker_result.get("missing_moves"):
+        flags.append(f"missing_moves={checker_result['missing_moves']}")
+    if checker_result.get("empty_moves"):
+        flags.append(f"empty_moves={checker_result['empty_moves']}")
+    if not checker_result.get("missing_moves") and not checker_result.get("order_ok"):
+        flags.append("lift_block_out_of_order")
+    if not checker_result.get("opens_with_intent"):
+        flags.append("does_not_open_with_intent")
+    if checker_result.get("generic_flags"):
+        flags.append(f"generic_hedges={checker_result['generic_flags']}")
+    if checker_result.get("weak_next_action"):
+        flags.append("weak_next_action")
+    if checker_result.get("filler_flags"):
+        flags.append(f"filler={checker_result['filler_flags']}")
+    if checker_result.get("unanchored_lift"):
+        flags.append("unanchored_lift")
+    if checker_result.get("weak_anchor_distribution"):
+        flags.append("weak_anchor_distribution")
+    if checker_result.get("intent_restates_prompt"):
+        flags.append("intent_restates_prompt")
+    return flags
+
+
+def _lift_preflight_case(case: Any, index: int, checker: Any) -> Dict[str, Any]:
+    finding: Dict[str, Any] = {
+        "task_id": f"cases[{index}]",
+        "state": "invalid_case",
+        "anchor_checks_vacuous": False,
+        "case_anchor_count": 0,
+        "structural_flags": [],
+        "detail": "",
+    }
+    if not isinstance(case, dict):
+        finding["detail"] = "case is not a JSON object"
+        return finding
+    if _is_nonempty_str(case.get("task_id")):
+        finding["task_id"] = case["task_id"]
+
+    if case.get("validation_status") == "excluded":
+        finding["state"] = "excluded_case"
+        finding["detail"] = "case was excluded during capture; preflight skipped"
+        return finding
+
+    prompt = case.get("prompt")
+    if not _is_nonempty_str(prompt):
+        finding["state"] = "missing_prompt"
+        finding["detail"] = (
+            "prompt is missing or empty; the preflight needs the prompt text"
+        )
+        return finding
+
+    routed_output = case.get("routed_output")
+    if not _is_nonempty_str(routed_output):
+        finding["state"] = "missing_routed_output"
+        finding["detail"] = (
+            "routed_output is missing or empty; there is no text to preflight"
+        )
+        return finding
+
+    if routed_output.strip().lower().startswith(_LIFT_PREFLIGHT_SAFEOUT_PREFIX):
+        finding["state"] = "safe_out_not_applicable"
+        finding["detail"] = (
+            "routed output is a bounded SAFE-OUT response; the Substantive "
+            "Lift wording contract does not apply to honest non-answers"
+        )
+        return finding
+
+    checker_result = checker(routed_output, prompt=prompt)
+    finding["case_anchor_count"] = len(checker_result.get("case_anchors", []))
+    finding["anchor_checks_vacuous"] = finding["case_anchor_count"] == 0
+    finding["checker"] = checker_result
+    if checker_result.get("ok"):
+        finding["state"] = "structural_pass"
+        finding["detail"] = "configured structural wording checks held"
+    else:
+        finding["state"] = "structural_fail"
+        finding["structural_flags"] = _lift_structural_flags(checker_result)
+        finding["detail"] = "; ".join(finding["structural_flags"])
+    return finding
+
+
+def lift_preflight_capture(capture: Any) -> Dict[str, Any]:
+    """Run the read-only Substantive Lift structural preflight over a capture.
+
+    Uses ``check_substantive_lift(routed_output, prompt=prompt)`` from the
+    portable spec monolith for every case that carries both texts. The result
+    is a local report structure, not an evidence packet: it carries no scores,
+    ranks, winners, blind labels, source maps, or identity maps, and the
+    input capture is never modified. A ``structural_pass`` state means only
+    that the configured local structural checks held for the supplied text
+    and prompt; it is not an answer-quality judgment.
+    """
+    # Local import so the harness stays importable on its own; the checker
+    # lives in the repo-root portable spec monolith.
+    from alpha_solver_portable import check_substantive_lift
+
+    if not isinstance(capture, dict):
+        raise ValueError("lift preflight: capture top level must be a JSON object")
+    cases = capture.get("cases")
+    if not isinstance(cases, list) or not cases:
+        raise ValueError("lift preflight: capture cases must be a non-empty list")
+
+    findings = [
+        _lift_preflight_case(case, index, check_substantive_lift)
+        for index, case in enumerate(cases)
+    ]
+    counts = {state: 0 for state in LIFT_PREFLIGHT_STATES}
+    for finding in findings:
+        counts[finding["state"]] += 1
+    needs_attention = [
+        finding["task_id"]
+        for finding in findings
+        if finding["state"] in LIFT_PREFLIGHT_ATTENTION_STATES
+    ]
+    packet_id = (
+        capture["packet_id"] if _is_nonempty_str(capture.get("packet_id")) else None
+    )
+    return {
+        "schema_version": LIFT_PREFLIGHT_REPORT_SCHEMA_VERSION,
+        "lane_id": LIFT_PREFLIGHT_LANE_ID,
+        "packet_id": packet_id,
+        "boundary": LIFT_PREFLIGHT_BOUNDARY,
+        "cases": findings,
+        "summary": {
+            "counts": {**counts, "total": len(findings)},
+            "needs_attention": needs_attention,
+        },
+    }
+
+
+def render_lift_preflight_text(report: Dict[str, Any]) -> str:
+    """Render a preflight report as operator-readable console text."""
+    lines = [
+        (
+            f"Substantive Lift preflight for packet {report['packet_id']!r} "
+            f"({report['summary']['counts']['total']} cases)"
+        ),
+        f"boundary: {report['boundary']}",
+    ]
+    for finding in report["cases"]:
+        line = f"  {finding['task_id']}: {finding['state']}"
+        if finding["state"] in ("structural_pass", "structural_fail"):
+            if finding["anchor_checks_vacuous"]:
+                line += (
+                    " (anchor checks vacuous: prompt has no extractable anchors)"
+                )
+            else:
+                line += f" (anchors={finding['case_anchor_count']})"
+        if finding["state"] not in ("structural_pass",) and finding["detail"]:
+            line += f" — {finding['detail']}"
+        lines.append(line)
+    counts = report["summary"]["counts"]
+    summary_bits = [
+        f"{state}={counts[state]}"
+        for state in LIFT_PREFLIGHT_STATES
+        if counts[state]
+    ]
+    lines.append("summary: " + (" ".join(summary_bits) if summary_bits else "empty"))
+    needs_attention = report["summary"]["needs_attention"]
+    if needs_attention:
+        lines.append("needs attention: " + ", ".join(needs_attention))
+    else:
+        lines.append("needs attention: none")
+    return "\n".join(lines)

--- a/alpha/eval/operator_run_capture.py
+++ b/alpha/eval/operator_run_capture.py
@@ -385,6 +385,29 @@ def _lift_structural_flags(checker_result: Dict[str, Any]) -> List[str]:
     return flags
 
 
+def _lift_preflight_capture_case_shape_errors(case: Any, index: int) -> List[str]:
+    """Validate capture-case shape before Substantive Lift preflight.
+
+    The preflight has separate states for empty prompt and empty routed output,
+    so this helper reuses the capture-case validator while allowing those two
+    text fields to be blank when their keys are present. Missing keys, unknown
+    keys, invalid statuses, invalid metadata, and malformed excluded cases stay
+    schema errors and must never be reported as structural lift results.
+    """
+    if not isinstance(case, dict):
+        return _validate_capture_case(case, index)
+    validation_case = dict(case)
+    if "prompt" in validation_case and not _is_nonempty_str(
+        validation_case.get("prompt")
+    ):
+        validation_case["prompt"] = "preflight prompt placeholder"
+    if "routed_output" in validation_case and not _is_nonempty_str(
+        validation_case.get("routed_output")
+    ):
+        validation_case["routed_output"] = "preflight routed output placeholder"
+    return _validate_capture_case(validation_case, index)
+
+
 def _lift_preflight_case(case: Any, index: int, checker: Any) -> Dict[str, Any]:
     finding: Dict[str, Any] = {
         "task_id": f"cases[{index}]",
@@ -394,8 +417,9 @@ def _lift_preflight_case(case: Any, index: int, checker: Any) -> Dict[str, Any]:
         "structural_flags": [],
         "detail": "",
     }
-    if not isinstance(case, dict):
-        finding["detail"] = "case is not a JSON object"
+    shape_errors = _lift_preflight_capture_case_shape_errors(case, index)
+    if shape_errors:
+        finding["detail"] = "; ".join(shape_errors)
         return finding
     if _is_nonempty_str(case.get("task_id")):
         finding["task_id"] = case["task_id"]

--- a/docs/OPERATOR_RUN_CAPTURE.md
+++ b/docs/OPERATOR_RUN_CAPTURE.md
@@ -83,6 +83,44 @@ passing result must not be described as answer quality, benchmark validation,
 readiness, production suitability, or Alpha superiority; it only means the
 checked text satisfied the local structural wording rules for that prompt.
 
+### Running the lift preflight CLI
+
+After filling a capture and before qualitative review, the operator can run
+the read-only preflight over the capture file:
+
+```bash
+python scripts/operator_run_capture.py lift-preflight \
+  --capture local/pr646_substantive_lift_capture.json \
+  --report-out local/pr646_lift_preflight_report.json
+```
+
+The command loads the capture, and for every case that has both a prompt and
+a routed output it runs `check_substantive_lift(routed_output, prompt=prompt)`
+and prints one state per case:
+
+- `structural_pass` / `structural_fail` — the configured structural wording
+  checks held or did not hold for the supplied routed output and prompt. When
+  the prompt has no extractable anchors, the line says the anchor-specific
+  checks were vacuous, so anchor-free prompts do not create false failures.
+- `missing_prompt` / `missing_routed_output` — the case cannot be preflighted
+  yet; fill the capture first.
+- `excluded_case` — excluded cases are skipped, never checked.
+- `safe_out_not_applicable` — the routed output is a bounded `SAFE-OUT:`
+  response; the lift wording contract does not apply to honest non-answers.
+
+Exit code 0 means no case needed attention; exit code 1 means at least one
+case was a structural fail, had missing text, or was malformed. The optional
+`--report-out` file is a local JSON report for the operator's own notes. It
+is not a capture file, not an evidence packet, and not an input to `export`;
+it carries no score, rank, winner, blind-label, source-map, or identity-map
+fields, and writing it never modifies the capture.
+
+The preflight is structural wording only. Its output must not be described
+as answer quality, benchmark validation, readiness, or Alpha superiority; a
+`structural_pass` means only that the configured local structural checks held
+for the supplied text and prompt. Comparative interpretation of baseline
+versus routed outputs remains out of scope for this harness.
+
 ## Packet contents
 
 Every exported packet embeds a `harness_boundaries` block recording, as

--- a/scripts/operator_run_capture.py
+++ b/scripts/operator_run_capture.py
@@ -2,13 +2,17 @@
 """Local-only CLI for the operator run capture harness.
 
 Subcommands:
-  init      Scaffold a capture file from an operator-authored case packet.
-  validate  Check a capture file (add --for-export for export completeness).
-  export    Validate and write the normalized evidence packet.
+  init            Scaffold a capture file from an operator-authored case packet.
+  validate        Check a capture file (add --for-export for export completeness).
+  export          Validate and write the normalized evidence packet.
+  lift-preflight  Read-only Substantive Lift structural preflight over a capture.
 
 This CLI reads and writes local JSON files only. It performs no provider,
 hosted-model, or local-model calls, no tool execution, and no network access,
-and it does not score, blind, or unblind outputs.
+and it does not score, blind, or unblind outputs. The lift-preflight
+subcommand is a structural wording preflight only: it never mutates the
+capture, and a pass is not answer quality, benchmark validation, readiness,
+or Alpha superiority.
 """
 from __future__ import annotations
 
@@ -97,6 +101,24 @@ def cmd_export(args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
+def cmd_lift_preflight(args: argparse.Namespace) -> int:
+    capture = _read_json(Path(args.capture), "capture file")
+    try:
+        report = orc.lift_preflight_capture(capture)
+    except ValueError as exc:
+        print(f"FAIL {exc}")
+        return EXIT_VALIDATION
+    print(orc.render_lift_preflight_text(report))
+    if args.report_out:
+        _write_bytes(
+            Path(args.report_out), orc.render_json_bytes(report), args.force
+        )
+        print(f"OK wrote preflight report -> {args.report_out}")
+    if report["summary"]["needs_attention"]:
+        return EXIT_VALIDATION
+    return EXIT_OK
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="operator_run_capture",
@@ -121,6 +143,22 @@ def build_parser() -> argparse.ArgumentParser:
     export_parser.add_argument("--out", required=True)
     export_parser.add_argument("--force", action="store_true")
     export_parser.set_defaults(func=cmd_export)
+
+    preflight_parser = sub.add_parser(
+        "lift-preflight",
+        help=(
+            "read-only Substantive Lift structural wording preflight "
+            "(not a quality, benchmark, readiness, or superiority check)"
+        ),
+    )
+    preflight_parser.add_argument("--capture", required=True)
+    preflight_parser.add_argument(
+        "--report-out",
+        help="optional path for a local JSON preflight report "
+        "(separate from the capture and export packet)",
+    )
+    preflight_parser.add_argument("--force", action="store_true")
+    preflight_parser.set_defaults(func=cmd_lift_preflight)
     return parser
 
 

--- a/tests/test_operator_run_capture.py
+++ b/tests/test_operator_run_capture.py
@@ -242,3 +242,313 @@ class TestCli:
         result = _run_cli("validate", "--capture", str(tmp_path / "missing.json"))
         assert result.returncode == 2
         assert "not found" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Substantive Lift preflight
+# (OPERATOR-RUN-CAPTURE-SUBSTANTIVE-LIFT-PREFLIGHT-CLI-001)
+# ---------------------------------------------------------------------------
+
+ANCHORED_PROMPT = (
+    "Decide whether `tests/fixtures/demo_plan.json` gains a rollback step "
+    "before the PR #701 review."
+)
+
+# Passes the prompt-aware checker: every line names a case object from the
+# anchored prompt. Synthetic operator-authored text; not a model output.
+ANCHORED_PASS_BLOCK = """Intent: Choose whether the rollback step lands in tests/fixtures/demo_plan.json before the PR #701 review window.
+Assumes: The packet in tests/fixtures/demo_plan.json is the only artifact reviewers exercise before PR #701.
+Tradeoff: Adding rollback coverage to tests/fixtures/demo_plan.json now versus keeping PR #701 small enough to review in one pass.
+Recommendation: Add the rollback step to tests/fixtures/demo_plan.json now and keep PR #701 limited to that packet change.
+Fails if: The rollback step needs fields that tests/fixtures/demo_plan.json cannot carry without breaking the packet loader.
+Next: Draft the rollback entry in tests/fixtures/demo_plan.json and attach it to the PR #701 description today."""
+
+# Structurally shaped six-move block with no case objects at all: fails the
+# prompt-aware checker for an anchored prompt, but is a legitimate pass when
+# the prompt itself has no extractable anchors (vacuous anchor checks).
+GENERIC_BLOCK = """Intent: Decide the best path forward for the team given the stated goal.
+Assumes: The strongest hidden assumption is that the current process is stable.
+Tradeoff: Speed of delivery versus completeness of the final outcome.
+Recommendation: Proceed with the smaller change under the current constraints.
+Fails if: The requirements change materially before the work completes.
+Next: Write down the decision and share it with the owning group today."""
+
+ANCHOR_FREE_PROMPT = "Should our weekly status update lead with wins or with risks?"
+
+PROHIBITED_KEY_MARKERS = (
+    "score",
+    "rank",
+    "winner",
+    "blind",
+    "source_map",
+    "identity_map",
+)
+
+
+def _preflight_case(task_id: str, prompt: str, routed_output: str, **overrides) -> dict:
+    case = {
+        "task_id": task_id,
+        "prompt": prompt,
+        "baseline_output": "baseline text placeholder",
+        "routed_output": routed_output,
+        "route_metadata": {"source": "unit-test synthetic case"},
+        "validation_status": "captured",
+    }
+    case.update(overrides)
+    return case
+
+
+def _preflight_capture(cases: list) -> dict:
+    return {
+        "schema_version": orc.CAPTURE_SCHEMA_VERSION,
+        "packet_id": "lift-preflight-tests",
+        "capture_mode": orc.CAPTURE_MODE,
+        "cases": cases,
+    }
+
+
+def _walk_keys(payload):
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            yield key
+            yield from _walk_keys(value)
+    elif isinstance(payload, list):
+        for item in payload:
+            yield from _walk_keys(item)
+
+
+class TestLiftPreflight:
+    def test_anchored_compliant_routed_output_passes(self):
+        capture = _preflight_capture(
+            [_preflight_case("case-a", ANCHORED_PROMPT, ANCHORED_PASS_BLOCK)]
+        )
+        report = orc.lift_preflight_capture(capture)
+        finding = report["cases"][0]
+        assert finding["state"] == "structural_pass"
+        assert finding["anchor_checks_vacuous"] is False
+        assert finding["case_anchor_count"] >= 2
+        assert finding["structural_flags"] == []
+        assert report["summary"]["needs_attention"] == []
+
+    def test_generic_block_fails_for_anchored_prompt(self):
+        capture = _preflight_capture(
+            [_preflight_case("case-b", ANCHORED_PROMPT, GENERIC_BLOCK)]
+        )
+        report = orc.lift_preflight_capture(capture)
+        finding = report["cases"][0]
+        assert finding["state"] == "structural_fail"
+        assert "unanchored_lift" in finding["structural_flags"]
+        assert report["summary"]["needs_attention"] == ["case-b"]
+
+    def test_anchor_free_prompt_is_vacuous_not_a_false_failure(self):
+        capture = _preflight_capture(
+            [_preflight_case("case-c", ANCHOR_FREE_PROMPT, GENERIC_BLOCK)]
+        )
+        report = orc.lift_preflight_capture(capture)
+        finding = report["cases"][0]
+        assert finding["state"] == "structural_pass"
+        assert finding["anchor_checks_vacuous"] is True
+        assert finding["case_anchor_count"] == 0
+        assert report["summary"]["needs_attention"] == []
+
+    def test_excluded_case_is_skipped_not_checked(self):
+        capture = _preflight_capture(
+            [
+                _preflight_case(
+                    "case-d",
+                    ANCHORED_PROMPT,
+                    "",
+                    validation_status="excluded",
+                    exclusion_reason="operator dropped this task",
+                )
+            ]
+        )
+        report = orc.lift_preflight_capture(capture)
+        finding = report["cases"][0]
+        assert finding["state"] == "excluded_case"
+        assert "checker" not in finding
+        assert report["summary"]["needs_attention"] == []
+
+    def test_missing_prompt_and_missing_routed_output_states(self):
+        capture = _preflight_capture(
+            [
+                _preflight_case("case-e", "", GENERIC_BLOCK),
+                _preflight_case(
+                    "case-f", ANCHORED_PROMPT, "", validation_status="pending"
+                ),
+            ]
+        )
+        report = orc.lift_preflight_capture(capture)
+        states = {f["task_id"]: f["state"] for f in report["cases"]}
+        assert states == {
+            "case-e": "missing_prompt",
+            "case-f": "missing_routed_output",
+        }
+        assert report["summary"]["needs_attention"] == ["case-e", "case-f"]
+
+    def test_safe_out_routed_output_is_not_applicable(self):
+        sys.path.insert(0, str(SCRIPT.parents[1]))
+        from alpha_solver_portable import PORTABLE_LOCAL_UNSUPPORTED_SAFEOUT
+
+        capture = _preflight_capture(
+            [
+                _preflight_case(
+                    "case-g", ANCHORED_PROMPT, PORTABLE_LOCAL_UNSUPPORTED_SAFEOUT
+                )
+            ]
+        )
+        report = orc.lift_preflight_capture(capture)
+        finding = report["cases"][0]
+        assert finding["state"] == "safe_out_not_applicable"
+        assert "checker" not in finding
+        assert report["summary"]["needs_attention"] == []
+
+    def test_preflight_does_not_mutate_capture(self):
+        capture = _preflight_capture(
+            [
+                _preflight_case("case-a", ANCHORED_PROMPT, ANCHORED_PASS_BLOCK),
+                _preflight_case("case-b", ANCHORED_PROMPT, GENERIC_BLOCK),
+            ]
+        )
+        snapshot = copy.deepcopy(capture)
+        orc.lift_preflight_capture(capture)
+        assert capture == snapshot
+
+    def test_report_carries_boundary_and_no_prohibited_fields(self):
+        capture = _preflight_capture(
+            [
+                _preflight_case("case-a", ANCHORED_PROMPT, ANCHORED_PASS_BLOCK),
+                _preflight_case("case-b", ANCHORED_PROMPT, GENERIC_BLOCK),
+                _preflight_case("case-c", ANCHOR_FREE_PROMPT, GENERIC_BLOCK),
+            ]
+        )
+        report = orc.lift_preflight_capture(capture)
+        assert report["boundary"] == orc.LIFT_PREFLIGHT_BOUNDARY
+        assert "not answer quality" in report["boundary"]
+        assert report["schema_version"] == orc.LIFT_PREFLIGHT_REPORT_SCHEMA_VERSION
+        assert report["schema_version"] != orc.PACKET_SCHEMA_VERSION
+        assert report["schema_version"] != orc.CAPTURE_SCHEMA_VERSION
+        for key in _walk_keys(report):
+            for marker in PROHIBITED_KEY_MARKERS:
+                assert marker not in key.lower(), key
+
+    def test_summary_counts_cover_all_states(self):
+        capture = _preflight_capture(
+            [
+                _preflight_case("case-a", ANCHORED_PROMPT, ANCHORED_PASS_BLOCK),
+                _preflight_case("case-b", ANCHORED_PROMPT, GENERIC_BLOCK),
+                _preflight_case(
+                    "case-d",
+                    ANCHORED_PROMPT,
+                    "",
+                    validation_status="excluded",
+                    exclusion_reason="dropped",
+                ),
+            ]
+        )
+        report = orc.lift_preflight_capture(capture)
+        counts = report["summary"]["counts"]
+        assert set(orc.LIFT_PREFLIGHT_STATES) <= set(counts)
+        assert counts["total"] == 3
+        assert counts["structural_pass"] == 1
+        assert counts["structural_fail"] == 1
+        assert counts["excluded_case"] == 1
+
+    def test_invalid_top_level_shapes_are_rejected(self):
+        with pytest.raises(ValueError):
+            orc.lift_preflight_capture(["not", "a", "dict"])
+        with pytest.raises(ValueError):
+            orc.lift_preflight_capture({"packet_id": "x", "cases": []})
+
+    def test_non_dict_case_is_flagged_not_crashed(self):
+        capture = _preflight_capture(
+            [_preflight_case("case-a", ANCHORED_PROMPT, ANCHORED_PASS_BLOCK)]
+        )
+        capture["cases"].append("not a case object")
+        report = orc.lift_preflight_capture(capture)
+        assert report["cases"][1]["state"] == "invalid_case"
+        assert report["summary"]["needs_attention"] == ["cases[1]"]
+
+    def test_render_text_names_boundary_and_vacuous_anchors(self):
+        capture = _preflight_capture(
+            [_preflight_case("case-c", ANCHOR_FREE_PROMPT, GENERIC_BLOCK)]
+        )
+        text = orc.render_lift_preflight_text(orc.lift_preflight_capture(capture))
+        assert "Structural wording preflight only" in text
+        assert "anchor checks vacuous" in text
+        assert "needs attention: none" in text
+
+
+class TestLiftPreflightCli:
+    def _write_capture(self, tmp_path: Path, cases: list) -> Path:
+        path = tmp_path / "capture.json"
+        path.write_text(json.dumps(_preflight_capture(cases)), encoding="utf-8")
+        return path
+
+    def test_passing_capture_exits_zero_with_boundary_language(self, tmp_path: Path):
+        capture_path = self._write_capture(
+            tmp_path, [_preflight_case("case-a", ANCHORED_PROMPT, ANCHORED_PASS_BLOCK)]
+        )
+        result = _run_cli("lift-preflight", "--capture", str(capture_path))
+        assert result.returncode == 0, result.stderr
+        assert "structural_pass" in result.stdout
+        assert "Structural wording preflight only" in result.stdout
+        assert "not answer quality" in result.stdout
+
+    def test_structural_fail_exits_one_and_writes_report(self, tmp_path: Path):
+        capture_path = self._write_capture(
+            tmp_path, [_preflight_case("case-b", ANCHORED_PROMPT, GENERIC_BLOCK)]
+        )
+        report_path = tmp_path / "report.json"
+        result = _run_cli(
+            "lift-preflight",
+            "--capture",
+            str(capture_path),
+            "--report-out",
+            str(report_path),
+        )
+        assert result.returncode == 1
+        assert "structural_fail" in result.stdout
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+        assert report["cases"][0]["state"] == "structural_fail"
+        for key in _walk_keys(report):
+            for marker in PROHIBITED_KEY_MARKERS:
+                assert marker not in key.lower(), key
+
+    def test_preflight_leaves_capture_bytes_unchanged(self, tmp_path: Path):
+        capture_path = self._write_capture(
+            tmp_path, [_preflight_case("case-b", ANCHORED_PROMPT, GENERIC_BLOCK)]
+        )
+        before = capture_path.read_bytes()
+        result = _run_cli("lift-preflight", "--capture", str(capture_path))
+        assert result.returncode == 1
+        assert capture_path.read_bytes() == before
+
+    def test_report_out_refuses_overwrite_without_force(self, tmp_path: Path):
+        capture_path = self._write_capture(
+            tmp_path, [_preflight_case("case-a", ANCHORED_PROMPT, ANCHORED_PASS_BLOCK)]
+        )
+        report_path = tmp_path / "report.json"
+        report_path.write_text("existing", encoding="utf-8")
+        result = _run_cli(
+            "lift-preflight",
+            "--capture",
+            str(capture_path),
+            "--report-out",
+            str(report_path),
+        )
+        assert result.returncode == 2
+        assert "refusing to overwrite" in result.stderr
+        assert report_path.read_text(encoding="utf-8") == "existing"
+
+    def test_existing_init_validate_export_flow_is_untouched(self, tmp_path: Path):
+        filled_path = tmp_path / "filled.json"
+        filled_path.write_text(json.dumps(_filled_capture()), encoding="utf-8")
+        packet_path = tmp_path / "packet.json"
+        result = _run_cli(
+            "export", "--capture", str(filled_path), "--out", str(packet_path)
+        )
+        assert result.returncode == 0, result.stderr
+        exported = json.loads(packet_path.read_text(encoding="utf-8"))
+        assert orc.verify_packet_digest(exported)
+        assert "lift_preflight" not in json.dumps(exported)

--- a/tests/test_operator_run_capture.py
+++ b/tests/test_operator_run_capture.py
@@ -469,6 +469,54 @@ class TestLiftPreflight:
         assert report["cases"][1]["state"] == "invalid_case"
         assert report["summary"]["needs_attention"] == ["cases[1]"]
 
+    def test_malformed_dict_case_with_compliant_output_is_invalid_case(self):
+        case = {
+            "prompt": ANCHORED_PROMPT,
+            "routed_output": ANCHORED_PASS_BLOCK,
+        }
+        report = orc.lift_preflight_capture(_preflight_capture([case]))
+        finding = report["cases"][0]
+        assert finding["state"] == "invalid_case"
+        assert "missing required keys" in finding["detail"]
+        assert "task_id" in finding["detail"]
+        assert "validation_status" in finding["detail"]
+        assert "baseline_output" in finding["detail"]
+        assert "route_metadata" in finding["detail"]
+        assert report["summary"]["needs_attention"] == ["cases[0]"]
+
+    def test_malformed_case_never_returns_structural_pass(self):
+        malformed_cases = [
+            {"prompt": ANCHORED_PROMPT, "routed_output": ANCHORED_PASS_BLOCK},
+            _preflight_case(
+                "case-unknown",
+                ANCHORED_PROMPT,
+                ANCHORED_PASS_BLOCK,
+                unexpected="not allowed",
+            ),
+            _preflight_case(
+                "case-status",
+                ANCHORED_PROMPT,
+                ANCHORED_PASS_BLOCK,
+                validation_status="done",
+            ),
+            _preflight_case(
+                "case-metadata",
+                ANCHORED_PROMPT,
+                ANCHORED_PASS_BLOCK,
+                route_metadata=[],
+            ),
+            _preflight_case(
+                "case-excluded",
+                ANCHORED_PROMPT,
+                "",
+                validation_status="excluded",
+                exclusion_reason="",
+            ),
+        ]
+        report = orc.lift_preflight_capture(_preflight_capture(malformed_cases))
+        assert {finding["state"] for finding in report["cases"]} == {"invalid_case"}
+        assert report["summary"]["counts"]["structural_pass"] == 0
+
     def test_render_text_names_boundary_and_vacuous_anchors(self):
         capture = _preflight_capture(
             [_preflight_case("case-c", ANCHOR_FREE_PROMPT, GENERIC_BLOCK)]
@@ -494,6 +542,16 @@ class TestLiftPreflightCli:
         assert "structural_pass" in result.stdout
         assert "Structural wording preflight only" in result.stdout
         assert "not answer quality" in result.stdout
+
+    def test_malformed_compliant_case_exits_one(self, tmp_path: Path):
+        capture_path = self._write_capture(
+            tmp_path,
+            [{"prompt": ANCHORED_PROMPT, "routed_output": ANCHORED_PASS_BLOCK}],
+        )
+        result = _run_cli("lift-preflight", "--capture", str(capture_path))
+        assert result.returncode == 1
+        assert "invalid_case" in result.stdout
+        assert "structural_pass" not in result.stdout
 
     def test_structural_fail_exits_one_and_writes_report(self, tmp_path: Path):
         capture_path = self._write_capture(


### PR DESCRIPTION
## Checklist

- [x] Spec linked: `.specs/OPERATOR-RUN-CAPTURE-SUBSTANTIVE-LIFT-PREFLIGHT-CLI-001.md`
- [x] Spec sections present/updated (Goal / Motivation / Acceptance Criteria / Definition of Done / Code Targets / Test Plan)
- [x] Tests run: `python -m pytest -q` (exit code 0; 3 known environment-gated skips — see validation below)

## Notes for reviewers

### Lane

`OPERATOR-RUN-CAPTURE-SUBSTANTIVE-LIFT-PREFLIGHT-CLI-001` — optional local Substantive Lift structural preflight CLI for the operator run capture harness.

### Live-state verification

Verified against live GitHub state and fetched `origin/main` (`5a78d8b`) before implementing:

- PR #646, #647, #648, #649, #651, #652, #654: all merged.
- Issue #653: closed, `state_reason: completed`.
- No open conflicting PRs (zero open PRs at branch time).
- Main contains `docs/evals/runs/pr646-substantive-lift-manual-eval/OBSERVATION_MEMO.md`, `.specs/ALPHA-SOLVER-SUBSTANTIVE-LIFT-CASE-ANCHOR-HARDENING-001.md`, `.specs/POST652-CAPTURE-PREFLIGHT-AND-LIFT-HONESTY-BOUNDARY-001.md`, the Substantive Lift capture preflight section in `docs/OPERATOR_RUN_CAPTURE.md`, and `test_unsupported_local_safeout_is_not_lift_cosplay_for_anchored_prompt` in `tests/test_alpha_local_runtime_honesty.py`.

### Implementation summary

Turns the post-#654 preflight guidance ("`check_substantive_lift(solution, prompt=prompt)` may be used only as a non-scoring structural preflight") into an optional, read-only CLI path:

- `alpha/eval/operator_run_capture.py`: new preflight helpers. `lift_preflight_capture(capture)` classifies every case into one of seven states — `invalid_case`, `excluded_case`, `missing_prompt`, `missing_routed_output`, `safe_out_not_applicable`, `structural_pass`, `structural_fail` — calling `check_substantive_lift(routed_output, prompt=prompt)` from `alpha_solver_portable.py` only for cases carrying both texts. Anchor-free prompts are reported as `anchor_checks_vacuous`, never as failures. Bounded `SAFE-OUT:`-prefixed routed output is reported as not applicable (the lift contract does not apply to honest non-answers, mirroring the POST652 boundary). Every report embeds the structural-only boundary statement. `render_lift_preflight_text(report)` renders operator console output.
- `scripts/operator_run_capture.py`: new `lift-preflight` subcommand (`--capture`, optional `--report-out`, `--force` overwrite guard). Exit 0 when no case needs attention; exit 1 when any case is a structural fail, has missing text, or is malformed. `init` / `validate` / `export` are untouched.
- `docs/OPERATOR_RUN_CAPTURE.md`: CLI usage, state meanings, exit codes, and boundary language under the existing preflight section.
- `.specs/OPERATOR-RUN-CAPTURE-SUBSTANTIVE-LIFT-PREFLIGHT-CLI-001.md` + `.specs/INDEX.md` row.

### Changed files

- `alpha/eval/operator_run_capture.py`
- `scripts/operator_run_capture.py`
- `docs/OPERATOR_RUN_CAPTURE.md`
- `tests/test_operator_run_capture.py`
- `.specs/OPERATOR-RUN-CAPTURE-SUBSTANTIVE-LIFT-PREFLIGHT-CLI-001.md`
- `.specs/INDEX.md`

### CLI usage

```bash
python scripts/operator_run_capture.py lift-preflight \
  --capture local/pr646_substantive_lift_capture.json \
  --report-out local/pr646_lift_preflight_report.json
```

Console output prints the boundary statement, one state line per case (with anchor counts or an explicit "anchor checks vacuous" note), a state summary, and a needs-attention list. `--report-out` writes a local JSON report with its own `operator_lift_preflight_report/v1` schema version; it is not a capture file, not an evidence packet, and not an input to `export`.

### Validation

- `python -m pytest tests/test_operator_run_capture.py -q` — pass (41 tests: 24 existing + 17 new).
- `python -m pytest tests/test_pr646_substantive_lift_eval_prep.py tests/test_alpha_substantive_lift_contract.py tests/test_alpha_local_runtime_honesty.py -q` — pass (55 tests).
- `python -m pytest -q` (full suite) — pass, exit code 0; 3 environment-gated skips (live-OpenAI smoke requires `ALPHA_LIVE_OPENAI=1`, decks web adapter disabled in test env, packaging build module missing) — the same known skip set noted on PR #647; no provider calls ran.
- `python scripts/check_narrative_claim_safety.py docs/OPERATOR_RUN_CAPTURE.md .specs/OPERATOR-RUN-CAPTURE-SUBSTANTIVE-LIFT-PREFLIGHT-CLI-001.md` — pass (2 files scanned).
- `ruff check alpha/eval/operator_run_capture.py scripts/operator_run_capture.py tests/test_operator_run_capture.py` — pass.
- Manual end-to-end smoke: a six-case mixed capture (pass / fail / vacuous / SAFE-OUT / excluded / pending) produced the expected states, boundary text, exit code 1, and JSON report; the capture file bytes were unchanged.

New tests cover: anchored compliant routed output passes; a generic six-move block under an anchored prompt fails with `unanchored_lift` named; anchor-free prompts yield a vacuous pass, not a false failure; excluded cases are skipped and never checked; missing prompt / missing routed output map to their own states; bounded SAFE-OUT maps to `safe_out_not_applicable`; the preflight never mutates the capture (in-memory equality and on-disk byte checks); report and console output carry no score/rank/winner/blind/source-map/identity-map keys; `--report-out` refuses overwrite without `--force`; invalid shapes raise or flag instead of crashing; the existing init/validate/export flow still passes byte-identically.

### Schema and behavior scope

- **Did any schema change?** No. The capture schema (`operator_run_capture/v1`) and export packet schema (`operator_run_capture_packet/v1`) are untouched; existing validation tests pass unchanged. The optional report file uses a separate new local report structure (`operator_lift_preflight_report/v1`) that is never consumed by `init`/`validate`/`export`.
- **Did behavior change beyond local CLI/preflight tooling?** No. No runtime solve, provider, model, SAFE-OUT, SolverEnvelope, low-headroom precedence, route/persona, `/v1/solve`, or dashboard/API change. `alpha_solver_portable.py` is consumed read-only, not modified.

### Explicit non-claims

This lane performs and claims no scoring, ranking, winner selection, blinding, source maps, identity maps, or A/B identity keys. It makes no benchmark, readiness, production, provider-validation, local-model-validation, model-superiority, or Alpha-superiority claims, and it does not claim PR #646, #652, #654, or this lane improves answer quality. A `structural_pass` means only that the configured local structural wording checks held for the supplied routed output text and prompt; comparative interpretation of baseline versus routed outputs remains out of scope.

### Remaining risks

- The preflight inherits the portable checker's deterministic regex heuristics: anchor name-dropping can pass anchoring checks, and a pass is deliberately weak evidence (structure only). The boundary text states this on every run.
- The `SAFE-OUT:` prefix match is explicit and case-insensitive; a routed output that paraphrases a SAFE-OUT without the prefix would be structurally checked instead. This mirrors the repo's explicit-prefix honesty-guard style and avoids fuzzy heuristics.
- The report is schema-light by design; operators must keep qualitative notes out of it and in the run's own docs, as the docs section states.

### Follow-up candidates intentionally not implemented

- A one-line pointer in `docs/evals/runbooks/PR646_SUBSTANTIVE_LIFT_MANUAL_EVAL.md` (between the validate and export steps) referencing the new subcommand. Left out to keep this PR inside the lane's named file set; the runbook already defers to `docs/OPERATOR_RUN_CAPTURE.md` for harness mechanics.
- An optional `baseline_output` preflight mode. Left out because preflighting baseline text against the Alpha lift contract could invite comparative interpretation, which is out of scope for this harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPyEukcpCCn7SxwUeU9iCF)_