### PR TITLE
Add post-#657 qualitative run packet, runbook, spec, and tests

### DIFF
--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -83,6 +83,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `PROVIDER-SAFEOUT-001.md` | PROVIDER-SAFEOUT-001 · Structured Provider SAFE-OUT Responses | ✅ `SPEC_OK` |
 | `POST-551-NO-ECHO-WIRING-FIX-001.md` | POST-551-NO-ECHO-WIRING-FIX-001 · Local Alpha No-Echo Wiring Fix | ✅ `SPEC_OK` |
 | `POST652-CAPTURE-PREFLIGHT-AND-LIFT-HONESTY-BOUNDARY-001.md` | POST652-CAPTURE-PREFLIGHT-AND-LIFT-HONESTY-BOUNDARY-001 · Capture Preflight and Lift Honesty Boundary | ✅ `SPEC_OK` |
+| `POST657-QUALITATIVE-RUN-PACKET-001.md` | POST657-QUALITATIVE-RUN-PACKET-001 · Post-#657 Qualitative Run Packet | ✅ `SPEC_OK` |
 | `RES-03.md` | CODE SPEC — RES-03 · Decision Rules & Scoring (RES) | ✅ `SPEC_RECONSTRUCTED_FROM_SOURCE` |
 | `RES-04.md` | CODE SPEC — RES-04 · Confidence & Budget Gates (RES) | ✅ `SPEC_RECONSTRUCTED_FROM_SOURCE` |
 | `RES-05.md` | CODE SPEC — RES-05 · Tool Adapters (Playwright, GSheets) — MVP stubs (RES) | ✅ `SPEC_RECONSTRUCTED_FROM_SOURCE` |

--- a/.specs/POST657-QUALITATIVE-RUN-PACKET-001.md
+++ b/.specs/POST657-QUALITATIVE-RUN-PACKET-001.md
@@ -1,0 +1,69 @@
+# POST657-QUALITATIVE-RUN-PACKET-001 · Post-#657 Qualitative Run Packet
+
+Status: Implemented
+
+## Goal
+
+Prepare a bounded post-#657 manual qualitative run packet and operator runbook
+that use the existing `operator_run_capture.py` init, validate,
+`lift-preflight`, and export flow before human reviewer handoff.
+
+## Scope
+
+- Add `tests/fixtures/operator_run_capture/post657_qualitative_case_packet.json`
+  as a case packet with six high-headroom prompts.
+- Add `docs/evals/runbooks/POST657_QUALITATIVE_RUN_PACKET.md` with copyable
+  command sequence, manual paste instructions, preflight interpretation, export
+  instructions, reviewer handoff, non-claims, and stop conditions.
+- Add tests that validate packet shape, prompt anchors, required six-move
+  prompt language, runbook command sequence, structural-only preflight wording,
+  and non-claim boundaries.
+
+## Packet requirements
+
+The case packet uses packet id `POST657-QUALITATIVE-RUN-PACKET-001`, contains
+four to six cases, and contains no baseline outputs, routed outputs, expected
+answers, reviewer score fields, rating fields, rank fields, winner fields,
+benchmark fields, readiness fields, validation-result claims, or superiority
+fields. Each prompt names concrete repo anchors and requires Intent, Assumes,
+Tradeoff, Recommendation, Fails if, and Next.
+
+## Runbook requirements
+
+The runbook is operator-facing and copyable. It includes the exact command
+sequence:
+
+1. `init` with the post-#657 case packet and local capture path.
+2. `validate` over the local capture.
+3. `lift-preflight` with a local report path.
+4. `validate --for-export`.
+5. `export` to a local capture packet.
+
+It instructs the operator to paste plain baseline answers into
+`baseline_output`, paste full routed Alpha answers into `routed_output`, allow a
+leading `SOLUTION:` label after PR #657, keep `route_metadata` limited to route
+and provenance facts, keep qualitative notes outside `route_metadata`, and use
+`captured` or `excluded` statuses only under the documented conditions.
+
+## Non-goals and boundaries
+
+- No runtime behavior changes.
+- No API, dashboard, route, persona, SAFE-OUT, SolverEnvelope, or provider
+  changes.
+- No provider calls, local-model calls, hosted-model calls, tool execution, or
+  outside-service calls.
+- No execution of the manual qualitative review.
+- No scoring, ranking, winner selection, identity maps, A/B identity keys,
+  benchmark claims, readiness claims, provider-validation claims,
+  local-validation claims, or Alpha-superiority claims.
+- A passing preflight means only that configured local structural wording checks
+  held for the supplied routed output and prompt; it is not an answer-quality
+  judgment.
+
+## Validation
+
+- `python -m pytest tests/test_post657_qualitative_run_packet.py -q`
+- `python -m pytest tests/test_operator_run_capture.py tests/test_pr646_substantive_lift_eval_prep.py -q`
+- `python -m pytest -q`
+- `python scripts/check_narrative_claim_safety.py docs/evals/runbooks/POST657_QUALITATIVE_RUN_PACKET.md .specs/POST657-QUALITATIVE-RUN-PACKET-001.md`
+- `ruff check tests/test_post657_qualitative_run_packet.py`

--- a/docs/evals/runbooks/POST657_QUALITATIVE_RUN_PACKET.md
+++ b/docs/evals/runbooks/POST657_QUALITATIVE_RUN_PACKET.md
@@ -1,0 +1,140 @@
+# POST657 Qualitative Run Packet Runbook
+
+Lane: `POST657-QUALITATIVE-RUN-PACKET-001`
+
+## Purpose and boundary
+
+Prepare one local manual qualitative capture after PR #655 and PR #657 using
+the current operator-run capture stack. This runbook is operator-facing setup
+for capture, structural preflight, export, and reviewer handoff only. It does
+not execute the manual review and does not change runtime behavior.
+
+## Required files
+
+- `tests/fixtures/operator_run_capture/post657_qualitative_case_packet.json`
+- `docs/OPERATOR_RUN_CAPTURE.md`
+- `alpha/eval/operator_run_capture.py`
+- `scripts/operator_run_capture.py`
+- `tests/fixtures/operator_run_capture/post655_lift_preflight_smoke_capture.json`
+- `tests/fixtures/operator_run_capture/post655_lift_preflight_smoke_report.json`
+- `.specs/OPERATOR-RUN-CAPTURE-SUBSTANTIVE-LIFT-PREFLIGHT-CLI-001.md`
+
+## Exact command sequence
+
+Run these commands from the repository root:
+
+```bash
+python scripts/operator_run_capture.py init \
+  --case-packet tests/fixtures/operator_run_capture/post657_qualitative_case_packet.json \
+  --out local/post657_qualitative_capture.json
+```
+
+After manually filling the capture file as described below:
+
+```bash
+python scripts/operator_run_capture.py validate \
+  --capture local/post657_qualitative_capture.json
+
+python scripts/operator_run_capture.py lift-preflight \
+  --capture local/post657_qualitative_capture.json \
+  --report-out local/post657_qualitative_lift_preflight_report.json
+
+python scripts/operator_run_capture.py validate \
+  --capture local/post657_qualitative_capture.json \
+  --for-export
+
+python scripts/operator_run_capture.py export \
+  --capture local/post657_qualitative_capture.json \
+  --out local/post657_qualitative_capture_packet.json
+```
+
+## Manual paste instructions
+
+For each case in `local/post657_qualitative_capture.json`:
+
+1. Paste the plain baseline answer into `baseline_output`.
+2. Paste the full routed Alpha answer into `routed_output`.
+3. Do not manually trim a full routed Alpha answer only because it has a
+   leading `SOLUTION:` label; after PR #657, full routed answers may include
+   that label and `lift-preflight` handles the leading envelope label.
+4. Fill `route_metadata` only with route and provenance facts, such as the
+   route observed, capture method, source artifact, prompt identifier, and
+   relevant transcript provenance.
+5. Keep qualitative notes, reviewer interpretations, concerns, and follow-up
+   ideas outside `route_metadata`.
+6. Set `validation_status` to `captured` only after both outputs are present
+   and `route_metadata` is a non-empty object.
+7. Set `validation_status` to `excluded` only when `exclusion_reason` is
+   non-empty and explains why that case should not move to handoff.
+
+## Preflight interpretation
+
+`lift-preflight` is a local structural wording preflight over the routed output
+and prompt. It is not answer quality, not scoring, not a benchmark, not readiness evidence, and not superiority evidence.
+
+- `structural_pass` means only that configured local structural wording checks
+  held for the supplied routed text and prompt.
+- `structural_fail` means the answer should be reviewed or recaptured before
+  qualitative review.
+- `safe_out_not_applicable` is allowed for bounded `SAFE-OUT:` responses
+  because the Substantive Lift answer-body contract does not apply to an honest
+  non-answer.
+- `anchor_checks_vacuous` means the prompt did not expose extractable anchors;
+  this should usually be treated as packet-design feedback rather than as a
+  finding about the routed answer.
+- Missing prompt text, missing routed output, malformed cases, or excluded
+  cases should be resolved according to `docs/OPERATOR_RUN_CAPTURE.md` before
+  reviewer handoff.
+
+## Export instructions
+
+Run `validate --for-export` only after every non-excluded case has both pasted
+outputs, a non-empty `route_metadata` object, and `validation_status:
+captured`. Then run `export` to produce
+`local/post657_qualitative_capture_packet.json`. The exported packet is the
+handoff artifact; the preflight report is local operator context and is not an
+input to export.
+
+## Reviewer handoff instructions
+
+Hand off these local artifacts together:
+
+- `local/post657_qualitative_capture_packet.json`
+- `local/post657_qualitative_lift_preflight_report.json`
+- this runbook
+- the case packet fixture
+
+Ask the reviewer to read the captured outputs qualitatively against the case
+prompts and the six requested moves: Intent, Assumes, Tradeoff,
+Recommendation, Fails if, and Next. The reviewer should keep notes outside the
+capture/export schema and should not add score, rank, winner, blind-label,
+source-map, identity-map, or A/B identity-key fields.
+
+## Explicit non-claims
+
+This packet and runbook do not claim answer quality, benchmark results,
+production suitability, public suitability, provider validation, local-model
+validation, or Alpha superiority. They do not claim that a `structural_pass`
+means a good answer. They do not make identity comparisons and do not ask the operator
+or reviewer to score, rank, select winners, or turn the packet into a
+benchmark.
+
+## Stop conditions
+
+Stop and report instead of proceeding if any of these conditions is observed:
+
+- PR #655 is not merged on `main`.
+- PR #657 is not merged on `main`.
+- Issue #656 is not closed as completed.
+- An open conflicting PR changes the same capture, preflight, packet, or
+  runbook surface.
+- `main` does not contain `scripts/operator_run_capture.py lift-preflight`.
+- `main` does not contain
+  `tests/fixtures/operator_run_capture/post655_lift_preflight_smoke_capture.json`.
+- `python scripts/operator_run_capture.py validate --capture local/post657_qualitative_capture.json`
+  reports schema errors that cannot be corrected by local paste edits.
+- `lift-preflight` reports `structural_fail` for a non-excluded case and the
+  operator cannot decide whether to review or recapture before handoff.
+- The operator needs scoring, ranking, provider calls, local-model calls,
+  runtime `/v1/solve` wiring, route/persona changes, or dashboard/API changes
+  to proceed.

--- a/tests/fixtures/operator_run_capture/post657_qualitative_case_packet.json
+++ b/tests/fixtures/operator_run_capture/post657_qualitative_case_packet.json
@@ -1,0 +1,36 @@
+{
+  "packet_id": "POST657-QUALITATIVE-RUN-PACKET-001",
+  "description": "Post-#657 qualitative manual-review case packet for capture with the current operator_run_capture init, validate, lift-preflight, and export flow. This fixture contains prompts only: no outputs, expected answers, scores, ranks, winners, benchmark statements, readiness claims, provider validation, local validation, or superiority claims.",
+  "cases": [
+    {
+      "task_id": "post657-case-001-preflight-signal",
+      "prompt": "After PR #655 and PR #657, decide what the new `lift-preflight` CLI should help the operator detect before a qualitative Alpha Solver review. Ground the answer in `docs/OPERATOR_RUN_CAPTURE.md`, `alpha/eval/operator_run_capture.py`, `tests/test_operator_run_capture.py`, `tests/fixtures/operator_run_capture/post655_lift_preflight_smoke_capture.json`, and `.specs/OPERATOR-RUN-CAPTURE-SUBSTANTIVE-LIFT-PREFLIGHT-CLI-001.md`. Include Intent, Assumes, Tradeoff, Recommendation, Fails if, and Next.",
+      "notes": "Capture prompt only; asks for a committed recommendation about structural preflight signal boundaries without requesting any score, rank, winner, benchmark, readiness, validation, or superiority claim."
+    },
+    {
+      "task_id": "post657-case-002-safeout-lift-boundary",
+      "prompt": "Choose the safest manual-review interpretation when a routed Alpha output is a bounded SAFE-OUT instead of a Substantive Lift answer. Ground the answer in `alpha_solver_portable.py`, `tests/test_alpha_local_runtime_honesty.py`, `tests/test_operator_run_capture.py`, PR #647, PR #648, PR #654, and PR #655. Include Intent, Assumes, Tradeoff, Recommendation, Fails if, and Next.",
+      "notes": "Capture prompt only; targets the SAFE-OUT versus lift-contract boundary while preserving the local structural-only interpretation of preflight."
+    },
+    {
+      "task_id": "post657-case-003-solution-envelope-capture",
+      "prompt": "Decide whether operators should paste full routed Alpha responses, including a leading `SOLUTION:` label, or manually trim to the six-move answer body before running `lift-preflight`. Ground the answer in PR #657, `alpha/eval/operator_run_capture.py`, `docs/OPERATOR_RUN_CAPTURE.md`, `tests/test_operator_run_capture.py`, and `tests/fixtures/operator_run_capture/post655_lift_preflight_smoke_report.json`. Include Intent, Assumes, Tradeoff, Recommendation, Fails if, and Next.",
+      "notes": "Capture prompt only; targets the post-#657 response-envelope handling guidance without changing capture or preflight behavior."
+    },
+    {
+      "task_id": "post657-case-004-route-metadata-minimality",
+      "prompt": "Define what belongs in `route_metadata` versus qualitative reviewer notes for a post-#657 manual run packet. Ground the answer in `docs/OPERATOR_RUN_CAPTURE.md`, `alpha/eval/operator_run_capture.py`, PR #644, PR #654, PR #655, and `docs/evals/runs/pr646-substantive-lift-manual-eval/OBSERVATION_MEMO.md`. Include Intent, Assumes, Tradeoff, Recommendation, Fails if, and Next.",
+      "notes": "Capture prompt only; keeps route metadata limited to route and provenance facts and leaves reviewer interpretation outside the capture schema."
+    },
+    {
+      "task_id": "post657-case-005-reviewer-instruction-boundary",
+      "prompt": "Write the operating boundary for a human reviewer who will read post-#657 routed outputs after `lift-preflight` passes, without turning the review into scoring or ranking. Ground the answer in `docs/evals/runbooks/PR646_SUBSTANTIVE_LIFT_MANUAL_EVAL.md`, `docs/evals/runs/pr646-substantive-lift-manual-eval/OBSERVATION_MEMO.md`, `docs/OPERATOR_RUN_CAPTURE.md`, PR #649, PR #655, and PR #657. Include Intent, Assumes, Tradeoff, Recommendation, Fails if, and Next.",
+      "notes": "Capture prompt only; asks for reviewer operating boundaries and explicitly excludes score/rank framing."
+    },
+    {
+      "task_id": "post657-case-006-next-fork-after-run",
+      "prompt": "After a post-#657 qualitative run is captured and preflighted, choose exactly one next fork for Alpha Solver: stop and lock the current portable/capture layer, run another qualitative packet, investigate route/persona causality, explore runtime `/v1/solve` wiring, or investigate model-backed synthesis requirements. Ground the choice in `.specs/INDEX.md`, `alpha_solver_portable.py`, `docs/OPERATOR_RUN_CAPTURE.md`, `docs/evals/runs/pr646-substantive-lift-manual-eval/OBSERVATION_MEMO.md`, PR #652, PR #655, and PR #657. Include Intent, Assumes, Tradeoff, Recommendation, Fails if, and Next.",
+      "notes": "Capture prompt only; forces one next-fork recommendation after the manual run is captured, without executing that follow-up lane."
+    }
+  ]
+}

--- a/tests/test_post657_qualitative_run_packet.py
+++ b/tests/test_post657_qualitative_run_packet.py
@@ -1,0 +1,163 @@
+"""Tests for the post-#657 qualitative run packet prep artifacts.
+
+These checks validate static docs, spec, and fixture shape only. They do not
+execute a manual review, call providers, call hosted or local models, score,
+rank, select winners, compare identities, or produce readiness evidence.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from alpha.eval import operator_run_capture as orc
+
+PACKET_PATH = Path(
+    "tests/fixtures/operator_run_capture/post657_qualitative_case_packet.json"
+)
+RUNBOOK_PATH = Path("docs/evals/runbooks/POST657_QUALITATIVE_RUN_PACKET.md")
+SPEC_PATH = Path(".specs/POST657-QUALITATIVE-RUN-PACKET-001.md")
+INDEX_PATH = Path(".specs/INDEX.md")
+
+REQUIRED_MOVES = ("Intent", "Assumes", "Tradeoff", "Recommendation", "Fails if", "Next")
+ANCHOR_TERMS = (".md", ".py", ".json", ".specs/", "PR #", "Issue #")
+FORBIDDEN_PACKET_KEYS = {
+    "score",
+    "scores",
+    "rating",
+    "ratings",
+    "rank",
+    "ranking",
+    "winner",
+    "benchmark",
+    "readiness",
+    "blind_label",
+    "source_map",
+    "identity_map",
+    "ab_identity_key",
+    "baseline_output",
+    "routed_output",
+    "expected_answer",
+    "expected_answers",
+}
+FORBIDDEN_RUNBOOK_DIRECTIVES = (
+    "score the",
+    "rank the",
+    "select a winner",
+    "choose a winner",
+    "compare identities",
+    "a/b identity key",
+)
+
+
+def _packet() -> dict:
+    return json.loads(PACKET_PATH.read_text(encoding="utf-8"))
+
+
+def _walk_keys(value):
+    if isinstance(value, dict):
+        for key, child in value.items():
+            yield key
+            yield from _walk_keys(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _walk_keys(child)
+
+
+def test_post657_case_packet_validates_under_existing_harness():
+    packet = _packet()
+    assert orc.validate_case_packet(packet) == []
+    capture = orc.scaffold_capture(packet)
+    assert orc.validate_capture(capture) == []
+
+
+def test_packet_id_and_case_count_are_bounded():
+    packet = _packet()
+    assert packet["packet_id"] == "POST657-QUALITATIVE-RUN-PACKET-001"
+    assert 4 <= len(packet["cases"]) <= 6
+
+
+def test_cases_have_stable_non_empty_task_ids_and_prompts():
+    cases = _packet()["cases"]
+    task_ids = [case["task_id"] for case in cases]
+    assert task_ids == [
+        "post657-case-001-preflight-signal",
+        "post657-case-002-safeout-lift-boundary",
+        "post657-case-003-solution-envelope-capture",
+        "post657-case-004-route-metadata-minimality",
+        "post657-case-005-reviewer-instruction-boundary",
+        "post657-case-006-next-fork-after-run",
+    ]
+    assert len(task_ids) == len(set(task_ids))
+    for case in cases:
+        assert case["task_id"].strip()
+        assert case["prompt"].strip()
+
+
+def test_each_prompt_requires_six_moves_and_repo_anchors():
+    for case in _packet()["cases"]:
+        prompt = case["prompt"]
+        for move in REQUIRED_MOVES:
+            assert move in prompt, case["task_id"]
+        assert any(term in prompt for term in ANCHOR_TERMS), case["task_id"]
+
+
+def test_packet_has_no_output_expected_answer_or_review_result_fields():
+    keys = set(_walk_keys(_packet()))
+    assert keys.isdisjoint(FORBIDDEN_PACKET_KEYS)
+
+
+def test_runbook_contains_exact_command_sequence():
+    text = RUNBOOK_PATH.read_text(encoding="utf-8")
+    expected_commands = (
+        "python scripts/operator_run_capture.py init \\\n  --case-packet tests/fixtures/operator_run_capture/post657_qualitative_case_packet.json \\\n  --out local/post657_qualitative_capture.json",
+        "python scripts/operator_run_capture.py validate \\\n  --capture local/post657_qualitative_capture.json",
+        "python scripts/operator_run_capture.py lift-preflight \\\n  --capture local/post657_qualitative_capture.json \\\n  --report-out local/post657_qualitative_lift_preflight_report.json",
+        "python scripts/operator_run_capture.py validate \\\n  --capture local/post657_qualitative_capture.json \\\n  --for-export",
+        "python scripts/operator_run_capture.py export \\\n  --capture local/post657_qualitative_capture.json \\\n  --out local/post657_qualitative_capture_packet.json",
+    )
+    cursor = 0
+    for command in expected_commands:
+        index = text.find(command, cursor)
+        assert index != -1, command
+        cursor = index + len(command)
+
+
+def test_runbook_documents_manual_paste_and_preflight_boundaries():
+    text = RUNBOOK_PATH.read_text(encoding="utf-8")
+    required = (
+        "baseline_output",
+        "routed_output",
+        "SOLUTION:",
+        "route_metadata",
+        "validation_status` to `captured`",
+        "validation_status` to `excluded`",
+        "structural_pass` means only",
+        "structural_fail` means",
+        "safe_out_not_applicable",
+        "anchor_checks_vacuous",
+        "not answer quality",
+        "not scoring",
+        "not a benchmark",
+        "not readiness evidence",
+        "not superiority evidence",
+    )
+    for phrase in required:
+        assert phrase in text
+
+
+def test_runbook_does_not_direct_scoring_ranking_winners_or_identity_comparison():
+    text = RUNBOOK_PATH.read_text(encoding="utf-8").lower()
+    normalized = " ".join(text.split())
+    for phrase in FORBIDDEN_RUNBOOK_DIRECTIVES:
+        assert phrase not in text
+    assert "should not add score, rank, winner" in text
+    assert "do not ask the operator or reviewer to score, rank, select winners" in normalized
+
+
+def test_spec_is_indexed_and_names_static_scope():
+    index = INDEX_PATH.read_text(encoding="utf-8")
+    spec = SPEC_PATH.read_text(encoding="utf-8")
+    assert SPEC_PATH.name in index
+    assert "POST657-QUALITATIVE-RUN-PACKET-001" in index
+    assert "No runtime behavior changes" in spec
+    assert "No execution of the manual qualitative review" in spec


### PR DESCRIPTION
### Motivation
- Prepare a bounded post-#657 manual qualitative capture packet and an operator-facing runbook so operators can scaffold, fill, structurally preflight (`lift-preflight`), validate for export, and export a handoff evidence packet without changing runtime behavior. 
- Ensure the packet and runbook preserve the existing operator-run capture harness boundaries (no provider/local/hosted model calls, no scoring/ranking/winners/identity maps, and no `/v1/solve` wiring). 

### Description
- Add an operator-facing runbook `docs/evals/runbooks/POST657_QUALITATIVE_RUN_PACKET.md` that contains purpose/boundary, required files, the exact copy-paste command sequence (`init`, `validate`, `lift-preflight`, `validate --for-export`, `export`), manual-paste guidance, preflight interpretation, export steps, reviewer handoff, explicit non-claims, and stop conditions. 
- Add a six-case case-packet fixture `tests/fixtures/operator_run_capture/post657_qualitative_case_packet.json` (packet id `POST657-QUALITATIVE-RUN-PACKET-001`) with repo-anchored, high-headroom prompts that require the six Substantive Lift moves (Intent, Assumes, Tradeoff, Recommendation, Fails if, Next) and contain no outputs, expectations, scores, ranks, or superiority claims. 
- Add a narrow implementation spec `.specs/POST657-QUALITATIVE-RUN-PACKET-001.md` and index it in `.specs/INDEX.md`. 
- Add static tests `tests/test_post657_qualitative_run_packet.py` that validate harness compatibility, packet shape and case IDs, required six-move wording and repo anchors in prompts, runbook command ordering, preflight structural-only language, and absence of scoring/claim fields. 

### Testing
- `python -m pytest tests/test_post657_qualitative_run_packet.py -q` passed, confirming fixture, runbook text checks, and prompt requirements. 
- `python -m pytest tests/test_operator_run_capture.py tests/test_pr646_substantive_lift_eval_prep.py -q` passed, confirming the new packet integrates with the existing harness helpers and related prep materials. 
- Full test run `python -m pytest -q` passed locally (no provider or network calls were invoked). 
- Narrative claim-safety and lint checks `python scripts/check_narrative_claim_safety.py docs/evals/runbooks/POST657_QUALITATIVE_RUN_PACKET.md .specs/POST657-QUALITATIVE-RUN-PACKET-001.md` and `ruff check tests/test_post657_qualitative_run_packet.py` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c222b86d88329afde8e20a0a5317f)