### PR TITLE
ui: add protected Alpha Solver operator console shell

### DIFF
--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -94,6 +94,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `SOLVE-EXPERT-EMPTY-ANSWER-GUARD-001.md` | SOLVE-EXPERT-EMPTY-ANSWER-GUARD-001 · Expert Route Empty Primary Answer Guard | ✅ `SPEC_OK` |
 | `SOLVE-PROVIDER-FINAL-ANSWER-EMPTY-GUARD-001.md` | SOLVE-PROVIDER-FINAL-ANSWER-EMPTY-GUARD-001 · Provider Final Answer Empty Output Guard | ✅ `SPEC_OK` |
 | `SOLVE-SANITIZER-FALSE-POSITIVE-001.md` | SOLVE-SANITIZER-FALSE-POSITIVE-001 · Narrow Import-Substring Sanitizer Fix | ✅ `SPEC_OK` |
+| `UI-ALPHA-OPERATOR-CONSOLE-MVP-001.md` | UI-ALPHA-OPERATOR-CONSOLE-MVP-001 · Alpha Solver Operator Console Shell (MVP) | ✅ `SPEC_OK` |
 | `UI-JOBS-001.md` | UI-JOBS-001 · Dashboard Job History & Metrics (RES_Dash) | ✅ `SPEC_OK` |
 | `UI-PREVIEW-001.md` | UI-PREVIEW-001 · Authenticated Expert Preview UI | ✅ `SPEC_OK` |
 | `UI-PREVIEW-LOADING-STATE-001.md` | UI-PREVIEW-LOADING-STATE-001 · Expert Preview Loading State | ✅ `SPEC_OK` |

--- a/.specs/UI-ALPHA-OPERATOR-CONSOLE-MVP-001.md
+++ b/.specs/UI-ALPHA-OPERATOR-CONSOLE-MVP-001.md
@@ -1,0 +1,102 @@
+# UI-ALPHA-OPERATOR-CONSOLE-MVP-001 · Alpha Solver Operator Console Shell (MVP)
+
+Status: Implemented
+
+## Goal
+
+Give the operator a protected, local-first console shell that exposes Alpha
+Solver contract/status surfaces as a cockpit of read-only cards, so an operator
+can open one protected page and immediately understand the current mode,
+which contract/status surfaces exist, and what stays blocked until future
+lanes — without spending API credits and without weakening the honesty or
+evidence boundaries.
+
+## Motivation
+
+The bundled dashboard mounts login plus the supervised expert-preview page, but
+there is no single read-only surface that summarizes the local-first operating
+mode, the portable behavior contract's presence, the provider/cost gate state,
+and the existing capture/preflight entry points. Operators had to read code and
+docs to answer "what mode am I in, are live providers off, and where will
+route/SAFE-OUT/confidence/receipts appear." This lane adds that summary as a
+protected shell. It reports status only; it starts no run and calls no provider.
+
+## Scope
+
+- `alpha/webapp/routes/operator_console.py`: read-only route module mounted
+  under the protected `/dashboard` prefix.
+  - `GET /dashboard/operator-console` renders an HTML cockpit of seven cards:
+    header, portable contract status, run setup, route/trace, provider/cost
+    gate, preflight/capture entry, and evidence/receipt.
+  - `GET /dashboard/operator-console/status` returns the same information as
+    read-only JSON.
+  - `build_console_status()` assembles the payload purely from configuration
+    and environment *presence*. It performs no provider, network, model, or
+    tool call and never reads a secret value into the returned structure.
+- `service/app.py`: include the operator console router in `_mount_dashboard`
+  alongside auth and expert-preview, so the console inherits the same
+  fail-closed mount (non-default `ALPHA_DASHBOARD_PASSWORD` plus explicit
+  `ALPHA_DASHBOARD_SECRET_KEY`) and session/CSRF middleware.
+- `docs/OPERATOR_CONSOLE.md`: what the console is, how to reach it, the
+  no-provider boundary, and the honesty/evidence boundary.
+- Tests in `tests/test_operator_console.py`.
+
+## Non-goals and boundaries
+
+- Live provider calls stay disabled. This shell does not enable live API
+  execution; the live-run button is rendered disabled.
+- No provider, hosted-model, local-model, MCP, tool, browser, or network call.
+  No provider client is imported, instantiated, or executed by this module.
+- No API key storage. Key status is boolean/categorical (`present` / `missing`
+  / `unknown`) only; raw environment values are never returned by the JSON
+  endpoint and never rendered in HTML.
+- No change to `alpha_solver_portable.py` behavior. The portable contract is
+  read for presence only; private chain-of-thought is not parsed or exposed.
+- No change to provider runtime, model routing, `/v1/solve` execution, or the
+  capture/export schemas. No change to `operator_run_capture.py` CLI semantics.
+- No scoring, ranking, winner fields, blind labels, source maps, identity maps,
+  A/B identity keys, or model-comparison UI.
+- No benchmark, readiness, production, provider-validation, local-model, or
+  superiority claims. Preflight/capture outputs are described as structural
+  support artifacts, not answer-quality evidence.
+
+## Code Targets
+
+- `alpha/webapp/routes/operator_console.py`
+- `service/app.py`
+- `docs/OPERATOR_CONSOLE.md`
+- `tests/test_operator_console.py`
+
+## Test Plan
+
+`tests/test_operator_console.py`: the page and status routes are registered on
+the real app and on a freshly mounted app; both are protected (a logged-out GET
+redirects to `/login`) and are not served by an unmounted app; an authenticated
+page renders all seven cards and the required boundary text; the live-run
+button is disabled; the status JSON has the expected sections with
+`live_provider_calls` disabled and `live_run_button_enabled` false; key status
+is categorical only; a fake secret placed in the environment never appears in
+the HTML or JSON (and `build_console_status()` never embeds it); and rendering
+never constructs or executes a provider client (the module references no
+provider client class).
+
+## Validation
+
+- `python -m pytest tests/test_operator_console.py -q`
+- `python -m pytest tests/ui/test_expert_preview_real_app.py tests/ui/test_auth.py -q`
+- `python -m pytest tests/test_operator_run_capture.py -q`
+- `python -m pytest tests/test_api_endpoints.py -q`
+- `python -m pytest -q`
+- `python scripts/check_narrative_claim_safety.py docs/OPERATOR_CONSOLE.md`
+- `python scripts/check_narrative_claim_safety.py .specs/UI-ALPHA-OPERATOR-CONSOLE-MVP-001.md`
+- `ruff check service alpha scripts tests`
+
+## Definition of Done
+
+The console route module, app wiring, docs, tests, and this spec merged; all
+validation commands pass; the console is reachable only behind the fail-closed
+`/dashboard` auth mount; live provider calls stay disabled; no raw secret is
+exposed; and no provider-call path is exercised. Opening the console is a status
+read, not a run: it presents no benchmark, readiness, production, or superiority
+evidence, and reporting a surface as present means only that the named surface
+exists in the codebase, not that any answer-quality judgment has been made.

--- a/alpha/webapp/routes/operator_console.py
+++ b/alpha/webapp/routes/operator_console.py
@@ -1,0 +1,438 @@
+"""Read-only Alpha Solver Operator Console shell.
+
+This module renders a protected, local-first operator cockpit made of status
+cards. It exposes contract/status information for the operator and clearly
+marks every not-yet-wired surface. It intentionally does **not** enable live
+API execution:
+
+* No provider client is imported, instantiated, or called here.
+* No network, model, MCP, tool, or browser call is made.
+* Status is assembled only from configuration and environment *presence*.
+
+Secret handling: key status is boolean/categorical only. Raw environment values
+(API keys, secrets) are never returned by the JSON endpoint and never rendered
+in HTML. Only ``present`` / ``missing`` / ``unknown`` categories are surfaced.
+
+The console is mounted behind the shared dashboard auth/CSRF middleware (see
+``alpha/webapp/routes/auth.py``) under the protected ``/dashboard`` prefix, so
+it is fail-closed: it is only reachable when the dashboard is enabled with a
+non-default password and an explicit signing secret, and only for an
+authenticated session.
+"""
+
+from __future__ import annotations
+
+import html
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Mapping
+
+from fastapi import APIRouter
+from fastapi.responses import HTMLResponse, JSONResponse
+
+router = APIRouter()
+
+ROUTE = "/dashboard/operator-console"
+STATUS_ROUTE = "/dashboard/operator-console/status"
+
+# ---------------------------------------------------------------------------
+# Boundary text. These strings are asserted by tests and must appear verbatim
+# in the rendered console so an operator immediately understands the mode and
+# the honesty/evidence boundaries.
+# ---------------------------------------------------------------------------
+LOCAL_FIRST_TEXT = "Local-first operator console"
+LIVE_DISABLED_TEXT = "Live provider calls are disabled in this MVP"
+ARTIFACT_BOUNDARY_TEXT = (
+    "Preflight and capture outputs are structural support artifacts, not "
+    "answer-quality, benchmark, readiness, or superiority evidence"
+)
+NO_KEYS_TEXT = "No API keys are displayed"
+CLAIM_BOUNDARY_TEXT = (
+    "No benchmark, readiness, production, provider-validation, or "
+    "superiority evidence is presented here"
+)
+
+# Portable behavior-contract file. We only check for its presence and list
+# well-known high-level surface labels. We never parse or expose private
+# chain-of-thought or the file's internal prompt content.
+_PORTABLE_CONTRACT_PATH = "alpha_solver_portable.py"
+_PORTABLE_CONTRACT_SURFACES = (
+    "SolverEnvelope",
+    "SAFE-OUT",
+    "confidence",
+    "route/expert trace",
+    "local-output honesty",
+    "Substantive Lift",
+)
+
+# Environment variables inspected for *presence* only. Values are never read
+# into any response.
+_PROVIDER_ENV = "MODEL_PROVIDER"
+_EMERGENCY_STOP_ENV = "ALPHA_PROVIDER_EMERGENCY_STOP"
+_LIVE_PREVIEW_ENV = "ALPHA_LIVE_PREVIEW_ENABLED"
+_COST_CAP_ENVS = (
+    "ALPHA_PROVIDER_MAX_COST_USD",
+    "ALPHA_PROVIDER_MAX_INPUT_TOKENS",
+    "ALPHA_PROVIDER_MAX_OUTPUT_TOKENS",
+    "ALPHA_PROVIDER_MAX_REQUESTS",
+)
+# Provider credential env var names surfaced as present/missing only. The names
+# are shown; the values never are.
+_KEY_ENVS = ("OPENAI_API_KEY", "ANTHROPIC_API_KEY")
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def _escape(value: Any) -> str:
+    return html.escape("" if value is None else str(value), quote=True)
+
+
+def _truthy_env(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in _TRUTHY
+
+
+def _key_presence(name: str) -> str:
+    """Return only a categorical presence marker, never the value."""
+
+    raw = os.getenv(name)
+    if raw is None:
+        return "missing"
+    return "present" if raw.strip() else "missing"
+
+
+def _contract_present() -> bool:
+    root = Path(__file__).resolve().parents[3]
+    return (root / _PORTABLE_CONTRACT_PATH).is_file()
+
+
+def _cost_caps_status() -> str:
+    present = sum(1 for name in _COST_CAP_ENVS if os.getenv(name, "").strip())
+    if present == 0:
+        return "not configured"
+    if present == len(_COST_CAP_ENVS):
+        return "configured"
+    return "partially configured"
+
+
+def build_console_status() -> Dict[str, Any]:
+    """Assemble the read-only operator console status payload.
+
+    Pure function over configuration and environment *presence*. Performs no
+    provider, network, model, or tool call, and never reads a secret value into
+    the returned structure.
+    """
+
+    provider = os.getenv(_PROVIDER_ENV, "local").strip().lower() or "local"
+
+    return {
+        "console": {
+            "title": "Alpha Solver Operator Console",
+            "mode": "local-first",
+            "live_provider_calls": "disabled",
+            "claim_boundary": (
+                "no benchmark/readiness/superiority evidence"
+            ),
+            "boundary_notes": [
+                LOCAL_FIRST_TEXT,
+                LIVE_DISABLED_TEXT,
+                NO_KEYS_TEXT,
+            ],
+        },
+        "portable_contract": {
+            "present": _contract_present(),
+            "source_path": _PORTABLE_CONTRACT_PATH,
+            "contract_mode": "portable standalone behavior contract",
+            "surfaces": list(_PORTABLE_CONTRACT_SURFACES),
+            "note": (
+                "High-level surfaces only. Private chain-of-thought is not "
+                "parsed or exposed and this console does not modify the "
+                "contract file."
+            ),
+        },
+        "run_setup": {
+            "run_modes": [
+                {"id": "dry-run", "available": True},
+                {"id": "local-only", "available": True},
+                {"id": "chatgpt-copy-paste", "available": True},
+                {"id": "live-provider", "available": False},
+            ],
+            "live_run_button_enabled": False,
+            "note": (
+                "This MVP does not enable live API execution. "
+                + LIVE_DISABLED_TEXT
+                + "."
+            ),
+        },
+        "route_trace": {
+            "route": "not run yet",
+            "confidence": "not run yet",
+            "safe_out_state": "not run yet",
+            "expert_team": "not run yet",
+            "shortlist": "not run yet",
+            "diagnostics": "not run yet",
+            "note": "No solve has run from this console; fields are placeholders.",
+        },
+        "provider_gate": {
+            "configured_provider": provider,
+            "live_provider_calls": "disabled",
+            "console_calls_providers": False,
+            "emergency_stop": (
+                "engaged" if _truthy_env(_EMERGENCY_STOP_ENV) else "not engaged"
+            ),
+            "cost_caps": _cost_caps_status(),
+            "live_preview_surface": (
+                "enabled" if _truthy_env(_LIVE_PREVIEW_ENV) else "disabled"
+            ),
+            "key_status": {name: _key_presence(name) for name in _KEY_ENVS},
+            "note": NO_KEYS_TEXT + ". Key status is present/missing only.",
+        },
+        "preflight_capture": {
+            "workflows": [
+                {
+                    "id": "anchor-preflight",
+                    "command": (
+                        "python scripts/operator_run_capture.py anchor-preflight "
+                        "--case-packet <case_packet.json>"
+                    ),
+                },
+                {
+                    "id": "lift-preflight",
+                    "command": (
+                        "python scripts/operator_run_capture.py lift-preflight "
+                        "--capture <capture.json>"
+                    ),
+                },
+                {
+                    "id": "init-capture",
+                    "command": (
+                        "python scripts/operator_run_capture.py init "
+                        "--out <capture.json>"
+                    ),
+                },
+                {
+                    "id": "validate-capture",
+                    "command": (
+                        "python scripts/operator_run_capture.py validate "
+                        "--capture <capture.json>"
+                    ),
+                },
+                {
+                    "id": "export-evidence-packet",
+                    "command": (
+                        "python scripts/operator_run_capture.py export "
+                        "--capture <capture.json> --out <packet.json>"
+                    ),
+                },
+            ],
+            "docs": "docs/OPERATOR_RUN_CAPTURE.md",
+            "note": ARTIFACT_BOUNDARY_TEXT + ".",
+        },
+        "evidence_receipt": {
+            "receipt_id": "not generated yet",
+            "export_digest": "not generated yet",
+            "validation_status": "not run yet",
+            "note": (
+                "Receipts are structural support artifacts, not answer-quality "
+                "proof."
+            ),
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Rendering. All rendering runs through ``_escape`` so no assembled value can
+# inject markup, and the status payload never carries a secret value.
+# ---------------------------------------------------------------------------
+def _kv_rows(pairs: Mapping[str, Any]) -> str:
+    return "".join(
+        f'<div class="kv"><dt>{_escape(key)}</dt>'
+        f"<dd>{_escape(value)}</dd></div>"
+        for key, value in pairs.items()
+    )
+
+
+def _list_items(items: List[Any]) -> str:
+    return "".join(f"<li>{_escape(item)}</li>" for item in items)
+
+
+def _render_page(status: Mapping[str, Any]) -> str:
+    console = status["console"]
+    contract = status["portable_contract"]
+    run_setup = status["run_setup"]
+    trace = status["route_trace"]
+    gate = status["provider_gate"]
+    capture = status["preflight_capture"]
+    receipt = status["evidence_receipt"]
+
+    run_mode_rows = "".join(
+        '<li class="mode">'
+        f'<span class="mode-id">{_escape(mode["id"])}</span>'
+        f'<span class="badge {"ok" if mode["available"] else "off"}">'
+        f'{"available" if mode["available"] else "disabled"}</span>'
+        "</li>"
+        for mode in run_setup["run_modes"]
+    )
+
+    key_rows = "".join(
+        f'<div class="kv"><dt>{_escape(name)}</dt>'
+        f'<dd><span class="badge {"ok" if state == "present" else "muted"}">'
+        f"{_escape(state)}</span></dd></div>"
+        for name, state in gate["key_status"].items()
+    )
+
+    workflow_rows = "".join(
+        "<li class=\"workflow\">"
+        f'<code class="wf-id">{_escape(item["id"])}</code>'
+        f'<pre class="wf-cmd">{_escape(item["command"])}</pre>'
+        "</li>"
+        for item in capture["workflows"]
+    )
+
+    contract_badge = "present" if contract["present"] else "missing"
+
+    return f"""<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Alpha Solver · Operator Console</title>
+    <style>
+      :root {{ color-scheme: light dark; font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; line-height: 1.5; }}
+      body {{ margin: 0; min-height: 100vh; background: radial-gradient(circle at top, #f6f8ff, #e4e8f4); color: #1d2038; }}
+      .container {{ max-width: 1120px; margin: 0 auto; padding: 2.5rem 1.25rem 4rem; }}
+      h1 {{ margin: 0 0 0.35rem; font-size: 1.75rem; }}
+      .subtitle {{ color: #565b8f; margin: 0 0 1.25rem; font-weight: 600; }}
+      .banner {{ border: 1px solid #c7d2fe; background: rgba(238, 242, 255, 0.9); border-radius: 14px; padding: 1rem 1.15rem; color: #30365f; margin-bottom: 1.5rem; }}
+      .banner ul {{ margin: 0.5rem 0 0; padding-left: 1.1rem; }}
+      .cards {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 1.1rem; align-items: start; }}
+      .card {{ background: rgba(255, 255, 255, 0.94); border-radius: 16px; padding: 1.15rem 1.25rem; box-shadow: 0 18px 55px rgba(31, 35, 71, 0.08); min-width: 0; }}
+      .card h2 {{ margin: 0 0 0.75rem; font-size: 1.08rem; }}
+      .kv {{ display: grid; grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr); gap: 0.4rem 0.75rem; padding: 0.25rem 0; border-bottom: 1px solid rgba(86, 97, 246, 0.1); }}
+      dt {{ color: #565b8f; font-size: 0.78rem; font-weight: 700; letter-spacing: 0.03em; text-transform: uppercase; margin: 0; }}
+      dd {{ margin: 0; font-weight: 600; overflow-wrap: anywhere; }}
+      ul {{ margin: 0; padding-left: 1.1rem; }}
+      li {{ margin: 0.2rem 0; overflow-wrap: anywhere; }}
+      li.mode, li.workflow {{ list-style: none; }}
+      ul.modes, ul.workflows {{ padding-left: 0; }}
+      .mode {{ display: flex; align-items: center; justify-content: space-between; gap: 0.5rem; padding: 0.35rem 0; border-bottom: 1px solid rgba(86, 97, 246, 0.1); }}
+      .mode-id {{ font-weight: 700; }}
+      .badge {{ display: inline-block; border-radius: 999px; padding: 0.12rem 0.6rem; font-size: 0.76rem; font-weight: 800; }}
+      .badge.ok {{ background: rgba(16, 185, 129, 0.16); color: #047857; }}
+      .badge.off {{ background: rgba(244, 63, 94, 0.14); color: #9f1239; }}
+      .badge.muted {{ background: rgba(100, 116, 139, 0.16); color: #475569; }}
+      .surfaces li {{ font-weight: 600; }}
+      .workflow {{ padding: 0.4rem 0; border-bottom: 1px solid rgba(86, 97, 246, 0.1); }}
+      .wf-id {{ font-weight: 800; color: #3730a3; }}
+      pre.wf-cmd {{ white-space: pre-wrap; overflow-wrap: anywhere; background: #111827; color: #e5e7eb; border-radius: 10px; padding: 0.55rem 0.7rem; margin: 0.35rem 0 0; font-size: 0.82rem; }}
+      .note {{ color: #5f668f; font-size: 0.85rem; margin: 0.65rem 0 0; }}
+      .disabled-btn {{ margin-top: 0.75rem; border: 0; border-radius: 999px; padding: 0.6rem 1.15rem; font: inherit; font-weight: 700; color: #475569; background: rgba(100, 116, 139, 0.16); cursor: not-allowed; }}
+      a.status-link {{ display: inline-block; margin-top: 0.75rem; color: #4f46e5; font-weight: 700; }}
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <h1>{_escape(console["title"])}</h1>
+      <p class="subtitle">{_escape(LOCAL_FIRST_TEXT)}</p>
+      <section class="banner" aria-label="Operator console mode and boundaries">
+        <strong>{_escape(LIVE_DISABLED_TEXT)}.</strong>
+        <ul>
+          <li>Mode: {_escape(console["mode"])}</li>
+          <li>Live provider calls: {_escape(console["live_provider_calls"])}</li>
+          <li>Claim boundary: {_escape(console["claim_boundary"])}</li>
+          <li>{_escape(CLAIM_BOUNDARY_TEXT)}.</li>
+          <li>{_escape(NO_KEYS_TEXT)}.</li>
+        </ul>
+      </section>
+
+      <div class="cards">
+        <article class="card" id="card-portable-contract">
+          <h2>Portable Contract Status</h2>
+          {_kv_rows({
+              "present": contract_badge,
+              "source path": contract["source_path"],
+              "contract mode": contract["contract_mode"],
+          })}
+          <p class="note">Surfaces (high-level only):</p>
+          <ul class="surfaces">{_list_items(contract["surfaces"])}</ul>
+          <p class="note">{_escape(contract["note"])}</p>
+        </article>
+
+        <article class="card" id="card-run-setup">
+          <h2>Run Setup</h2>
+          <p class="note">Prompt input is disabled in this MVP shell.</p>
+          <textarea placeholder="Prompt entry is disabled in this MVP" disabled aria-disabled="true" style="width:100%;min-height:70px;border-radius:10px;border:1px solid #cdd5ef;padding:0.6rem;font:inherit;background:rgba(255,255,255,0.6);"></textarea>
+          <ul class="modes">{run_mode_rows}</ul>
+          <button type="button" class="disabled-btn" disabled aria-disabled="true">Live run (disabled)</button>
+          <p class="note">{_escape(run_setup["note"])}</p>
+        </article>
+
+        <article class="card" id="card-route-trace">
+          <h2>Route and Trace</h2>
+          {_kv_rows({
+              "route": trace["route"],
+              "confidence": trace["confidence"],
+              "SAFE-OUT state": trace["safe_out_state"],
+              "expert/team": trace["expert_team"],
+              "shortlist": trace["shortlist"],
+              "diagnostics": trace["diagnostics"],
+          })}
+          <p class="note">{_escape(trace["note"])}</p>
+        </article>
+
+        <article class="card" id="card-provider-gate">
+          <h2>Provider and Cost Gate</h2>
+          {_kv_rows({
+              "configured provider": gate["configured_provider"],
+              "live provider calls": gate["live_provider_calls"],
+              "console calls providers": gate["console_calls_providers"],
+              "emergency stop": gate["emergency_stop"],
+              "cost caps": gate["cost_caps"],
+              "live preview surface": gate["live_preview_surface"],
+          })}
+          <p class="note">Key presence (categorical only):</p>
+          {key_rows}
+          <p class="note">{_escape(gate["note"])}</p>
+        </article>
+
+        <article class="card" id="card-preflight-capture">
+          <h2>Preflight and Capture Entry</h2>
+          <p class="note">Local workflows (run from a terminal, not from this console):</p>
+          <ul class="workflows">{workflow_rows}</ul>
+          <p class="note">Docs: {_escape(capture["docs"])}</p>
+          <p class="note">{_escape(capture["note"])}</p>
+        </article>
+
+        <article class="card" id="card-evidence-receipt">
+          <h2>Evidence and Receipt</h2>
+          {_kv_rows({
+              "receipt id": receipt["receipt_id"],
+              "export digest": receipt["export_digest"],
+              "validation status": receipt["validation_status"],
+          })}
+          <p class="note">{_escape(receipt["note"])}</p>
+          <p class="note">{_escape(ARTIFACT_BOUNDARY_TEXT)}.</p>
+        </article>
+      </div>
+
+      <a class="status-link" href="{STATUS_ROUTE}">Read-only status JSON</a>
+    </main>
+  </body>
+</html>"""
+
+
+@router.get(ROUTE, response_class=HTMLResponse)
+async def operator_console_page() -> HTMLResponse:
+    """Render the read-only operator console shell."""
+
+    return HTMLResponse(content=_render_page(build_console_status()))
+
+
+@router.get(STATUS_ROUTE)
+async def operator_console_status() -> JSONResponse:
+    """Return the read-only operator console status as JSON.
+
+    The payload is assembled by :func:`build_console_status` and never contains
+    a raw secret value.
+    """
+
+    return JSONResponse(content=build_console_status())

--- a/alpha/webapp/routes/operator_console.py
+++ b/alpha/webapp/routes/operator_console.py
@@ -206,7 +206,7 @@ def build_console_status() -> Dict[str, Any]:
                     "id": "init-capture",
                     "command": (
                         "python scripts/operator_run_capture.py init "
-                        "--out <capture.json>"
+                        "--case-packet <case_packet.json> --out <capture.json>"
                     ),
                 },
                 {

--- a/docs/OPERATOR_CONSOLE.md
+++ b/docs/OPERATOR_CONSOLE.md
@@ -1,0 +1,81 @@
+# Alpha Solver Operator Console
+
+Lane: `UI-ALPHA-OPERATOR-CONSOLE-MVP-001`
+
+A protected, local-first operator console shell. It is a read-only cockpit of
+status cards, not a runner and not a public dashboard. Opening it is a status
+read: it starts no run, calls no provider, and spends no API credits.
+
+## What it is
+
+The console summarizes, on one protected page, the answers to:
+
+- What mode am I in? (**local-first**, live provider calls **disabled**.)
+- Which contract/status surfaces exist?
+- Where will route, SAFE-OUT, confidence, expert/team, shortlist, preflight,
+  capture, and evidence receipts appear once wired?
+- What stays blocked until future lanes?
+
+**Live provider calls are disabled in this MVP.** The console does not enable
+live API execution. The live-run control is rendered disabled.
+
+## How to reach it
+
+The console mounts behind the shared dashboard auth/CSRF middleware, under the
+protected `/dashboard` prefix, and is fail-closed exactly like the bundled
+expert-preview page. It is served only when both of these are set:
+
+- a non-default `ALPHA_DASHBOARD_PASSWORD`, and
+- an explicit `ALPHA_DASHBOARD_SECRET_KEY`.
+
+When either is missing the dashboard is not mounted and the console routes
+return 404. When mounted, an unauthenticated `GET` redirects to `/login`.
+
+- Page: `GET /dashboard/operator-console`
+- Read-only status JSON: `GET /dashboard/operator-console/status`
+
+## Cards
+
+1. **Operator Console Header** — title, `local-first` mode, live provider calls
+   disabled, and the claim boundary.
+2. **Portable Contract Status** — that `alpha_solver_portable.py` is present,
+   its source path, that it is a portable standalone behavior contract, and a
+   high-level surface list (SolverEnvelope, SAFE-OUT, confidence, route/expert
+   trace, local-output honesty, Substantive Lift). Private chain-of-thought is
+   not parsed or exposed, and the contract file is not modified.
+3. **Run Setup** — a disabled prompt input and the visible run modes (dry-run,
+   local-only, ChatGPT copy/paste, and live-provider shown disabled). The
+   live-run button is disabled; this MVP does not enable live API execution.
+4. **Route and Trace** — placeholder fields for route, confidence, SAFE-OUT
+   state, expert/team, shortlist, and diagnostics. They read "not run yet"; the
+   console does not invent route output or imply a solve ran.
+5. **Provider and Cost Gate** — the configured provider, that the console does
+   not call providers, emergency-stop and cost-cap status, the live-preview
+   surface state, and API key **presence** only (`present` / `missing`). No raw
+   or partial key values are shown.
+6. **Preflight and Capture Entry** — the local workflows (anchor-preflight,
+   lift-preflight, init capture, validate capture, export evidence packet) with
+   command snippets and a docs pointer. These run from a terminal, not from the
+   console.
+7. **Evidence and Receipt** — placeholders for a future receipt id, export
+   digest, and validation status.
+
+## Secret handling
+
+- Key status is boolean/categorical only (`present` / `missing` / `unknown`).
+- **No API keys are displayed.** Raw environment values are never returned by
+  the JSON endpoint and never rendered in HTML.
+
+## Boundaries
+
+- No provider, hosted-model, local-model, MCP, tool, browser, or network call
+  is made by the console.
+- The console does not change model routing, provider runtime, `/v1/solve`
+  execution, or the capture/export schemas, and it does not change the
+  `operator_run_capture.py` CLI.
+- Preflight and capture outputs are structural support artifacts, not
+  answer-quality, benchmark, readiness, or superiority evidence. Reporting a
+  surface as present means only that the named surface exists in the codebase;
+  it does not claim any answer-quality result. This page is not a benchmark,
+  readiness, production, or superiority claim, and it does not validate the
+  product.

--- a/service/app.py
+++ b/service/app.py
@@ -71,7 +71,11 @@ from .security import validate_api_key, sanitize_query
 from .otel import init_tracer
 from .health import healthcheck
 from .gating.gates import evaluate_gates
-from alpha.webapp.routes import auth as dashboard_auth, expert_preview
+from alpha.webapp.routes import (
+    auth as dashboard_auth,
+    expert_preview,
+    operator_console,
+)
 
 
 class JsonFormatter(logging.Formatter):
@@ -191,6 +195,10 @@ def _mount_dashboard(target: FastAPI) -> None:
     dashboard_auth.configure_login_redirect(target, expert_preview.ROUTE)
     target.include_router(dashboard_auth.router)
     target.include_router(expert_preview.router)
+    # Read-only, local-first operator console shell. It is protected by the same
+    # /dashboard auth/CSRF middleware and never calls a provider (see
+    # alpha/webapp/routes/operator_console.py).
+    target.include_router(operator_console.router)
 
 
 if _dashboard_enabled():

--- a/tests/test_operator_console.py
+++ b/tests/test_operator_console.py
@@ -13,6 +13,7 @@ They mirror the wiring/auth style of ``tests/ui/test_expert_preview_real_app.py`
 
 from __future__ import annotations
 
+import html
 import sys
 from pathlib import Path
 
@@ -165,6 +166,25 @@ def test_preflight_workflows_present_without_scoring_language(
     # No scoring/ranking/winner language.
     for forbidden in ("winner", "ranking", "leaderboard", "score:"):
         assert forbidden not in html.lower()
+
+
+def test_init_capture_command_includes_required_case_packet(
+    client: TestClient,
+) -> None:
+    _login(client)
+    expected_command = (
+        "python scripts/operator_run_capture.py init "
+        "--case-packet <case_packet.json> --out <capture.json>"
+    )
+
+    payload = client.get(STATUS_ROUTE).json()
+    workflows = {
+        workflow["id"]: workflow["command"]
+        for workflow in payload["preflight_capture"]["workflows"]
+    }
+
+    assert workflows["init-capture"] == expected_command
+    assert html.escape(expected_command) in client.get(PAGE_ROUTE).text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_operator_console.py
+++ b/tests/test_operator_console.py
@@ -1,0 +1,290 @@
+"""Focused tests for the read-only Alpha Solver Operator Console shell.
+
+These assert the console is:
+
+* mounted on the real ``service.app:app`` behind the shared dashboard
+  auth/CSRF middleware (fail-closed, session-protected);
+* live-provider disabled by default with a disabled live-run button;
+* free of any raw secret value in HTML or JSON;
+* reachable without exercising any provider-call path.
+
+They mirror the wiring/auth style of ``tests/ui/test_expert_preview_real_app.py``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from alpha.webapp.routes import auth, operator_console  # noqa: E402
+from service.app import app, _mount_dashboard  # noqa: E402
+
+PAGE_ROUTE = operator_console.ROUTE
+STATUS_ROUTE = operator_console.STATUS_ROUTE
+
+# A recognizable fake secret. It is placed in the environment and must never
+# appear in any console response (HTML or JSON).
+FAKE_SECRET = "sk-operator-console-should-never-render-0123456789"
+
+
+@pytest.fixture()
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setenv("ALPHA_DASHBOARD_PASSWORD", "testing-secret")
+    monkeypatch.setenv("ALPHA_DASHBOARD_SECRET_KEY", "unit-test-secret")
+    monkeypatch.setenv("MODEL_PROVIDER", "local")
+    auth.reset_state()
+
+    # https base_url: login sets Secure cookies the test client only resends
+    # over https.
+    test_client = TestClient(app, base_url="https://testserver")
+    try:
+        yield test_client
+    finally:
+        test_client.close()
+        auth.reset_state()
+
+
+def _login(client: TestClient) -> None:
+    response = client.post(
+        "/login", data={"password": "testing-secret"}, follow_redirects=False
+    )
+    assert response.status_code == 303
+    assert client.cookies.get(auth.SESSION_COOKIE_NAME)
+
+
+# ---------------------------------------------------------------------------
+# Mounting and protection
+# ---------------------------------------------------------------------------
+def test_routes_registered_in_real_app() -> None:
+    paths = {getattr(route, "path", None) for route in app.routes}
+    assert PAGE_ROUTE in paths
+    assert STATUS_ROUTE in paths
+
+
+def test_mount_dashboard_adds_protected_console_routes() -> None:
+    fresh = FastAPI()
+    _mount_dashboard(fresh)
+
+    paths = {getattr(route, "path", None) for route in fresh.routes}
+    assert PAGE_ROUTE in paths
+    assert STATUS_ROUTE in paths
+
+    fresh_client = TestClient(fresh, base_url="https://testserver")
+    try:
+        response = fresh_client.get(PAGE_ROUTE, follow_redirects=False)
+    finally:
+        fresh_client.close()
+    assert response.status_code == 303
+    assert response.headers["location"] == "/login"
+
+
+def test_unmounted_app_does_not_serve_console() -> None:
+    """Without an explicit mount the console is not globally registered."""
+
+    bare = FastAPI()
+    bare_client = TestClient(bare, base_url="https://testserver")
+    try:
+        assert bare_client.get(PAGE_ROUTE).status_code == 404
+        assert bare_client.get(STATUS_ROUTE).status_code == 404
+    finally:
+        bare_client.close()
+
+
+def test_logged_out_page_redirects_to_login(client: TestClient) -> None:
+    response = client.get(PAGE_ROUTE, follow_redirects=False)
+    assert response.status_code == 303
+    assert response.headers["location"] == "/login"
+
+
+def test_logged_out_status_redirects_to_login(client: TestClient) -> None:
+    response = client.get(STATUS_ROUTE, follow_redirects=False)
+    assert response.status_code == 303
+    assert response.headers["location"] == "/login"
+
+
+# ---------------------------------------------------------------------------
+# Rendered shell content
+# ---------------------------------------------------------------------------
+def test_authenticated_page_renders_all_cards(client: TestClient) -> None:
+    _login(client)
+    response = client.get(PAGE_ROUTE)
+    assert response.status_code == 200
+    html = response.text
+
+    for card_id in (
+        "card-portable-contract",
+        "card-run-setup",
+        "card-route-trace",
+        "card-provider-gate",
+        "card-preflight-capture",
+        "card-evidence-receipt",
+    ):
+        assert card_id in html
+
+    assert "Alpha Solver Operator Console" in html
+
+
+def test_authenticated_page_includes_boundary_text(client: TestClient) -> None:
+    _login(client)
+    html = client.get(PAGE_ROUTE).text
+
+    assert operator_console.LOCAL_FIRST_TEXT in html
+    assert operator_console.LIVE_DISABLED_TEXT in html
+    assert operator_console.ARTIFACT_BOUNDARY_TEXT in html
+    assert operator_console.NO_KEYS_TEXT in html
+
+
+def test_live_run_button_is_disabled_in_page(client: TestClient) -> None:
+    _login(client)
+    html = client.get(PAGE_ROUTE).text
+    assert "Live run (disabled)" in html
+    assert "class=\"disabled-btn\" disabled" in html
+
+
+def test_preflight_workflows_present_without_scoring_language(
+    client: TestClient,
+) -> None:
+    _login(client)
+    html = client.get(PAGE_ROUTE).text
+    for workflow in (
+        "anchor-preflight",
+        "lift-preflight",
+        "init-capture",
+        "validate-capture",
+        "export-evidence-packet",
+    ):
+        assert workflow in html
+    # No scoring/ranking/winner language.
+    for forbidden in ("winner", "ranking", "leaderboard", "score:"):
+        assert forbidden not in html.lower()
+
+
+# ---------------------------------------------------------------------------
+# Status JSON shape and provider gate
+# ---------------------------------------------------------------------------
+def test_status_json_shape(client: TestClient) -> None:
+    _login(client)
+    response = client.get(STATUS_ROUTE)
+    assert response.status_code == 200
+    payload = response.json()
+
+    for section in (
+        "console",
+        "portable_contract",
+        "run_setup",
+        "route_trace",
+        "provider_gate",
+        "preflight_capture",
+        "evidence_receipt",
+    ):
+        assert section in payload
+
+    assert payload["console"]["mode"] == "local-first"
+    assert payload["portable_contract"]["present"] is True
+    assert payload["portable_contract"]["source_path"] == "alpha_solver_portable.py"
+
+
+def test_status_live_provider_disabled_by_default(client: TestClient) -> None:
+    _login(client)
+    payload = client.get(STATUS_ROUTE).json()
+
+    assert payload["console"]["live_provider_calls"] == "disabled"
+    assert payload["provider_gate"]["live_provider_calls"] == "disabled"
+    assert payload["provider_gate"]["console_calls_providers"] is False
+    assert payload["run_setup"]["live_run_button_enabled"] is False
+
+    live_modes = [
+        mode
+        for mode in payload["run_setup"]["run_modes"]
+        if mode["id"] == "live-provider"
+    ]
+    assert live_modes and live_modes[0]["available"] is False
+
+
+def test_status_key_status_is_categorical_only(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", FAKE_SECRET)
+    _login(client)
+    payload = client.get(STATUS_ROUTE).json()
+
+    key_status = payload["provider_gate"]["key_status"]
+    assert key_status["OPENAI_API_KEY"] == "present"
+    for value in key_status.values():
+        assert value in {"present", "missing", "unknown"}
+
+
+# ---------------------------------------------------------------------------
+# Secret non-leakage
+# ---------------------------------------------------------------------------
+def test_fake_secret_never_leaks_in_html(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", FAKE_SECRET)
+    _login(client)
+    html = client.get(PAGE_ROUTE).text
+    assert FAKE_SECRET not in html
+    # The key is still reported as present (categorical), just never by value.
+    assert "OPENAI_API_KEY" in html
+
+
+def test_fake_secret_never_leaks_in_json(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", FAKE_SECRET)
+    _login(client)
+    response = client.get(STATUS_ROUTE)
+    assert FAKE_SECRET not in response.text
+
+
+def test_build_console_status_never_embeds_secret_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", FAKE_SECRET)
+    monkeypatch.setenv("ALPHA_DASHBOARD_SECRET_KEY", "another-fake-secret-value")
+    status = operator_console.build_console_status()
+    assert FAKE_SECRET not in repr(status)
+    assert "another-fake-secret-value" not in repr(status)
+
+
+# ---------------------------------------------------------------------------
+# No provider-call path
+# ---------------------------------------------------------------------------
+def test_console_never_calls_provider_client(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Rendering the console must not construct or execute a provider client."""
+
+    import alpha.providers.openai as openai_provider
+
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("provider client must not be used by operator console")
+
+    monkeypatch.setattr(openai_provider.OpenAIProviderClient, "__init__", _boom)
+    monkeypatch.setattr(openai_provider.OpenAIProviderClient, "execute", _boom)
+    monkeypatch.setattr(
+        app.state,
+        "provider_client_factory",
+        lambda *_a, **_k: _boom(),
+        raising=False,
+    )
+
+    _login(client)
+    assert client.get(PAGE_ROUTE).status_code == 200
+    assert client.get(STATUS_ROUTE).status_code == 200
+
+
+def test_console_module_does_not_import_provider_clients() -> None:
+    """The module source must not reference provider client classes."""
+
+    source = Path(operator_console.__file__).read_text(encoding="utf-8")
+    for forbidden in ("ProviderClient", "OpenAIProviderClient", "httpx", "requests."):
+        assert forbidden not in source


### PR DESCRIPTION
## Checklist

- [x] Spec linked: `.specs/UI-ALPHA-OPERATOR-CONSOLE-MVP-001.md`
- [x] Spec sections present/updated (Goal / Motivation / Acceptance Criteria (Definition of Done) / Code Targets / Test Plan)
- [x] Tests run: `python -m pytest -q` (full suite passed; 3 known environment-gated skips — see Validation)

## Notes for reviewers

### Lane

- Lane id: `AOC-B001-PORTABLE-CONTRACT-CONSOLE-SHELL-001`
- Spec id: `UI-ALPHA-OPERATOR-CONSOLE-MVP-001`
- Accepted baseline commit SHA: `fb4b64419c460617c8e3b0a4e48684e4e052ced8` (main, includes PR #663)

### Live-state gate (verified before editing)

- Branch `claude/alpha-solver-console-shell-6urq8p` was cut from current `main` @ `fb4b644`.
- PR #663 **merged** into main; PR #659 **closed, unmerged**; issue #662 **closed / completed**; no open conflicting PRs.
- Dashboard/webapp route + fail-closed auth patterns present (`alpha/webapp/routes/auth.py`, mounted in `service/app.py`).
- `alpha_solver_portable.py` present on main; `scripts/operator_run_capture.py` supports `anchor-preflight` and `lift-preflight`.

No stop condition triggered.

### Summary of changed files

- `alpha/webapp/routes/operator_console.py` (new) — read-only console route module.
- `service/app.py` (+10/-1) — include the console router in `_mount_dashboard`.
- `tests/test_operator_console.py` (new) — 17 focused tests.
- `.specs/UI-ALPHA-OPERATOR-CONSOLE-MVP-001.md` (new) — spec.
- `.specs/INDEX.md` (+1) — spec index row.
- `docs/OPERATOR_CONSOLE.md` (new) — console + no-provider-boundary docs.

### User-visible behavior

A protected, local-first cockpit under the already-protected `/dashboard` prefix:

- `GET /dashboard/operator-console` — HTML shell: a header banner plus six status cards (Portable Contract Status, Run Setup, Route and Trace, Provider and Cost Gate, Preflight and Capture Entry, Evidence and Receipt).
- `GET /dashboard/operator-console/status` — the same information as read-only JSON.

The operator immediately sees: `local-first` mode, live provider calls disabled, which contract/status surfaces exist, where route/SAFE-OUT/confidence/expert/preflight/capture/receipt will appear (all "not run yet" placeholders), and what stays blocked. The live-run button is rendered disabled. Run modes shown: dry-run, local-only, ChatGPT copy/paste, and live-provider (disabled).

### Security and no-secret handling

- Mounts only behind the existing fail-closed dashboard gate (non-default `ALPHA_DASHBOARD_PASSWORD` **and** explicit `ALPHA_DASHBOARD_SECRET_KEY`); otherwise routes 404. Logged-out `GET` on either route redirects to `/login`.
- Key status is categorical only (`present` / `missing` / `unknown`). Raw env values (API keys, signing secret) are never returned by the JSON endpoint and never rendered in HTML. A test places a fake secret in `OPENAI_API_KEY` and asserts it is absent from both the HTML and the JSON while the key still reports `present`.
- All rendered values pass through `html.escape`.

### Explicit no-provider-call boundary

- `operator_console.py` imports no provider client and references no provider client class (asserted by a source-scan test). Status is assembled purely from configuration and environment *presence* — no provider, network, model, MCP, tool, or browser call.
- A test monkeypatches `OpenAIProviderClient.__init__`/`execute` (and a factory) to raise, then loads both routes and asserts `200`, proving no provider-call path is exercised.
- Full-suite run left the live-OpenAI smoke test skipped (`ALPHA_LIVE_OPENAI` unset), confirming no live provider call ran.

### Tests and validation results

- `python -m pytest tests/test_operator_console.py -q` — **17 passed**.
- `python -m pytest tests/test_operator_console.py tests/ui/test_expert_preview_real_app.py tests/ui/test_auth.py tests/test_operator_run_capture.py tests/test_api_endpoints.py -q` — **151 passed**.
- `python -m pytest -q` (full suite) — **passed**, 3 known environment-gated skips (live-OpenAI smoke, decks web adapter, packaging build); no regressions.
- `ruff check service alpha scripts tests` — the two new files (`operator_console.py`, `test_operator_console.py`) are clean; the remaining repo lint findings (incl. the `get_openapi` redefinition in `service/app.py`) pre-exist on `main` @ `fb4b644` and are untouched by this PR.
- `python scripts/check_narrative_claim_safety.py docs/OPERATOR_CONSOLE.md .specs/UI-ALPHA-OPERATOR-CONSOLE-MVP-001.md` — **passed** (2 files scanned).

### Remaining risks

- The console reports configuration/environment *presence* at request time; it does not attempt to prove a provider is truly unreachable, only that the console itself never calls one.
- Placeholder trace/receipt fields are static strings; wiring real values is deferred to future lanes.

### What was intentionally not built

- No live run execution, prompt submission, or provider/model/tool/MCP/network call.
- No API key storage; no raw/partial key display.
- No scoring, ranking, winner fields, blind labels, source/identity maps, or model-comparison UI.
- No changes to `alpha_solver_portable.py`, provider runtime, model routing, `/v1/solve`, or capture/export schemas; no change to `operator_run_capture.py` CLI semantics.
- No new frontend framework or dependency; the shell is self-contained inline HTML matching the existing `expert_preview.py` style.

### Confirmations

- This PR does **not** enable live API execution.
- This PR does **not** change model routing, provider runtime, `/v1/solve` execution, or capture/export schemas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXTbqrG9ieRRrX2d82pLkw)_