### PR TITLE
Operator Console Dry-Run Preview (AOC-B005-DRY-RUN-PREVIEW-001)

### DIFF
--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -98,6 +98,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `UI-ALPHA-OPERATOR-CONSOLE-LOCAL-ARTIFACT-STATUS-001.md` | UI-ALPHA-OPERATOR-CONSOLE-LOCAL-ARTIFACT-STATUS-001 · Operator Console Local Artifact Status | ✅ `SPEC_OK` |
 | `UI-ALPHA-OPERATOR-CONSOLE-ARTIFACT-FRESHNESS-001.md` | UI-ALPHA-OPERATOR-CONSOLE-ARTIFACT-FRESHNESS-001 · Operator Console Artifact Freshness and Sequence Coherence | ✅ `SPEC_OK` |
 | `UI-ALPHA-OPERATOR-CONSOLE-PROVIDER-COST-GATE-PANEL-001.md` | UI-ALPHA-OPERATOR-CONSOLE-PROVIDER-COST-GATE-PANEL-001 · Operator Console Provider, Model, and Cost Gate Panel | ✅ `SPEC_OK` |
+| `UI-ALPHA-OPERATOR-CONSOLE-DRY-RUN-PREVIEW-001.md` | UI-ALPHA-OPERATOR-CONSOLE-DRY-RUN-PREVIEW-001 · Operator Console Dry-Run Preview | ✅ `SPEC_OK` |
 | `UI-JOBS-001.md` | UI-JOBS-001 · Dashboard Job History & Metrics (RES_Dash) | ✅ `SPEC_OK` |
 | `UI-PREVIEW-001.md` | UI-PREVIEW-001 · Authenticated Expert Preview UI | ✅ `SPEC_OK` |
 | `UI-PREVIEW-LOADING-STATE-001.md` | UI-PREVIEW-LOADING-STATE-001 · Expert Preview Loading State | ✅ `SPEC_OK` |

--- a/.specs/UI-ALPHA-OPERATOR-CONSOLE-DRY-RUN-PREVIEW-001.md
+++ b/.specs/UI-ALPHA-OPERATOR-CONSOLE-DRY-RUN-PREVIEW-001.md
@@ -1,0 +1,178 @@
+# UI-ALPHA-OPERATOR-CONSOLE-DRY-RUN-PREVIEW-001 · Operator Console Dry-Run Preview
+
+Status: Implemented
+
+Lane: `AOC-B005-DRY-RUN-PREVIEW-001`
+
+## Goal
+
+Add a **display-only** Dry-Run Preview panel to the existing protected,
+local-first Operator Console. The console already lists `dry-run` as an available
+run mode, but it never explains what dry-run readiness means, what inputs a
+dry-run would need, what would be previewed, or why it still is not execution.
+This panel answers a single cockpit question: what would a future dry-run prepare,
+and what is missing before a separate dry-run execution lane could be considered?
+
+This is a dry-run **preview** lane, not a dry-run **execution** lane. It executes
+nothing. It is a status/visibility lane, not a runner lane, not a provider lane,
+not a `/v1/solve` lane, not a CLI lane, and not an artifact-mutation lane.
+
+## Motivation
+
+The Run Setup card advertises `dry-run` as an available mode, but the operator has
+no way to see what a dry-run would prepare or require. The next cockpit question
+is: is dry-run preview available, what input source would a dry-run need, is local
+capture present and structurally valid, is an evidence packet present and
+self-consistent, are the anchor/lift preflight reports present, are any derived
+artifacts stale relative to capture, is provider/live execution still blocked, and
+what is explicitly not happening now? This lane answers those from the local
+metadata this console already assembles, without adding any execution path.
+
+## Scope
+
+- `alpha/webapp/routes/operator_console.py`: add a new top-level `dry_run_preview`
+  status section and a compact "Dry-Run Preview" card.
+  - Pure helpers derive everything from the already-assembled, already-safe
+    `local_artifacts` and `provider_gate` sub-payloads:
+    `_dry_run_input_source_status`, `_dry_run_preflight_status`,
+    `_dry_run_freshness_warnings`, `_dry_run_preview_blockers`,
+    `_dry_run_preview_readiness`, and `_build_dry_run_preview`. No new input is
+    read: no raw artifact content, no secret value, no provider, no CLI, no solve.
+  - Fields on `dry_run_preview`: `preview_mode` (`display_only`),
+    `dry_run_execution` (`not_enabled`), `would_use` (safe surface names),
+    `input_source_status` (`capture_missing` / `capture_invalid` /
+    `capture_structurally_valid` / `capture_export_ready`),
+    `evidence_packet_status` (the existing packet state: `missing` /
+    `invalid_json` / `invalid_structure` / `digest_valid` / `digest_invalid` /
+    `digest_unverifiable`), `preflight_status` (`anchor_*` / `lift_*`
+    present/missing/invalid), `freshness_warnings` (safe labels drawn only from
+    `local_artifacts.freshness.sequence_coherence`), `provider_gate_summary`
+    (`live_execution_gate`, `provider_key_status`, `cap_completeness`,
+    `live_execution_blockers`), `preview_readiness` (`unavailable` /
+    `needs_artifacts` / `preview_ready`), `preview_blockers` (safe labels),
+    `boundary`, and `boundary_notes`.
+  - The card keeps the disabled live-run button. No POST action, no live-run/
+    execute/submit/generate/solve button, and no new endpoint.
+- `docs/OPERATOR_CONSOLE.md`: document the panel, define preview readiness in
+  operator terms, and preserve the existing no-provider/no-runner/no-secret/
+  no-raw/no-readiness/no-validation boundaries.
+- `tests/test_operator_console.py`: focused dry-run preview tests.
+- `.specs/INDEX.md`: one new row for this spec.
+
+## Non-goals and boundaries
+
+- No dry-run execution. This lane previews prerequisites and missing readiness
+  only; it never runs a dry-run.
+- No provider, hosted-model, local-model, MCP, tool, browser, or network call; no
+  CLI or subprocess execution from the console; no `/v1/solve` call; no call to
+  internal solve functions.
+- No prompt submission and no generated output. The console does not generate
+  route, confidence, SAFE-OUT state, expert trace, shortlist, diagnostics, answer
+  text, model output, provider result, billing result, benchmark result, or
+  readiness result.
+- No credential validation and no provider ping. The provider gate summary reuses
+  the existing environment-presence gate; it validates nothing.
+- No API pricing lookup and no exact billing or spend calculation.
+- No artifact creation, edit, deletion, upload, save, or mutation; no receipt
+  store.
+- No POST action, no executable action button, and no newly exposed route beyond
+  the existing read-only page and status JSON. No page redesign and no new
+  dependency.
+- No raw or partial API key display, no environment dump, and no raw
+  prompt/baseline/routed/route-metadata/system-prompt/provider-payload/full-JSON
+  display.
+- No change to `alpha_solver_portable.py`, provider runtime, model routing,
+  `/v1/solve`, the capture/export/preflight schemas, or the
+  `operator_run_capture.py` CLI semantics.
+- No scoring, ranking, winner fields, or model-comparison UI.
+- The console must not synthesize Alpha Solver runtime fields when no solve has
+  run from the console: no route, expert trace, confidence, SAFE-OUT state,
+  shortlist, SolverEnvelope output, provider model choice, provider result,
+  billing result, benchmark result, readiness result, generated answer, or
+  dry-run output is invented.
+
+## Preview-only boundary
+
+The Dry-Run Preview panel is display-only. It previews what a future dry-run would
+prepare or require; it does not run a dry-run and does not enable one.
+`preview_mode` is always `display_only` and `dry_run_execution` is always
+`not_enabled`. A future dry-run execution lane must be separately authorized.
+
+## No-execution / no-solve / no-provider / no-artifact-mutation / no-runtime-output boundary
+
+This lane adds no execution path. It performs no provider/model/MCP/network/
+browser/CLI/subprocess call, no `/v1/solve` call, no internal solve-function call,
+no dry-run execution, and no prompt submission. It creates, edits, deletes,
+uploads, and mutates no artifact, and stores no receipt. It generates no route,
+confidence, SAFE-OUT, expert trace, shortlist, diagnostics, answer text, model
+output, provider result, billing result, benchmark result, or readiness result. It
+displays no raw or partial secret and no raw prompt/output/route-metadata/provider
+payload.
+
+## No-readiness / no-validation / no-benchmark / no-superiority boundary
+
+`preview_readiness` means only whether the preview has enough local metadata to
+explain the next step. It is not answer quality, route readiness, provider
+readiness, production readiness, validation, benchmark evidence, billing accuracy,
+or superiority evidence. A `preview_ready` state does not claim any of those and
+does not authorize execution. Evidence-packet `digest_valid` is packet
+self-integrity only, not freshness or answer quality. Freshness warnings are local
+filesystem metadata only. The provider gate summary reports that live execution is
+blocked; it does not claim provider readiness and does not authorize live
+execution.
+
+## Code Targets
+
+- `alpha/webapp/routes/operator_console.py`
+- `tests/test_operator_console.py`
+- `docs/OPERATOR_CONSOLE.md`
+- `.specs/INDEX.md`
+- `.specs/UI-ALPHA-OPERATOR-CONSOLE-DRY-RUN-PREVIEW-001.md`
+
+## Test Plan
+
+`tests/test_operator_console.py`: the status JSON includes the new
+`dry_run_preview` section; preview mode is `display_only`; dry-run execution is
+`not_enabled`; the live-run button stays disabled; no POST/action route is added;
+missing capture and invalid capture each produce safe preview blockers and still
+render; structurally valid and export-ready capture produce a local input status
+without exposing raw prompts or outputs; a missing evidence packet produces a safe
+blocker; a digest-valid packet is treated as self-integrity only (not
+quality/readiness); digest-invalid and digest-unverifiable states produce safe
+warnings/blockers; missing anchor/lift reports produce a safe blocker while present
+reports are shown as local metadata; stale evidence-packet/anchor/lift artifacts vs
+capture each produce a safe freshness warning; the provider gate summary is
+included but live execution stays blocked; complete provider/cap configuration does
+not enable dry-run execution; fake API keys never appear in HTML, JSON, or reprs;
+raw prompt/baseline/routed/route-metadata/system-prompt/provider-payload sentinels
+never appear; provider client constructors patched to raise still allow both routes
+to return; a source scan confirms no provider client, httpx, requests, subprocess,
+socket, browser, MCP, CLI, or solve imports are introduced in the route module; the
+UI contains the dry-run preview boundary text; the UI contains no misleading
+execution/claim language; and existing provider gate, artifact status, and freshness
+surfaces persist alongside the panel.
+
+## Validation
+
+- `python -m pytest tests/test_operator_console.py -q`
+- `python -m pytest tests/test_operator_console.py tests/test_operator_run_capture.py tests/test_api_endpoints.py -q`
+- `python -m pytest -q`
+- `ruff check alpha/webapp/routes/operator_console.py tests/test_operator_console.py`
+- `python scripts/check_narrative_claim_safety.py docs/OPERATOR_CONSOLE.md .specs/UI-ALPHA-OPERATOR-CONSOLE-DRY-RUN-PREVIEW-001.md`
+
+## Definition of Done
+
+The route addition, docs, tests, and this spec merged; all validation commands
+pass; the dry-run preview reads only the existing safe `local_artifacts` and
+`provider_gate` sub-payloads; `preview_mode` stays `display_only` and
+`dry_run_execution` stays `not_enabled` under every configuration; the live-run
+button stays disabled; no POST/action route or new endpoint is added; no provider,
+model, MCP, network, browser, CLI, subprocess, `/v1/solve`, internal solve, or
+dry-run execution path is added; no credential is validated and no provider is
+pinged; no exact billing or spend is claimed; no artifact is mutated; no raw or
+partial secret and no raw prompt/output/route-metadata/provider payload is
+displayed; and no schema is changed. Reporting `preview_ready` means only that the
+local metadata is complete enough to explain the next step; it is not
+answer-quality, validation, production, provider readiness, benchmark, billing, or
+superiority evidence, and it does not authorize live or dry-run execution, which
+remains a separate future lane.

--- a/alpha/webapp/routes/operator_console.py
+++ b/alpha/webapp/routes/operator_console.py
@@ -98,6 +98,75 @@ GATE_BOUNDARY_TEXTS = (
     GATE_LIVE_BLOCKED_TEXT,
 )
 
+# ---------------------------------------------------------------------------
+# Dry-run preview boundary text. The dry-run preview panel is a display-only
+# read of what a *future* dry-run execution lane would prepare or require. It
+# executes nothing. These strings are asserted by tests and rendered verbatim so
+# an operator sees that this is a preview of readiness, not a dry-run run, and
+# that preview readiness is local metadata completeness only.
+# ---------------------------------------------------------------------------
+DRY_RUN_PREVIEW_DISPLAY_ONLY_TEXT = "Dry-run preview is display-only."
+DRY_RUN_NO_SOLVE_TEXT = (
+    "This console does not execute a solve from this panel."
+)
+DRY_RUN_NO_V1_SOLVE_TEXT = "This console does not call /v1/solve."
+DRY_RUN_NO_PROVIDER_TEXT = (
+    "This console does not call providers, models, MCP, browser automation, "
+    "network, CLI, or subprocesses."
+)
+DRY_RUN_NO_ARTIFACT_MUTATION_TEXT = (
+    "This console does not create, edit, delete, upload, save, or mutate "
+    "artifacts."
+)
+DRY_RUN_NO_OUTPUT_TEXT = (
+    "This console does not generate route, confidence, SAFE-OUT, expert trace, "
+    "shortlist, diagnostics, answer text, model output, provider result, "
+    "billing result, benchmark result, or readiness result."
+)
+DRY_RUN_READINESS_MEANING_TEXT = (
+    "Preview readiness is local metadata completeness only."
+)
+DRY_RUN_NOT_EVIDENCE_TEXT = (
+    "A preview-ready state is not answer-quality, validation, production, "
+    "provider readiness, benchmark evidence, billing accuracy, or superiority "
+    "evidence."
+)
+DRY_RUN_FUTURE_LANE_TEXT = (
+    "A future dry-run execution lane must be separately authorized."
+)
+
+DRY_RUN_BOUNDARY_TEXTS = (
+    DRY_RUN_PREVIEW_DISPLAY_ONLY_TEXT,
+    DRY_RUN_NO_SOLVE_TEXT,
+    DRY_RUN_NO_V1_SOLVE_TEXT,
+    DRY_RUN_NO_PROVIDER_TEXT,
+    DRY_RUN_NO_ARTIFACT_MUTATION_TEXT,
+    DRY_RUN_NO_OUTPUT_TEXT,
+    DRY_RUN_READINESS_MEANING_TEXT,
+    DRY_RUN_NOT_EVIDENCE_TEXT,
+    DRY_RUN_FUTURE_LANE_TEXT,
+)
+DRY_RUN_BOUNDARY_NOTE = (
+    "display-only; no solve, provider call, CLI, artifact mutation, or "
+    "generated output"
+)
+
+# Safe labels naming the existing local metadata a future dry-run would read.
+# These are display-only names for surfaces this console already assembles; the
+# preview never reads or synthesizes any runtime output.
+DRY_RUN_WOULD_USE = (
+    "local_capture_summary",
+    "local_artifact_status",
+    "artifact_freshness_metadata",
+    "provider_cost_gate_status",
+)
+
+# Safe freshness-warning labels (mismatch flags surfaced from the existing
+# sequence-coherence metadata, not ordering states).
+_DRY_RUN_MISMATCH_FLAGS = frozenset(
+    {"packet_id_mismatch", "counts_mismatch", "digest_invalid", "digest_unverifiable"}
+)
+
 # Portable behavior-contract file. We only check for its presence and list
 # well-known high-level surface labels. We never parse or expose private
 # chain-of-thought or the file's internal prompt content.
@@ -361,6 +430,196 @@ def _build_provider_gate(provider: str) -> Dict[str, Any]:
     }
 
 
+# ---------------------------------------------------------------------------
+# Dry-run preview. A display-only read over the *already assembled* local
+# artifact status and provider-gate status. It maps that existing safe metadata
+# to bounded labels that answer "what would a future dry-run prepare, and what is
+# still missing before a separate dry-run execution lane could be considered?".
+#
+# It executes nothing. It never reads raw artifact content, never calls a
+# provider, never runs a solve or CLI, never mutates an artifact, and never
+# synthesizes any Alpha Solver runtime field. Every value is derived from the
+# two safe sub-payloads passed in.
+# ---------------------------------------------------------------------------
+def _dry_run_input_source_status(capture_state: Any) -> str:
+    """Map the local capture state to a bounded input-source label."""
+
+    if capture_state == "export_ready":
+        return "capture_export_ready"
+    if capture_state == "structurally_valid":
+        return "capture_structurally_valid"
+    if capture_state in {"invalid_json", "invalid_structure"}:
+        return "capture_invalid"
+    return "capture_missing"
+
+
+def _dry_run_preflight_status(anchor_state: Any, lift_state: Any) -> Dict[str, str]:
+    """Map anchor/lift preflight states to bounded present/missing/invalid labels."""
+
+    def _one(prefix: str, state: Any) -> str:
+        if state == "present":
+            return f"{prefix}_present"
+        if state == "missing":
+            return f"{prefix}_missing"
+        return f"{prefix}_invalid"
+
+    return {
+        "anchor": _one("anchor", anchor_state),
+        "lift": _one("lift", lift_state),
+    }
+
+
+def _dry_run_freshness_warnings(sequence_coherence: Mapping[str, Any]) -> List[str]:
+    """Derive safe freshness warnings from the existing sequence-coherence data.
+
+    Only bounded labels are emitted, drawn solely from the ordering ``state`` and
+    the already-safe mismatch ``flags`` in ``local_artifacts.freshness``. The
+    always-present ``metadata_only_no_claim`` marker is dropped, and no raw
+    artifact content is read.
+    """
+
+    warnings: List[str] = []
+
+    def _add(label: str) -> None:
+        if label not in warnings:
+            warnings.append(label)
+
+    older_labels = {
+        "evidence_packet_vs_capture": "evidence_packet_older_than_capture",
+        "anchor_preflight_vs_capture": "anchor_preflight_older_than_capture",
+        "lift_preflight_vs_capture": "lift_preflight_older_than_capture",
+    }
+    for key, older_label in older_labels.items():
+        entry = sequence_coherence.get(key) or {}
+        if entry.get("state") == "older_than_capture":
+            _add(older_label)
+        for flag in entry.get("flags", []):
+            if flag in _DRY_RUN_MISMATCH_FLAGS:
+                _add(flag)
+    return warnings
+
+
+def _dry_run_preview_blockers(
+    *,
+    capture_state: Any,
+    packet_state: Any,
+    anchor_state: Any,
+    lift_state: Any,
+    freshness_warnings: List[str],
+) -> List[str]:
+    """Return safe labels naming what is missing before a future dry-run lane.
+
+    ``provider_live_execution_blocked`` and ``display_only_lane`` are always
+    present: provider/live execution is always blocked from this console and this
+    is a display-only lane, regardless of how complete the local metadata is.
+    """
+
+    blockers: List[str] = []
+    if capture_state == "missing":
+        blockers.append("missing_capture")
+    elif capture_state in {"invalid_json", "invalid_structure"}:
+        blockers.append("invalid_capture")
+    if packet_state == "missing":
+        blockers.append("missing_evidence_packet")
+    elif packet_state in {
+        "invalid_json",
+        "invalid_structure",
+        "digest_invalid",
+        "digest_unverifiable",
+    }:
+        blockers.append("invalid_or_unverified_evidence_packet")
+    if anchor_state == "missing" or lift_state == "missing":
+        blockers.append("missing_preflight_reports")
+    if any(w.endswith("_older_than_capture") for w in freshness_warnings):
+        blockers.append("stale_derived_artifacts")
+    blockers.append("provider_live_execution_blocked")
+    blockers.append("display_only_lane")
+    return blockers
+
+
+def _dry_run_preview_readiness(
+    *,
+    capture_state: Any,
+    packet_state: Any,
+    anchor_state: Any,
+    lift_state: Any,
+    freshness_warnings: List[str],
+) -> str:
+    """Return a bounded local-metadata-completeness label.
+
+    This means only whether the preview has enough local metadata to explain the
+    next step. It is never answer quality, route readiness, provider readiness,
+    production readiness, validation, benchmark evidence, or superiority.
+    """
+
+    if capture_state in {"invalid_json", "invalid_structure"}:
+        return "unavailable"
+    capture_ok = capture_state in {"structurally_valid", "export_ready"}
+    packet_ok = packet_state == "digest_valid"
+    preflight_ok = anchor_state == "present" and lift_state == "present"
+    stale = any(w.endswith("_older_than_capture") for w in freshness_warnings)
+    mismatch = any(w in _DRY_RUN_MISMATCH_FLAGS for w in freshness_warnings)
+    if capture_ok and packet_ok and preflight_ok and not stale and not mismatch:
+        return "preview_ready"
+    return "needs_artifacts"
+
+
+def _build_dry_run_preview(
+    local_artifacts: Mapping[str, Any], provider_gate: Mapping[str, Any]
+) -> Dict[str, Any]:
+    """Assemble the display-only dry-run preview payload.
+
+    Pure function over the already-safe ``local_artifacts`` and ``provider_gate``
+    sub-payloads. Executes nothing and synthesizes no runtime field.
+    """
+
+    capture_state = (local_artifacts.get("capture") or {}).get("state")
+    packet_state = (local_artifacts.get("evidence_packet") or {}).get("state")
+    anchor_state = (local_artifacts.get("anchor_preflight") or {}).get("state")
+    lift_state = (local_artifacts.get("lift_preflight") or {}).get("state")
+    sequence_coherence = (local_artifacts.get("freshness") or {}).get(
+        "sequence_coherence", {}
+    )
+
+    freshness_warnings = _dry_run_freshness_warnings(sequence_coherence)
+    preview_blockers = _dry_run_preview_blockers(
+        capture_state=capture_state,
+        packet_state=packet_state,
+        anchor_state=anchor_state,
+        lift_state=lift_state,
+        freshness_warnings=freshness_warnings,
+    )
+    preview_readiness = _dry_run_preview_readiness(
+        capture_state=capture_state,
+        packet_state=packet_state,
+        anchor_state=anchor_state,
+        lift_state=lift_state,
+        freshness_warnings=freshness_warnings,
+    )
+
+    return {
+        "preview_mode": "display_only",
+        "dry_run_execution": "not_enabled",
+        "would_use": list(DRY_RUN_WOULD_USE),
+        "input_source_status": _dry_run_input_source_status(capture_state),
+        "evidence_packet_status": packet_state or "missing",
+        "preflight_status": _dry_run_preflight_status(anchor_state, lift_state),
+        "freshness_warnings": freshness_warnings,
+        "provider_gate_summary": {
+            "live_execution_gate": provider_gate.get("live_execution_gate"),
+            "provider_key_status": provider_gate.get("provider_key_status"),
+            "cap_completeness": provider_gate.get("cap_completeness"),
+            "live_execution_blockers": list(
+                provider_gate.get("live_execution_blockers", [])
+            ),
+        },
+        "preview_readiness": preview_readiness,
+        "preview_blockers": preview_blockers,
+        "boundary": DRY_RUN_BOUNDARY_NOTE,
+        "boundary_notes": list(DRY_RUN_BOUNDARY_TEXTS),
+    }
+
+
 def build_console_status() -> Dict[str, Any]:
     """Assemble the read-only operator console status payload.
 
@@ -371,6 +630,8 @@ def build_console_status() -> Dict[str, Any]:
 
     provider = os.getenv(_PROVIDER_ENV, "local").strip().lower() or "local"
     local_artifacts = artifacts.build_artifact_status()
+    provider_gate = _build_provider_gate(provider)
+    dry_run_preview = _build_dry_run_preview(local_artifacts, provider_gate)
 
     return {
         "console": {
@@ -420,7 +681,8 @@ def build_console_status() -> Dict[str, Any]:
             "diagnostics": "not run yet",
             "note": "No solve has run from this console; fields are placeholders.",
         },
-        "provider_gate": _build_provider_gate(provider),
+        "provider_gate": provider_gate,
+        "dry_run_preview": dry_run_preview,
         "preflight_capture": {
             "workflows": [
                 {
@@ -497,6 +759,7 @@ def _render_page(status: Mapping[str, Any]) -> str:
     run_setup = status["run_setup"]
     trace = status["route_trace"]
     gate = status["provider_gate"]
+    dry_run = status["dry_run_preview"]
     capture = status["preflight_capture"]
     receipt = status["evidence_receipt"]
 
@@ -673,6 +936,26 @@ def _render_page(status: Mapping[str, Any]) -> str:
         f"<li>{_escape(text)}</li>" for text in freshness["boundaries"]
     )
 
+    # Dry-Run Preview card (display-only). Every value comes from the already-safe
+    # dry_run_preview payload; nothing here executes, mutates, or synthesizes
+    # runtime output.
+    dr_would_use_html = "".join(
+        f"<li>{_escape(item)}</li>" for item in dry_run["would_use"]
+    )
+    dr_warnings = dry_run["freshness_warnings"]
+    dr_warnings_html = (
+        "".join(f"<li>{_escape(w)}</li>" for w in dr_warnings)
+        if dr_warnings
+        else "<li>none</li>"
+    )
+    dr_blockers_html = "".join(
+        f"<li>{_escape(b)}</li>" for b in dry_run["preview_blockers"]
+    )
+    dr_boundary_html = "".join(
+        f"<li>{_escape(text)}</li>" for text in dry_run["boundary_notes"]
+    )
+    dr_gate = dry_run["provider_gate_summary"]
+
     return f"""<!doctype html>
 <html lang="en">
   <head>
@@ -750,6 +1033,35 @@ def _render_page(status: Mapping[str, Any]) -> str:
           <ul class="modes">{run_mode_rows}</ul>
           <button type="button" class="disabled-btn" disabled aria-disabled="true">Live run (disabled)</button>
           <p class="note">{_escape(run_setup["note"])}</p>
+        </article>
+
+        <article class="card" id="card-dry-run-preview">
+          <h2>Dry-Run Preview</h2>
+          <p class="note">Display-only preview of what a future dry-run would prepare and require. Nothing on this panel starts a dry-run.</p>
+          {_kv_rows({
+              "preview mode": dry_run["preview_mode"],
+              "dry-run execution": dry_run["dry_run_execution"],
+              "preview readiness": dry_run["preview_readiness"],
+              "input source": dry_run["input_source_status"],
+              "evidence packet": dry_run["evidence_packet_status"],
+              "anchor preflight": dry_run["preflight_status"]["anchor"],
+              "lift preflight": dry_run["preflight_status"]["lift"],
+          })}
+          <p class="note">Would use (existing local metadata only):</p>
+          <ul class="surfaces">{dr_would_use_html}</ul>
+          <p class="note">Freshness warnings (local metadata only):</p>
+          <ul class="surfaces">{dr_warnings_html}</ul>
+
+          <h3 class="subhead">Provider gate summary (live execution stays blocked)</h3>
+          {_kv_rows({
+              "live execution gate": dr_gate["live_execution_gate"],
+              "provider key (configured provider)": dr_gate["provider_key_status"],
+              "cap completeness": dr_gate["cap_completeness"],
+          })}
+          <p class="note">Preview blockers (what is missing before a future dry-run lane):</p>
+          <ul class="surfaces">{dr_blockers_html}</ul>
+          <p class="note">{_escape(dry_run["boundary"])}.</p>
+          <ul class="surfaces">{dr_boundary_html}</ul>
         </article>
 
         <article class="card" id="card-route-trace">

--- a/docs/OPERATOR_CONSOLE.md
+++ b/docs/OPERATOR_CONSOLE.md
@@ -46,20 +46,23 @@ return 404. When mounted, an unauthenticated `GET` redirects to `/login`.
 3. **Run Setup** — a disabled prompt input and the visible run modes (dry-run,
    local-only, ChatGPT copy/paste, and live-provider shown disabled). The
    live-run button is disabled; this MVP does not enable live API execution.
-4. **Route and Trace** — placeholder fields for route, confidence, SAFE-OUT
+4. **Dry-Run Preview** — a display-only read of what a future dry-run would
+   prepare or require, derived only from the local artifact status and provider
+   gate below. It runs no dry-run and enables none (see below).
+5. **Route and Trace** — placeholder fields for route, confidence, SAFE-OUT
    state, expert/team, shortlist, and diagnostics. They read "not run yet"; the
    console does not invent route output or imply a solve ran.
-5. **Provider and Cost Gate** — the configured provider and mode label, that the
+6. **Provider and Cost Gate** — the configured provider and mode label, that the
    console does not call providers, emergency-stop and live-preview surface
    state, API key **presence** only (`present` / `missing`), and a display-only
    Live Execution Gate that reports whether live execution is blocked, the
    blockers, and cap completeness (see below). No raw or partial key values are
    shown.
-6. **Preflight and Capture Entry** — the local workflows (anchor-preflight,
+7. **Preflight and Capture Entry** — the local workflows (anchor-preflight,
    lift-preflight, init capture, validate capture, export evidence packet) with
    command snippets and a docs pointer. These run from a terminal, not from the
    console.
-7. **Evidence and Receipt** — placeholders for a future receipt id, export
+8. **Evidence and Receipt** — placeholders for a future receipt id, export
    digest, and validation status, plus local artifact status and a read-only
    artifact freshness / sequence-coherence subsection (see below).
 
@@ -273,6 +276,118 @@ estimation.
 Environment presence is not credential validity: a key reported `present` may
 still be invalid, and the console does not check. A cap reported `present` is a
 configured limit only, not proof of billing behavior.
+
+## Dry-Run Preview panel
+
+Lane: `UI-ALPHA-OPERATOR-CONSOLE-DRY-RUN-PREVIEW-001`
+
+The Run Setup card lists `dry-run` as an available mode, but it does not explain
+what dry-run readiness means or what a dry-run would need. The **Dry-Run Preview**
+card answers that one cockpit question: what would a future dry-run prepare, and
+what is missing before a separate dry-run execution lane could be considered? It is
+**display-only**. It runs no dry-run and enables none: `preview_mode` is always
+`display_only` and `dry_run_execution` is always `not_enabled`. Every value is
+derived from the local artifact status and provider gate described above; nothing
+here executes, submits, mutates, or generates output.
+
+### What the panel reports
+
+- `preview_mode` / `dry_run_execution` — always `display_only` and `not_enabled`.
+- `would_use` — safe names of the existing local metadata a dry-run would read
+  (`local_capture_summary`, `local_artifact_status`, `artifact_freshness_metadata`,
+  `provider_cost_gate_status`). These are surface names only, not contents.
+- `input_source_status` — the local capture's readiness as an input source:
+  `capture_missing`, `capture_invalid`, `capture_structurally_valid`, or
+  `capture_export_ready`, mapped from the existing capture summary.
+- `evidence_packet_status` — the existing evidence-packet state (`missing`,
+  `invalid_json`, `invalid_structure`, `digest_valid`, `digest_invalid`,
+  `digest_unverifiable`).
+- `preflight_status` — whether the anchor and lift preflight reports are
+  `*_present`, `*_missing`, or `*_invalid`, as local metadata only.
+- `freshness_warnings` — safe labels drawn only from the existing
+  `local_artifacts.freshness.sequence_coherence` (for example
+  `evidence_packet_older_than_capture`, `anchor_preflight_older_than_capture`,
+  `lift_preflight_older_than_capture`, `packet_id_mismatch`, `counts_mismatch`,
+  `digest_invalid`, `digest_unverifiable`).
+- `provider_gate_summary` — the existing gate's `live_execution_gate` (always
+  `blocked`), `provider_key_status`, `cap_completeness`, and
+  `live_execution_blockers`.
+- `preview_readiness` — `unavailable`, `needs_artifacts`, or `preview_ready`.
+- `preview_blockers` — safe labels naming what is missing before a future dry-run
+  lane (for example `missing_capture`, `invalid_capture`,
+  `missing_evidence_packet`, `invalid_or_unverified_evidence_packet`,
+  `stale_derived_artifacts`, `missing_preflight_reports`,
+  `provider_live_execution_blocked`, `display_only_lane`).
+
+### What preview readiness means
+
+Preview readiness is local metadata completeness only: whether the panel has enough
+local metadata to explain the operator's next step. `preview_ready` requires that
+local capture is structurally valid or export-ready, the evidence packet's own
+digest is valid, both preflight reports are present, and no stale-or-mismatched
+freshness warnings apply. If capture is missing or a prerequisite is absent the
+panel reports `needs_artifacts` and still renders; if capture cannot be read it
+reports `unavailable` and still renders.
+
+A preview-ready state does not claim answer quality, route readiness, provider
+readiness, production readiness, validation, benchmark evidence, billing accuracy,
+or superiority, and it does not authorize execution. It is not a readiness claim
+about the product.
+
+### Input source status
+
+`input_source_status` reflects only the local capture file already summarized by
+the artifact status card. `capture_structurally_valid` and `capture_export_ready`
+expose local counts that the artifact summary already surfaces; they never expose
+raw prompts or raw outputs. `capture_missing` and `capture_invalid` mean the local
+capture is absent or cannot be read; the panel says so and does not invent input.
+
+### Evidence packet digest status is self-integrity only
+
+`digest_valid` means the evidence packet's recorded digest matches its own body. It
+is packet self-integrity only. It is not freshness, not answer quality, and not a
+readiness or validation claim, and it does not prove the packet reflects the latest
+capture file. `digest_invalid` and `digest_unverifiable` are surfaced as safe
+warnings and blockers, never as failure claims about answer quality.
+
+### Freshness warnings are local metadata only
+
+Freshness warnings come only from local filesystem modified-time metadata and the
+existing sequence-coherence flags. They are hints, not guarantees: copied or
+restored files can carry misleading modified times. A stale warning is not a
+failure claim and does not validate or invalidate any answer; it just flags that a
+derived file's timestamp appears older than capture on disk.
+
+### Provider gate summary blocks live execution
+
+The provider gate summary reuses the existing display-only gate. `live_execution_gate`
+is always `blocked` and `provider_live_execution_blocked` is always a preview
+blocker. Provider/live execution stays blocked regardless of preview readiness: a
+`preview_ready` panel does not authorize live execution, and complete provider or
+cap configuration does not authorize it either. The summary validates no credential
+and contacts no provider.
+
+### Dry-Run Preview boundaries
+
+The following boundary statements appear in the panel:
+
+- Dry-run preview is display-only.
+- This console does not execute a solve from this panel.
+- This console does not call /v1/solve.
+- This console does not call providers, models, MCP, browser automation, network,
+  CLI, or subprocesses.
+- This console does not create, edit, delete, upload, save, or mutate artifacts.
+- This console does not generate route, confidence, SAFE-OUT, expert trace,
+  shortlist, diagnostics, answer text, model output, provider result, billing
+  result, benchmark result, or readiness result.
+- Preview readiness is local metadata completeness only.
+- A preview-ready state is not answer-quality, validation, production, provider
+  readiness, benchmark evidence, billing accuracy, or superiority evidence.
+- A future dry-run execution lane must be separately authorized.
+
+A preview-ready panel is not a readiness, validation, benchmark, production, or
+superiority claim. This lane does not enable dry-run execution; that remains a
+separate future lane that must be separately authorized.
 
 ## Secret handling
 

--- a/tests/test_operator_console.py
+++ b/tests/test_operator_console.py
@@ -1628,3 +1628,511 @@ def test_provider_gating_does_not_call_provider_clients(
     _login(client)
     assert client.get(PAGE_ROUTE).status_code == 200
     assert client.get(STATUS_ROUTE).status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Dry-Run Preview panel
+# (AOC-B005-DRY-RUN-PREVIEW-001 /
+# UI-ALPHA-OPERATOR-CONSOLE-DRY-RUN-PREVIEW-001). The panel is a display-only
+# read of what a *future* dry-run would prepare or require, derived only from the
+# existing local artifact status and provider-gate status. It executes nothing:
+# no solve, no provider call, no /v1/solve, no CLI/subprocess, no artifact
+# mutation, and no synthesized runtime output.
+# ---------------------------------------------------------------------------
+# Additional recognizable raw content that must never surface in HTML or JSON.
+RAW_SYS_PROMPT = "RAW-SYSTEM-PROMPT-must-not-render-zzz"
+RAW_PROVIDER_PAYLOAD = "RAW-PROVIDER-PAYLOAD-must-not-render-zzz"
+
+
+def _dry_run(client: TestClient) -> dict:
+    return client.get(STATUS_ROUTE).json()["dry_run_preview"]
+
+
+def _dry_run_card_html(html_text: str) -> str:
+    start = html_text.index('id="card-dry-run-preview"')
+    end = html_text.index("</article>", start)
+    return html_text[start:end]
+
+
+def _scaffold_capture() -> dict:
+    """A structurally valid (but not export-ready) capture with a raw prompt."""
+
+    packet = {
+        "packet_id": "ORC-TEST-001",
+        "cases": [{"task_id": "t1", "prompt": RAW_PROMPT}],
+    }
+    return capture_lib.scaffold_capture(packet)
+
+
+def _capture_with_sensitive_metadata() -> dict:
+    """An export-ready capture whose route_metadata carries extra raw sentinels."""
+
+    capture = _valid_capture()
+    capture["cases"][0]["route_metadata"] = {
+        "route": RAW_ROUTE_META,
+        "system_prompt": RAW_SYS_PROMPT,
+        "provider_payload": RAW_PROVIDER_PAYLOAD,
+    }
+    return capture
+
+
+# 1. Status JSON includes the new dry-run preview section.
+def test_dry_run_preview_section_in_status(client: TestClient) -> None:
+    _login(client)
+    payload = client.get(STATUS_ROUTE).json()
+    assert "dry_run_preview" in payload
+    dr = payload["dry_run_preview"]
+    for field in (
+        "preview_mode",
+        "dry_run_execution",
+        "would_use",
+        "input_source_status",
+        "evidence_packet_status",
+        "preflight_status",
+        "freshness_warnings",
+        "provider_gate_summary",
+        "preview_readiness",
+        "preview_blockers",
+        "boundary",
+        "boundary_notes",
+    ):
+        assert field in dr, field
+    assert dr["would_use"] == list(operator_console.DRY_RUN_WOULD_USE)
+    assert set(dr["preflight_status"].keys()) == {"anchor", "lift"}
+
+
+# 2. Dry-run preview mode is display-only.
+def test_dry_run_preview_mode_display_only(client: TestClient) -> None:
+    _login(client)
+    assert _dry_run(client)["preview_mode"] == "display_only"
+
+
+# 3. Dry-run execution is not enabled.
+def test_dry_run_execution_not_enabled(client: TestClient) -> None:
+    _login(client)
+    assert _dry_run(client)["dry_run_execution"] == "not_enabled"
+
+
+# 4. Live-run button remains disabled with the dry-run preview panel present.
+def test_dry_run_live_run_button_remains_disabled(client: TestClient) -> None:
+    _login(client)
+    html_text = client.get(PAGE_ROUTE).text
+    assert "Live run (disabled)" in html_text
+    assert 'class="disabled-btn" disabled' in html_text
+    assert (
+        client.get(STATUS_ROUTE).json()["run_setup"]["live_run_button_enabled"]
+        is False
+    )
+
+
+# 5. No POST/action route (or any non-GET route) is added for dry-run preview.
+def test_dry_run_no_post_or_extra_console_routes() -> None:
+    console_routes = [
+        route
+        for route in app.routes
+        if getattr(route, "path", "").startswith("/dashboard/operator-console")
+    ]
+    for route in console_routes:
+        methods = getattr(route, "methods", set()) or set()
+        assert "POST" not in methods
+        assert "PUT" not in methods
+        assert "DELETE" not in methods
+        assert "PATCH" not in methods
+    assert {getattr(route, "path", None) for route in console_routes} == {
+        PAGE_ROUTE,
+        STATUS_ROUTE,
+    }
+
+
+# 6. Missing capture produces safe preview blockers and still renders.
+def test_dry_run_missing_capture_blockers_and_renders(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _use_root(monkeypatch, tmp_path)
+    _login(client)
+    dr = _dry_run(client)
+    assert dr["input_source_status"] == "capture_missing"
+    assert "missing_capture" in dr["preview_blockers"]
+    assert "missing_evidence_packet" in dr["preview_blockers"]
+    assert "missing_preflight_reports" in dr["preview_blockers"]
+    assert dr["preview_readiness"] == "needs_artifacts"
+    assert client.get(PAGE_ROUTE).status_code == 200
+
+
+# 7. Invalid capture produces safe preview blockers and still renders.
+def test_dry_run_invalid_capture_blockers_and_renders(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    (tmp_path / "capture.json").write_text("{ not valid json", encoding="utf-8")
+    _use_root(monkeypatch, tmp_path)
+    _login(client)
+    dr = _dry_run(client)
+    assert dr["input_source_status"] == "capture_invalid"
+    assert "invalid_capture" in dr["preview_blockers"]
+    assert dr["preview_readiness"] == "unavailable"
+    assert client.get(PAGE_ROUTE).status_code == 200
+
+
+# 8. Structurally valid capture -> local input status, no raw prompt/output.
+def test_dry_run_structurally_valid_capture_no_raw(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _write(tmp_path, "capture.json", _scaffold_capture())
+    _use_root(monkeypatch, tmp_path)
+    _login(client)
+    dr = _dry_run(client)
+    assert dr["input_source_status"] == "capture_structurally_valid"
+
+    html_text = client.get(PAGE_ROUTE).text
+    body = client.get(STATUS_ROUTE).text
+    for raw in (RAW_PROMPT, RAW_BASELINE, RAW_ROUTED, RAW_ROUTE_META):
+        assert raw not in html_text
+        assert raw not in body
+
+
+# 9. Export-ready capture -> local input status, no raw prompt/output.
+def test_dry_run_export_ready_capture_no_raw(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _write(tmp_path, "capture.json", _valid_capture())
+    _use_root(monkeypatch, tmp_path)
+    _login(client)
+    dr = _dry_run(client)
+    assert dr["input_source_status"] == "capture_export_ready"
+
+    html_text = client.get(PAGE_ROUTE).text
+    body = client.get(STATUS_ROUTE).text
+    for raw in (RAW_PROMPT, RAW_BASELINE, RAW_ROUTED, RAW_ROUTE_META):
+        assert raw not in html_text
+        assert raw not in body
+
+
+# 10. Missing evidence packet produces a safe preview blocker.
+def test_dry_run_missing_evidence_packet_blocker(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _write(tmp_path, "capture.json", _valid_capture())
+    _use_root(monkeypatch, tmp_path)
+    _login(client)
+    dr = _dry_run(client)
+    assert dr["evidence_packet_status"] == "missing"
+    assert "missing_evidence_packet" in dr["preview_blockers"]
+
+
+# 11. Digest-valid evidence packet is self-integrity only, not readiness/quality.
+def test_dry_run_digest_valid_is_self_integrity_only(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    capture = _valid_capture()
+    _write(tmp_path, "capture.json", capture)
+    _write(
+        tmp_path, "evidence_packet.json", capture_lib.build_evidence_packet(capture)
+    )
+    # No preflight reports written, so the packet's valid digest alone must not
+    # promote the preview to preview_ready.
+    _use_root(monkeypatch, tmp_path)
+    _login(client)
+    dr = _dry_run(client)
+    assert dr["evidence_packet_status"] == "digest_valid"
+    assert dr["preview_readiness"] == "needs_artifacts"
+    assert "missing_preflight_reports" in dr["preview_blockers"]
+    # The boundary that a preview-ready state is not evidence appears in the UI.
+    assert operator_console.DRY_RUN_NOT_EVIDENCE_TEXT in client.get(PAGE_ROUTE).text
+
+
+# 12. Digest-invalid and digest-unverifiable states produce safe warnings/blockers.
+def test_dry_run_digest_invalid_and_unverifiable_states(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    capture = _valid_capture()
+
+    # digest_invalid: tamper the packet body after the digest was computed.
+    invalid = capture_lib.build_evidence_packet(capture)
+    invalid["packet_id"] = "tampered-after-digest"
+    _write(tmp_path, "capture.json", capture)
+    _write(tmp_path, "evidence_packet.json", invalid)
+    _use_root(monkeypatch, tmp_path)
+    _login(client)
+    dr = _dry_run(client)
+    assert dr["evidence_packet_status"] == "digest_invalid"
+    assert "invalid_or_unverified_evidence_packet" in dr["preview_blockers"]
+    assert "digest_invalid" in dr["freshness_warnings"]
+
+    # digest_unverifiable: remove the recorded digest entirely.
+    unverifiable = capture_lib.build_evidence_packet(capture)
+    del unverifiable["content_digest"]
+    _write(tmp_path, "evidence_packet.json", unverifiable)
+    dr = _dry_run(client)
+    assert dr["evidence_packet_status"] == "digest_unverifiable"
+    assert "invalid_or_unverified_evidence_packet" in dr["preview_blockers"]
+    assert "digest_unverifiable" in dr["freshness_warnings"]
+
+
+# 13. Missing anchor/lift preflight reports produce a safe preview blocker.
+def test_dry_run_missing_preflight_reports_blocker(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _write(tmp_path, "capture.json", _valid_capture())
+    _use_root(monkeypatch, tmp_path)
+    _login(client)
+    dr = _dry_run(client)
+    assert dr["preflight_status"] == {"anchor": "anchor_missing", "lift": "lift_missing"}
+    assert "missing_preflight_reports" in dr["preview_blockers"]
+
+
+# 14. Present anchor/lift reports are shown as local metadata only; a complete,
+#     fresh, digest-valid set reaches preview_ready (metadata completeness only).
+def test_dry_run_present_preflight_reports_metadata_only(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _write_all_four(tmp_path)
+    _use_root(monkeypatch, tmp_path)
+    _login(client)
+    dr = _dry_run(client)
+    assert dr["preflight_status"] == {"anchor": "anchor_present", "lift": "lift_present"}
+    assert dr["preview_readiness"] == "preview_ready"
+    assert "missing_preflight_reports" not in dr["preview_blockers"]
+    # Even preview_ready never authorizes execution or leaks raw content.
+    assert dr["dry_run_execution"] == "not_enabled"
+    body = client.get(STATUS_ROUTE).text
+    html_text = client.get(PAGE_ROUTE).text
+    for raw in (RAW_PROMPT, RAW_BASELINE, RAW_ROUTED, RAW_ROUTE_META):
+        assert raw not in body
+        assert raw not in html_text
+
+
+# 15. Stale evidence packet vs capture produces a safe freshness warning.
+def test_dry_run_stale_evidence_packet_warning(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    capture = _valid_capture()
+    _write(tmp_path, "capture.json", capture)
+    _write(
+        tmp_path, "evidence_packet.json", capture_lib.build_evidence_packet(capture)
+    )
+    _set_age(tmp_path / "capture.json", 10)
+    _set_age(tmp_path / "evidence_packet.json", 3600)
+    _use_root(monkeypatch, tmp_path)
+    _login(client)
+    dr = _dry_run(client)
+    assert "evidence_packet_older_than_capture" in dr["freshness_warnings"]
+    assert "stale_derived_artifacts" in dr["preview_blockers"]
+
+
+# 16. Stale anchor preflight vs capture produces a safe freshness warning.
+def test_dry_run_stale_anchor_preflight_warning(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _write(tmp_path, "capture.json", _valid_capture())
+    _write(tmp_path, "anchor_preflight_report.json", _anchor_report())
+    _set_age(tmp_path / "capture.json", 10)
+    _set_age(tmp_path / "anchor_preflight_report.json", 3600)
+    _use_root(monkeypatch, tmp_path)
+    _login(client)
+    dr = _dry_run(client)
+    assert "anchor_preflight_older_than_capture" in dr["freshness_warnings"]
+    assert "stale_derived_artifacts" in dr["preview_blockers"]
+
+
+# 17. Stale lift preflight vs capture produces a safe freshness warning.
+def test_dry_run_stale_lift_preflight_warning(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _write(tmp_path, "capture.json", _valid_capture())
+    _write(tmp_path, "lift_preflight_report.json", _lift_report())
+    _set_age(tmp_path / "capture.json", 10)
+    _set_age(tmp_path / "lift_preflight_report.json", 3600)
+    _use_root(monkeypatch, tmp_path)
+    _login(client)
+    dr = _dry_run(client)
+    assert "lift_preflight_older_than_capture" in dr["freshness_warnings"]
+    assert "stale_derived_artifacts" in dr["preview_blockers"]
+
+
+# 18. Provider gate summary is included but live execution remains blocked.
+def test_dry_run_provider_gate_summary_blocked(client: TestClient) -> None:
+    _login(client)
+    dr = _dry_run(client)
+    summary = dr["provider_gate_summary"]
+    for field in (
+        "live_execution_gate",
+        "provider_key_status",
+        "cap_completeness",
+        "live_execution_blockers",
+    ):
+        assert field in summary
+    assert summary["live_execution_gate"] == "blocked"
+    assert "provider_live_execution_blocked" in dr["preview_blockers"]
+    assert "display_only_lane" in dr["preview_blockers"]
+
+
+# 19. Complete provider/cap configuration does not enable dry-run execution.
+def test_dry_run_complete_config_does_not_enable_execution(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _clear_gate_env(monkeypatch)
+    monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    monkeypatch.setenv("OPENAI_API_KEY", FAKE_SECRET)
+    for env in (
+        "ALPHA_PROVIDER_MAX_COST_USD",
+        "ALPHA_PROVIDER_MAX_INPUT_TOKENS",
+        "ALPHA_PROVIDER_MAX_OUTPUT_TOKENS",
+        "ALPHA_PROVIDER_MAX_REQUESTS",
+    ):
+        monkeypatch.setenv(env, "5")
+    _login(client)
+    dr = _dry_run(client)
+    assert dr["dry_run_execution"] == "not_enabled"
+    summary = dr["provider_gate_summary"]
+    assert summary["cap_completeness"] == "configured"
+    assert summary["provider_key_status"] == "present"
+    assert summary["live_execution_gate"] == "blocked"
+    assert "provider_live_execution_blocked" in dr["preview_blockers"]
+    assert "display_only_lane" in dr["preview_blockers"]
+
+
+# 20. Fake API keys never appear in HTML, JSON, or reprs with the panel present.
+def test_dry_run_fake_secret_never_leaks(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", FAKE_SECRET)
+    _write_all_four(tmp_path)
+    _use_root(monkeypatch, tmp_path)
+    _login(client)
+    assert FAKE_SECRET not in client.get(PAGE_ROUTE).text
+    assert FAKE_SECRET not in client.get(STATUS_ROUTE).text
+    assert FAKE_SECRET not in repr(operator_console.build_console_status())
+
+
+# 21. Raw prompt/baseline/routed/route-metadata/system-prompt/provider-payload
+#     sentinels never appear in HTML or JSON.
+def test_dry_run_raw_sentinels_never_leak(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    capture = _capture_with_sensitive_metadata()
+    _write(tmp_path, "capture.json", capture)
+    _write(
+        tmp_path, "evidence_packet.json", capture_lib.build_evidence_packet(capture)
+    )
+    _write(tmp_path, "anchor_preflight_report.json", _anchor_report())
+    _write(tmp_path, "lift_preflight_report.json", _lift_report())
+    _use_root(monkeypatch, tmp_path)
+    _login(client)
+    html_text = client.get(PAGE_ROUTE).text
+    body = client.get(STATUS_ROUTE).text
+    for raw in (
+        RAW_PROMPT,
+        RAW_BASELINE,
+        RAW_ROUTED,
+        RAW_ROUTE_META,
+        RAW_SYS_PROMPT,
+        RAW_PROVIDER_PAYLOAD,
+    ):
+        assert raw not in html_text
+        assert raw not in body
+
+
+# 22. Provider client constructors patched to raise still allow both routes.
+def test_dry_run_provider_client_patched_raise_routes_ok(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import alpha.providers.openai as openai_provider
+
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("provider client must not be used by operator console")
+
+    monkeypatch.setattr(openai_provider.OpenAIProviderClient, "__init__", _boom)
+    monkeypatch.setattr(openai_provider.OpenAIProviderClient, "execute", _boom)
+    _write_all_four(tmp_path)
+    _use_root(monkeypatch, tmp_path)
+    _login(client)
+    assert client.get(PAGE_ROUTE).status_code == 200
+    assert client.get(STATUS_ROUTE).status_code == 200
+
+
+# 23. Source-scan: no provider client / httpx / requests / subprocess / socket /
+#     browser / MCP / CLI / solve imports are introduced in the route module.
+def test_dry_run_console_route_has_no_execution_or_solve_imports() -> None:
+    source = Path(operator_console.__file__).read_text(encoding="utf-8")
+    import_lines = [
+        line
+        for line in source.splitlines()
+        if line.strip().startswith(("import ", "from "))
+    ]
+    joined = "\n".join(import_lines).lower()
+    for token in (
+        "solve",
+        "provider",
+        "mcp",
+        "httpx",
+        "requests",
+        "subprocess",
+        "socket",
+        "urllib",
+        "playwright",
+        "selenium",
+        "webdriver",
+        "webbrowser",
+        "pexpect",
+        "openai",
+        "anthropic",
+    ):
+        assert token not in joined, token
+
+
+# 24. UI text contains the dry-run preview boundary text.
+def test_dry_run_boundary_text_in_ui(client: TestClient) -> None:
+    _login(client)
+    html_text = client.get(PAGE_ROUTE).text
+    for text in operator_console.DRY_RUN_BOUNDARY_TEXTS:
+        assert text in html_text
+    assert operator_console.DRY_RUN_BOUNDARY_NOTE in html_text
+
+
+# 25. UI does not contain misleading dry-run execution/claim language.
+def test_dry_run_no_misleading_execution_language(client: TestClient) -> None:
+    _login(client)
+    card = _dry_run_card_html(client.get(PAGE_ROUTE).text).lower()
+    for forbidden in (
+        "run now",
+        "execute now",
+        "submit to provider",
+        "generate answer",
+        "solve now",
+        "start solve",
+        "production ready",
+        "ready for production",
+        "estimated spend",
+        "estimated cost",
+        "winner",
+        "leaderboard",
+        "outperforms",
+        "model comparison",
+    ):
+        assert forbidden not in card, forbidden
+
+
+# 26/27. Existing provider gate, artifact status, and freshness surfaces persist
+#        alongside the dry-run preview panel.
+def test_dry_run_preview_coexists_with_existing_sections(client: TestClient) -> None:
+    _login(client)
+    payload = client.get(STATUS_ROUTE).json()
+    for section in (
+        "console",
+        "portable_contract",
+        "run_setup",
+        "route_trace",
+        "provider_gate",
+        "dry_run_preview",
+        "preflight_capture",
+        "evidence_receipt",
+        "local_artifacts",
+    ):
+        assert section in payload
+    assert payload["provider_gate"]["live_execution_gate"] == "blocked"
+    local = payload["local_artifacts"]
+    assert "freshness" in local
+    assert "status_generated_at_utc" in local
+    html_text = client.get(PAGE_ROUTE).text
+    for card_id in ("card-provider-gate", "card-dry-run-preview", "card-evidence-receipt"):
+        assert card_id in html_text


### PR DESCRIPTION
## Checklist

- [x] Spec linked: `.specs/UI-ALPHA-OPERATOR-CONSOLE-DRY-RUN-PREVIEW-001.md`
- [x] Spec sections present/updated (Goal / Motivation / Scope / Non-goals and boundaries / Code Targets / Test Plan / Definition of Done + explicit preview-only, no-execution/no-solve/no-provider/no-artifact-mutation/no-runtime-output, and no-readiness/no-validation/no-benchmark/no-superiority boundaries)
- [x] Tests run: `python -m pytest -q` (1655 passed, 3 pre-existing unrelated skips)

## Notes for reviewers

**Lane:** `AOC-B005-DRY-RUN-PREVIEW-001`
**Spec id:** `UI-ALPHA-OPERATOR-CONSOLE-DRY-RUN-PREVIEW-001`
**Verified baseline main SHA:** `c02ac6d84c47d6ad95ba60b95395a3c8049cc416` (PR #666 merged, PR #667 merged, no open conflicting PRs)
**PR head SHA:** `c0885c1dbad06855ed0a4cf47f08a28b37253a28`

### Summary

Adds a **display-only** Dry-Run Preview panel to the protected local-first Operator Console. The console already lists `dry-run` as an available run mode but never explained what dry-run readiness means or what a dry-run would need. The new panel answers one cockpit question — *what would a future dry-run prepare, and what is missing before a separate dry-run execution lane could be considered?* — derived **only** from the local artifact status and provider-gate status this console already assembles. It is a preview lane, not an execution lane: it runs no dry-run and enables none.

### Files changed

- `alpha/webapp/routes/operator_console.py` — new `dry_run_preview` status section + compact "Dry-Run Preview" card; pure helpers over the existing `local_artifacts` / `provider_gate` sub-payloads
- `tests/test_operator_console.py` — 27 new focused dry-run preview tests (file totals 114)
- `docs/OPERATOR_CONSOLE.md` — Dry-Run Preview panel section + card-list entry
- `.specs/UI-ALPHA-OPERATOR-CONSOLE-DRY-RUN-PREVIEW-001.md` — new spec
- `.specs/INDEX.md` — one new row

### User-visible behavior

- Status JSON gains a top-level `dry_run_preview` section: `preview_mode` (`display_only`), `dry_run_execution` (`not_enabled`), `would_use` (safe surface names), `input_source_status` (`capture_missing` / `capture_invalid` / `capture_structurally_valid` / `capture_export_ready`), `evidence_packet_status` (the existing packet state), `preflight_status` (`anchor_*` / `lift_*` present/missing/invalid), `freshness_warnings` (safe labels from the existing `sequence_coherence` metadata), `provider_gate_summary` (`live_execution_gate` always `blocked`, `provider_key_status`, `cap_completeness`, `live_execution_blockers`), `preview_readiness` (`unavailable` / `needs_artifacts` / `preview_ready`), `preview_blockers` (safe labels), and boundary text.
- A compact "Dry-Run Preview" card renders the same, keeps the disabled live-run button, and adds no action button and no new endpoint.
- `preview_readiness` is local-metadata completeness only. `preview_ready` requires structurally-valid/export-ready capture, a digest-valid evidence packet, both preflight reports present, and no stale/mismatched freshness warnings — and even then it never enables execution.

### Boundary confirmations

- No provider / hosted-model / local-model / MCP / network / browser / CLI / subprocess call
- No `/v1/solve` call and no internal solve-function call
- No dry-run execution and no prompt submission
- No route / confidence / SAFE-OUT / expert-trace / shortlist / diagnostics / answer / model-output / provider-result / billing-result / benchmark-result / readiness-result generation
- No credential validation and no provider ping
- No API pricing lookup and no exact billing or spend claim (gate summary reuses the existing presence-only gate)
- No artifact creation, edit, deletion, upload, save, or mutation; no receipt store
- No raw or partial API key display; no environment dump
- No raw prompt / baseline output / routed output / route metadata / system prompt / provider payload / full-JSON display
- No capture / export / preflight schema changes; `operator_run_capture.py` CLI semantics unchanged; `alpha_solver_portable.py` untouched
- No scoring / ranking / winner fields / model-comparison UI
- No readiness / validation / benchmark / production / superiority claim
- No POST action, no new endpoint, no page redesign, no new dependency

### Tests and validation commands run (all passed)

- `python -m pytest tests/test_operator_console.py -q` → 114 passed
- `python -m pytest tests/test_operator_console.py tests/test_operator_run_capture.py tests/test_api_endpoints.py -q` → 226 passed
- `python -m pytest -q` → 1655 passed, 3 skipped (pre-existing unrelated: live OpenAI smoke, web-adapter decks smoke, packaging build)
- `ruff check alpha/webapp/routes/operator_console.py tests/test_operator_console.py` → All checks passed
- `python scripts/check_narrative_claim_safety.py docs/OPERATOR_CONSOLE.md .specs/UI-ALPHA-OPERATOR-CONSOLE-DRY-RUN-PREVIEW-001.md` → passed

### Remaining risks

- Preview readiness is local metadata completeness only — not answer quality, provider readiness, production readiness, validation, benchmark, billing accuracy, or superiority evidence.
- Evidence-packet `digest_valid` is packet self-integrity only, not proof the packet reflects the latest capture file.
- Freshness warnings are local filesystem modified-time metadata only; copied/restored files can carry misleading mtimes.
- The provider gate summary does not authorize live execution; `live_execution_gate` stays `blocked`.
- A future dry-run execution lane must be a separate, separately-authorized lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UM3qqEcKXJ8s2ks8k6gmdK

---
_Generated by [Claude Code](https://claude.ai/code/session_01UM3qqEcKXJ8s2ks8k6gmdK)_