### PR TITLE
Operator Console provider, model, and cost gate panel (AOC-B004-PROVIDER-COST-GATE-PANEL-001)

### DIFF
--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -97,6 +97,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `UI-ALPHA-OPERATOR-CONSOLE-MVP-001.md` | UI-ALPHA-OPERATOR-CONSOLE-MVP-001 · Alpha Solver Operator Console Shell (MVP) | ✅ `SPEC_OK` |
 | `UI-ALPHA-OPERATOR-CONSOLE-LOCAL-ARTIFACT-STATUS-001.md` | UI-ALPHA-OPERATOR-CONSOLE-LOCAL-ARTIFACT-STATUS-001 · Operator Console Local Artifact Status | ✅ `SPEC_OK` |
 | `UI-ALPHA-OPERATOR-CONSOLE-ARTIFACT-FRESHNESS-001.md` | UI-ALPHA-OPERATOR-CONSOLE-ARTIFACT-FRESHNESS-001 · Operator Console Artifact Freshness and Sequence Coherence | ✅ `SPEC_OK` |
+| `UI-ALPHA-OPERATOR-CONSOLE-PROVIDER-COST-GATE-PANEL-001.md` | UI-ALPHA-OPERATOR-CONSOLE-PROVIDER-COST-GATE-PANEL-001 · Operator Console Provider, Model, and Cost Gate Panel | ✅ `SPEC_OK` |
 | `UI-JOBS-001.md` | UI-JOBS-001 · Dashboard Job History & Metrics (RES_Dash) | ✅ `SPEC_OK` |
 | `UI-PREVIEW-001.md` | UI-PREVIEW-001 · Authenticated Expert Preview UI | ✅ `SPEC_OK` |
 | `UI-PREVIEW-LOADING-STATE-001.md` | UI-PREVIEW-LOADING-STATE-001 · Expert Preview Loading State | ✅ `SPEC_OK` |

--- a/.specs/UI-ALPHA-OPERATOR-CONSOLE-PROVIDER-COST-GATE-PANEL-001.md
+++ b/.specs/UI-ALPHA-OPERATOR-CONSOLE-PROVIDER-COST-GATE-PANEL-001.md
@@ -1,0 +1,144 @@
+# UI-ALPHA-OPERATOR-CONSOLE-PROVIDER-COST-GATE-PANEL-001 · Operator Console Provider, Model, and Cost Gate Panel
+
+Status: Implemented
+
+## Goal
+
+Expand the existing protected local-first Operator Console Provider and Cost Gate
+card into a clearer **display-only** safety panel that tells the operator whether
+live-provider execution remains blocked and why. This is a status and
+safety-gate visibility lane. It is not a live-provider lane, not a cost-metering
+lane, not a credential-validation lane, not a smoke-test lane, not a
+workbench-action lane, and not a `/v1/solve` lane.
+
+## Motivation
+
+The current Provider and Cost Gate card is shallow: it shows that provider calls
+are disabled and whether caps are configured, partially configured, or missing,
+but it does not clearly explain whether live-provider execution remains blocked,
+which safety gates are missing, or what would need to be present before any
+future live lane could even be considered. The next cockpit question is: can
+live execution even be considered later, and if not, what safety gate is missing?
+This lane answers that from configuration presence only, without enabling any
+execution path.
+
+## Scope
+
+- `alpha/webapp/routes/operator_console.py`: expand the `provider_gate` payload
+  and rendered card into a display-only gate-readiness panel.
+  - New safe derived fields on `provider_gate`: `provider_mode_label`,
+    `cap_status` (per cap `present`/`missing`), `cap_completeness`
+    (`none_configured` / `partially_configured` / `configured`),
+    `cost_cap_status` (`missing` / `present`), `token_request_cap_status`
+    (`missing` / `partial` / `present`), `live_execution_gate` (always
+    `blocked`), `live_execution_blockers` (safe blocker labels), and
+    `gate_boundary` (display-only note). Existing fields
+    (`configured_provider`, `live_provider_calls`, `console_calls_providers`,
+    `emergency_stop`, `live_preview_surface`, `key_status`, `cost_caps`, `note`)
+    are preserved.
+  - Pure helpers derive everything from environment *presence* and truthiness
+    only: `_cap_status`, `_cap_completeness`, `_cost_cap_status`,
+    `_token_request_cap_status`, `_provider_mode_label`,
+    `_live_execution_blockers`, and `_build_provider_gate`. No secret value is
+    read, no credential is validated, and no provider is contacted.
+  - The card keeps the disabled live-run button, adds a compact "Live Execution
+    Gate" subsection (gate result, cap completeness, cost cap, token/request
+    caps), a blockers list, per-cap presence rows, key presence rows, and the
+    gate boundary statements. No POST action, no executable live-run button, no
+    new endpoint.
+- `docs/OPERATOR_CONSOLE.md`: document the expanded panel, define each visible
+  gate state in operator terms, and state that caps are configured limits (not
+  billing truth), key status is categorical only, and complete configuration
+  does not authorize live execution.
+- `tests/test_operator_console.py`: focused provider/cost gate tests.
+- `.specs/INDEX.md`: one new row for this spec.
+
+## Non-goals and boundaries
+
+- No provider, hosted-model, local-model, MCP, tool, browser, network, or
+  `/v1/solve` call; no CLI or subprocess execution from the console.
+- No provider ping and no credential validation. Key and cap status are
+  environment *presence* only.
+- No API pricing lookup, exact billing, or spend calculation. Caps are
+  configured limits, not billing accuracy or spend verification.
+- No POST action, no executable live-run button, no newly exposed route beyond
+  the existing read-only status JSON, and no page redesign.
+- No raw or partial API key display, no environment dump, and no raw
+  prompt/output/route-metadata/provider-payload/full-JSON display.
+- No artifact creation, edit, deletion, upload, or mutation; no receipt store; no
+  workbench action buttons.
+- No change to `alpha_solver_portable.py`, provider runtime, model routing,
+  `/v1/solve` execution, the capture/export/preflight schemas, or the
+  `operator_run_capture.py` CLI semantics.
+- No scoring, ranking, winner fields, or model-comparison UI.
+- The console must not synthesize Alpha Solver runtime fields when no solve has
+  run from the console: no route, expert trace, confidence, SAFE-OUT state,
+  shortlist, SolverEnvelope output, provider model choice, provider result,
+  billing result, benchmark result, or readiness result is invented.
+
+## Display-only provider/cost boundary
+
+Provider and cost gate status is configuration visibility only. It does not imply
+route confidence, SAFE-OUT confidence, answer quality, validation, production
+readiness, public/API readiness, autonomous readiness, model superiority,
+provider readiness, benchmark evidence, or exact billing accuracy. Environment
+presence is not credential validity, and a configured cap is not billing truth.
+
+## No-execution / no-secret / no-billing-claim / no-readiness boundary
+
+This lane adds no execution path. It performs no provider/model/MCP/network/
+browser/CLI/subprocess call, no `/v1/solve` call, no provider ping, and no
+credential validation. It displays no raw or partial secret and no raw
+prompt/output/route metadata/provider payload. It performs no pricing lookup and
+no exact spend calculation. `live_execution_gate` is always `blocked`: complete
+cap or key configuration does not authorize live execution, which remains blocked
+unless a separate future live-provider lane explicitly authorizes it. A complete
+display-only gate is not provider readiness, production readiness, validation,
+benchmark evidence, or superiority evidence.
+
+## Code Targets
+
+- `alpha/webapp/routes/operator_console.py`
+- `tests/test_operator_console.py`
+- `docs/OPERATOR_CONSOLE.md`
+- `.specs/INDEX.md`
+
+## Test Plan
+
+`tests/test_operator_console.py`: the status JSON includes the expanded
+`provider_gate` fields; the default gate stays blocked and display-only; live
+provider calls stay disabled and the live-run button stays disabled; emergency
+stop engaged appears as a blocker; a missing provider key appears as a safe
+blocker without displaying any value; a present key reports `present` only (no
+raw or partial value); a missing cost cap appears as a safe blocker; partial cap
+configuration reports `partially_configured` / `partial`; complete cap
+configuration reports `configured` / `present` yet stays blocked; live-preview
+enabled does not by itself permit execution; the gate never validates
+credentials and never calls provider clients; provider client constructors
+patched to raise still allow both routes to return; fake API keys never appear
+in HTML, JSON, or reprs; the status JSON contains no raw environment values for
+any inspected env var; the rendered HTML contains the gate boundary text; a
+source scan confirms no provider/network/subprocess/browser/CLI execution
+imports in the route module; no scoring/ranking/winner/billing/model-comparison
+claim language appears in the gate UI; and existing artifact status and freshness
+surfaces persist alongside the gate.
+
+## Validation
+
+- `python -m pytest tests/test_operator_console.py -q`
+- `python -m pytest tests/test_operator_console.py tests/test_operator_run_capture.py tests/test_api_endpoints.py -q`
+- `python -m pytest -q`
+- `ruff check alpha/webapp/routes/operator_console.py tests/test_operator_console.py`
+- `python scripts/check_narrative_claim_safety.py docs/OPERATOR_CONSOLE.md .specs/UI-ALPHA-OPERATOR-CONSOLE-PROVIDER-COST-GATE-PANEL-001.md`
+
+## Definition of Done
+
+The route expansion, docs, tests, and this spec merged; all validation commands
+pass; the provider/cost gate reads environment presence only; `live_execution_gate`
+stays `blocked` under every configuration; no credential is validated, no provider
+is contacted, no raw or partial secret is displayed, no raw env value is exposed,
+and no schema is changed. Reporting a key or cap as `present`, or a gate as
+complete, means only that the named environment variable is set; it is not
+credential validity, billing truth, provider readiness, production readiness,
+validation, benchmark, or superiority evidence, and it does not authorize live
+execution.

--- a/.specs/UI-ALPHA-OPERATOR-CONSOLE-PROVIDER-COST-GATE-PANEL-001.md
+++ b/.specs/UI-ALPHA-OPERATOR-CONSOLE-PROVIDER-COST-GATE-PANEL-001.md
@@ -39,8 +39,18 @@ execution path.
   - Pure helpers derive everything from environment *presence* and truthiness
     only: `_cap_status`, `_cap_completeness`, `_cost_cap_status`,
     `_token_request_cap_status`, `_provider_mode_label`,
+    `_required_key_envs_for_provider`, `_provider_key_status`,
     `_live_execution_blockers`, and `_build_provider_gate`. No secret value is
     read, no credential is validated, and no provider is contacted.
+  - The `missing_provider_key` blocker is derived from the **configured
+    provider's** required key, not from any known key, mirroring the categorical
+    provider-key mapping in `scripts/check_env.py` (`openai` →
+    `OPENAI_API_KEY`, `anthropic` → `ANTHROPIC_API_KEY`, `google` / `gemini` →
+    `GOOGLE_API_KEY`, `local` / `none` → no key). `local_llm` is never satisfied
+    by a hosted-provider key: it reports `provider_key_status: not_evaluated` and
+    adds a `local_llm_configuration_not_evaluated` blocker. `GOOGLE_API_KEY` is
+    included in `key_status`, and `required_provider_keys` /
+    `provider_key_status` are surfaced on the payload.
   - The card keeps the disabled live-run button, adds a compact "Live Execution
     Gate" subsection (gate result, cap completeness, cost cap, token/request
     caps), a blockers list, per-cap presence rows, key presence rows, and the

--- a/alpha/webapp/routes/operator_console.py
+++ b/alpha/webapp/routes/operator_console.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 import html
 import os
 from pathlib import Path
-from typing import Any, Dict, List, Mapping
+from typing import Any, Dict, List, Mapping, Tuple
 
 from fastapi import APIRouter
 from fastapi.responses import HTMLResponse, JSONResponse
@@ -137,8 +137,26 @@ _TOKEN_REQUEST_CAP_ENVS = (
     "ALPHA_PROVIDER_MAX_REQUESTS",
 )
 # Provider credential env var names surfaced as present/missing only. The names
-# are shown; the values never are.
-_KEY_ENVS = ("OPENAI_API_KEY", "ANTHROPIC_API_KEY")
+# are shown; the values never are. GOOGLE_API_KEY is included so google/gemini
+# provider gating can reason about its required key categorically.
+_KEY_ENVS = ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY")
+
+# Provider -> required credential env var(s), mirroring the categorical
+# provider-key requirements in ``scripts/check_env.py``
+# (``_required_keys_for_provider`` + ``_NO_KEY_PROVIDERS``). This is a small,
+# display-only copy: it reasons about env *presence* categories only, never reads
+# or validates a key value, and is intentionally not imported from that CLI
+# script to avoid coupling the console route to CLI code. ``local`` and ``none``
+# require no key; ``local_llm`` is handled separately below (it must never be
+# satisfied by a hosted-provider key).
+_NO_KEY_PROVIDERS = frozenset({"local", "none"})
+_LOCAL_LLM_PROVIDER = "local_llm"
+_PROVIDER_REQUIRED_KEYS = {
+    "openai": ("OPENAI_API_KEY",),
+    "anthropic": ("ANTHROPIC_API_KEY",),
+    "gemini": ("GOOGLE_API_KEY",),
+    "google": ("GOOGLE_API_KEY",),
+}
 
 _TRUTHY = {"1", "true", "yes", "on"}
 
@@ -222,10 +240,46 @@ def _provider_mode_label(provider: str) -> str:
     return f"{provider} (live provider execution not enabled from this console)"
 
 
+def _required_key_envs_for_provider(provider: str) -> Tuple[str, ...]:
+    """Return the credential env var(s) the configured provider would require.
+
+    Mirrors ``scripts/check_env.py`` categorically (presence only). ``local`` and
+    ``none`` need no key; ``local_llm`` is handled separately (it must not be
+    satisfied by any hosted-provider key). Unknown providers declare no required
+    key here — live execution stays blocked by the always-on blockers regardless.
+    """
+
+    return _PROVIDER_REQUIRED_KEYS.get(provider, ())
+
+
+def _provider_key_status(provider: str, key_status: Mapping[str, str]) -> str:
+    """Categorical status of the *configured provider's* required key(s).
+
+    Returns ``not_required`` (local/none), ``not_evaluated`` (local_llm, whose
+    local runtime configuration this display-only gate does not assess),
+    ``present`` (all required keys present), or ``missing`` (a required key is
+    absent). Reasoning is over ``key_status`` presence categories only; no key
+    value is read or validated.
+    """
+
+    if provider == _LOCAL_LLM_PROVIDER:
+        return "not_evaluated"
+    if provider in _NO_KEY_PROVIDERS:
+        return "not_required"
+    required = _required_key_envs_for_provider(provider)
+    if not required:
+        # Unknown provider: no known required key here. Live execution stays
+        # blocked by the always-on blockers regardless.
+        return "not_required"
+    if all(key_status.get(env) == "present" for env in required):
+        return "present"
+    return "missing"
+
+
 def _live_execution_blockers(
     *,
     emergency_stop_engaged: bool,
-    any_key_present: bool,
+    provider_key_status: str,
     cost_cap_status: str,
     token_request_cap_status: str,
     live_preview_enabled: bool,
@@ -235,14 +289,20 @@ def _live_execution_blockers(
     ``display_only_lane`` and ``live_provider_calls_disabled`` are always
     present: this console is display-only and never enables live calls,
     regardless of configuration. The remaining labels describe what a future,
-    separately authorized live-provider lane would still need in place. No
-    credential is validated and no provider is contacted to derive these.
+    separately authorized live-provider lane would still need in place. The
+    provider-key blocker is derived from the *configured provider's* required
+    key, not from any key. No credential is validated and no provider is
+    contacted to derive these.
     """
 
     blockers = ["display_only_lane", "live_provider_calls_disabled"]
     if emergency_stop_engaged:
         blockers.append("emergency_stop_engaged")
-    if not any_key_present:
+    if provider_key_status == "not_evaluated":
+        # local_llm: keep the gate blocked with a specific, safe label rather
+        # than treating any hosted-provider key as satisfying it.
+        blockers.append("local_llm_configuration_not_evaluated")
+    elif provider_key_status == "missing":
         blockers.append("missing_provider_key")
     if cost_cap_status != "present":
         blockers.append("missing_cost_cap")
@@ -265,12 +325,12 @@ def _build_provider_gate(provider: str) -> Dict[str, Any]:
     emergency_stop_engaged = _truthy_env(_EMERGENCY_STOP_ENV)
     live_preview_enabled = _truthy_env(_LIVE_PREVIEW_ENV)
     key_status = {name: _key_presence(name) for name in _KEY_ENVS}
-    any_key_present = any(state == "present" for state in key_status.values())
+    provider_key_status = _provider_key_status(provider, key_status)
     cost_cap_status = _cost_cap_status()
     token_request_cap_status = _token_request_cap_status()
     blockers = _live_execution_blockers(
         emergency_stop_engaged=emergency_stop_engaged,
-        any_key_present=any_key_present,
+        provider_key_status=provider_key_status,
         cost_cap_status=cost_cap_status,
         token_request_cap_status=token_request_cap_status,
         live_preview_enabled=live_preview_enabled,
@@ -284,6 +344,10 @@ def _build_provider_gate(provider: str) -> Dict[str, Any]:
         "emergency_stop": "engaged" if emergency_stop_engaged else "not engaged",
         "live_preview_surface": "enabled" if live_preview_enabled else "disabled",
         "key_status": key_status,
+        # Required key(s) for the configured provider (env var names only) and the
+        # categorical status of that specific requirement.
+        "required_provider_keys": list(_required_key_envs_for_provider(provider)),
+        "provider_key_status": provider_key_status,
         # ``cost_caps`` retains the prior categorical summary for compatibility.
         "cost_caps": _cost_caps_status(),
         "cap_status": _cap_status(),
@@ -717,6 +781,7 @@ def _render_page(status: Mapping[str, Any]) -> str:
           <h3 class="subhead">Live Execution Gate (display-only)</h3>
           {_kv_rows({
               "gate result": gate["live_execution_gate"],
+              "provider key (configured provider)": gate["provider_key_status"],
               "cap completeness": gate["cap_completeness"],
               "cost cap": gate["cost_cap_status"],
               "token/request caps": gate["token_request_cap_status"],

--- a/alpha/webapp/routes/operator_console.py
+++ b/alpha/webapp/routes/operator_console.py
@@ -54,6 +54,50 @@ CLAIM_BOUNDARY_TEXT = (
     "superiority evidence is presented here"
 )
 
+# ---------------------------------------------------------------------------
+# Provider and cost gate boundary text. The provider/cost gate panel is a
+# display-only view of configuration and safety-gate state. These strings are
+# asserted by tests and rendered verbatim so an operator sees that gate status
+# is visibility only: no credential validation, no provider call, no billing
+# truth, and no authorization of live execution.
+# ---------------------------------------------------------------------------
+GATE_CONFIG_VISIBILITY_TEXT = (
+    "Provider and cost gate status is configuration visibility only."
+)
+GATE_NO_CREDENTIAL_VALIDATION_TEXT = "This console does not validate credentials."
+GATE_NO_EXECUTION_TEXT = (
+    "This console does not call providers, models, /v1/solve, MCP, tools, "
+    "browser automation, network, CLI, or subprocesses."
+)
+GATE_CAPS_NOT_BILLING_TEXT = (
+    "Cost caps are configured limits, not billing accuracy or spend verification."
+)
+GATE_KEY_CATEGORICAL_TEXT = (
+    "Key status is present/missing only; no raw or partial key values are "
+    "displayed."
+)
+GATE_NOT_READINESS_TEXT = (
+    "A complete display-only gate is not provider readiness, production "
+    "readiness, validation, benchmark evidence, or superiority evidence."
+)
+GATE_LIVE_BLOCKED_TEXT = (
+    "Live execution remains blocked unless a separate future live-provider lane "
+    "explicitly authorizes it."
+)
+GATE_BOUNDARY_NOTE = (
+    "display-only; no provider call or credential validation performed"
+)
+
+GATE_BOUNDARY_TEXTS = (
+    GATE_CONFIG_VISIBILITY_TEXT,
+    GATE_NO_CREDENTIAL_VALIDATION_TEXT,
+    GATE_NO_EXECUTION_TEXT,
+    GATE_CAPS_NOT_BILLING_TEXT,
+    GATE_KEY_CATEGORICAL_TEXT,
+    GATE_NOT_READINESS_TEXT,
+    GATE_LIVE_BLOCKED_TEXT,
+)
+
 # Portable behavior-contract file. We only check for its presence and list
 # well-known high-level surface labels. We never parse or expose private
 # chain-of-thought or the file's internal prompt content.
@@ -74,6 +118,20 @@ _EMERGENCY_STOP_ENV = "ALPHA_PROVIDER_EMERGENCY_STOP"
 _LIVE_PREVIEW_ENV = "ALPHA_LIVE_PREVIEW_ENABLED"
 _COST_CAP_ENVS = (
     "ALPHA_PROVIDER_MAX_COST_USD",
+    "ALPHA_PROVIDER_MAX_INPUT_TOKENS",
+    "ALPHA_PROVIDER_MAX_OUTPUT_TOKENS",
+    "ALPHA_PROVIDER_MAX_REQUESTS",
+)
+# Safe per-cap labels (env name -> stable payload key). Only presence/absence of
+# each cap is ever surfaced; the configured value itself is never read.
+_CAP_LABELS = {
+    "ALPHA_PROVIDER_MAX_COST_USD": "max_cost_usd",
+    "ALPHA_PROVIDER_MAX_INPUT_TOKENS": "max_input_tokens",
+    "ALPHA_PROVIDER_MAX_OUTPUT_TOKENS": "max_output_tokens",
+    "ALPHA_PROVIDER_MAX_REQUESTS": "max_requests",
+}
+_COST_CAP_ENV = "ALPHA_PROVIDER_MAX_COST_USD"
+_TOKEN_REQUEST_CAP_ENVS = (
     "ALPHA_PROVIDER_MAX_INPUT_TOKENS",
     "ALPHA_PROVIDER_MAX_OUTPUT_TOKENS",
     "ALPHA_PROVIDER_MAX_REQUESTS",
@@ -114,6 +172,129 @@ def _cost_caps_status() -> str:
     if present == len(_COST_CAP_ENVS):
         return "configured"
     return "partially configured"
+
+
+def _cap_present(name: str) -> str:
+    """Return only a categorical presence marker for a cap, never its value."""
+
+    return "present" if os.getenv(name, "").strip() else "missing"
+
+
+def _cap_status() -> Dict[str, str]:
+    """Per-cap present/missing status (no configured value is ever read)."""
+
+    return {label: _cap_present(env) for env, label in _CAP_LABELS.items()}
+
+
+def _cap_completeness() -> str:
+    """Overall cap completeness across the four cost/token/request caps."""
+
+    present = sum(1 for name in _COST_CAP_ENVS if os.getenv(name, "").strip())
+    if present == 0:
+        return "none_configured"
+    if present == len(_COST_CAP_ENVS):
+        return "configured"
+    return "partially_configured"
+
+
+def _cost_cap_status() -> str:
+    """present/missing for the spend cap only (a configured limit, not billing)."""
+
+    return "present" if os.getenv(_COST_CAP_ENV, "").strip() else "missing"
+
+
+def _token_request_cap_status() -> str:
+    """missing/partial/present across the token and request caps."""
+
+    present = sum(
+        1 for name in _TOKEN_REQUEST_CAP_ENVS if os.getenv(name, "").strip()
+    )
+    if present == 0:
+        return "missing"
+    if present == len(_TOKEN_REQUEST_CAP_ENVS):
+        return "present"
+    return "partial"
+
+
+def _provider_mode_label(provider: str) -> str:
+    """Human-readable mode label; never implies live execution is enabled."""
+
+    return f"{provider} (live provider execution not enabled from this console)"
+
+
+def _live_execution_blockers(
+    *,
+    emergency_stop_engaged: bool,
+    any_key_present: bool,
+    cost_cap_status: str,
+    token_request_cap_status: str,
+    live_preview_enabled: bool,
+) -> List[str]:
+    """Return safe blocker labels explaining why live execution stays blocked.
+
+    ``display_only_lane`` and ``live_provider_calls_disabled`` are always
+    present: this console is display-only and never enables live calls,
+    regardless of configuration. The remaining labels describe what a future,
+    separately authorized live-provider lane would still need in place. No
+    credential is validated and no provider is contacted to derive these.
+    """
+
+    blockers = ["display_only_lane", "live_provider_calls_disabled"]
+    if emergency_stop_engaged:
+        blockers.append("emergency_stop_engaged")
+    if not any_key_present:
+        blockers.append("missing_provider_key")
+    if cost_cap_status != "present":
+        blockers.append("missing_cost_cap")
+    if token_request_cap_status != "present":
+        blockers.append("missing_token_or_request_cap")
+    if not live_preview_enabled:
+        blockers.append("live_preview_surface_disabled")
+    return blockers
+
+
+def _build_provider_gate(provider: str) -> Dict[str, Any]:
+    """Assemble the display-only provider / model / cost gate status.
+
+    Pure function over environment *presence* and truthiness only. It never
+    reads a secret value, never validates a credential, and never contacts a
+    provider. ``live_execution_gate`` is always ``blocked`` because this console
+    is display-only; the blockers list explains why.
+    """
+
+    emergency_stop_engaged = _truthy_env(_EMERGENCY_STOP_ENV)
+    live_preview_enabled = _truthy_env(_LIVE_PREVIEW_ENV)
+    key_status = {name: _key_presence(name) for name in _KEY_ENVS}
+    any_key_present = any(state == "present" for state in key_status.values())
+    cost_cap_status = _cost_cap_status()
+    token_request_cap_status = _token_request_cap_status()
+    blockers = _live_execution_blockers(
+        emergency_stop_engaged=emergency_stop_engaged,
+        any_key_present=any_key_present,
+        cost_cap_status=cost_cap_status,
+        token_request_cap_status=token_request_cap_status,
+        live_preview_enabled=live_preview_enabled,
+    )
+
+    return {
+        "configured_provider": provider,
+        "provider_mode_label": _provider_mode_label(provider),
+        "live_provider_calls": "disabled",
+        "console_calls_providers": False,
+        "emergency_stop": "engaged" if emergency_stop_engaged else "not engaged",
+        "live_preview_surface": "enabled" if live_preview_enabled else "disabled",
+        "key_status": key_status,
+        # ``cost_caps`` retains the prior categorical summary for compatibility.
+        "cost_caps": _cost_caps_status(),
+        "cap_status": _cap_status(),
+        "cap_completeness": _cap_completeness(),
+        "cost_cap_status": cost_cap_status,
+        "token_request_cap_status": token_request_cap_status,
+        "live_execution_gate": "blocked",
+        "live_execution_blockers": blockers,
+        "gate_boundary": GATE_BOUNDARY_NOTE,
+        "note": NO_KEYS_TEXT + ". Key status is present/missing only.",
+    }
 
 
 def build_console_status() -> Dict[str, Any]:
@@ -175,20 +356,7 @@ def build_console_status() -> Dict[str, Any]:
             "diagnostics": "not run yet",
             "note": "No solve has run from this console; fields are placeholders.",
         },
-        "provider_gate": {
-            "configured_provider": provider,
-            "live_provider_calls": "disabled",
-            "console_calls_providers": False,
-            "emergency_stop": (
-                "engaged" if _truthy_env(_EMERGENCY_STOP_ENV) else "not engaged"
-            ),
-            "cost_caps": _cost_caps_status(),
-            "live_preview_surface": (
-                "enabled" if _truthy_env(_LIVE_PREVIEW_ENV) else "disabled"
-            ),
-            "key_status": {name: _key_presence(name) for name in _KEY_ENVS},
-            "note": NO_KEYS_TEXT + ". Key status is present/missing only.",
-        },
+        "provider_gate": _build_provider_gate(provider),
         "preflight_capture": {
             "workflows": [
                 {
@@ -282,6 +450,22 @@ def _render_page(status: Mapping[str, Any]) -> str:
         f'<dd><span class="badge {"ok" if state == "present" else "muted"}">'
         f"{_escape(state)}</span></dd></div>"
         for name, state in gate["key_status"].items()
+    )
+
+    # Per-cap presence rows (configured limits only; the value is never read).
+    cap_rows = "".join(
+        f'<div class="kv"><dt>{_escape(label)}</dt>'
+        f'<dd><span class="badge {"ok" if state == "present" else "muted"}">'
+        f"{_escape(state)}</span></dd></div>"
+        for label, state in gate["cap_status"].items()
+    )
+    # Safe blocker labels explaining why live execution stays blocked.
+    blocker_rows = "".join(
+        f"<li>{_escape(blocker)}</li>"
+        for blocker in gate["live_execution_blockers"]
+    )
+    gate_boundary_html = "".join(
+        f"<li>{_escape(text)}</li>" for text in GATE_BOUNDARY_TEXTS
     )
 
     workflow_rows = "".join(
@@ -523,14 +707,28 @@ def _render_page(status: Mapping[str, Any]) -> str:
           <h2>Provider and Cost Gate</h2>
           {_kv_rows({
               "configured provider": gate["configured_provider"],
+              "provider mode": gate["provider_mode_label"],
               "live provider calls": gate["live_provider_calls"],
               "console calls providers": gate["console_calls_providers"],
               "emergency stop": gate["emergency_stop"],
-              "cost caps": gate["cost_caps"],
               "live preview surface": gate["live_preview_surface"],
           })}
+
+          <h3 class="subhead">Live Execution Gate (display-only)</h3>
+          {_kv_rows({
+              "gate result": gate["live_execution_gate"],
+              "cap completeness": gate["cap_completeness"],
+              "cost cap": gate["cost_cap_status"],
+              "token/request caps": gate["token_request_cap_status"],
+          })}
+          <p class="note">Blockers (why live execution stays blocked):</p>
+          <ul class="surfaces">{blocker_rows}</ul>
+          <p class="note">Cap presence (configured limits only, not billing truth):</p>
+          {cap_rows}
           <p class="note">Key presence (categorical only):</p>
           {key_rows}
+          <p class="note">{_escape(gate["gate_boundary"])}.</p>
+          <ul class="surfaces">{gate_boundary_html}</ul>
           <p class="note">{_escape(gate["note"])}</p>
         </article>
 

--- a/docs/OPERATOR_CONSOLE.md
+++ b/docs/OPERATOR_CONSOLE.md
@@ -212,7 +212,17 @@ authorizes live execution.
   `ALPHA_PROVIDER_EMERGENCY_STOP`).
 - `live_preview_surface` — `enabled` / `disabled` (from
   `ALPHA_LIVE_PREVIEW_ENABLED`).
-- `key_status` — per credential env, `present` / `missing` only.
+- `key_status` — per credential env (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`,
+  `GOOGLE_API_KEY`), `present` / `missing` only.
+- `required_provider_keys` — the credential env var name(s) the **configured
+  provider** would require (names only, never values).
+- `provider_key_status` — the categorical status of that specific requirement:
+  `not_required` (`local` / `none`), `not_evaluated` (`local_llm`, whose local
+  runtime configuration this display-only gate does not assess), `present` (all
+  required keys present), or `missing` (a required key is absent). This mirrors
+  the provider-key mapping in `scripts/check_env.py` categorically: `openai`
+  requires `OPENAI_API_KEY`, `anthropic` requires `ANTHROPIC_API_KEY`, and
+  `google` / `gemini` require `GOOGLE_API_KEY`.
 
 ### Live Execution Gate (display-only)
 
@@ -222,7 +232,10 @@ authorizes live execution.
   blocked. `display_only_lane` and `live_provider_calls_disabled` are always
   present. The rest describe what a future, separately authorized live-provider
   lane would still need in place: `emergency_stop_engaged`,
-  `missing_provider_key`, `missing_cost_cap`, `missing_token_or_request_cap`,
+  `missing_provider_key` (derived from the **configured provider's** required
+  key, not from any key), `local_llm_configuration_not_evaluated` (for
+  `local_llm`, which is never satisfied by a hosted-provider key),
+  `missing_cost_cap`, `missing_token_or_request_cap`,
   `live_preview_surface_disabled`.
 - `gate_boundary` — `display-only; no provider call or credential validation
   performed`.

--- a/docs/OPERATOR_CONSOLE.md
+++ b/docs/OPERATOR_CONSOLE.md
@@ -49,10 +49,12 @@ return 404. When mounted, an unauthenticated `GET` redirects to `/login`.
 4. **Route and Trace** — placeholder fields for route, confidence, SAFE-OUT
    state, expert/team, shortlist, and diagnostics. They read "not run yet"; the
    console does not invent route output or imply a solve ran.
-5. **Provider and Cost Gate** — the configured provider, that the console does
-   not call providers, emergency-stop and cost-cap status, the live-preview
-   surface state, and API key **presence** only (`present` / `missing`). No raw
-   or partial key values are shown.
+5. **Provider and Cost Gate** — the configured provider and mode label, that the
+   console does not call providers, emergency-stop and live-preview surface
+   state, API key **presence** only (`present` / `missing`), and a display-only
+   Live Execution Gate that reports whether live execution is blocked, the
+   blockers, and cap completeness (see below). No raw or partial key values are
+   shown.
 6. **Preflight and Capture Entry** — the local workflows (anchor-preflight,
    lift-preflight, init capture, validate capture, export evidence packet) with
    command snippets and a docs pointer. These run from a terminal, not from the
@@ -187,6 +189,77 @@ model, calls a CLI, mutates an artifact, or creates a receipt.
   reflects the latest capture file.
 - Copied or restored files can carry misleading modified times, so freshness and
   ordering are hints for the operator, not guarantees about run order.
+
+## Provider, model, and cost gate panel
+
+Lane: `UI-ALPHA-OPERATOR-CONSOLE-PROVIDER-COST-GATE-PANEL-001`
+
+The Provider and Cost Gate card is a **display-only** view of provider, model,
+and cost-gate configuration. It answers a single cockpit question: can live
+execution even be considered later, and if not, what safety gate is missing? It
+reads environment-variable *presence* and truthiness only. It never reads a
+secret value, never validates a credential, never contacts a provider, and never
+authorizes live execution.
+
+### Configuration rows
+
+- `configured_provider` / `provider_mode_label` — the configured provider mode
+  (from `MODEL_PROVIDER`, default `local`). The label always notes that live
+  provider execution is not enabled from this console.
+- `live_provider_calls` — always `disabled`; `console_calls_providers` is always
+  `false`.
+- `emergency_stop` — `engaged` / `not engaged` (from
+  `ALPHA_PROVIDER_EMERGENCY_STOP`).
+- `live_preview_surface` — `enabled` / `disabled` (from
+  `ALPHA_LIVE_PREVIEW_ENABLED`).
+- `key_status` — per credential env, `present` / `missing` only.
+
+### Live Execution Gate (display-only)
+
+- `live_execution_gate` — always `blocked` from this console. This lane does not
+  enable live execution under any configuration.
+- `live_execution_blockers` — safe labels explaining why live execution stays
+  blocked. `display_only_lane` and `live_provider_calls_disabled` are always
+  present. The rest describe what a future, separately authorized live-provider
+  lane would still need in place: `emergency_stop_engaged`,
+  `missing_provider_key`, `missing_cost_cap`, `missing_token_or_request_cap`,
+  `live_preview_surface_disabled`.
+- `gate_boundary` — `display-only; no provider call or credential validation
+  performed`.
+
+### Cap completeness
+
+Cost, token, and request caps are inspected for presence only:
+
+- `cap_status` — per cap (`max_cost_usd`, `max_input_tokens`,
+  `max_output_tokens`, `max_requests`), `present` / `missing`.
+- `cap_completeness` — `none_configured` / `partially_configured` /
+  `configured` across the four caps.
+- `cost_cap_status` — `missing` / `present` for the spend cap only.
+- `token_request_cap_status` — `missing` / `partial` / `present` across the
+  token and request caps.
+
+Caps are **configured limits, not billing truth**. Presence of a cap does not
+verify spend, pricing, or billing accuracy, and this console performs no spend
+estimation.
+
+### Gate boundaries
+
+- Provider and cost gate status is configuration visibility only.
+- This console does not validate credentials.
+- This console does not call providers, models, /v1/solve, MCP, tools, browser
+  automation, network, CLI, or subprocesses.
+- Cost caps are configured limits, not billing accuracy or spend verification.
+- Key status is present/missing only; no raw or partial key values are displayed.
+- A complete display-only gate is not provider readiness, production readiness,
+  validation, benchmark evidence, or superiority evidence.
+- Live execution remains blocked unless a separate future live-provider lane
+  explicitly authorizes it. Complete cap or key configuration does not authorize
+  live execution — the gate result stays `blocked`.
+
+Environment presence is not credential validity: a key reported `present` may
+still be invalid, and the console does not check. A cap reported `present` is a
+configured limit only, not proof of billing behavior.
 
 ## Secret handling
 

--- a/tests/test_operator_console.py
+++ b/tests/test_operator_console.py
@@ -1133,6 +1133,8 @@ _GATE_ENVS = (
     "ALPHA_PROVIDER_MAX_REQUESTS",
     "OPENAI_API_KEY",
     "ANTHROPIC_API_KEY",
+    "GOOGLE_API_KEY",
+    "GEMINI_API_KEY",
 )
 
 
@@ -1157,6 +1159,8 @@ def test_provider_gate_includes_expanded_fields(client: TestClient) -> None:
         "emergency_stop",
         "live_preview_surface",
         "key_status",
+        "required_provider_keys",
+        "provider_key_status",
         "cap_status",
         "cap_completeness",
         "cost_cap_status",
@@ -1218,28 +1222,34 @@ def test_emergency_stop_appears_as_blocker(
     assert "emergency_stop_engaged" in gate["live_execution_blockers"]
 
 
-# 6. Missing provider key appears as a safe blocker without displaying a value.
+# 6. Missing provider key for the configured provider appears as a safe blocker
+#    without displaying any value.
 def test_missing_provider_key_blocker(
     client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     _clear_gate_env(monkeypatch)
+    # Configured provider requires a key that is absent.
+    monkeypatch.setenv("MODEL_PROVIDER", "openai")
     _login(client)
     gate = _gate(client)
+    assert gate["provider_key_status"] == "missing"
     assert "missing_provider_key" in gate["live_execution_blockers"]
     assert gate["key_status"]["OPENAI_API_KEY"] == "missing"
-    assert gate["key_status"]["ANTHROPIC_API_KEY"] == "missing"
 
 
-# 7. Present provider key reports present only, never raw or partial value.
+# 7. Present provider key for the configured provider reports present only,
+#    never a raw or partial value.
 def test_present_provider_key_categorical_only(
     client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     _clear_gate_env(monkeypatch)
+    monkeypatch.setenv("MODEL_PROVIDER", "openai")
     monkeypatch.setenv("OPENAI_API_KEY", FAKE_SECRET)
     _login(client)
     status_text = client.get(STATUS_ROUTE).text
     gate = _gate(client)
     assert gate["key_status"]["OPENAI_API_KEY"] == "present"
+    assert gate["provider_key_status"] == "present"
     assert "missing_provider_key" not in gate["live_execution_blockers"]
     assert FAKE_SECRET not in status_text
     # Not even a partial (prefix or suffix) of the key value is surfaced.
@@ -1459,3 +1469,162 @@ def test_artifact_surfaces_persist_with_gate_panel(client: TestClient) -> None:
     assert "status_generated_at_utc" in local
     for section in ("capture", "evidence_packet", "anchor_preflight", "lift_preflight"):
         assert section in local
+
+
+# ---------------------------------------------------------------------------
+# Provider-specific required-key gating (Codex P2 regression).
+# The missing_provider_key blocker must be derived from the *configured
+# provider's* required key, not from any known key. Mirrors the categorical
+# provider-key mapping in scripts/check_env.py without reading or validating a
+# key value.
+# ---------------------------------------------------------------------------
+def _gate_for_provider(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    provider: str,
+    present_keys: tuple = (),
+) -> dict:
+    _clear_gate_env(monkeypatch)
+    monkeypatch.setenv("MODEL_PROVIDER", provider)
+    for env in present_keys:
+        monkeypatch.setenv(env, FAKE_SECRET)
+    _login(client)
+    return _gate(client)
+
+
+# 1. anthropic + only OPENAI_API_KEY present still blocks with missing_provider_key.
+def test_anthropic_with_only_openai_key_still_missing_provider_key(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    gate = _gate_for_provider(
+        client, monkeypatch, "anthropic", present_keys=("OPENAI_API_KEY",)
+    )
+    assert gate["configured_provider"] == "anthropic"
+    assert gate["required_provider_keys"] == ["ANTHROPIC_API_KEY"]
+    assert gate["provider_key_status"] == "missing"
+    assert "missing_provider_key" in gate["live_execution_blockers"]
+    assert gate["live_execution_gate"] == "blocked"
+
+
+# 2. anthropic + ANTHROPIC_API_KEY present removes missing_provider_key.
+def test_anthropic_with_anthropic_key_removes_missing_provider_key(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    gate = _gate_for_provider(
+        client, monkeypatch, "anthropic", present_keys=("ANTHROPIC_API_KEY",)
+    )
+    assert gate["provider_key_status"] == "present"
+    assert "missing_provider_key" not in gate["live_execution_blockers"]
+    assert gate["live_execution_gate"] == "blocked"
+
+
+# 3. openai + OPENAI_API_KEY present removes missing_provider_key.
+def test_openai_with_openai_key_removes_missing_provider_key(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    gate = _gate_for_provider(
+        client, monkeypatch, "openai", present_keys=("OPENAI_API_KEY",)
+    )
+    assert gate["required_provider_keys"] == ["OPENAI_API_KEY"]
+    assert gate["provider_key_status"] == "present"
+    assert "missing_provider_key" not in gate["live_execution_blockers"]
+
+
+# 4. google + GOOGLE_API_KEY present removes missing_provider_key.
+def test_google_with_google_key_removes_missing_provider_key(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    gate = _gate_for_provider(
+        client, monkeypatch, "google", present_keys=("GOOGLE_API_KEY",)
+    )
+    assert gate["required_provider_keys"] == ["GOOGLE_API_KEY"]
+    assert gate["provider_key_status"] == "present"
+    assert "missing_provider_key" not in gate["live_execution_blockers"]
+
+
+# 5. gemini + GOOGLE_API_KEY present removes missing_provider_key.
+def test_gemini_with_google_key_removes_missing_provider_key(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    gate = _gate_for_provider(
+        client, monkeypatch, "gemini", present_keys=("GOOGLE_API_KEY",)
+    )
+    assert gate["required_provider_keys"] == ["GOOGLE_API_KEY"]
+    assert gate["provider_key_status"] == "present"
+    assert "missing_provider_key" not in gate["live_execution_blockers"]
+
+
+# 6. local requires no provider key.
+def test_local_provider_requires_no_key(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    gate = _gate_for_provider(client, monkeypatch, "local")
+    assert gate["required_provider_keys"] == []
+    assert gate["provider_key_status"] == "not_required"
+    assert "missing_provider_key" not in gate["live_execution_blockers"]
+    assert gate["live_execution_gate"] == "blocked"
+
+
+# 7. none requires no provider key.
+def test_none_provider_requires_no_key(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    gate = _gate_for_provider(client, monkeypatch, "none")
+    assert gate["required_provider_keys"] == []
+    assert gate["provider_key_status"] == "not_required"
+    assert "missing_provider_key" not in gate["live_execution_blockers"]
+    assert gate["live_execution_gate"] == "blocked"
+
+
+# 8. local_llm is not satisfied by any hosted-provider key; stays blocked.
+def test_local_llm_not_satisfied_by_hosted_keys(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    gate = _gate_for_provider(
+        client,
+        monkeypatch,
+        "local_llm",
+        present_keys=(
+            "OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "GOOGLE_API_KEY",
+            "GEMINI_API_KEY",
+        ),
+    )
+    assert gate["provider_key_status"] == "not_evaluated"
+    # Hosted-provider keys do not satisfy local_llm.
+    assert "missing_provider_key" not in gate["live_execution_blockers"]
+    assert "local_llm_configuration_not_evaluated" in gate["live_execution_blockers"]
+    assert gate["live_execution_gate"] == "blocked"
+
+
+# 9. Raw key values never appear in HTML, JSON, or reprs under provider gating.
+def test_provider_gating_never_leaks_key_values(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _clear_gate_env(monkeypatch)
+    monkeypatch.setenv("MODEL_PROVIDER", "google")
+    monkeypatch.setenv("GOOGLE_API_KEY", FAKE_SECRET)
+    monkeypatch.setenv("OPENAI_API_KEY", FAKE_SECRET)
+    _login(client)
+    assert FAKE_SECRET not in client.get(PAGE_ROUTE).text
+    assert FAKE_SECRET not in client.get(STATUS_ROUTE).text
+    assert FAKE_SECRET not in repr(operator_console.build_console_status())
+
+
+# 10. Provider clients patched to raise still allow both routes with gating.
+def test_provider_gating_does_not_call_provider_clients(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import alpha.providers.openai as openai_provider
+
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("provider client must not be used by operator console")
+
+    monkeypatch.setattr(openai_provider.OpenAIProviderClient, "__init__", _boom)
+    monkeypatch.setattr(openai_provider.OpenAIProviderClient, "execute", _boom)
+    _clear_gate_env(monkeypatch)
+    monkeypatch.setenv("MODEL_PROVIDER", "anthropic")
+    _login(client)
+    assert client.get(PAGE_ROUTE).status_code == 200
+    assert client.get(STATUS_ROUTE).status_code == 200

--- a/tests/test_operator_console.py
+++ b/tests/test_operator_console.py
@@ -1112,3 +1112,350 @@ def test_no_path_taken_from_request_data(client: TestClient) -> None:
     # The fixed default root is used regardless of request-supplied paths.
     assert local["artifact_root"] == "local/operator_console"
     assert "/etc" not in json.dumps(local)
+
+
+# ---------------------------------------------------------------------------
+# Provider, model, and cost gate panel
+# (AOC-B004-PROVIDER-COST-GATE-PANEL-001 /
+# UI-ALPHA-OPERATOR-CONSOLE-PROVIDER-COST-GATE-PANEL-001). The gate is a
+# display-only view of configuration and safety-gate state: no credential
+# validation, no provider call, no billing truth, no authorization of live
+# execution.
+# ---------------------------------------------------------------------------
+# Every environment variable the gate inspects. Cleared so tests start from a
+# known "nothing configured" baseline unless a test sets a value explicitly.
+_GATE_ENVS = (
+    "ALPHA_PROVIDER_EMERGENCY_STOP",
+    "ALPHA_LIVE_PREVIEW_ENABLED",
+    "ALPHA_PROVIDER_MAX_COST_USD",
+    "ALPHA_PROVIDER_MAX_INPUT_TOKENS",
+    "ALPHA_PROVIDER_MAX_OUTPUT_TOKENS",
+    "ALPHA_PROVIDER_MAX_REQUESTS",
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+)
+
+
+def _clear_gate_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for env in _GATE_ENVS:
+        monkeypatch.delenv(env, raising=False)
+
+
+def _gate(client: TestClient) -> dict:
+    return client.get(STATUS_ROUTE).json()["provider_gate"]
+
+
+# 1. Status JSON includes the expanded provider_gate fields.
+def test_provider_gate_includes_expanded_fields(client: TestClient) -> None:
+    _login(client)
+    gate = _gate(client)
+    for field in (
+        "configured_provider",
+        "provider_mode_label",
+        "live_provider_calls",
+        "console_calls_providers",
+        "emergency_stop",
+        "live_preview_surface",
+        "key_status",
+        "cap_status",
+        "cap_completeness",
+        "cost_cap_status",
+        "token_request_cap_status",
+        "live_execution_gate",
+        "live_execution_blockers",
+        "gate_boundary",
+    ):
+        assert field in gate, field
+    assert set(gate["cap_status"].keys()) == {
+        "max_cost_usd",
+        "max_input_tokens",
+        "max_output_tokens",
+        "max_requests",
+    }
+
+
+# 2. Default provider gate remains blocked and display-only.
+def test_provider_gate_default_blocked_and_display_only(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _clear_gate_env(monkeypatch)
+    _login(client)
+    gate = _gate(client)
+    assert gate["live_execution_gate"] == "blocked"
+    assert "display_only_lane" in gate["live_execution_blockers"]
+    assert "live_provider_calls_disabled" in gate["live_execution_blockers"]
+    assert "display-only" in gate["gate_boundary"]
+
+
+# 3. Live provider calls remain disabled.
+def test_provider_gate_live_calls_disabled(client: TestClient) -> None:
+    _login(client)
+    gate = _gate(client)
+    assert gate["live_provider_calls"] == "disabled"
+    assert gate["console_calls_providers"] is False
+
+
+# 4. Live-run button remains disabled (with the expanded gate panel present).
+def test_live_run_button_still_disabled_with_gate_panel(client: TestClient) -> None:
+    _login(client)
+    html_text = client.get(PAGE_ROUTE).text
+    assert "Live run (disabled)" in html_text
+    assert 'class="disabled-btn" disabled' in html_text
+    assert client.get(STATUS_ROUTE).json()["run_setup"][
+        "live_run_button_enabled"
+    ] is False
+
+
+# 5. Emergency stop engaged appears as a blocker.
+def test_emergency_stop_appears_as_blocker(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _clear_gate_env(monkeypatch)
+    monkeypatch.setenv("ALPHA_PROVIDER_EMERGENCY_STOP", "1")
+    _login(client)
+    gate = _gate(client)
+    assert gate["emergency_stop"] == "engaged"
+    assert "emergency_stop_engaged" in gate["live_execution_blockers"]
+
+
+# 6. Missing provider key appears as a safe blocker without displaying a value.
+def test_missing_provider_key_blocker(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _clear_gate_env(monkeypatch)
+    _login(client)
+    gate = _gate(client)
+    assert "missing_provider_key" in gate["live_execution_blockers"]
+    assert gate["key_status"]["OPENAI_API_KEY"] == "missing"
+    assert gate["key_status"]["ANTHROPIC_API_KEY"] == "missing"
+
+
+# 7. Present provider key reports present only, never raw or partial value.
+def test_present_provider_key_categorical_only(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _clear_gate_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", FAKE_SECRET)
+    _login(client)
+    status_text = client.get(STATUS_ROUTE).text
+    gate = _gate(client)
+    assert gate["key_status"]["OPENAI_API_KEY"] == "present"
+    assert "missing_provider_key" not in gate["live_execution_blockers"]
+    assert FAKE_SECRET not in status_text
+    # Not even a partial (prefix or suffix) of the key value is surfaced.
+    assert FAKE_SECRET[:20] not in status_text
+    assert FAKE_SECRET[-20:] not in status_text
+
+
+# 8. Missing cost cap appears as a safe blocker.
+def test_missing_cost_cap_blocker(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _clear_gate_env(monkeypatch)
+    _login(client)
+    gate = _gate(client)
+    assert gate["cost_cap_status"] == "missing"
+    assert "missing_cost_cap" in gate["live_execution_blockers"]
+
+
+# 9. Partial cap configuration reports partial or equivalent safe state.
+def test_partial_cap_configuration_reports_partial(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _clear_gate_env(monkeypatch)
+    monkeypatch.setenv("ALPHA_PROVIDER_MAX_INPUT_TOKENS", "1000")
+    _login(client)
+    gate = _gate(client)
+    assert gate["cap_completeness"] == "partially_configured"
+    assert gate["token_request_cap_status"] == "partial"
+    assert gate["cap_status"]["max_input_tokens"] == "present"
+    assert gate["cap_status"]["max_output_tokens"] == "missing"
+    assert "missing_token_or_request_cap" in gate["live_execution_blockers"]
+
+
+# 10. Complete cap configuration reports configured or equivalent safe state.
+def test_complete_cap_configuration_reports_configured(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _clear_gate_env(monkeypatch)
+    for env in (
+        "ALPHA_PROVIDER_MAX_COST_USD",
+        "ALPHA_PROVIDER_MAX_INPUT_TOKENS",
+        "ALPHA_PROVIDER_MAX_OUTPUT_TOKENS",
+        "ALPHA_PROVIDER_MAX_REQUESTS",
+    ):
+        monkeypatch.setenv(env, "5")
+    _login(client)
+    gate = _gate(client)
+    assert gate["cap_completeness"] == "configured"
+    assert gate["cost_cap_status"] == "present"
+    assert gate["token_request_cap_status"] == "present"
+    assert "missing_cost_cap" not in gate["live_execution_blockers"]
+    assert "missing_token_or_request_cap" not in gate["live_execution_blockers"]
+    # Complete caps do not authorize live execution; the gate stays blocked.
+    assert gate["live_execution_gate"] == "blocked"
+
+
+# 11. Live-preview surface enabled does not by itself permit live execution.
+def test_live_preview_enabled_does_not_permit_execution(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _clear_gate_env(monkeypatch)
+    monkeypatch.setenv("ALPHA_LIVE_PREVIEW_ENABLED", "1")
+    _login(client)
+    gate = _gate(client)
+    assert gate["live_preview_surface"] == "enabled"
+    assert "live_preview_surface_disabled" not in gate["live_execution_blockers"]
+    assert gate["live_execution_gate"] == "blocked"
+    assert "live_provider_calls_disabled" in gate["live_execution_blockers"]
+    assert "display_only_lane" in gate["live_execution_blockers"]
+
+
+# 12. Provider gate never validates credentials.
+def test_provider_gate_never_validates_credentials(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _clear_gate_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", FAKE_SECRET)
+    _login(client)
+    gate = _gate(client)
+    # Key status is categorical presence only, never a validity verdict.
+    assert set(gate["key_status"].values()) <= {"present", "missing"}
+    # The gate explicitly states no credential validation is performed.
+    assert "credential validation" in gate["gate_boundary"]
+    assert (
+        operator_console.GATE_NO_CREDENTIAL_VALIDATION_TEXT
+        in client.get(PAGE_ROUTE).text
+    )
+
+
+# 13. Provider gate never calls provider clients.
+def test_provider_gate_never_calls_provider_clients(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import alpha.providers.openai as openai_provider
+
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("provider client must not be used by operator console")
+
+    monkeypatch.setattr(openai_provider.OpenAIProviderClient, "__init__", _boom)
+    monkeypatch.setattr(openai_provider.OpenAIProviderClient, "execute", _boom)
+    monkeypatch.setenv("OPENAI_API_KEY", FAKE_SECRET)
+    _login(client)
+    assert client.get(STATUS_ROUTE).status_code == 200
+    assert operator_console.build_console_status()["provider_gate"][
+        "console_calls_providers"
+    ] is False
+
+
+# 14. Provider client constructors patched to raise still allow both routes.
+def test_provider_client_patched_raise_both_routes_ok_with_gate(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import alpha.providers.openai as openai_provider
+
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("provider client must not be used by operator console")
+
+    monkeypatch.setattr(openai_provider.OpenAIProviderClient, "__init__", _boom)
+    monkeypatch.setattr(openai_provider.OpenAIProviderClient, "execute", _boom)
+    monkeypatch.setenv("OPENAI_API_KEY", FAKE_SECRET)
+    _login(client)
+    assert client.get(PAGE_ROUTE).status_code == 200
+    assert client.get(STATUS_ROUTE).status_code == 200
+
+
+# 15. Fake API keys never appear in HTML, JSON, or reprs.
+def test_fake_key_never_appears_in_gate_html_json_repr(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", FAKE_SECRET)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", FAKE_SECRET)
+    _login(client)
+    assert FAKE_SECRET not in client.get(PAGE_ROUTE).text
+    assert FAKE_SECRET not in client.get(STATUS_ROUTE).text
+    assert FAKE_SECRET not in repr(operator_console.build_console_status())
+
+
+# 16. Status JSON contains no raw environment values for inspected env vars.
+def test_no_raw_env_values_in_status_json(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sentinels = {
+        "ALPHA_PROVIDER_MAX_COST_USD": "CAP-COST-SENTINEL-123",
+        "ALPHA_PROVIDER_MAX_INPUT_TOKENS": "CAP-IN-SENTINEL-123",
+        "ALPHA_PROVIDER_MAX_OUTPUT_TOKENS": "CAP-OUT-SENTINEL-123",
+        "ALPHA_PROVIDER_MAX_REQUESTS": "CAP-REQ-SENTINEL-123",
+        "ALPHA_PROVIDER_EMERGENCY_STOP": "STOP-SENTINEL-123",
+        "ALPHA_LIVE_PREVIEW_ENABLED": "PREVIEW-SENTINEL-123",
+        "OPENAI_API_KEY": FAKE_SECRET,
+    }
+    for env, value in sentinels.items():
+        monkeypatch.setenv(env, value)
+    _login(client)
+    body = client.get(STATUS_ROUTE).text
+    for value in sentinels.values():
+        assert value not in body
+
+
+# 17. Rendered HTML contains the provider/cost gate boundary text.
+def test_gate_boundary_text_in_html(client: TestClient) -> None:
+    _login(client)
+    html_text = client.get(PAGE_ROUTE).text
+    for text in operator_console.GATE_BOUNDARY_TEXTS:
+        assert text in html_text
+
+
+# 18. Source-scan: no execution imports in the console route module.
+def test_route_module_has_no_execution_imports() -> None:
+    source = Path(operator_console.__file__).read_text(encoding="utf-8")
+    forbidden = (
+        "ProviderClient",
+        "OpenAIProviderClient",
+        "httpx",
+        "requests.",
+        "import subprocess",
+        "subprocess.",
+        "import socket",
+        "urllib",
+        "playwright",
+        "selenium",
+        "webdriver",
+        "webbrowser",
+        "pexpect",
+    )
+    for token in forbidden:
+        assert token not in source, f"{token!r} found in {operator_console.__file__}"
+
+
+# 19. No scoring/ranking/winner/billing/model-comparison claim language in the UI.
+def test_gate_ui_has_no_scoring_or_billing_claim_language(client: TestClient) -> None:
+    _login(client)
+    html_text = client.get(PAGE_ROUTE).text.lower()
+    for forbidden in (
+        "winner",
+        "ranking",
+        "leaderboard",
+        "score:",
+        "outperforms",
+        "production ready",
+        "ready for production",
+        "exact spend",
+        "estimated cost",
+        "estimated spend",
+        "model comparison",
+    ):
+        assert forbidden not in html_text
+
+
+# 20. Existing artifact status / freshness surfaces persist alongside the gate.
+def test_artifact_surfaces_persist_with_gate_panel(client: TestClient) -> None:
+    _login(client)
+    payload = client.get(STATUS_ROUTE).json()
+    assert "provider_gate" in payload
+    assert payload["provider_gate"]["live_execution_gate"] == "blocked"
+    local = payload["local_artifacts"]
+    assert "freshness" in local
+    assert "status_generated_at_utc" in local
+    for section in ("capture", "evidence_packet", "anchor_preflight", "lift_preflight"):
+        assert section in local


### PR DESCRIPTION
## Checklist

- [x] Spec linked: `.specs/UI-ALPHA-OPERATOR-CONSOLE-PROVIDER-COST-GATE-PANEL-001.md`
- [x] Spec sections present/updated (Goal / Motivation / Scope / Non-goals and boundaries / Code Targets / Test Plan / Definition of Done + explicit display-only provider/cost and no-execution/no-secret/no-billing-claim/no-readiness boundaries)
- [x] Tests run: `python -m pytest -q` (1619 passed, 3 pre-existing unrelated skips)

## Notes for reviewers

**Lane:** `AOC-B004-PROVIDER-COST-GATE-PANEL-001`
**Spec id:** `UI-ALPHA-OPERATOR-CONSOLE-PROVIDER-COST-GATE-PANEL-001`
**Verified baseline main SHA:** `570ef1460cc7f3e51364c974f4417424a019fcf8` (PR #666 merged)
**PR head SHA:** `36177e5e6cff79fdeb5bd3e6de7b3fd5ae0d90eb`

### Summary

Expands the existing protected local-first Operator Console **Provider and Cost Gate** card into a clearer **display-only** gate-readiness panel that answers: can live execution even be considered later, and if not, what safety gate is missing? Everything is derived from environment-variable **presence/truthiness only** — no secret value is read, no credential is validated, no provider is contacted, and no execution path is added.

### Files changed

- `alpha/webapp/routes/operator_console.py` — expanded `provider_gate` payload + card subsection
- `tests/test_operator_console.py` — 20 new focused tests (file totals 78)
- `docs/OPERATOR_CONSOLE.md` — provider/model/cost gate panel section
- `.specs/UI-ALPHA-OPERATOR-CONSOLE-PROVIDER-COST-GATE-PANEL-001.md` — new spec
- `.specs/INDEX.md` — one new row

### User-visible behavior

- `provider_gate` gains `provider_mode_label`, `cap_status` (per cap `present`/`missing`), `cap_completeness` (`none_configured`/`partially_configured`/`configured`), `cost_cap_status` (`missing`/`present`), `token_request_cap_status` (`missing`/`partial`/`present`), `live_execution_gate` (always `blocked`), `live_execution_blockers` (safe labels: `display_only_lane`, `live_provider_calls_disabled`, `emergency_stop_engaged`, `missing_provider_key`, `missing_cost_cap`, `missing_token_or_request_cap`, `live_preview_surface_disabled`), and `gate_boundary`. All prior fields preserved.
- The Provider and Cost Gate card renders a compact "Live Execution Gate (display-only)" subsection, a blockers list, per-cap presence rows, and the gate boundary statements. The live-run button stays disabled.
- Complete cap or key configuration does **not** authorize live execution — the gate result stays `blocked` under every configuration.

### Boundary confirmations

- No provider / hosted-model / local-model / MCP / network / browser / CLI / subprocess calls
- No `/v1/solve` call
- No credential validation; no provider ping
- No API pricing lookup, exact billing, or spend calculation (caps are configured limits only)
- No artifact creation, edit, deletion, upload, or mutation; no receipt store
- No raw or partial API key display; no environment dump; key status stays categorical `present`/`missing`
- No raw prompt / baseline output / routed output / route-metadata / provider-payload / full-JSON display
- No capture / export / preflight schema changes; `operator_run_capture.py` CLI semantics unchanged; `alpha_solver_portable.py` untouched
- No scoring / ranking / winner fields / model-comparison UI
- No readiness / validation / benchmark / production / superiority claim
- No new endpoint, no POST action, no page redesign, no new dependency

### Tests and validation commands run (all passed)

- `python -m pytest tests/test_operator_console.py -q` → passed (78 tests)
- `python -m pytest tests/test_operator_console.py tests/test_operator_run_capture.py tests/test_api_endpoints.py -q` → passed
- `python -m pytest -q` → 1619 passed, 3 skipped (pre-existing unrelated)
- `ruff check alpha/webapp/routes/operator_console.py tests/test_operator_console.py` → All checks passed
- `python scripts/check_narrative_claim_safety.py docs/OPERATOR_CONSOLE.md .specs/UI-ALPHA-OPERATOR-CONSOLE-PROVIDER-COST-GATE-PANEL-001.md` → passed

### Remaining risks

- Environment presence is not credential validity: a key reported `present` may still be invalid; the console does not check.
- Configured caps are not billing truth: cap presence does not verify spend, pricing, or billing.
- Display-only gate completeness does not authorize live execution; `live_execution_gate` stays `blocked`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QE3af5rMkhUfTCgsYnDXA

---
_Generated by [Claude Code](https://claude.ai/code/session_012QE3af5rMkhUfTCgsYnDXA)_