### PR TITLE
lift-preflight: accept pasted full-response SOLUTION: envelopes and add post-655 smoke

### DIFF
--- a/.specs/OPERATOR-RUN-CAPTURE-SUBSTANTIVE-LIFT-PREFLIGHT-CLI-001.md
+++ b/.specs/OPERATOR-RUN-CAPTURE-SUBSTANTIVE-LIFT-PREFLIGHT-CLI-001.md
@@ -26,8 +26,10 @@ already-approved guidance; it adds no new evaluation semantics.
   `LIFT_PREFLIGHT_STATES` (`invalid_case`, `excluded_case`, `missing_prompt`,
   `missing_routed_output`, `safe_out_not_applicable`, `structural_pass`,
   `structural_fail`), calling
-  `check_substantive_lift(routed_output, prompt=prompt)` from
-  `alpha_solver_portable.py` only for cases that carry both texts;
+  `check_substantive_lift(solution_text, prompt=prompt)` from
+  `alpha_solver_portable.py` only for cases that carry both texts. If a
+  pasted routed output starts with a full-response `SOLUTION:` label, the
+  preflight strips that narrow leading envelope label before checking;
   `render_lift_preflight_text(report)` renders operator-readable console
   output. Every report embeds `LIFT_PREFLIGHT_BOUNDARY`, the structural-only
   boundary statement.

--- a/alpha/eval/operator_run_capture.py
+++ b/alpha/eval/operator_run_capture.py
@@ -357,6 +357,22 @@ LIFT_PREFLIGHT_ATTENTION_STATES = frozenset(
 # instead of failing them. Explicit prefix match only, mirroring the portable
 # honesty guard's explicit-prefix style.
 _LIFT_PREFLIGHT_SAFEOUT_PREFIX = "safe-out:"
+_LIFT_PREFLIGHT_SOLUTION_LABEL = "solution:"
+
+
+def _lift_preflight_solution_text(routed_output: str) -> str:
+    """Return the SOLUTION body when an operator pasted a full envelope.
+
+    Capture docs ask operators to paste the routed Alpha output they collected,
+    which can be a full ChatGPT/Alpha Solver response that begins with a
+    ``SOLUTION:`` label before the six Substantive Lift moves. The portable
+    checker intentionally checks the six-move solution text itself, so the
+    preflight peels only that narrow leading label when it is present.
+    """
+    stripped = routed_output.strip()
+    if stripped.lower().startswith(_LIFT_PREFLIGHT_SOLUTION_LABEL):
+        return stripped[len(_LIFT_PREFLIGHT_SOLUTION_LABEL) :].lstrip()
+    return routed_output
 
 
 def _lift_structural_flags(checker_result: Dict[str, Any]) -> List[str]:
@@ -445,7 +461,9 @@ def _lift_preflight_case(case: Any, index: int, checker: Any) -> Dict[str, Any]:
         )
         return finding
 
-    if routed_output.strip().lower().startswith(_LIFT_PREFLIGHT_SAFEOUT_PREFIX):
+    solution_text = _lift_preflight_solution_text(routed_output)
+
+    if solution_text.strip().lower().startswith(_LIFT_PREFLIGHT_SAFEOUT_PREFIX):
         finding["state"] = "safe_out_not_applicable"
         finding["detail"] = (
             "routed output is a bounded SAFE-OUT response; the Substantive "
@@ -453,7 +471,7 @@ def _lift_preflight_case(case: Any, index: int, checker: Any) -> Dict[str, Any]:
         )
         return finding
 
-    checker_result = checker(routed_output, prompt=prompt)
+    checker_result = checker(solution_text, prompt=prompt)
     finding["case_anchor_count"] = len(checker_result.get("case_anchors", []))
     finding["anchor_checks_vacuous"] = finding["case_anchor_count"] == 0
     finding["checker"] = checker_result

--- a/docs/OPERATOR_RUN_CAPTURE.md
+++ b/docs/OPERATOR_RUN_CAPTURE.md
@@ -95,8 +95,11 @@ python scripts/operator_run_capture.py lift-preflight \
 ```
 
 The command loads the capture, and for every case that has both a prompt and
-a routed output it runs `check_substantive_lift(routed_output, prompt=prompt)`
-and prints one state per case:
+a routed output it runs the local checker over the solution body and prints one
+state per case. If the pasted routed output begins with a full-response
+`SOLUTION:` label, the preflight strips that leading label before checking so
+operators may paste the collected routed output rather than hand-editing it
+down to only the six-line body.
 
 - `structural_pass` / `structural_fail` — the configured structural wording
   checks held or did not hold for the supplied routed output and prompt. When

--- a/tests/fixtures/operator_run_capture/post655_lift_preflight_smoke_capture.json
+++ b/tests/fixtures/operator_run_capture/post655_lift_preflight_smoke_capture.json
@@ -1,0 +1,19 @@
+{
+  "capture_mode": "operator_manual",
+  "cases": [
+    {
+      "baseline_output": "Synthetic baseline placeholder retained only to satisfy the capture schema for this smoke fixture.",
+      "prompt": "Decide whether `tests/fixtures/demo_plan.json` gains a rollback step before the PR #701 review.",
+      "route_metadata": {
+        "contains_solution_label": true,
+        "source": "post-655 smoke fixture derived from realistic pasted Alpha routed output shape"
+      },
+      "routed_output": "SOLUTION:\nIntent: Choose whether the rollback step lands in tests/fixtures/demo_plan.json before the PR #701 review window.\nAssumes: The packet in tests/fixtures/demo_plan.json is the only artifact reviewers exercise before PR #701.\nTradeoff: Adding rollback coverage to tests/fixtures/demo_plan.json now versus keeping PR #701 small enough to review in one pass.\nRecommendation: Add the rollback step to tests/fixtures/demo_plan.json now and keep PR #701 limited to that packet change.\nFails if: The rollback step needs fields that tests/fixtures/demo_plan.json cannot carry without breaking the packet loader.\nNext: Draft the rollback entry in tests/fixtures/demo_plan.json and attach it to the PR #701 description today.",
+      "task_id": "post655-full-solution-envelope-smoke",
+      "validation_status": "captured"
+    }
+  ],
+  "description": "Small post-655 lift-preflight smoke capture with a realistic pasted routed output that includes a SOLUTION envelope label.",
+  "packet_id": "POST655-PREFLIGHT-SMOKE-RUN-001",
+  "schema_version": "operator_run_capture/v1"
+}

--- a/tests/fixtures/operator_run_capture/post655_lift_preflight_smoke_report.json
+++ b/tests/fixtures/operator_run_capture/post655_lift_preflight_smoke_report.json
@@ -1,0 +1,86 @@
+{
+  "boundary": "Structural wording preflight only: not answer quality, not benchmark validation, not readiness, and not Alpha superiority. A pass means only that the configured local structural checks held for the supplied routed output text and prompt.",
+  "cases": [
+    {
+      "anchor_checks_vacuous": false,
+      "case_anchor_count": 4,
+      "checker": {
+        "anchored_lift_lines": {
+          "Assumes:": [
+            "tests/fixtures/demo_plan.json",
+            "PR #701",
+            "#701",
+            "demo_plan.json"
+          ],
+          "Fails if:": [
+            "tests/fixtures/demo_plan.json",
+            "demo_plan.json"
+          ],
+          "Intent:": [
+            "tests/fixtures/demo_plan.json",
+            "PR #701",
+            "#701",
+            "demo_plan.json"
+          ],
+          "Next:": [
+            "tests/fixtures/demo_plan.json",
+            "PR #701",
+            "#701",
+            "demo_plan.json"
+          ],
+          "Recommendation:": [
+            "tests/fixtures/demo_plan.json",
+            "PR #701",
+            "#701",
+            "demo_plan.json"
+          ],
+          "Tradeoff:": [
+            "tests/fixtures/demo_plan.json",
+            "PR #701",
+            "#701",
+            "demo_plan.json"
+          ]
+        },
+        "case_anchors": [
+          "tests/fixtures/demo_plan.json",
+          "PR #701",
+          "#701",
+          "demo_plan.json"
+        ],
+        "empty_moves": [],
+        "filler_flags": [],
+        "generic_flags": [],
+        "has_lift_block": true,
+        "intent_restates_prompt": false,
+        "lane": "ALPHA-SOLVER-SUBSTANTIVE-LIFT-ANSWER-CONTRACT-001",
+        "missing_moves": [],
+        "ok": true,
+        "opens_with_intent": true,
+        "order_ok": true,
+        "unanchored_lift": false,
+        "weak_anchor_distribution": false,
+        "weak_next_action": false
+      },
+      "detail": "configured structural wording checks held",
+      "state": "structural_pass",
+      "structural_flags": [],
+      "task_id": "post655-full-solution-envelope-smoke"
+    }
+  ],
+  "lane_id": "OPERATOR-RUN-CAPTURE-SUBSTANTIVE-LIFT-PREFLIGHT-CLI-001",
+  "packet_id": "POST655-PREFLIGHT-SMOKE-RUN-001",
+  "schema_version": "operator_lift_preflight_report/v1",
+  "summary": {
+    "counts": {
+      "excluded_case": 0,
+      "invalid_case": 0,
+      "missing_prompt": 0,
+      "missing_routed_output": 0,
+      "safe_out_not_applicable": 0,
+      "structural_fail": 0,
+      "structural_pass": 1,
+      "total": 1
+    },
+    "needs_attention": []
+  }
+}

--- a/tests/test_operator_run_capture.py
+++ b/tests/test_operator_run_capture.py
@@ -263,6 +263,9 @@ Recommendation: Add the rollback step to tests/fixtures/demo_plan.json now and k
 Fails if: The rollback step needs fields that tests/fixtures/demo_plan.json cannot carry without breaking the packet loader.
 Next: Draft the rollback entry in tests/fixtures/demo_plan.json and attach it to the PR #701 description today."""
 
+FULL_ENVELOPE_PASS_BLOCK = f"""SOLUTION:
+{ANCHORED_PASS_BLOCK}"""
+
 # Structurally shaped six-move block with no case objects at all: fails the
 # prompt-aware checker for an anchored prompt, but is a legitimate pass when
 # the prompt itself has no extractable anchors (vacuous anchor checks).
@@ -328,6 +331,21 @@ class TestLiftPreflight:
         assert finding["anchor_checks_vacuous"] is False
         assert finding["case_anchor_count"] >= 2
         assert finding["structural_flags"] == []
+        assert report["summary"]["needs_attention"] == []
+
+    def test_full_solution_envelope_is_checked_as_solution_body(self):
+        capture = _preflight_capture(
+            [
+                _preflight_case(
+                    "case-full-envelope", ANCHORED_PROMPT, FULL_ENVELOPE_PASS_BLOCK
+                )
+            ]
+        )
+        report = orc.lift_preflight_capture(capture)
+        finding = report["cases"][0]
+        assert finding["state"] == "structural_pass"
+        assert finding["structural_flags"] == []
+        assert finding["checker"]["opens_with_intent"] is True
         assert report["summary"]["needs_attention"] == []
 
     def test_generic_block_fails_for_anchored_prompt(self):
@@ -542,6 +560,16 @@ class TestLiftPreflightCli:
         assert "structural_pass" in result.stdout
         assert "Structural wording preflight only" in result.stdout
         assert "not answer quality" in result.stdout
+
+    def test_post655_smoke_fixture_with_solution_label_exits_zero(self):
+        result = _run_cli(
+            "lift-preflight",
+            "--capture",
+            str(FIXTURES / "post655_lift_preflight_smoke_capture.json"),
+        )
+        assert result.returncode == 0, result.stderr
+        assert "post655-full-solution-envelope-smoke: structural_pass" in result.stdout
+        assert "needs attention: none" in result.stdout
 
     def test_malformed_compliant_case_exits_one(self, tmp_path: Path):
         capture_path = self._write_capture(


### PR DESCRIPTION
### Motivation
- Verify the new `lift-preflight` CLI works on realistic operator-pasted routed outputs that include a leading `SOLUTION:` envelope label and preserve a smoke capture for future regressions.
- If the preflight assumed `routed_output` started with `Intent:`, operators pasting full chat responses could get false failures, so the CLI should extract the six-move solution body when appropriate.

### Description
- Add a narrow extractor ` _lift_preflight_solution_text` and label constant ` _LIFT_PREFLIGHT_SOLUTION_LABEL` so `lift_preflight_capture` strips a leading `SOLUTION:` label before SAFE-OUT detection and before calling the portable checker, leaving SAFE-OUT handling unchanged (file: `alpha/eval/operator_run_capture.py`).
- Add a focused unit test `test_full_solution_envelope_is_checked_as_solution_body` and a CLI smoke test `test_post655_smoke_fixture_with_solution_label_exits_zero` plus a preserved smoke capture and its generated report under `tests/fixtures/operator_run_capture/` (files: `tests/test_operator_run_capture.py`, `tests/fixtures/...post655_lift_preflight_smoke_capture.json`, and `..._smoke_report.json`).
- Update operator docs and the implementing spec to document that the preflight strips a leading `SOLUTION:` label when present (files: `docs/OPERATOR_RUN_CAPTURE.md`, `.specs/OPERATOR-RUN-CAPTURE-SUBSTANTIVE-LIFT-PREFLIGHT-CLI-001.md`).

### Testing
- Ran the smoke CLI: `python scripts/operator_run_capture.py lift-preflight --capture tests/fixtures/operator_run_capture/post655_lift_preflight_smoke_capture.json --report-out tests/fixtures/operator_run_capture/post655_lift_preflight_smoke_report.json --force` and it reported `structural_pass` with `needs attention: none`.
- Ran the targeted tests with `python -m pytest tests/test_operator_run_capture.py -q` which passed, and ran the full test suite with `python -m pytest -q` which also completed successfully.
- Ran narrative-claim safety and style checks with `python scripts/check_narrative_claim_safety.py` and `ruff check` against the modified files and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c11558f748329800d88ccf09fd8cc)