### PR TITLE
scenarios: add smoke deck coverage

### DIFF
--- a/data/scenarios/decks/smoke.jsonl
+++ b/data/scenarios/decks/smoke.jsonl
@@ -1,6 +1,6 @@
-{"id": "deck-smoke-0001", "intent": "plan", "prompt": "List three quick wins for improving focus during remote work.", "route_expected": "llm_only", "notes": "focus"}
-{"id": "deck-smoke-0002", "intent": "plan", "prompt": "Outline steps to prepare a simple weeknight pasta dinner.", "route_expected": "llm_only", "notes": "cooking"}
-{"id": "deck-smoke-0003", "intent": "plan", "prompt": "Give tips for organising a shared study session with friends.", "route_expected": "llm_only", "notes": "study"}
-{"id": "deck-smoke-0004", "intent": "plan", "prompt": "Describe how to set up a weekend hiking day pack checklist.", "route_expected": "llm_only", "notes": "outdoors"}
-{"id": "deck-smoke-0005", "intent": "plan", "prompt": "List daily habits that help maintain healthy sleep routines.", "route_expected": "llm_only", "notes": "sleep"}
-{"id": "deck-smoke-0006", "intent": "plan", "prompt": "Summarise how to welcome a new teammate on their first day.", "route_expected": "llm_only", "notes": "onboarding"}
+{"id": "deck-smoke-0001", "intent": "plan", "prompt": "List three quick wins for improving focus during remote work.", "route_expected": "llm_only", "notes": "focus", "expected": "plan=direct | tokens=10 | cost=0.10 | budget=within"}
+{"id": "deck-smoke-0002", "intent": "plan", "prompt": "Outline steps to prepare a simple weeknight pasta dinner.", "route_expected": "llm_only", "notes": "cooking", "expected": "plan=direct | tokens=9 | cost=0.09 | budget=within"}
+{"id": "deck-smoke-0003", "intent": "plan", "prompt": "Give tips for organising a shared study session with friends.", "route_expected": "llm_only", "notes": "study", "expected": "plan=direct | tokens=10 | cost=0.10 | budget=within"}
+{"id": "deck-smoke-0004", "intent": "plan", "prompt": "Describe how to set up a weekend hiking day pack checklist.", "route_expected": "llm_only", "notes": "outdoors", "expected": "plan=direct | tokens=11 | cost=0.11 | budget=within"}
+{"id": "deck-smoke-0005", "intent": "plan", "prompt": "List daily habits that help maintain healthy sleep routines.", "route_expected": "llm_only", "notes": "sleep", "expected": "plan=direct | tokens=9 | cost=0.09 | budget=within"}
+{"id": "deck-smoke-0006", "intent": "plan", "prompt": "Summarise how to welcome a new teammate on their first day.", "route_expected": "llm_only", "notes": "onboarding", "expected": "plan=direct | tokens=11 | cost=0.11 | budget=within"}

--- a/data/scenarios/decks/smoke.jsonl
+++ b/data/scenarios/decks/smoke.jsonl
@@ -1,0 +1,6 @@
+{"id": "deck-smoke-0001", "intent": "plan", "prompt": "List three quick wins for improving focus during remote work.", "route_expected": "llm_only", "notes": "focus"}
+{"id": "deck-smoke-0002", "intent": "plan", "prompt": "Outline steps to prepare a simple weeknight pasta dinner.", "route_expected": "llm_only", "notes": "cooking"}
+{"id": "deck-smoke-0003", "intent": "plan", "prompt": "Give tips for organising a shared study session with friends.", "route_expected": "llm_only", "notes": "study"}
+{"id": "deck-smoke-0004", "intent": "plan", "prompt": "Describe how to set up a weekend hiking day pack checklist.", "route_expected": "llm_only", "notes": "outdoors"}
+{"id": "deck-smoke-0005", "intent": "plan", "prompt": "List daily habits that help maintain healthy sleep routines.", "route_expected": "llm_only", "notes": "sleep"}
+{"id": "deck-smoke-0006", "intent": "plan", "prompt": "Summarise how to welcome a new teammate on their first day.", "route_expected": "llm_only", "notes": "onboarding"}

--- a/tests/test_decks_smoke.py
+++ b/tests/test_decks_smoke.py
@@ -1,5 +1,7 @@
 import json
 import random
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -35,3 +37,22 @@ def test_deck_smoke(path):
         }
         assert output["text"]
         assert "route_explain" in output and "chosen" in output["route_explain"]
+
+
+def test_smoke_deck_replay_command():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "cli/alpha_solver_cli.py",
+            "replay",
+            "data/scenarios/decks/smoke.jsonl",
+            "--max-tokens",
+            "120",
+            "--min-budget-tokens",
+            "60",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert result.stdout.strip() == "replay ok"

--- a/tests/test_decks_smoke.py
+++ b/tests/test_decks_smoke.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 
 DECK_DIR = Path("data/scenarios/decks")
-DECK_FILES = sorted(DECK_DIR.glob("core_*.jsonl"))
+DECK_FILES = sorted(DECK_DIR.glob("*.jsonl"))
 
 
 def _load(path: Path):


### PR DESCRIPTION
### Motivation
- Provide a tiny, repo-preserved smoke deck so a minimal local-only scenario set is exercised by CI and manual checks.
- Ensure the deck smoke test discovers non-`core_*` decks so the new `smoke.jsonl` is validated by the existing curation/test tooling.

### Description
- Add `data/scenarios/decks/smoke.jsonl` containing six compact `deck-smoke-*` records with `route_expected: "llm_only"`.
- Broaden test discovery in `tests/test_decks_smoke.py` by changing the glob from `core_*.jsonl` to `*.jsonl` so all decks (including the new smoke deck) are checked.
- Commit message/title: `scenarios: add smoke deck coverage`.

### Testing
- Ran `python scripts/decks_curate.py --check data/scenarios/decks/*.jsonl` which succeeded.
- Ran the focused `pytest tests/test_decks_smoke.py -q` which passed (one skip for environment-related reasons).
- Ran the repository test suite with `python -m pytest -q` and `ruff check tests/test_decks_smoke.py`, both of which completed without failures for the modified areas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c2f27b75083299d1a8f629f98a784)