### PR TITLE
Operator Console artifact freshness and sequence coherence (AOC-B003-ARTIFACT-FRESHNESS-001)

### DIFF
--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -96,6 +96,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `SOLVE-SANITIZER-FALSE-POSITIVE-001.md` | SOLVE-SANITIZER-FALSE-POSITIVE-001 · Narrow Import-Substring Sanitizer Fix | ✅ `SPEC_OK` |
 | `UI-ALPHA-OPERATOR-CONSOLE-MVP-001.md` | UI-ALPHA-OPERATOR-CONSOLE-MVP-001 · Alpha Solver Operator Console Shell (MVP) | ✅ `SPEC_OK` |
 | `UI-ALPHA-OPERATOR-CONSOLE-LOCAL-ARTIFACT-STATUS-001.md` | UI-ALPHA-OPERATOR-CONSOLE-LOCAL-ARTIFACT-STATUS-001 · Operator Console Local Artifact Status | ✅ `SPEC_OK` |
+| `UI-ALPHA-OPERATOR-CONSOLE-ARTIFACT-FRESHNESS-001.md` | UI-ALPHA-OPERATOR-CONSOLE-ARTIFACT-FRESHNESS-001 · Operator Console Artifact Freshness and Sequence Coherence | ✅ `SPEC_OK` |
 | `UI-JOBS-001.md` | UI-JOBS-001 · Dashboard Job History & Metrics (RES_Dash) | ✅ `SPEC_OK` |
 | `UI-PREVIEW-001.md` | UI-PREVIEW-001 · Authenticated Expert Preview UI | ✅ `SPEC_OK` |
 | `UI-PREVIEW-LOADING-STATE-001.md` | UI-PREVIEW-LOADING-STATE-001 · Expert Preview Loading State | ✅ `SPEC_OK` |

--- a/.specs/UI-ALPHA-OPERATOR-CONSOLE-ARTIFACT-FRESHNESS-001.md
+++ b/.specs/UI-ALPHA-OPERATOR-CONSOLE-ARTIFACT-FRESHNESS-001.md
@@ -1,0 +1,163 @@
+# UI-ALPHA-OPERATOR-CONSOLE-ARTIFACT-FRESHNESS-001 · Operator Console Artifact Freshness and Sequence Coherence
+
+Status: Implemented
+
+## Goal
+
+Extend the protected, read-only Operator Console so the existing local artifact
+status cards also show read-only temporal metadata and simple
+dependency-coherence warnings for the four fixed local artifacts introduced by
+`UI-ALPHA-OPERATOR-CONSOLE-LOCAL-ARTIFACT-STATUS-001`. This lane infers
+freshness from local filesystem modified-time metadata and the existing safe
+summaries only. It executes no workflow, provider, model, `/v1/solve`, MCP,
+browser automation, network call, or CLI command, and it changes no artifact and
+no schema.
+
+## Motivation
+
+After the local-artifact-status lane the console can show whether local
+artifacts exist and whether they are structurally valid, but it cannot tell the
+operator whether the artifacts are current relative to each other. The next
+cockpit question is: am I looking at a fresh capture and matching derived
+artifacts, or stale evidence/preflight files from an older local run? A valid
+evidence-packet digest proves only packet self-integrity; it does not prove that
+`evidence_packet.json` reflects the latest `capture.json` on disk. This lane adds
+read-only freshness and sequence-coherence metadata so an operator can spot stale
+or out-of-sequence local artifacts.
+
+## Scope
+
+- `alpha/webapp/operator_console_artifacts.py`: extend the read-only helper.
+  - Preserve the fixed-root policy: default `local/operator_console/`, optional
+    `ALPHA_OPERATOR_CONSOLE_ARTIFACT_ROOT` override honored only when it resolves
+    inside the repository root, path-traversal and outside-root values rejected,
+    and no path taken from query params, form data, request bodies, cookies, or
+    headers.
+  - Preserve the exact four fixed filenames.
+  - Add `status_generated_at_utc` (UTC ISO-8601) generated when
+    `build_artifact_status` runs. `build_artifact_status` accepts an injectable
+    `now` so freshness labels are deterministic in tests.
+  - Add safe per-file metadata for each fixed file via `file_freshness`:
+    `path_label` (safe relative label), `exists`, `modified_at_utc`,
+    `age_seconds`, `metadata_state` (`missing` / `present` / `unavailable`), and
+    a deterministic `age_label` (`missing` / `just_updated` / `recent` /
+    `older` / `unknown`) via the pure `age_label` helper and fixed thresholds
+    (5 minutes, 24 hours).
+  - Add derived-vs-capture ordering under `sequence_coherence`:
+    `evidence_packet_vs_capture`, `anchor_preflight_vs_capture`, and
+    `lift_preflight_vs_capture`, each with a `state`
+    (`not_comparable` / `same_or_newer_than_capture` / `older_than_capture`) and
+    a `flags` list of safe mismatch signals (`packet_id_mismatch`,
+    `counts_mismatch`, `digest_invalid`, `digest_unverifiable`,
+    `metadata_only_no_claim`) drawn only from existing safe summaries.
+- `alpha/webapp/routes/operator_console.py`: add a compact
+  "Artifact Freshness and Sequence Coherence" subsection to the existing
+  Evidence and Receipt card (status generation time, per-file freshness rows,
+  derived-vs-capture ordering rows, and the freshness boundary statements), plus
+  a "Refresh" link that only reloads the current read-only `GET` page. No new
+  endpoint is added; the freshness data extends the existing `local_artifacts`
+  payload returned by the read-only status JSON.
+- `docs/OPERATOR_CONSOLE.md`: artifact freshness and sequence-coherence section,
+  per-state operator definitions, and the freshness boundaries.
+- `tests/test_operator_console.py`: focused freshness/coherence tests.
+- `.specs/INDEX.md`: one new row for this spec.
+
+## Non-goals and boundaries
+
+- No provider, hosted-model, local-model, MCP, tool, browser, network, or
+  `/v1/solve` call; no CLI or subprocess execution from the console.
+- No create, modify, delete, upload, edit, or save of any artifact; the four
+  files are read-only inputs. No receipt store and no workbench action buttons.
+- The Refresh affordance is a plain `GET` page reload; it never POSTs, runs a
+  workflow, calls providers/models/CLI, mutates artifacts, or creates receipts.
+- No raw prompts, baseline outputs, routed outputs, raw route metadata, system
+  prompts, provider payloads, or full artifact JSON are displayed. Only counts,
+  states, schema versions, ids, the content digest (a hash), and safe filesystem
+  metadata (labels, timestamps, ages, ordering states) are surfaced. No raw JSON
+  viewer is added.
+- No API key storage or raw/partial key display; existing categorical key status
+  is preserved.
+- No change to `alpha_solver_portable.py`, provider runtime, model routing,
+  `/v1/solve` execution, the capture/export/preflight schemas, or the
+  `operator_run_capture.py` CLI semantics. Freshness is inferred from filesystem
+  metadata and existing safe summaries only.
+- No scoring, ranking, winner fields, or model-comparison UI.
+- The console must not synthesize Alpha Solver runtime fields when no solve has
+  run from the console: no route, expert trace, confidence, SAFE-OUT state,
+  shortlist, SolverEnvelope output, model choice, provider result, benchmark
+  result, or readiness result is invented.
+
+## Freshness / no-claim boundary
+
+Freshness and sequence coherence are local filesystem metadata only. They do not
+imply route confidence, SAFE-OUT confidence, answer quality, validation,
+production readiness, public/API readiness, autonomous readiness, model
+superiority, provider readiness, or benchmark evidence. Specifically:
+
+- Freshness is local filesystem metadata only.
+- A newer artifact is not answer-quality, benchmark, readiness, production,
+  validation, or superiority evidence.
+- An older derived artifact means only that the local file timestamp appears
+  older than the capture timestamp.
+- Digest validity is packet self-integrity only, not proof that the packet
+  reflects the latest capture file.
+- Copied or restored files can carry misleading modified times, so these are
+  operator hints, not guarantees.
+
+## No-execution / no-raw / no-schema-change boundary
+
+This lane adds no execution path. It performs no provider/model/MCP/network/
+browser/CLI/subprocess call and no `/v1/solve` call. It displays no raw prompt,
+raw baseline output, raw routed output, raw route metadata, provider payload, or
+full artifact JSON, and adds no raw viewer. It changes no capture, export, or
+preflight schema and does not modify any artifact.
+
+## Code Targets
+
+- `alpha/webapp/operator_console_artifacts.py`
+- `alpha/webapp/routes/operator_console.py`
+- `tests/test_operator_console.py`
+- `docs/OPERATOR_CONSOLE.md`
+- `.specs/INDEX.md`
+
+## Test Plan
+
+`tests/test_operator_console.py`: the status JSON includes
+`status_generated_at_utc`; each of the four fixed files exposes safe metadata
+when present; missing files return safe missing states and still render; invalid
+JSON and invalid UTF-8 fail safe without a server error while still surfacing
+filesystem metadata; file mtimes surface only as safe metadata (ISO string and
+integer age, no absolute path or raw epoch); freshness labels are deterministic
+under injected time and controlled mtimes; `evidence_packet.json`,
+`anchor_preflight_report.json`, and `lift_preflight_report.json` older than
+`capture.json` each report `older_than_capture`; a derived artifact at or newer
+than capture reports `same_or_newer_than_capture`; a packet id mismatch is
+reported without raw artifact display; a valid digest older than capture still
+reports the stale sequence state; digest invalid/unverifiable are not hidden by
+freshness metadata; fake API keys and recognizable raw prompt/baseline/routed/
+route-metadata strings never appear in HTML or JSON; provider client
+constructors patched to raise still allow both console routes to succeed; a
+source scan confirms no provider/network/subprocess/browser/CLI execution
+imports are introduced; the outside-root override remains rejected and an
+inside-repo override remains honored; and no path is taken from request data.
+
+## Validation
+
+- `python -m pytest tests/test_operator_console.py -q`
+- `python -m pytest tests/test_operator_console.py tests/test_operator_run_capture.py tests/test_api_endpoints.py -q`
+- `python -m pytest -q`
+- `ruff check alpha/webapp/operator_console_artifacts.py alpha/webapp/routes/operator_console.py tests/test_operator_console.py`
+- `python scripts/check_narrative_claim_safety.py docs/OPERATOR_CONSOLE.md .specs/UI-ALPHA-OPERATOR-CONSOLE-ARTIFACT-FRESHNESS-001.md`
+
+## Definition of Done
+
+The helper extension, console wiring, docs, tests, and this spec merged; all
+validation commands pass; the console reads only the fixed local directory (or a
+safe inside-repo override) plus filesystem metadata for the four fixed files;
+missing and malformed artifacts fail safe; no raw prompt, output, route
+metadata, provider payload, full artifact JSON, or secret is displayed; no
+schema is changed; and no provider/model/MCP/network/browser/CLI/subprocess or
+`/v1/solve` path is exercised. Reporting an artifact as fresh, or a derived
+artifact as older than capture, means only what the local file timestamps and
+recorded summaries show; it is not an answer-quality, benchmark, readiness,
+production, validation, or superiority judgment.

--- a/alpha/webapp/operator_console_artifacts.py
+++ b/alpha/webapp/operator_console_artifacts.py
@@ -21,8 +21,9 @@ from __future__ import annotations
 import json
 import os
 import re
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 from alpha.eval import operator_run_capture as capture_lib
 
@@ -39,11 +40,20 @@ __all__ = [
     "NO_CLAIM_TEXT",
     "NO_ARTIFACTS_TEXT",
     "BOUNDARY_TEXTS",
+    "FRESHNESS_JUST_UPDATED_SECONDS",
+    "FRESHNESS_RECENT_SECONDS",
+    "FRESHNESS_METADATA_ONLY_TEXT",
+    "FRESHNESS_NO_CLAIM_TEXT",
+    "FRESHNESS_OLDER_MEANING_TEXT",
+    "FRESHNESS_DIGEST_TEXT",
+    "FRESHNESS_BOUNDARY_TEXTS",
     "resolve_artifact_root",
     "summarize_capture",
     "summarize_evidence_packet",
     "summarize_anchor_preflight",
     "summarize_lift_preflight",
+    "age_label",
+    "file_freshness",
     "build_artifact_status",
 ]
 
@@ -84,6 +94,39 @@ BOUNDARY_TEXTS = (
     NO_EXECUTION_TEXT,
     NO_RAW_TEXT,
     NO_CLAIM_TEXT,
+)
+
+# ---------------------------------------------------------------------------
+# Freshness / sequence-coherence configuration and boundary text.
+#
+# Freshness is derived purely from local filesystem modified-time metadata and
+# from the existing safe summaries above. It is never a quality, readiness,
+# validation, benchmark, production, or superiority signal. Thresholds are fixed
+# and deterministic; ``build_artifact_status`` accepts an injectable ``now`` so
+# tests never depend on the wall clock.
+# ---------------------------------------------------------------------------
+FRESHNESS_JUST_UPDATED_SECONDS = 300  # <= 5 minutes old -> just_updated
+FRESHNESS_RECENT_SECONDS = 86_400  # <= 24 hours old -> recent
+
+FRESHNESS_METADATA_ONLY_TEXT = "Freshness is local filesystem metadata only."
+FRESHNESS_NO_CLAIM_TEXT = (
+    "A newer artifact is not answer-quality, benchmark, readiness, production, "
+    "validation, or superiority evidence."
+)
+FRESHNESS_OLDER_MEANING_TEXT = (
+    "An older derived artifact means only that the local file timestamp appears "
+    "older than the capture timestamp."
+)
+FRESHNESS_DIGEST_TEXT = (
+    "Digest validity is packet self-integrity only, not proof that the packet "
+    "reflects the latest capture file."
+)
+
+FRESHNESS_BOUNDARY_TEXTS = (
+    FRESHNESS_METADATA_ONLY_TEXT,
+    FRESHNESS_NO_CLAIM_TEXT,
+    FRESHNESS_OLDER_MEANING_TEXT,
+    FRESHNESS_DIGEST_TEXT,
 )
 
 
@@ -310,6 +353,158 @@ def summarize_lift_preflight(root: Path) -> Dict[str, Any]:
     )
 
 
+# ---------------------------------------------------------------------------
+# Freshness and sequence-coherence helpers. These read only filesystem
+# modified-time metadata for the four fixed files and compare against the
+# existing safe summaries. They never read raw artifact content.
+# ---------------------------------------------------------------------------
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso_utc(ts: float) -> str:
+    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+
+
+def age_label(age_seconds: Optional[int], metadata_state: str) -> str:
+    """Map an age (seconds) to a deterministic, bounded freshness label.
+
+    Returns one of ``missing`` / ``just_updated`` / ``recent`` / ``older`` /
+    ``unknown``. Purely a function of the (already computed) age and metadata
+    state; it makes no quality or readiness judgment.
+    """
+
+    if metadata_state == "missing":
+        return "missing"
+    if metadata_state != "present" or age_seconds is None:
+        return "unknown"
+    if age_seconds <= FRESHNESS_JUST_UPDATED_SECONDS:
+        return "just_updated"
+    if age_seconds <= FRESHNESS_RECENT_SECONDS:
+        return "recent"
+    return "older"
+
+
+def _file_mtime(path: Path) -> Optional[float]:
+    """Return the file's modified-time epoch, or ``None`` if unavailable."""
+
+    try:
+        if not path.is_file():
+            return None
+        return path.stat().st_mtime
+    except OSError:
+        return None
+
+
+def file_freshness(path: Path, now_ts: float) -> Dict[str, Any]:
+    """Return safe filesystem freshness metadata for one fixed file.
+
+    Only a safe relative label (the fixed filename), existence, a UTC ISO-8601
+    modified time, a nonnegative integer age, and a bounded metadata/age state
+    are returned. No absolute path, no raw file content, and no non-metadata
+    field is exposed.
+    """
+
+    label = path.name
+    try:
+        exists = path.is_file()
+    except OSError:  # pragma: no cover - defensive: treat as missing
+        exists = False
+    if not exists:
+        return {
+            "path_label": label,
+            "exists": False,
+            "modified_at_utc": None,
+            "age_seconds": None,
+            "metadata_state": "missing",
+            "age_label": "missing",
+        }
+    try:
+        mtime = path.stat().st_mtime
+    except OSError:  # pragma: no cover - defensive: unreadable stat
+        return {
+            "path_label": label,
+            "exists": True,
+            "modified_at_utc": None,
+            "age_seconds": None,
+            "metadata_state": "unavailable",
+            "age_label": "unknown",
+        }
+    age_seconds = max(0, int(now_ts - mtime))
+    return {
+        "path_label": label,
+        "exists": True,
+        "modified_at_utc": _iso_utc(mtime),
+        "age_seconds": age_seconds,
+        "metadata_state": "present",
+        "age_label": age_label(age_seconds, "present"),
+    }
+
+
+def _ordering_state(
+    derived_mtime: Optional[float], capture_mtime: Optional[float]
+) -> str:
+    """Compare two file modified times into a bounded ordering state."""
+
+    if derived_mtime is None or capture_mtime is None:
+        return "not_comparable"
+    if derived_mtime < capture_mtime:
+        return "older_than_capture"
+    return "same_or_newer_than_capture"
+
+
+def _sequence_coherence(
+    derived_summary: Mapping[str, Any],
+    derived_mtime: Optional[float],
+    capture_summary: Mapping[str, Any],
+    capture_mtime: Optional[float],
+    *,
+    compare_counts: bool = False,
+    include_digest: bool = False,
+) -> Dict[str, Any]:
+    """Derive a bounded coherence entry for one derived artifact vs capture.
+
+    ``state`` is the filesystem ordering (``not_comparable`` /
+    ``same_or_newer_than_capture`` / ``older_than_capture``). ``flags`` carries
+    additional safe mismatch signals drawn only from the existing safe summaries
+    (packet ids, counts, digest state). ``metadata_only_no_claim`` is always
+    present to reinforce that this is metadata, not a quality claim.
+    """
+
+    state = _ordering_state(derived_mtime, capture_mtime)
+    flags: List[str] = []
+
+    derived_id = derived_summary.get("packet_id")
+    capture_id = capture_summary.get("packet_id")
+    if derived_id and capture_id and derived_id != capture_id:
+        flags.append("packet_id_mismatch")
+
+    if compare_counts:
+        d_counts = derived_summary.get("counts")
+        c_counts = capture_summary.get("counts")
+        if isinstance(d_counts, dict) and isinstance(c_counts, dict):
+            for key in ("total", "captured", "excluded"):
+                d_val = d_counts.get(key)
+                c_val = c_counts.get(key)
+                if (
+                    isinstance(d_val, int)
+                    and isinstance(c_val, int)
+                    and d_val != c_val
+                ):
+                    flags.append("counts_mismatch")
+                    break
+
+    if include_digest:
+        derived_state = derived_summary.get("state")
+        if derived_state == "digest_invalid":
+            flags.append("digest_invalid")
+        elif derived_state == "digest_unverifiable":
+            flags.append("digest_unverifiable")
+
+    flags.append("metadata_only_no_claim")
+    return {"state": state, "flags": flags}
+
+
 def _display_root(root: Path) -> str:
     try:
         rel = root.resolve().relative_to(_REPO_ROOT.resolve())
@@ -318,15 +513,26 @@ def _display_root(root: Path) -> str:
         return root.name
 
 
-def build_artifact_status(root: Optional[Path] = None) -> Dict[str, Any]:
+def build_artifact_status(
+    root: Optional[Path] = None, now: Optional[datetime] = None
+) -> Dict[str, Any]:
     """Assemble the read-only local artifact status payload.
 
     Pure function over the local filesystem. Reads at most the four fixed
-    artifact files, returns counts/states/digests only, and performs no
-    provider, network, model, tool, or CLI call.
+    artifact files (content plus modified-time metadata), returns
+    counts/states/digests and safe freshness/coherence metadata only, and
+    performs no provider, network, model, tool, or CLI call.
+
+    ``now`` may be injected (a timezone-aware UTC ``datetime``) so freshness age
+    labels are deterministic in tests; when omitted the current UTC time is
+    used. Sequence-coherence ordering compares file modified times only and is
+    independent of ``now``.
     """
 
     resolved = root if root is not None else resolve_artifact_root()
+    now_dt = now if now is not None else _utcnow()
+    now_ts = now_dt.timestamp()
+
     capture = summarize_capture(resolved)
     packet = summarize_evidence_packet(resolved)
     anchor = summarize_anchor_preflight(resolved)
@@ -337,13 +543,51 @@ def build_artifact_status(root: Optional[Path] = None) -> Dict[str, Any]:
         for section in (capture, packet, anchor, lift)
     )
 
+    capture_path = resolved / CAPTURE_FILENAME
+    packet_path = resolved / EVIDENCE_PACKET_FILENAME
+    anchor_path = resolved / ANCHOR_PREFLIGHT_FILENAME
+    lift_path = resolved / LIFT_PREFLIGHT_FILENAME
+
+    capture_mtime = _file_mtime(capture_path)
+    packet_mtime = _file_mtime(packet_path)
+    anchor_mtime = _file_mtime(anchor_path)
+    lift_mtime = _file_mtime(lift_path)
+
+    freshness = {
+        "files": {
+            "capture": file_freshness(capture_path, now_ts),
+            "evidence_packet": file_freshness(packet_path, now_ts),
+            "anchor_preflight": file_freshness(anchor_path, now_ts),
+            "lift_preflight": file_freshness(lift_path, now_ts),
+        },
+        "sequence_coherence": {
+            "evidence_packet_vs_capture": _sequence_coherence(
+                packet,
+                packet_mtime,
+                capture,
+                capture_mtime,
+                compare_counts=True,
+                include_digest=True,
+            ),
+            "anchor_preflight_vs_capture": _sequence_coherence(
+                anchor, anchor_mtime, capture, capture_mtime
+            ),
+            "lift_preflight_vs_capture": _sequence_coherence(
+                lift, lift_mtime, capture, capture_mtime
+            ),
+        },
+        "boundaries": list(FRESHNESS_BOUNDARY_TEXTS),
+    }
+
     return {
         "artifact_root": _display_root(resolved),
+        "status_generated_at_utc": now_dt.isoformat(),
         "detected": detected,
         "no_artifacts_message": NO_ARTIFACTS_TEXT,
         "capture": capture,
         "evidence_packet": packet,
         "anchor_preflight": anchor,
         "lift_preflight": lift,
+        "freshness": freshness,
         "boundaries": list(BOUNDARY_TEXTS),
     }

--- a/alpha/webapp/routes/operator_console.py
+++ b/alpha/webapp/routes/operator_console.py
@@ -376,6 +376,55 @@ def _render_page(status: Mapping[str, Any]) -> str:
     )
     evidence_no_artifacts = "" if local["detected"] else _no_artifacts_note()
 
+    # Artifact freshness and sequence coherence (local filesystem metadata only;
+    # never a quality/readiness signal). Only safe labels/timestamps/states are
+    # rendered — no absolute path and no raw artifact content.
+    freshness = local["freshness"]
+    fresh_files = freshness["files"]
+    fresh_seq = freshness["sequence_coherence"]
+
+    def _freshness_row(label: str, meta: Mapping[str, Any]) -> str:
+        return (
+            f'<div class="kv"><dt>{_escape(label)}</dt><dd>'
+            f'<span class="badge muted">{_escape(meta["age_label"])}</span>'
+            f' · {_escape(meta["modified_at_utc"] or "—")}'
+            f' · age {_escape(meta["age_seconds"] if meta["age_seconds"] is not None else "—")}s'
+            "</dd></div>"
+        )
+
+    freshness_files_html = (
+        _freshness_row("capture", fresh_files["capture"])
+        + _freshness_row("evidence packet", fresh_files["evidence_packet"])
+        + _freshness_row("anchor preflight", fresh_files["anchor_preflight"])
+        + _freshness_row("lift preflight", fresh_files["lift_preflight"])
+    )
+
+    def _coherence_row(label: str, entry: Mapping[str, Any]) -> str:
+        # Drop the always-present metadata-only marker from the visible flags.
+        flags = [f for f in entry["flags"] if f != "metadata_only_no_claim"]
+        flag_text = ", ".join(flags) if flags else "—"
+        return (
+            f'<div class="kv"><dt>{_escape(label)}</dt><dd>'
+            f'<span class="badge muted">{_escape(entry["state"])}</span>'
+            f' · flags: {_escape(flag_text)}</dd></div>'
+        )
+
+    coherence_html = (
+        _coherence_row(
+            "evidence packet vs capture", fresh_seq["evidence_packet_vs_capture"]
+        )
+        + _coherence_row(
+            "anchor preflight vs capture", fresh_seq["anchor_preflight_vs_capture"]
+        )
+        + _coherence_row(
+            "lift preflight vs capture", fresh_seq["lift_preflight_vs_capture"]
+        )
+    )
+
+    freshness_boundary_html = "".join(
+        f"<li>{_escape(text)}</li>" for text in freshness["boundaries"]
+    )
+
     return f"""<!doctype html>
 <html lang="en">
   <head>
@@ -411,8 +460,10 @@ def _render_page(status: Mapping[str, Any]) -> str:
       .wf-id {{ font-weight: 800; color: #3730a3; }}
       pre.wf-cmd {{ white-space: pre-wrap; overflow-wrap: anywhere; background: #111827; color: #e5e7eb; border-radius: 10px; padding: 0.55rem 0.7rem; margin: 0.35rem 0 0; font-size: 0.82rem; }}
       .note {{ color: #5f668f; font-size: 0.85rem; margin: 0.65rem 0 0; }}
+      .subhead {{ margin: 1rem 0 0.35rem; font-size: 0.95rem; color: #30365f; }}
       .disabled-btn {{ margin-top: 0.75rem; border: 0; border-radius: 999px; padding: 0.6rem 1.15rem; font: inherit; font-weight: 700; color: #475569; background: rgba(100, 116, 139, 0.16); cursor: not-allowed; }}
-      a.status-link {{ display: inline-block; margin-top: 0.75rem; color: #4f46e5; font-weight: 700; }}
+      a.status-link, a.refresh-link {{ display: inline-block; margin-top: 0.75rem; color: #4f46e5; font-weight: 700; }}
+      a.refresh-link {{ margin-right: 0.85rem; }}
     </style>
   </head>
   <body>
@@ -506,6 +557,14 @@ def _render_page(status: Mapping[str, Any]) -> str:
           {evidence_no_artifacts}
           <ul class="surfaces">{boundary_html}</ul>
           <p class="note">{_escape(ARTIFACT_BOUNDARY_TEXT)}.</p>
+
+          <h3 class="subhead">Artifact Freshness and Sequence Coherence</h3>
+          <p class="note">Local filesystem metadata only. Status generated at: {_escape(local["status_generated_at_utc"])}</p>
+          {freshness_files_html}
+          <p class="note">Derived-vs-capture ordering (metadata only):</p>
+          {coherence_html}
+          <ul class="surfaces">{freshness_boundary_html}</ul>
+          <a class="refresh-link" href="{ROUTE}">Refresh (reload this read-only page)</a>
         </article>
       </div>
 

--- a/docs/OPERATOR_CONSOLE.md
+++ b/docs/OPERATOR_CONSOLE.md
@@ -58,7 +58,8 @@ return 404. When mounted, an unauthenticated `GET` redirects to `/login`.
    command snippets and a docs pointer. These run from a terminal, not from the
    console.
 7. **Evidence and Receipt** — placeholders for a future receipt id, export
-   digest, and validation status, plus local artifact status (see below).
+   digest, and validation status, plus local artifact status and a read-only
+   artifact freshness / sequence-coherence subsection (see below).
 
 ## Local artifact status
 
@@ -108,6 +109,84 @@ following boundary statements appear in both the page and the status JSON:
   superiority claim is made.
 
 A preflight report being present is not a quality or readiness signal.
+
+## Artifact freshness and sequence coherence
+
+Lane: `UI-ALPHA-OPERATOR-CONSOLE-ARTIFACT-FRESHNESS-001`
+
+Structural validity answers "does this artifact exist and is it well formed."
+It does not answer "am I looking at a fresh capture and matching derived
+artifacts, or stale evidence/preflight files from an older local run." The
+console adds a small, read-only **Artifact Freshness and Sequence Coherence**
+subsection to the Evidence and Receipt card to help answer that second
+question. It infers everything from local filesystem modified-time metadata and
+the existing safe summaries above; it changes no schema and reads no raw
+content.
+
+### Status generation time
+
+The status payload includes `status_generated_at_utc`, a UTC ISO-8601 timestamp
+recorded when the status is assembled. It is the reference point the console
+uses to describe how old each file is.
+
+### Per-file freshness
+
+For each of the four fixed files the console surfaces only safe metadata:
+
+- `path_label` — the fixed filename (never an absolute local path).
+- `exists` — whether the file is present.
+- `modified_at_utc` — the file's modified time as a UTC ISO-8601 string, or
+  `null`.
+- `age_seconds` — a nonnegative integer age relative to the status time, or
+  `null`.
+- `metadata_state` — `missing`, `present`, or `unavailable`.
+- `age_label` — a deterministic bounded label:
+  - `missing` — the file is not present.
+  - `just_updated` — modified within the last 5 minutes.
+  - `recent` — modified within the last 24 hours.
+  - `older` — modified more than 24 hours ago.
+  - `unknown` — the file exists but its modified time could not be read.
+
+### Sequence coherence (derived vs capture)
+
+`capture.json` is treated as the source. Each derived artifact is compared to it
+under `sequence_coherence`:
+
+- `evidence_packet_vs_capture`
+- `anchor_preflight_vs_capture`
+- `lift_preflight_vs_capture`
+
+Each comparison reports an ordering `state`:
+
+- `not_comparable` — one or both modified times are unavailable (for example a
+  missing file).
+- `same_or_newer_than_capture` — the derived file's timestamp is at or after the
+  capture timestamp.
+- `older_than_capture` — the derived file's timestamp appears older than the
+  capture timestamp, so it may reflect an earlier local run.
+
+Each comparison also carries a `flags` list of safe mismatch signals drawn only
+from the existing summaries: `packet_id_mismatch` (packet ids differ),
+`counts_mismatch` (evidence-packet counts differ from capture counts),
+`digest_invalid` / `digest_unverifiable` (the evidence packet's own digest
+state), and `metadata_only_no_claim` (always present as a reminder that this is
+metadata, not a quality claim).
+
+A "Refresh" affordance on the page is a plain link that reloads the current
+read-only `GET` page. It never POSTs, runs a workflow, calls a provider or
+model, calls a CLI, mutates an artifact, or creates a receipt.
+
+### Freshness boundaries
+
+- Freshness is local filesystem metadata only.
+- A newer artifact is not answer-quality, benchmark, readiness, production,
+  validation, or superiority evidence.
+- An older derived artifact means only that the local file timestamp appears
+  older than the capture timestamp.
+- Digest validity is packet self-integrity only, not proof that the packet
+  reflects the latest capture file.
+- Copied or restored files can carry misleading modified times, so freshness and
+  ordering are hints for the operator, not guarantees about run order.
 
 ## Secret handling
 

--- a/tests/test_operator_console.py
+++ b/tests/test_operator_console.py
@@ -15,7 +15,9 @@ from __future__ import annotations
 
 import html
 import json
+import os
 import sys
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -666,3 +668,447 @@ def test_invalid_utf8_artifact_fails_safe(
     assert response.status_code == 200
     assert response.json()["local_artifacts"]["capture"]["state"] == "invalid_json"
     assert client.get(PAGE_ROUTE).status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Artifact freshness and sequence coherence
+# (AOC-B003-ARTIFACT-FRESHNESS-001 / UI-ALPHA-OPERATOR-CONSOLE-ARTIFACT-
+# FRESHNESS-001). Timestamps are injected and mtimes are controlled so the
+# freshness labels and ordering states are deterministic.
+# ---------------------------------------------------------------------------
+FIXED_NOW = datetime(2026, 7, 7, 12, 0, 0, tzinfo=timezone.utc)
+FIXED_NOW_TS = FIXED_NOW.timestamp()
+
+
+def _set_age(path: Path, seconds_old: float) -> None:
+    """Set a file's mtime to ``FIXED_NOW`` minus ``seconds_old``."""
+
+    ts = FIXED_NOW_TS - seconds_old
+    os.utime(path, (ts, ts))
+
+
+def _status(tmp_path: Path, now: datetime = FIXED_NOW) -> dict:
+    return artifacts.build_artifact_status(root=tmp_path, now=now)
+
+
+def _anchor_report(packet_id: str = "ORC-TEST-001") -> dict:
+    return {
+        "schema_version": capture_lib.ANCHOR_PREFLIGHT_REPORT_SCHEMA_VERSION,
+        "packet_id": packet_id,
+        "boundary": "structural only",
+        "summary": {
+            "counts": {
+                "anchor_bearing": 1,
+                "anchor_free": 0,
+                "invalid_case": 1,
+                "total": 2,
+            },
+            "needs_attention": ["t2"],
+        },
+        "cases": [{"task_id": "t1", "state": "anchor_bearing", "prompt": RAW_PROMPT}],
+    }
+
+
+def _lift_report(packet_id: str = "ORC-TEST-001") -> dict:
+    return {
+        "schema_version": capture_lib.LIFT_PREFLIGHT_REPORT_SCHEMA_VERSION,
+        "packet_id": packet_id,
+        "boundary": "structural only",
+        "summary": {
+            "counts": {"structural_pass": 1, "total": 1},
+            "needs_attention": [],
+        },
+        "cases": [{"task_id": "t1", "state": "structural_pass", "routed": RAW_ROUTED}],
+    }
+
+
+def _write_all_four(tmp_path: Path) -> None:
+    capture = _valid_capture()
+    _write(tmp_path, "capture.json", capture)
+    _write(
+        tmp_path,
+        "evidence_packet.json",
+        capture_lib.build_evidence_packet(capture),
+    )
+    _write(tmp_path, "anchor_preflight_report.json", _anchor_report())
+    _write(tmp_path, "lift_preflight_report.json", _lift_report())
+
+
+# 1. Status JSON includes status_generated_at_utc.
+def test_status_json_includes_status_generated_at_utc(client: TestClient) -> None:
+    _login(client)
+    local = client.get(STATUS_ROUTE).json()["local_artifacts"]
+    generated = local["status_generated_at_utc"]
+    assert isinstance(generated, str) and generated
+    parsed = datetime.fromisoformat(generated)
+    assert parsed.tzinfo is not None
+
+
+# 2. Each of the four fixed summaries includes safe metadata when present.
+def test_freshness_metadata_present_for_all_four_files(tmp_path: Path) -> None:
+    _write_all_four(tmp_path)
+    names = {
+        "capture": "capture.json",
+        "evidence_packet": "evidence_packet.json",
+        "anchor_preflight": "anchor_preflight_report.json",
+        "lift_preflight": "lift_preflight_report.json",
+    }
+    for filename in names.values():
+        _set_age(tmp_path / filename, 10)
+
+    files = _status(tmp_path)["freshness"]["files"]
+    for key, filename in names.items():
+        meta = files[key]
+        assert meta["path_label"] == filename
+        assert meta["exists"] is True
+        assert meta["metadata_state"] == "present"
+        assert isinstance(meta["age_seconds"], int) and meta["age_seconds"] >= 0
+        assert meta["modified_at_utc"] is not None
+        assert meta["age_label"] == "just_updated"
+
+
+# 3. Missing files still return safe missing states and render normally.
+def test_freshness_missing_files_safe_and_render(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _use_root(monkeypatch, tmp_path)
+    _login(client)
+
+    freshness = client.get(STATUS_ROUTE).json()["local_artifacts"]["freshness"]
+    for key in ("capture", "evidence_packet", "anchor_preflight", "lift_preflight"):
+        meta = freshness["files"][key]
+        assert meta["exists"] is False
+        assert meta["metadata_state"] == "missing"
+        assert meta["age_label"] == "missing"
+        assert meta["modified_at_utc"] is None
+        assert meta["age_seconds"] is None
+    for key in (
+        "evidence_packet_vs_capture",
+        "anchor_preflight_vs_capture",
+        "lift_preflight_vs_capture",
+    ):
+        assert freshness["sequence_coherence"][key]["state"] == "not_comparable"
+
+    assert client.get(PAGE_ROUTE).status_code == 200
+
+
+# 4. Invalid JSON still fails safe and does not 500 (freshness still present).
+def test_freshness_invalid_json_fails_safe(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    (tmp_path / "capture.json").write_text("{ not valid json", encoding="utf-8")
+    _use_root(monkeypatch, tmp_path)
+    _login(client)
+
+    response = client.get(STATUS_ROUTE)
+    assert response.status_code == 200
+    local = response.json()["local_artifacts"]
+    assert local["capture"]["state"] == "invalid_json"
+    # The file exists on disk, so filesystem metadata is still surfaced.
+    assert local["freshness"]["files"]["capture"]["metadata_state"] == "present"
+    assert client.get(PAGE_ROUTE).status_code == 200
+
+
+# 5. Invalid UTF-8 still fails safe and does not 500 (freshness still present).
+def test_freshness_invalid_utf8_fails_safe(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    (tmp_path / "capture.json").write_bytes(b"\xff\xfe\x00 not utf-8 \xff")
+    _use_root(monkeypatch, tmp_path)
+    _login(client)
+
+    response = client.get(STATUS_ROUTE)
+    assert response.status_code == 200
+    local = response.json()["local_artifacts"]
+    assert local["capture"]["state"] == "invalid_json"
+    assert local["freshness"]["files"]["capture"]["metadata_state"] == "present"
+    assert client.get(PAGE_ROUTE).status_code == 200
+
+
+# 6. File mtimes are surfaced only as safe metadata (ISO string + int age).
+def test_file_mtime_surfaced_only_as_safe_metadata(tmp_path: Path) -> None:
+    _write(tmp_path, "capture.json", _valid_capture())
+    _set_age(tmp_path / "capture.json", 42)
+
+    status = _status(tmp_path)
+    meta = status["freshness"]["files"]["capture"]
+    assert meta["age_seconds"] == 42
+    assert meta["path_label"] == "capture.json"
+    parsed = datetime.fromisoformat(meta["modified_at_utc"])
+    expected = FIXED_NOW - timedelta(seconds=42)
+    assert abs((parsed - expected).total_seconds()) < 1
+
+    body = json.dumps(status)
+    # No absolute path and no raw epoch float leak into the payload.
+    assert str(tmp_path) not in body
+    assert repr(FIXED_NOW_TS - 42) not in body
+
+
+# 7. Freshness labels are deterministic under injected time / controlled mtimes.
+def test_freshness_labels_are_deterministic(tmp_path: Path) -> None:
+    path = tmp_path / "capture.json"
+    _write(tmp_path, "capture.json", _valid_capture())
+
+    cases = {
+        0: "just_updated",
+        300: "just_updated",
+        301: "recent",
+        3600: "recent",
+        86_400: "recent",
+        86_401: "older",
+    }
+    for seconds_old, expected in cases.items():
+        _set_age(path, seconds_old)
+        label = _status(tmp_path)["freshness"]["files"]["capture"]["age_label"]
+        assert label == expected, (seconds_old, label)
+
+    # The pure helper is deterministic for edge/metadata states too.
+    assert artifacts.age_label(None, "missing") == "missing"
+    assert artifacts.age_label(None, "unavailable") == "unknown"
+    assert artifacts.age_label(0, "present") == "just_updated"
+
+
+# 8. evidence_packet.json older than capture.json -> older_than_capture.
+def test_evidence_packet_older_than_capture(tmp_path: Path) -> None:
+    capture = _valid_capture()
+    _write(tmp_path, "capture.json", capture)
+    _write(
+        tmp_path, "evidence_packet.json", capture_lib.build_evidence_packet(capture)
+    )
+    _set_age(tmp_path / "capture.json", 10)
+    _set_age(tmp_path / "evidence_packet.json", 3600)
+
+    seq = _status(tmp_path)["freshness"]["sequence_coherence"]
+    assert seq["evidence_packet_vs_capture"]["state"] == "older_than_capture"
+
+
+# 9. anchor_preflight_report.json older than capture.json -> older_than_capture.
+def test_anchor_preflight_older_than_capture(tmp_path: Path) -> None:
+    _write(tmp_path, "capture.json", _valid_capture())
+    _write(tmp_path, "anchor_preflight_report.json", _anchor_report())
+    _set_age(tmp_path / "capture.json", 10)
+    _set_age(tmp_path / "anchor_preflight_report.json", 3600)
+
+    seq = _status(tmp_path)["freshness"]["sequence_coherence"]
+    assert seq["anchor_preflight_vs_capture"]["state"] == "older_than_capture"
+
+
+# 10. lift_preflight_report.json older than capture.json -> older_than_capture.
+def test_lift_preflight_older_than_capture(tmp_path: Path) -> None:
+    _write(tmp_path, "capture.json", _valid_capture())
+    _write(tmp_path, "lift_preflight_report.json", _lift_report())
+    _set_age(tmp_path / "capture.json", 10)
+    _set_age(tmp_path / "lift_preflight_report.json", 3600)
+
+    seq = _status(tmp_path)["freshness"]["sequence_coherence"]
+    assert seq["lift_preflight_vs_capture"]["state"] == "older_than_capture"
+
+
+# 11. Derived same-age-or-newer than capture -> same_or_newer_than_capture.
+def test_derived_same_or_newer_than_capture(tmp_path: Path) -> None:
+    _write_all_four(tmp_path)
+    _set_age(tmp_path / "capture.json", 100)
+    for filename in (
+        "evidence_packet.json",
+        "anchor_preflight_report.json",
+        "lift_preflight_report.json",
+    ):
+        _set_age(tmp_path / filename, 10)
+
+    seq = _status(tmp_path)["freshness"]["sequence_coherence"]
+    assert seq["evidence_packet_vs_capture"]["state"] == "same_or_newer_than_capture"
+    assert seq["anchor_preflight_vs_capture"]["state"] == "same_or_newer_than_capture"
+    assert seq["lift_preflight_vs_capture"]["state"] == "same_or_newer_than_capture"
+
+
+# 12. Packet id mismatch is reported without raw artifact display.
+def test_packet_id_mismatch_reported_without_raw(tmp_path: Path) -> None:
+    _write(tmp_path, "capture.json", _valid_capture())  # packet_id ORC-TEST-001
+    other = _valid_capture()
+    other["packet_id"] = "ORC-OTHER-999"
+    _write(
+        tmp_path, "evidence_packet.json", capture_lib.build_evidence_packet(other)
+    )
+    _set_age(tmp_path / "capture.json", 10)
+    _set_age(tmp_path / "evidence_packet.json", 10)
+
+    status = _status(tmp_path)
+    seq = status["freshness"]["sequence_coherence"]["evidence_packet_vs_capture"]
+    assert "packet_id_mismatch" in seq["flags"]
+
+    body = json.dumps(status)
+    for raw in (RAW_PROMPT, RAW_BASELINE, RAW_ROUTED, RAW_ROUTE_META):
+        assert raw not in body
+
+
+# 13. Digest valid but older than capture still reports a stale sequence state.
+def test_digest_valid_but_older_than_capture_still_flags_stale(
+    tmp_path: Path,
+) -> None:
+    capture = _valid_capture()
+    _write(tmp_path, "capture.json", capture)
+    _write(
+        tmp_path, "evidence_packet.json", capture_lib.build_evidence_packet(capture)
+    )
+    _set_age(tmp_path / "capture.json", 10)
+    _set_age(tmp_path / "evidence_packet.json", 3600)
+
+    status = _status(tmp_path)
+    # Packet self-integrity is intact...
+    assert status["evidence_packet"]["state"] == "digest_valid"
+    # ...yet the packet file appears older than capture on disk.
+    seq = status["freshness"]["sequence_coherence"]["evidence_packet_vs_capture"]
+    assert seq["state"] == "older_than_capture"
+
+
+# 14. Digest invalid / unverifiable are not hidden by freshness metadata.
+def test_digest_invalid_not_hidden_by_freshness(tmp_path: Path) -> None:
+    capture = _valid_capture()
+    _write(tmp_path, "capture.json", capture)
+    packet = capture_lib.build_evidence_packet(capture)
+    packet["packet_id"] = "tampered-after-digest"  # digest no longer matches body
+    _write(tmp_path, "evidence_packet.json", packet)
+    _set_age(tmp_path / "capture.json", 10)
+    _set_age(tmp_path / "evidence_packet.json", 10)
+
+    status = _status(tmp_path)
+    assert status["evidence_packet"]["state"] == "digest_invalid"
+    seq = status["freshness"]["sequence_coherence"]["evidence_packet_vs_capture"]
+    assert "digest_invalid" in seq["flags"]
+
+
+def test_digest_unverifiable_not_hidden_by_freshness(tmp_path: Path) -> None:
+    capture = _valid_capture()
+    _write(tmp_path, "capture.json", capture)
+    packet = capture_lib.build_evidence_packet(capture)
+    del packet["content_digest"]
+    _write(tmp_path, "evidence_packet.json", packet)
+    _set_age(tmp_path / "capture.json", 10)
+    _set_age(tmp_path / "evidence_packet.json", 10)
+
+    status = _status(tmp_path)
+    assert status["evidence_packet"]["state"] == "digest_unverifiable"
+    seq = status["freshness"]["sequence_coherence"]["evidence_packet_vs_capture"]
+    assert "digest_unverifiable" in seq["flags"]
+
+
+# 15. Fake API keys never appear in HTML or JSON when freshness is rendered.
+def test_fake_secret_never_leaks_with_freshness(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", FAKE_SECRET)
+    capture = _valid_capture()
+    _write(tmp_path, "capture.json", capture)
+    _write(
+        tmp_path, "evidence_packet.json", capture_lib.build_evidence_packet(capture)
+    )
+    _set_age(tmp_path / "capture.json", 10)
+    _set_age(tmp_path / "evidence_packet.json", 20)
+    _use_root(monkeypatch, tmp_path)
+    _login(client)
+
+    assert FAKE_SECRET not in client.get(PAGE_ROUTE).text
+    assert FAKE_SECRET not in client.get(STATUS_ROUTE).text
+
+
+# 16. Raw prompt / baseline / routed / route-metadata never appear with freshness.
+def test_raw_content_never_leaks_with_freshness(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _write_all_four(tmp_path)
+    for filename in (
+        "capture.json",
+        "evidence_packet.json",
+        "anchor_preflight_report.json",
+        "lift_preflight_report.json",
+    ):
+        _set_age(tmp_path / filename, 30)
+    _use_root(monkeypatch, tmp_path)
+    _login(client)
+
+    html_text = client.get(PAGE_ROUTE).text
+    body = client.get(STATUS_ROUTE).text
+    for raw in (RAW_PROMPT, RAW_BASELINE, RAW_ROUTED, RAW_ROUTE_META):
+        assert raw not in html_text
+        assert raw not in body
+
+
+# 17. Provider client constructors patched to raise still allow both routes.
+def test_provider_client_patched_raise_routes_ok_with_freshness(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import alpha.providers.openai as openai_provider
+
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("provider client must not be used by operator console")
+
+    monkeypatch.setattr(openai_provider.OpenAIProviderClient, "__init__", _boom)
+    monkeypatch.setattr(openai_provider.OpenAIProviderClient, "execute", _boom)
+
+    capture = _valid_capture()
+    _write(tmp_path, "capture.json", capture)
+    _write(
+        tmp_path, "evidence_packet.json", capture_lib.build_evidence_packet(capture)
+    )
+    _set_age(tmp_path / "capture.json", 10)
+    _set_age(tmp_path / "evidence_packet.json", 20)
+    _use_root(monkeypatch, tmp_path)
+    _login(client)
+
+    assert client.get(PAGE_ROUTE).status_code == 200
+    assert client.get(STATUS_ROUTE).status_code == 200
+
+
+# 18. Source-scan: no provider/network/subprocess/browser/CLI execution imports.
+def test_no_execution_imports_in_console_sources() -> None:
+    forbidden = (
+        "ProviderClient",
+        "OpenAIProviderClient",
+        "httpx",
+        "requests.",
+        "import subprocess",
+        "subprocess.",
+        "import socket",
+        "urllib",
+        "playwright",
+        "selenium",
+        "webdriver",
+        "webbrowser",
+        "pexpect",
+    )
+    for module in (artifacts, operator_console):
+        source = Path(module.__file__).read_text(encoding="utf-8")
+        for token in forbidden:
+            assert token not in source, f"{token!r} found in {module.__file__}"
+
+
+# 19. Outside-root override remains rejected.
+def test_freshness_outside_root_override_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(artifacts.ARTIFACT_ROOT_ENV, "/etc")
+    assert artifacts.resolve_artifact_root() == artifacts.DEFAULT_ARTIFACT_ROOT
+
+
+# 20. Inside-repo override remains honored.
+def test_freshness_inside_root_override_honored(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(artifacts.ARTIFACT_ROOT_ENV, "local/oc_freshness_subdir")
+    resolved = artifacts.resolve_artifact_root()
+    repo_root = Path(artifacts.__file__).resolve().parents[2]
+    assert resolved == (repo_root / "local" / "oc_freshness_subdir").resolve()
+
+
+# 21. No path is taken from request data (query params, headers).
+def test_no_path_taken_from_request_data(client: TestClient) -> None:
+    _login(client)
+    response = client.get(
+        STATUS_ROUTE + "?root=/etc&artifact_root=/etc&path=/etc/passwd",
+        headers={"X-Artifact-Root": "/etc"},
+    )
+    assert response.status_code == 200
+    local = response.json()["local_artifacts"]
+    # The fixed default root is used regardless of request-supplied paths.
+    assert local["artifact_root"] == "local/operator_console"
+    assert "/etc" not in json.dumps(local)


### PR DESCRIPTION
## Checklist

- [x] Spec linked: `.specs/UI-ALPHA-OPERATOR-CONSOLE-ARTIFACT-FRESHNESS-001.md`
- [x] Spec sections present/updated (Goal / Motivation / Scope / Non-goals and boundaries / Code Targets / Test Plan / Definition of Done + explicit freshness/no-claim and no-execution/no-raw/no-schema-change boundaries)
- [x] Tests run: `python -m pytest -q` (full suite passes; only 3 pre-existing unrelated skips)

## Notes for reviewers

**Lane:** `AOC-B003-ARTIFACT-FRESHNESS-001`
**Spec id:** `UI-ALPHA-OPERATOR-CONSOLE-ARTIFACT-FRESHNESS-001`
**Verified baseline main SHA:** `eae613f45253c2198c0d2c5ced827fec3233a21c`
**PR head SHA:** `0b6f9700fc0207f418ac7ffb4e7b39b6d8de77ec`

### Summary

Extends the protected local-first Operator Console (from #665) so the existing local artifact status cards also show **read-only** temporal metadata and simple dependency-coherence warnings for the four fixed local artifacts (`capture.json`, `evidence_packet.json`, `anchor_preflight_report.json`, `lift_preflight_report.json`). Freshness is inferred from local filesystem modified-time metadata and the existing safe summaries only — no schema change, no execution path, no raw-content surface.

### Files changed

- `alpha/webapp/operator_console_artifacts.py` — freshness helpers + payload extension
- `alpha/webapp/routes/operator_console.py` — compact freshness/coherence rows + GET-only refresh link
- `tests/test_operator_console.py` — 22 new focused tests (file totals 58)
- `docs/OPERATOR_CONSOLE.md` — artifact freshness & sequence coherence section
- `.specs/UI-ALPHA-OPERATOR-CONSOLE-ARTIFACT-FRESHNESS-001.md` — new spec
- `.specs/INDEX.md` — one new row

### User-visible behavior

- Status JSON gains `status_generated_at_utc` and a `local_artifacts.freshness` block: per-file safe metadata (`path_label`, `exists`, `modified_at_utc`, `age_seconds`, `metadata_state`, deterministic `age_label` of `missing`/`just_updated`/`recent`/`older`/`unknown`) and `sequence_coherence` for each derived artifact vs capture (`not_comparable`/`same_or_newer_than_capture`/`older_than_capture`, plus safe `flags`: `packet_id_mismatch`, `counts_mismatch`, `digest_invalid`, `digest_unverifiable`, `metadata_only_no_claim`).
- The Evidence and Receipt card renders a compact "Artifact Freshness and Sequence Coherence" subsection and a **Refresh** link that only reloads the current read-only GET page.
- Fixed thresholds (5 min / 24 h); `build_artifact_status(now=...)` is injectable so labels are deterministic in tests.

### Boundary confirmations

- No provider / hosted-model / local-model / MCP / network / browser / CLI / subprocess calls
- No `/v1/solve` call
- No artifact creation, edit, deletion, upload, or mutation; no receipt store
- No raw prompt / baseline output / routed output / route-metadata / provider-payload / full-JSON display; no raw viewer
- No secret (raw or partial API key) display; categorical key status preserved
- No capture / export / preflight schema changes; `operator_run_capture.py` CLI semantics unchanged; `alpha_solver_portable.py` untouched
- No scoring / ranking / winner fields / model-comparison UI
- No readiness / validation / benchmark / production / superiority claim; freshness is explicitly framed as metadata only
- Fixed-root policy preserved (default `local/operator_console/`, inside-repo override only, traversal/outside-root rejected, no path from request data)

### Tests and validation commands run (all passed)

- `python -m pytest tests/test_operator_console.py -q` → passed (58 tests)
- `python -m pytest tests/test_operator_console.py tests/test_operator_run_capture.py tests/test_api_endpoints.py -q` → passed
- `python -m pytest -q` → passed (3 pre-existing unrelated skips)
- `ruff check alpha/webapp/operator_console_artifacts.py alpha/webapp/routes/operator_console.py tests/test_operator_console.py` → All checks passed
- `python scripts/check_narrative_claim_safety.py docs/OPERATOR_CONSOLE.md .specs/UI-ALPHA-OPERATOR-CONSOLE-ARTIFACT-FRESHNESS-001.md` → passed

### Remaining risks

- Filesystem mtime can be misleading after copies/restores (freshness and ordering are operator hints, not guarantees).
- Digest validity is packet self-integrity only — not proof the packet reflects the latest capture file.
- Sequence coherence is metadata-only, not answer-quality proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QE3af5rMkhUfTCgsYnDXA