### PR TITLE
ui: show local artifact status in operator console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 .ruff_cache/
 logs/
 artifacts/
+local/
 telemetry/*.jsonl
 .DS_Store
 bench_out/

--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -95,6 +95,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `SOLVE-PROVIDER-FINAL-ANSWER-EMPTY-GUARD-001.md` | SOLVE-PROVIDER-FINAL-ANSWER-EMPTY-GUARD-001 · Provider Final Answer Empty Output Guard | ✅ `SPEC_OK` |
 | `SOLVE-SANITIZER-FALSE-POSITIVE-001.md` | SOLVE-SANITIZER-FALSE-POSITIVE-001 · Narrow Import-Substring Sanitizer Fix | ✅ `SPEC_OK` |
 | `UI-ALPHA-OPERATOR-CONSOLE-MVP-001.md` | UI-ALPHA-OPERATOR-CONSOLE-MVP-001 · Alpha Solver Operator Console Shell (MVP) | ✅ `SPEC_OK` |
+| `UI-ALPHA-OPERATOR-CONSOLE-LOCAL-ARTIFACT-STATUS-001.md` | UI-ALPHA-OPERATOR-CONSOLE-LOCAL-ARTIFACT-STATUS-001 · Operator Console Local Artifact Status | ✅ `SPEC_OK` |
 | `UI-JOBS-001.md` | UI-JOBS-001 · Dashboard Job History & Metrics (RES_Dash) | ✅ `SPEC_OK` |
 | `UI-PREVIEW-001.md` | UI-PREVIEW-001 · Authenticated Expert Preview UI | ✅ `SPEC_OK` |
 | `UI-PREVIEW-LOADING-STATE-001.md` | UI-PREVIEW-LOADING-STATE-001 · Expert Preview Loading State | ✅ `SPEC_OK` |

--- a/.specs/UI-ALPHA-OPERATOR-CONSOLE-LOCAL-ARTIFACT-STATUS-001.md
+++ b/.specs/UI-ALPHA-OPERATOR-CONSOLE-LOCAL-ARTIFACT-STATUS-001.md
@@ -1,0 +1,123 @@
+# UI-ALPHA-OPERATOR-CONSOLE-LOCAL-ARTIFACT-STATUS-001 · Operator Console Local Artifact Status
+
+Status: Implemented
+
+## Goal
+
+Make the read-only Operator Console more useful by showing whether local
+operator artifacts (capture, evidence packet, anchor/lift preflight reports)
+exist under a fixed local directory and whether they are structurally valid —
+without executing any workflow, provider, model, `/v1/solve`, MCP, browser
+automation, network call, or CLI command. This is an artifact-status lane, not
+a workbench-action lane.
+
+## Motivation
+
+The console shell (`UI-ALPHA-OPERATOR-CONSOLE-MVP-001`) renders route/trace and
+evidence/receipt fields as static "not run yet" placeholders. Operators already
+produce local capture and export artifacts with the operator run capture
+harness, but the console could not tell them whether those artifacts exist or
+whether they are structurally valid. This lane wires the console to read a
+narrow, fixed local directory and display compact, safe status for the four
+known artifact files, reusing the harness's own validation and digest helpers.
+
+## Scope
+
+- `alpha/webapp/operator_console_artifacts.py` (new): read-only helper.
+  - `resolve_artifact_root()` returns the fixed `local/operator_console/`
+    directory under the repo root. An optional override env
+    (`ALPHA_OPERATOR_CONSOLE_ARTIFACT_ROOT`) is honored only when it resolves to
+    a path inside the repository root; path-traversal and outside-root values
+    are rejected and the fixed default is used.
+  - `summarize_capture` / `summarize_evidence_packet` /
+    `summarize_anchor_preflight` / `summarize_lift_preflight` read at most one
+    fixed file each and return counts/states/schema-version/id/digest only.
+    Missing files report `missing`; malformed JSON reports `invalid_json`;
+    structurally invalid JSON reports `invalid_structure`.
+  - Capture reuses `operator_run_capture.validate_capture`; the evidence packet
+    reuses `operator_run_capture.verify_packet_digest`
+    (`digest_valid` / `digest_invalid` / `digest_unverifiable`).
+  - `build_artifact_status()` assembles the four summaries plus the artifact
+    root, a `detected` flag, and the boundary statements.
+- `alpha/webapp/routes/operator_console.py`: adds a `local_artifacts` section to
+  the status payload and surfaces artifact-derived rows in the Route and Trace,
+  Preflight and Capture, and Evidence and Receipt cards, plus the boundary
+  statements. When nothing is detected the cards remain stable and show
+  "No local operator artifacts detected."
+- `.gitignore`: ignore `local/` so operator artifacts stay untracked.
+- `docs/OPERATOR_CONSOLE.md`: artifact-status section, root/path policy, and the
+  raw-output non-display and no-execution boundaries.
+- Tests in `tests/test_operator_console.py`.
+
+## Non-goals and boundaries
+
+- No provider, hosted-model, local-model, MCP, tool, browser, network, or
+  `/v1/solve` call; no CLI execution from the UI.
+- No create, modify, delete, upload, edit, or save of any artifact; the four
+  files are read-only inputs.
+- No raw prompts, baseline outputs, routed outputs, raw route metadata, system
+  prompts, or provider payloads are displayed by default. Only counts, states,
+  schema versions, ids, and the content digest (a hash) are surfaced.
+- No API key storage or raw/partial key display; existing categorical key
+  status is preserved.
+- No change to `alpha_solver_portable.py`, provider runtime, model routing,
+  `/v1/solve` execution, the capture/export schemas, or the
+  `operator_run_capture.py` CLI semantics.
+- No scoring, ranking, winner fields, blind labels, source maps, identity maps,
+  A/B identity keys, or model-comparison UI.
+- No benchmark, readiness, production, provider-validation, local-model, or
+  superiority claims. A preflight report being present is not a quality or
+  readiness signal.
+
+## Boundary statements
+
+The UI and status JSON include language equivalent to:
+
+- Local artifacts are structural support artifacts only.
+- This console does not execute providers, models, /v1/solve, MCP, tools,
+  browser automation, or CLI commands.
+- No raw prompts or raw outputs are displayed by default.
+- No answer-quality, benchmark, readiness, production, validation, or
+  superiority claim is made.
+
+## Code Targets
+
+- `alpha/webapp/operator_console_artifacts.py`
+- `alpha/webapp/routes/operator_console.py`
+- `tests/test_operator_console.py`
+- `docs/OPERATOR_CONSOLE.md`
+- `.gitignore`
+
+## Test Plan
+
+`tests/test_operator_console.py`: no local artifacts (renders, status reports
+not detected); a valid capture (schema version, packet id, total/captured/
+excluded/pending counts, route-metadata presence count, no raw case content);
+invalid JSON and structurally invalid capture fail safe with no server error; a
+valid evidence packet (id, schema, counts, content digest, digest verified); a
+tampered packet reports `digest_invalid` and a digest-less packet reports
+`digest_unverifiable`; anchor/lift preflight reports surface needs-attention and
+state counts without raw case detail; the override env rejects outside-root and
+traversal paths and honors an inside-repo path; a fake `OPENAI_API_KEY` never
+appears in HTML or JSON; recognizable raw prompt/baseline/routed/route-metadata
+text never appears in HTML or JSON; and no provider client is constructed or
+executed when artifacts are present.
+
+## Validation
+
+- `python -m pytest tests/test_operator_console.py -q`
+- `python -m pytest tests/test_operator_run_capture.py -q`
+- `python -m pytest tests/test_api_endpoints.py -q`
+- `python -m pytest -q`
+- `ruff check alpha/webapp/operator_console_artifacts.py alpha/webapp/routes/operator_console.py tests/test_operator_console.py`
+- `python scripts/check_narrative_claim_safety.py docs/OPERATOR_CONSOLE.md .specs/UI-ALPHA-OPERATOR-CONSOLE-LOCAL-ARTIFACT-STATUS-001.md`
+
+## Definition of Done
+
+The helper, console wiring, docs, tests, and this spec merged; all validation
+commands pass; the console reads only the fixed local directory (or a safe
+inside-repo override); missing and malformed artifacts fail safe; no raw
+prompt, output, route metadata, or secret is displayed; and no provider-call
+path is exercised. Reporting an artifact as structurally valid or a digest as
+valid means only that the configured structural rules or the recorded hash
+held; it is not a quality, benchmark, readiness, or superiority judgment.

--- a/alpha/webapp/operator_console_artifacts.py
+++ b/alpha/webapp/operator_console_artifacts.py
@@ -1,0 +1,331 @@
+"""Read-only local artifact status for the Alpha Solver Operator Console.
+
+This module summarizes a narrow, fixed local artifact directory so the operator
+console can show whether local capture / export / preflight artifacts exist and
+whether they are structurally valid. It is strictly read-only and local-only:
+
+* It never creates, modifies, deletes, or writes any artifact.
+* It never runs providers, models, ``/v1/solve``, MCP, browser automation, CLI
+  commands, network calls, or external tools.
+* It never returns raw prompts, baseline outputs, routed outputs, or raw route
+  metadata. Only counts, states, schema versions, ids, and digests are exposed.
+
+Artifact root: the fixed directory ``local/operator_console/`` under the repo
+root. An optional narrow override env (`ALPHA_OPERATOR_CONSOLE_ARTIFACT_ROOT`)
+is honored only when it resolves to a path *inside* the repository root; any
+path-traversal or outside-root value is rejected and the fixed default is used.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+from alpha.eval import operator_run_capture as capture_lib
+
+__all__ = [
+    "ARTIFACT_ROOT_ENV",
+    "DEFAULT_ARTIFACT_ROOT",
+    "CAPTURE_FILENAME",
+    "EVIDENCE_PACKET_FILENAME",
+    "ANCHOR_PREFLIGHT_FILENAME",
+    "LIFT_PREFLIGHT_FILENAME",
+    "ARTIFACT_SUPPORT_TEXT",
+    "NO_EXECUTION_TEXT",
+    "NO_RAW_TEXT",
+    "NO_CLAIM_TEXT",
+    "NO_ARTIFACTS_TEXT",
+    "BOUNDARY_TEXTS",
+    "resolve_artifact_root",
+    "summarize_capture",
+    "summarize_evidence_packet",
+    "summarize_anchor_preflight",
+    "summarize_lift_preflight",
+    "build_artifact_status",
+]
+
+# Repository root: alpha/webapp/operator_console_artifacts.py -> parents[2].
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+ARTIFACT_ROOT_ENV = "ALPHA_OPERATOR_CONSOLE_ARTIFACT_ROOT"
+DEFAULT_ARTIFACT_ROOT = _REPO_ROOT / "local" / "operator_console"
+
+CAPTURE_FILENAME = "capture.json"
+EVIDENCE_PACKET_FILENAME = "evidence_packet.json"
+ANCHOR_PREFLIGHT_FILENAME = "anchor_preflight_report.json"
+LIFT_PREFLIGHT_FILENAME = "lift_preflight_report.json"
+
+# ---------------------------------------------------------------------------
+# Boundary text. Surfaced in both the rendered console and the status JSON so
+# the operator always sees the read-only, no-execution, no-claim boundaries.
+# ---------------------------------------------------------------------------
+ARTIFACT_SUPPORT_TEXT = "Local artifacts are structural support artifacts only."
+NO_EXECUTION_TEXT = (
+    "This console does not execute providers, models, /v1/solve, MCP, tools, "
+    "browser automation, or CLI commands."
+)
+NO_RAW_TEXT = "No raw prompts or raw outputs are displayed by default."
+NO_CLAIM_TEXT = (
+    "No answer-quality, benchmark, readiness, production, validation, or "
+    "superiority claim is made."
+)
+NO_ARTIFACTS_TEXT = "No local operator artifacts detected."
+
+BOUNDARY_TEXTS = (
+    ARTIFACT_SUPPORT_TEXT,
+    NO_EXECUTION_TEXT,
+    NO_RAW_TEXT,
+    NO_CLAIM_TEXT,
+)
+
+
+def _is_within(child: Path, parent: Path) -> bool:
+    try:
+        child.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def resolve_artifact_root() -> Path:
+    """Return the artifact root, honoring only a safe inside-repo override.
+
+    The fixed default is ``<repo>/local/operator_console``. If the override env
+    is set, it is resolved (relative values are anchored at the repo root) and
+    accepted only when it stays inside the repository root; otherwise the fixed
+    default is returned. Path traversal and outside-root values are rejected.
+    """
+
+    raw = os.getenv(ARTIFACT_ROOT_ENV)
+    if not raw or not raw.strip():
+        return DEFAULT_ARTIFACT_ROOT
+
+    candidate = Path(raw.strip())
+    if not candidate.is_absolute():
+        candidate = _REPO_ROOT / candidate
+    try:
+        resolved = candidate.resolve()
+    except (OSError, RuntimeError, ValueError):
+        return DEFAULT_ARTIFACT_ROOT
+
+    if not _is_within(resolved, _REPO_ROOT.resolve()):
+        # Reject path traversal / outside-root override; fall back to default.
+        return DEFAULT_ARTIFACT_ROOT
+    return resolved
+
+
+def _read_json(path: Path) -> Tuple[str, Any]:
+    """Return ``(state, data)`` where state is missing / invalid_json / ok.
+
+    Never raises: unreadable or malformed files map to a safe state.
+    """
+
+    try:
+        if not path.is_file():
+            return "missing", None
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return "missing", None
+    try:
+        return "ok", json.loads(text)
+    except (json.JSONDecodeError, ValueError, UnicodeDecodeError):
+        return "invalid_json", None
+
+
+def _safe_str(value: Any) -> Optional[str]:
+    return value if isinstance(value, str) and value.strip() else None
+
+
+def _int_counts(raw: Any, keys: Tuple[str, ...]) -> Dict[str, int]:
+    counts: Dict[str, int] = {}
+    if isinstance(raw, dict):
+        for key in keys:
+            value = raw.get(key)
+            if isinstance(value, bool):
+                continue
+            if isinstance(value, int):
+                counts[key] = value
+    return counts
+
+
+def summarize_capture(root: Path) -> Dict[str, Any]:
+    """Summarize ``capture.json`` as counts/states only (no raw case content)."""
+
+    state, data = _read_json(root / CAPTURE_FILENAME)
+    if state != "ok":
+        return {"state": state}
+
+    try:
+        errors = capture_lib.validate_capture(data)
+    except Exception:  # pragma: no cover - defensive: never 500 on bad input
+        return {"state": "invalid_structure"}
+    if errors:
+        return {"state": "invalid_structure", "error_count": len(errors)}
+
+    try:
+        export_ready = not capture_lib.validate_capture(data, for_export=True)
+    except Exception:  # pragma: no cover - defensive
+        export_ready = False
+
+    cases = data.get("cases") if isinstance(data, dict) else []
+    if not isinstance(cases, list):
+        cases = []
+
+    def _count(status: str) -> int:
+        return sum(
+            1
+            for case in cases
+            if isinstance(case, dict) and case.get("validation_status") == status
+        )
+
+    route_metadata_present = sum(
+        1
+        for case in cases
+        if isinstance(case, dict) and isinstance(case.get("route_metadata"), dict)
+        and case.get("route_metadata")
+    )
+
+    return {
+        "state": "export_ready" if export_ready else "structurally_valid",
+        "schema_version": _safe_str(data.get("schema_version")),
+        "packet_id": _safe_str(data.get("packet_id")),
+        "counts": {
+            "total": len(cases),
+            "captured": _count("captured"),
+            "excluded": _count("excluded"),
+            "pending": _count("pending"),
+        },
+        "route_metadata_present_count": route_metadata_present,
+    }
+
+
+def summarize_evidence_packet(root: Path) -> Dict[str, Any]:
+    """Summarize ``evidence_packet.json`` including digest verification."""
+
+    state, data = _read_json(root / EVIDENCE_PACKET_FILENAME)
+    if state != "ok":
+        return {"state": state}
+
+    if not isinstance(data, dict):
+        return {"state": "invalid_structure"}
+    if data.get("schema_version") != capture_lib.PACKET_SCHEMA_VERSION:
+        return {"state": "invalid_structure"}
+    if not _safe_str(data.get("packet_id")):
+        return {"state": "invalid_structure"}
+    if not isinstance(data.get("counts"), dict) or not isinstance(
+        data.get("cases"), list
+    ):
+        return {"state": "invalid_structure"}
+
+    content_digest = _safe_str(data.get("content_digest"))
+    if content_digest is None:
+        digest_state = "digest_unverifiable"
+    else:
+        try:
+            digest_state = (
+                "digest_valid"
+                if capture_lib.verify_packet_digest(data)
+                else "digest_invalid"
+            )
+        except Exception:  # pragma: no cover - defensive
+            digest_state = "digest_unverifiable"
+
+    return {
+        "state": digest_state,
+        "schema_version": _safe_str(data.get("schema_version")),
+        "packet_id": _safe_str(data.get("packet_id")),
+        "content_digest": content_digest,
+        "counts": _int_counts(
+            data.get("counts"), ("total", "captured", "excluded")
+        ),
+    }
+
+
+def _summarize_preflight(
+    root: Path, filename: str, schema_version: str, states: Tuple[str, ...]
+) -> Dict[str, Any]:
+    state, data = _read_json(root / filename)
+    if state != "ok":
+        return {"state": state}
+    if not isinstance(data, dict):
+        return {"state": "invalid_structure"}
+    if data.get("schema_version") != schema_version:
+        return {"state": "invalid_structure"}
+    summary = data.get("summary")
+    if not isinstance(summary, dict):
+        return {"state": "invalid_structure"}
+
+    needs_attention = summary.get("needs_attention")
+    needs_attention_count = (
+        len(needs_attention) if isinstance(needs_attention, list) else 0
+    )
+    return {
+        "state": "present",
+        "schema_version": _safe_str(data.get("schema_version")),
+        "packet_id": _safe_str(data.get("packet_id")),
+        "state_counts": _int_counts(summary.get("counts"), states + ("total",)),
+        "needs_attention_count": needs_attention_count,
+    }
+
+
+def summarize_anchor_preflight(root: Path) -> Dict[str, Any]:
+    """Summarize ``anchor_preflight_report.json`` (counts + attention only)."""
+
+    return _summarize_preflight(
+        root,
+        ANCHOR_PREFLIGHT_FILENAME,
+        capture_lib.ANCHOR_PREFLIGHT_REPORT_SCHEMA_VERSION,
+        capture_lib.ANCHOR_PREFLIGHT_STATES,
+    )
+
+
+def summarize_lift_preflight(root: Path) -> Dict[str, Any]:
+    """Summarize ``lift_preflight_report.json`` (counts + attention only)."""
+
+    return _summarize_preflight(
+        root,
+        LIFT_PREFLIGHT_FILENAME,
+        capture_lib.LIFT_PREFLIGHT_REPORT_SCHEMA_VERSION,
+        capture_lib.LIFT_PREFLIGHT_STATES,
+    )
+
+
+def _display_root(root: Path) -> str:
+    try:
+        rel = root.resolve().relative_to(_REPO_ROOT.resolve())
+        return str(rel)
+    except ValueError:  # pragma: no cover - resolve keeps root inside repo
+        return root.name
+
+
+def build_artifact_status(root: Optional[Path] = None) -> Dict[str, Any]:
+    """Assemble the read-only local artifact status payload.
+
+    Pure function over the local filesystem. Reads at most the four fixed
+    artifact files, returns counts/states/digests only, and performs no
+    provider, network, model, tool, or CLI call.
+    """
+
+    resolved = root if root is not None else resolve_artifact_root()
+    capture = summarize_capture(resolved)
+    packet = summarize_evidence_packet(resolved)
+    anchor = summarize_anchor_preflight(resolved)
+    lift = summarize_lift_preflight(resolved)
+
+    detected = any(
+        section.get("state") != "missing"
+        for section in (capture, packet, anchor, lift)
+    )
+
+    return {
+        "artifact_root": _display_root(resolved),
+        "detected": detected,
+        "no_artifacts_message": NO_ARTIFACTS_TEXT,
+        "capture": capture,
+        "evidence_packet": packet,
+        "anchor_preflight": anchor,
+        "lift_preflight": lift,
+        "boundaries": list(BOUNDARY_TEXTS),
+    }

--- a/alpha/webapp/operator_console_artifacts.py
+++ b/alpha/webapp/operator_console_artifacts.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
@@ -56,6 +57,11 @@ CAPTURE_FILENAME = "capture.json"
 EVIDENCE_PACKET_FILENAME = "evidence_packet.json"
 ANCHOR_PREFLIGHT_FILENAME = "anchor_preflight_report.json"
 LIFT_PREFLIGHT_FILENAME = "lift_preflight_report.json"
+
+# Expected shape of a packet content digest: ``sha256:<64 lowercase hex>``.
+# A content_digest that does not match this is never returned or rendered, so a
+# corrupted packet cannot smuggle raw prompt/output text through this field.
+_DIGEST_RE = re.compile(r"sha256:[0-9a-f]{64}")
 
 # ---------------------------------------------------------------------------
 # Boundary text. Surfaced in both the rendered console and the status JSON so
@@ -126,11 +132,15 @@ def _read_json(path: Path) -> Tuple[str, Any]:
         if not path.is_file():
             return "missing", None
         text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        # Undecodable bytes are a malformed artifact, not a missing one, and
+        # read_text raises this before the JSON handler below would run.
+        return "invalid_json", None
     except OSError:
         return "missing", None
     try:
         return "ok", json.loads(text)
-    except (json.JSONDecodeError, ValueError, UnicodeDecodeError):
+    except (json.JSONDecodeError, ValueError):
         return "invalid_json", None
 
 
@@ -219,10 +229,18 @@ def summarize_evidence_packet(root: Path) -> Dict[str, Any]:
     ):
         return {"state": "invalid_structure"}
 
-    content_digest = _safe_str(data.get("content_digest"))
-    if content_digest is None:
+    raw_digest = data.get("content_digest")
+    has_digest = isinstance(raw_digest, str) and bool(raw_digest.strip())
+    if not has_digest:
+        # No recorded digest: nothing to verify and nothing to expose.
         digest_state = "digest_unverifiable"
+        safe_digest: Optional[str] = None
+    elif not _DIGEST_RE.fullmatch(raw_digest):
+        # A malformed content_digest could carry raw prompt/output text; never
+        # return or render its value, and fail to a safe non-leaking state.
+        return {"state": "invalid_structure"}
     else:
+        safe_digest = raw_digest
         try:
             digest_state = (
                 "digest_valid"
@@ -236,7 +254,7 @@ def summarize_evidence_packet(root: Path) -> Dict[str, Any]:
         "state": digest_state,
         "schema_version": _safe_str(data.get("schema_version")),
         "packet_id": _safe_str(data.get("packet_id")),
-        "content_digest": content_digest,
+        "content_digest": safe_digest,
         "counts": _int_counts(
             data.get("counts"), ("total", "captured", "excluded")
         ),

--- a/alpha/webapp/routes/operator_console.py
+++ b/alpha/webapp/routes/operator_console.py
@@ -30,6 +30,8 @@ from typing import Any, Dict, List, Mapping
 from fastapi import APIRouter
 from fastapi.responses import HTMLResponse, JSONResponse
 
+from alpha.webapp import operator_console_artifacts as artifacts
+
 router = APIRouter()
 
 ROUTE = "/dashboard/operator-console"
@@ -123,6 +125,7 @@ def build_console_status() -> Dict[str, Any]:
     """
 
     provider = os.getenv(_PROVIDER_ENV, "local").strip().lower() or "local"
+    local_artifacts = artifacts.build_artifact_status()
 
     return {
         "console": {
@@ -236,6 +239,7 @@ def build_console_status() -> Dict[str, Any]:
                 "proof."
             ),
         },
+        "local_artifacts": local_artifacts,
     }
 
 
@@ -290,6 +294,88 @@ def _render_page(status: Mapping[str, Any]) -> str:
 
     contract_badge = "present" if contract["present"] else "missing"
 
+    # Local artifact status (read-only; counts/states/digests only).
+    local = status["local_artifacts"]
+    no_artifacts_msg = local["no_artifacts_message"]
+    cap = local["capture"]
+    pkt = local["evidence_packet"]
+    anchor = local["anchor_preflight"]
+    lift = local["lift_preflight"]
+
+    def _state_badge(state: Any) -> str:
+        good = {"structurally_valid", "export_ready", "digest_valid", "present"}
+        bad = {"invalid_json", "invalid_structure", "digest_invalid"}
+        text = str(state)
+        cls = "ok" if text in good else "off" if text in bad else "muted"
+        return f'<span class="badge {cls}">{_escape(text)}</span>'
+
+    def _no_artifacts_note() -> str:
+        return f'<p class="note">{_escape(no_artifacts_msg)}</p>'
+
+    # Route and Trace: local capture counts + route metadata presence count.
+    if cap.get("state") in {"structurally_valid", "export_ready"}:
+        cap_counts = cap.get("counts", {})
+        trace_artifact_html = _kv_rows(
+            {
+                "captured (local)": cap_counts.get("captured", 0),
+                "excluded (local)": cap_counts.get("excluded", 0),
+                "pending (local)": cap_counts.get("pending", 0),
+                "route metadata present": cap.get("route_metadata_present_count", 0),
+            }
+        )
+    elif cap.get("state") == "missing":
+        trace_artifact_html = _no_artifacts_note()
+    else:
+        trace_artifact_html = (
+            f'<div class="kv"><dt>local capture</dt><dd>'
+            f'{_state_badge(cap.get("state"))}</dd></div>'
+        )
+
+    # Preflight and Capture: whether reports exist and need attention.
+    def _preflight_rows(label: str, summary: Mapping[str, Any]) -> str:
+        state = summary.get("state")
+        if state == "present":
+            return (
+                f'<div class="kv"><dt>{_escape(label)}</dt><dd>'
+                f'{_state_badge(state)} · needs attention: '
+                f'{_escape(summary.get("needs_attention_count", 0))}</dd></div>'
+            )
+        return (
+            f'<div class="kv"><dt>{_escape(label)}</dt><dd>'
+            f'{_state_badge(state)}</dd></div>'
+        )
+
+    preflight_artifact_html = _preflight_rows(
+        "anchor preflight report", anchor
+    ) + _preflight_rows("lift preflight report", lift)
+
+    # Evidence and Receipt: root, capture/packet states, digest, id, counts.
+    pkt_counts = pkt.get("counts", {})
+    evidence_artifact_html = _kv_rows(
+        {
+            "artifact root": local["artifact_root"],
+            "local artifacts detected": "yes" if local["detected"] else "no",
+        }
+    ) + (
+        f'<div class="kv"><dt>capture state</dt><dd>'
+        f'{_state_badge(cap.get("state"))}</dd></div>'
+        f'<div class="kv"><dt>evidence packet state</dt><dd>'
+        f'{_state_badge(pkt.get("state"))}</dd></div>'
+        + _kv_rows(
+            {
+                "packet id": pkt.get("packet_id") or "—",
+                "content digest": pkt.get("content_digest") or "—",
+                "packet captured": pkt_counts.get("captured", "—"),
+                "packet excluded": pkt_counts.get("excluded", "—"),
+                "packet total": pkt_counts.get("total", "—"),
+            }
+        )
+    )
+    boundary_html = "".join(
+        f"<li>{_escape(text)}</li>" for text in local["boundaries"]
+    )
+    evidence_no_artifacts = "" if local["detected"] else _no_artifacts_note()
+
     return f"""<!doctype html>
 <html lang="en">
   <head>
@@ -341,6 +427,7 @@ def _render_page(status: Mapping[str, Any]) -> str:
           <li>Claim boundary: {_escape(console["claim_boundary"])}</li>
           <li>{_escape(CLAIM_BOUNDARY_TEXT)}.</li>
           <li>{_escape(NO_KEYS_TEXT)}.</li>
+          {boundary_html}
         </ul>
       </section>
 
@@ -377,6 +464,8 @@ def _render_page(status: Mapping[str, Any]) -> str:
               "diagnostics": trace["diagnostics"],
           })}
           <p class="note">{_escape(trace["note"])}</p>
+          <p class="note">Local capture counts (structural only):</p>
+          {trace_artifact_html}
         </article>
 
         <article class="card" id="card-provider-gate">
@@ -400,6 +489,8 @@ def _render_page(status: Mapping[str, Any]) -> str:
           <ul class="workflows">{workflow_rows}</ul>
           <p class="note">Docs: {_escape(capture["docs"])}</p>
           <p class="note">{_escape(capture["note"])}</p>
+          <p class="note">Local preflight report status:</p>
+          {preflight_artifact_html}
         </article>
 
         <article class="card" id="card-evidence-receipt">
@@ -410,6 +501,10 @@ def _render_page(status: Mapping[str, Any]) -> str:
               "validation status": receipt["validation_status"],
           })}
           <p class="note">{_escape(receipt["note"])}</p>
+          <p class="note">Local artifact status:</p>
+          {evidence_artifact_html}
+          {evidence_no_artifacts}
+          <ul class="surfaces">{boundary_html}</ul>
           <p class="note">{_escape(ARTIFACT_BOUNDARY_TEXT)}.</p>
         </article>
       </div>

--- a/docs/OPERATOR_CONSOLE.md
+++ b/docs/OPERATOR_CONSOLE.md
@@ -58,7 +58,56 @@ return 404. When mounted, an unauthenticated `GET` redirects to `/login`.
    command snippets and a docs pointer. These run from a terminal, not from the
    console.
 7. **Evidence and Receipt** — placeholders for a future receipt id, export
-   digest, and validation status.
+   digest, and validation status, plus local artifact status (see below).
+
+## Local artifact status
+
+The console reads a narrow, fixed local directory and shows compact status for
+local operator artifacts. It is read-only: it never creates, modifies, deletes,
+or writes any artifact, and it never runs a workflow.
+
+### Artifact root and path policy
+
+- Fixed root: `local/operator_console/` under the repository root (kept
+  untracked via `.gitignore`).
+- Optional override env `ALPHA_OPERATOR_CONSOLE_ARTIFACT_ROOT` is honored only
+  when it resolves to a path **inside** the repository root. Path-traversal and
+  outside-root values are rejected and the fixed default is used.
+- The console never reads a path from query parameters, form data, request
+  bodies, cookies, or headers.
+- If the directory does not exist, the console renders normally and shows
+  "No local operator artifacts detected."
+
+### Files and states
+
+Inside the root, these optional files are summarized:
+
+- `capture.json` — `missing` / `invalid_json` / `invalid_structure` /
+  `structurally_valid` / `export_ready`, with schema version, packet id, and
+  total/captured/excluded/pending counts plus a route-metadata presence count.
+- `evidence_packet.json` — `missing` / `invalid_json` / `invalid_structure` /
+  `digest_valid` / `digest_invalid` / `digest_unverifiable`, with schema
+  version, packet id, content digest, and counts. Digest verification reuses
+  `operator_run_capture.verify_packet_digest`.
+- `anchor_preflight_report.json` and `lift_preflight_report.json` — `missing` /
+  `invalid_json` / `invalid_structure` / `present`, with a needs-attention count
+  and state counts.
+
+### What is not shown
+
+Only counts, states, schema versions, ids, and the content digest (a hash) are
+surfaced. Raw prompts, baseline outputs, routed outputs, raw route metadata,
+system prompts, and provider payloads are **not** displayed by default. The
+following boundary statements appear in both the page and the status JSON:
+
+- Local artifacts are structural support artifacts only.
+- This console does not execute providers, models, /v1/solve, MCP, tools,
+  browser automation, or CLI commands.
+- No raw prompts or raw outputs are displayed by default.
+- No answer-quality, benchmark, readiness, production, validation, or
+  superiority claim is made.
+
+A preflight report being present is not a quality or readiness signal.
 
 ## Secret handling
 

--- a/tests/test_operator_console.py
+++ b/tests/test_operator_console.py
@@ -605,3 +605,64 @@ def test_artifacts_module_does_not_import_provider_clients() -> None:
     source = Path(artifacts.__file__).read_text(encoding="utf-8")
     for forbidden in ("ProviderClient", "OpenAIProviderClient", "httpx", "requests."):
         assert forbidden not in source
+
+
+# Recognizable raw text smuggled into a content_digest field must never render.
+RAW_DIGEST_LEAK = "RAW-DIGEST-LEAK-must-not-render-zzz"
+
+
+def test_malformed_content_digest_never_leaks_raw_content(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A corrupted content_digest carrying raw text is withheld and fails safe."""
+
+    packet = capture_lib.build_evidence_packet(_valid_capture())
+    # Corrupt the digest to smuggle raw prompt/output-like text.
+    packet["content_digest"] = "sha256:" + RAW_DIGEST_LEAK + " " + RAW_PROMPT
+    _write(tmp_path, "evidence_packet.json", packet)
+    _use_root(monkeypatch, tmp_path)
+    _login(client)
+
+    payload = client.get(STATUS_ROUTE).json()
+    pkt = payload["local_artifacts"]["evidence_packet"]
+
+    # Malformed digest -> safe non-leaking state, value not returned.
+    assert pkt["state"] == "invalid_structure"
+    assert pkt.get("content_digest") is None
+
+    html_text = client.get(PAGE_ROUTE).text
+    body = json.dumps(payload)
+    for raw in (RAW_DIGEST_LEAK, RAW_PROMPT, RAW_BASELINE, RAW_ROUTED):
+        assert raw not in html_text
+        assert raw not in body
+
+
+def test_wellformed_digest_value_is_still_exposed(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A valid sha256:<64 hex> digest is still surfaced (regression guard)."""
+
+    packet = capture_lib.build_evidence_packet(_valid_capture())
+    _write(tmp_path, "evidence_packet.json", packet)
+    _use_root(monkeypatch, tmp_path)
+    _login(client)
+
+    pkt = client.get(STATUS_ROUTE).json()["local_artifacts"]["evidence_packet"]
+    assert pkt["state"] == "digest_valid"
+    assert pkt["content_digest"] == packet["content_digest"]
+    assert pkt["content_digest"] in client.get(PAGE_ROUTE).text
+
+
+def test_invalid_utf8_artifact_fails_safe(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Undecodable artifact bytes report invalid_json and never 500."""
+
+    (tmp_path / "capture.json").write_bytes(b"\xff\xfe\x00\x80 not utf-8 \xff")
+    _use_root(monkeypatch, tmp_path)
+    _login(client)
+
+    response = client.get(STATUS_ROUTE)
+    assert response.status_code == 200
+    assert response.json()["local_artifacts"]["capture"]["state"] == "invalid_json"
+    assert client.get(PAGE_ROUTE).status_code == 200

--- a/tests/test_operator_console.py
+++ b/tests/test_operator_console.py
@@ -14,6 +14,7 @@ They mirror the wiring/auth style of ``tests/ui/test_expert_preview_real_app.py`
 from __future__ import annotations
 
 import html
+import json
 import sys
 from pathlib import Path
 
@@ -25,7 +26,9 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
+from alpha.webapp import operator_console_artifacts as artifacts  # noqa: E402
 from alpha.webapp.routes import auth, operator_console  # noqa: E402
+from alpha.eval import operator_run_capture as capture_lib  # noqa: E402
 from service.app import app, _mount_dashboard  # noqa: E402
 
 PAGE_ROUTE = operator_console.ROUTE
@@ -306,5 +309,299 @@ def test_console_module_does_not_import_provider_clients() -> None:
     """The module source must not reference provider client classes."""
 
     source = Path(operator_console.__file__).read_text(encoding="utf-8")
+    for forbidden in ("ProviderClient", "OpenAIProviderClient", "httpx", "requests."):
+        assert forbidden not in source
+
+
+# ---------------------------------------------------------------------------
+# Local artifact status (AOC-B002-LOCAL-ARTIFACT-STATUS-001)
+# ---------------------------------------------------------------------------
+# Recognizable raw content that must never surface in HTML or JSON.
+RAW_PROMPT = "RAW-PROMPT-must-not-render-zzz"
+RAW_BASELINE = "RAW-BASELINE-must-not-render-zzz"
+RAW_ROUTED = "RAW-ROUTED-must-not-render-zzz"
+RAW_ROUTE_META = "RAW-ROUTE-META-must-not-render-zzz"
+
+
+def _valid_capture() -> dict:
+    """A structurally valid, export-ready capture with recognizable raw fields."""
+
+    packet = {
+        "packet_id": "ORC-TEST-001",
+        "cases": [
+            {"task_id": "t1", "prompt": RAW_PROMPT},
+            {"task_id": "t2", "prompt": RAW_PROMPT},
+        ],
+    }
+    capture = capture_lib.scaffold_capture(packet)
+    capture["cases"][0].update(
+        {
+            "validation_status": "captured",
+            "baseline_output": RAW_BASELINE,
+            "routed_output": RAW_ROUTED,
+            "route_metadata": {"route": RAW_ROUTE_META},
+        }
+    )
+    capture["cases"][1].update(
+        {
+            "validation_status": "excluded",
+            "baseline_output": "",
+            "routed_output": "",
+            "route_metadata": {},
+            "exclusion_reason": "low headroom",
+        }
+    )
+    return capture
+
+
+def _write(tmp_path: Path, name: str, obj) -> None:
+    (tmp_path / name).write_text(json.dumps(obj), encoding="utf-8")
+
+
+def _use_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(artifacts, "resolve_artifact_root", lambda: tmp_path)
+
+
+def test_no_local_artifacts_status_and_render(client: TestClient) -> None:
+    _login(client)
+    payload = client.get(STATUS_ROUTE).json()
+    local = payload["local_artifacts"]
+
+    assert local["detected"] is False
+    assert local["no_artifacts_message"] == artifacts.NO_ARTIFACTS_TEXT
+    for section in ("capture", "evidence_packet", "anchor_preflight", "lift_preflight"):
+        assert local[section]["state"] == "missing"
+
+    html_text = client.get(PAGE_ROUTE).text
+    assert artifacts.NO_ARTIFACTS_TEXT in html_text
+
+
+def test_artifact_boundary_texts_present(client: TestClient) -> None:
+    _login(client)
+    html_text = client.get(PAGE_ROUTE).text
+    payload_text = json.dumps(client.get(STATUS_ROUTE).json())
+    for text in artifacts.BOUNDARY_TEXTS:
+        assert text in html_text
+        assert text in payload_text
+
+
+def test_valid_capture_summary(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _write(tmp_path, "capture.json", _valid_capture())
+    _use_root(monkeypatch, tmp_path)
+    _login(client)
+
+    payload = client.get(STATUS_ROUTE).json()
+    cap = payload["local_artifacts"]["capture"]
+    assert cap["state"] in {"structurally_valid", "export_ready"}
+    assert cap["schema_version"] == capture_lib.CAPTURE_SCHEMA_VERSION
+    assert cap["packet_id"] == "ORC-TEST-001"
+    assert cap["counts"] == {
+        "total": 2,
+        "captured": 1,
+        "excluded": 1,
+        "pending": 0,
+    }
+    assert cap["route_metadata_present_count"] == 1
+
+    html_text = client.get(PAGE_ROUTE).text
+    body = json.dumps(payload)
+    for raw in (RAW_PROMPT, RAW_BASELINE, RAW_ROUTED, RAW_ROUTE_META):
+        assert raw not in html_text
+        assert raw not in body
+
+
+def test_invalid_json_capture_fails_safe(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    (tmp_path / "capture.json").write_text("{ not valid json", encoding="utf-8")
+    _use_root(monkeypatch, tmp_path)
+    _login(client)
+
+    response = client.get(STATUS_ROUTE)
+    assert response.status_code == 200
+    assert response.json()["local_artifacts"]["capture"]["state"] == "invalid_json"
+    assert client.get(PAGE_ROUTE).status_code == 200
+
+
+def test_invalid_structure_capture_fails_safe(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _write(tmp_path, "capture.json", {"schema_version": "wrong", "cases": "nope"})
+    _use_root(monkeypatch, tmp_path)
+    _login(client)
+
+    response = client.get(STATUS_ROUTE)
+    assert response.status_code == 200
+    assert (
+        response.json()["local_artifacts"]["capture"]["state"] == "invalid_structure"
+    )
+    assert client.get(PAGE_ROUTE).status_code == 200
+
+
+def test_valid_evidence_packet_digest_valid(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    packet = capture_lib.build_evidence_packet(_valid_capture())
+    _write(tmp_path, "evidence_packet.json", packet)
+    _use_root(monkeypatch, tmp_path)
+    _login(client)
+
+    payload = client.get(STATUS_ROUTE).json()
+    pkt = payload["local_artifacts"]["evidence_packet"]
+    assert pkt["state"] == "digest_valid"
+    assert pkt["packet_id"] == "ORC-TEST-001"
+    assert pkt["schema_version"] == capture_lib.PACKET_SCHEMA_VERSION
+    assert pkt["content_digest"].startswith("sha256:")
+    assert pkt["counts"]["total"] == 2
+
+    # digest (a hash, not raw content) is shown; raw case content is not.
+    html_text = client.get(PAGE_ROUTE).text
+    assert pkt["content_digest"] in html_text
+    for raw in (RAW_PROMPT, RAW_BASELINE, RAW_ROUTED, RAW_ROUTE_META):
+        assert raw not in html_text
+        assert raw not in json.dumps(payload)
+
+
+def test_bad_evidence_packet_digest_fails_safe(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    packet = capture_lib.build_evidence_packet(_valid_capture())
+    packet["packet_id"] = "tampered-after-digest"  # digest no longer matches body
+    _write(tmp_path, "evidence_packet.json", packet)
+    _use_root(monkeypatch, tmp_path)
+    _login(client)
+
+    response = client.get(STATUS_ROUTE)
+    assert response.status_code == 200
+    assert (
+        response.json()["local_artifacts"]["evidence_packet"]["state"]
+        == "digest_invalid"
+    )
+
+
+def test_evidence_packet_missing_digest_unverifiable(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    packet = capture_lib.build_evidence_packet(_valid_capture())
+    del packet["content_digest"]
+    _write(tmp_path, "evidence_packet.json", packet)
+    _use_root(monkeypatch, tmp_path)
+    _login(client)
+
+    payload = client.get(STATUS_ROUTE).json()
+    assert (
+        payload["local_artifacts"]["evidence_packet"]["state"] == "digest_unverifiable"
+    )
+
+
+def test_preflight_report_summaries(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    anchor_report = {
+        "schema_version": capture_lib.ANCHOR_PREFLIGHT_REPORT_SCHEMA_VERSION,
+        "packet_id": "ORC-TEST-001",
+        "boundary": "structural only",
+        "summary": {
+            "counts": {
+                "anchor_bearing": 1,
+                "anchor_free": 0,
+                "invalid_case": 1,
+                "total": 2,
+            },
+            "needs_attention": ["t2"],
+        },
+        # A raw prompt buried in case detail must never surface.
+        "cases": [{"task_id": "t1", "state": "anchor_bearing", "prompt": RAW_PROMPT}],
+    }
+    lift_report = {
+        "schema_version": capture_lib.LIFT_PREFLIGHT_REPORT_SCHEMA_VERSION,
+        "packet_id": "ORC-TEST-001",
+        "boundary": "structural only",
+        "summary": {
+            "counts": {"structural_pass": 1, "total": 1},
+            "needs_attention": [],
+        },
+        "cases": [{"task_id": "t1", "state": "structural_pass", "routed": RAW_ROUTED}],
+    }
+    _write(tmp_path, "anchor_preflight_report.json", anchor_report)
+    _write(tmp_path, "lift_preflight_report.json", lift_report)
+    _use_root(monkeypatch, tmp_path)
+    _login(client)
+
+    payload = client.get(STATUS_ROUTE).json()
+    anchor = payload["local_artifacts"]["anchor_preflight"]
+    lift = payload["local_artifacts"]["lift_preflight"]
+
+    assert anchor["state"] == "present"
+    assert anchor["needs_attention_count"] == 1
+    assert anchor["state_counts"]["invalid_case"] == 1
+    assert lift["state"] == "present"
+    assert lift["needs_attention_count"] == 0
+
+    # Preflight presence is not a quality/readiness signal, and raw case detail
+    # never surfaces.
+    html_text = client.get(PAGE_ROUTE).text
+    body = json.dumps(payload)
+    for raw in (RAW_PROMPT, RAW_ROUTED):
+        assert raw not in html_text
+        assert raw not in body
+
+
+def test_path_override_outside_root_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(artifacts.ARTIFACT_ROOT_ENV, "/etc")
+    assert artifacts.resolve_artifact_root() == artifacts.DEFAULT_ARTIFACT_ROOT
+
+
+def test_path_override_traversal_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(artifacts.ARTIFACT_ROOT_ENV, "../../../../../etc")
+    assert artifacts.resolve_artifact_root() == artifacts.DEFAULT_ARTIFACT_ROOT
+
+
+def test_path_override_inside_repo_honored(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(artifacts.ARTIFACT_ROOT_ENV, "local/oc_test_subdir")
+    resolved = artifacts.resolve_artifact_root()
+    repo_root = Path(artifacts.__file__).resolve().parents[2]
+    assert resolved == (repo_root / "local" / "oc_test_subdir").resolve()
+    assert str(resolved).startswith(str(repo_root.resolve()))
+
+
+def test_no_secret_leak_with_artifacts_present(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", FAKE_SECRET)
+    capture = _valid_capture()
+    _write(tmp_path, "capture.json", capture)
+    _write(tmp_path, "evidence_packet.json", capture_lib.build_evidence_packet(capture))
+    _use_root(monkeypatch, tmp_path)
+    _login(client)
+
+    assert FAKE_SECRET not in client.get(PAGE_ROUTE).text
+    assert FAKE_SECRET not in client.get(STATUS_ROUTE).text
+
+
+def test_no_provider_call_with_artifacts_present(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import alpha.providers.openai as openai_provider
+
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("provider client must not be used by operator console")
+
+    monkeypatch.setattr(openai_provider.OpenAIProviderClient, "__init__", _boom)
+    monkeypatch.setattr(openai_provider.OpenAIProviderClient, "execute", _boom)
+    _write(tmp_path, "capture.json", _valid_capture())
+    _use_root(monkeypatch, tmp_path)
+    _login(client)
+
+    assert client.get(PAGE_ROUTE).status_code == 200
+    assert client.get(STATUS_ROUTE).status_code == 200
+
+
+def test_artifacts_module_does_not_import_provider_clients() -> None:
+    source = Path(artifacts.__file__).read_text(encoding="utf-8")
     for forbidden in ("ProviderClient", "OpenAIProviderClient", "httpx", "requests."):
         assert forbidden not in source


### PR DESCRIPTION
## Checklist

- [x] Spec linked: `.specs/UI-ALPHA-OPERATOR-CONSOLE-LOCAL-ARTIFACT-STATUS-001.md`
- [x] Spec sections present/updated (Goal / Motivation / Scope / Non-goals / Code Targets / Test Plan / Definition of Done)
- [x] Tests run: `python -m pytest -q` (full suite passed; 3 known environment-gated skips — see Validation)

## Notes for reviewers

### Lane

- Lane id: `AOC-B002-LOCAL-ARTIFACT-STATUS-001`
- Spec id: `UI-ALPHA-OPERATOR-CONSOLE-LOCAL-ARTIFACT-STATUS-001`
- Accepted baseline commit SHA: `9206765` (main, includes merged PR #664)

### Live-state gate (verified before editing)

- Branch created fresh from current `main` @ `9206765`.
- PR #664 **merged** into main; no open conflicting PRs.
- `alpha/webapp/routes/operator_console.py` exists and still has placeholder route/trace + evidence/receipt fields.
- `alpha/eval/operator_run_capture.py` exposes `build_evidence_packet`, `validate_capture`, `verify_packet_digest`, `load_json`, and schema-version constants.
- `scripts/operator_run_capture.py` still supports `init`, `validate`, `export`, `lift-preflight`, `anchor-preflight`.
- Dashboard remains protected under `/dashboard` (fail-closed).
- `.gitignore` did not ignore `local/` → added.

No stop condition triggered.

### Summary of changed files

- `alpha/webapp/operator_console_artifacts.py` (new) — read-only artifact summarizers + safe root resolution.
- `alpha/webapp/routes/operator_console.py` (+95) — `local_artifacts` status section + card wiring + boundary text.
- `tests/test_operator_console.py` (+297) — 15 new focused tests.
- `.specs/UI-ALPHA-OPERATOR-CONSOLE-LOCAL-ARTIFACT-STATUS-001.md` (new) — spec.
- `.specs/INDEX.md` (+1) — spec index row.
- `docs/OPERATOR_CONSOLE.md` (+51) — artifact-status section, path policy, boundaries.
- `.gitignore` (+1) — ignore `local/`.

### User-visible behavior

When local artifacts exist under the fixed root, the protected console shows compact, safe status:

- **Evidence and Receipt** — artifact root, capture state, evidence packet state, digest status, packet id, counts, and the no-claim boundary.
- **Route and Trace** — local captured/excluded/pending counts and the route-metadata presence count.
- **Preflight and Capture** — whether the anchor/lift preflight reports exist and their needs-attention count.

When nothing is detected, all cards stay stable and show "No local operator artifacts detected." Missing files report `missing`, malformed JSON reports `invalid_json`, structurally invalid JSON reports `invalid_structure` — all fail safe with no server error.

### Local artifact root / path policy

- Fixed root: `local/operator_console/` under the repo root (kept untracked via `.gitignore`).
- Optional override env `ALPHA_OPERATOR_CONSOLE_ARTIFACT_ROOT` is honored **only** when it resolves inside the repository root; path-traversal and outside-root values are rejected and the fixed default is used.
- No path is ever read from query params, form data, request bodies, cookies, or headers.
- Four fixed filenames only: `capture.json`, `evidence_packet.json`, `anchor_preflight_report.json`, `lift_preflight_report.json`.

### Security and no-secret handling

- Existing categorical key status (`present`/`missing`/`unknown`) is preserved; no raw or partial key values are shown.
- A test sets a fake `OPENAI_API_KEY` and asserts it is absent from both HTML and JSON while artifacts are present.

### Raw prompt/output non-display policy

- Only counts, states, schema versions, ids, and the content digest (a hash) are surfaced.
- Raw prompts, baseline outputs, routed outputs, and raw route metadata are never returned. A test fixture embeds recognizable raw prompt/baseline/routed/route-metadata strings in capture, evidence-packet, and preflight files and asserts none appear in HTML or JSON.

### Explicit no-provider-call boundary

- The helper imports no provider client and references no provider client class (asserted by a source-scan test). Status comes only from the local filesystem — no provider, network, model, MCP, tool, browser, or CLI call, and no artifact is created/modified/deleted.
- A test patches `OpenAIProviderClient.__init__`/`execute` to raise, then loads both routes with artifacts present and asserts `200`.
- Full-suite run left the live-OpenAI smoke test skipped (`ALPHA_LIVE_OPENAI` unset), confirming no live provider call ran.

### Tests and validation results

- `python -m pytest tests/test_operator_console.py -q` — **33 passed** (18 existing + 15 new).
- `python -m pytest tests/test_operator_console.py tests/test_operator_run_capture.py tests/test_api_endpoints.py -q` — **145 passed**.
- `python -m pytest -q` (full) — **passed**, 3 known environment-gated skips (live-OpenAI smoke, decks web adapter, packaging build); no regressions.
- `ruff check alpha/webapp/operator_console_artifacts.py alpha/webapp/routes/operator_console.py tests/test_operator_console.py` — **All checks passed**.
- `python scripts/check_narrative_claim_safety.py docs/OPERATOR_CONSOLE.md .specs/UI-ALPHA-OPERATOR-CONSOLE-LOCAL-ARTIFACT-STATUS-001.md` — **passed** (2 files scanned).

### Remaining risks

- Structural validity and a valid digest confirm only that the configured structural rules or the recorded hash held; they are not quality, readiness, or benchmark signals.
- The evidence-packet structural check is intentionally light (schema version, packet id, counts, cases) since the harness has no dedicated packet validator; digest verification is the primary integrity signal.

### What was intentionally not built

- No workflow execution, upload, edit, save, delete, or artifact mutation.
- No provider/model/`/v1/solve`/MCP/network/browser/CLI call from the UI.
- No display of raw prompts, outputs, raw route metadata, or provider payloads.
- No scoring, ranking, winner fields, blind labels, source/identity maps, or model-comparison UI.
- No change to `alpha_solver_portable.py`, provider runtime, model routing, `/v1/solve`, `operator_run_capture.py` CLI semantics, or capture/export schemas.

### Confirmations

- This PR does **not** enable live API execution.
- This PR does **not** change model routing, provider runtime, `/v1/solve`, `alpha_solver_portable.py`, `operator_run_capture.py` CLI semantics, or capture/export schemas.
- This PR does **not** tag Codex anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXTbqrG9ieRRrX2d82pLkw)_