### PR TITLE
Add Local Receipt Store to Operator Console (AOC-B006)

### DIFF
--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -99,6 +99,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `UI-ALPHA-OPERATOR-CONSOLE-ARTIFACT-FRESHNESS-001.md` | UI-ALPHA-OPERATOR-CONSOLE-ARTIFACT-FRESHNESS-001 · Operator Console Artifact Freshness and Sequence Coherence | ✅ `SPEC_OK` |
 | `UI-ALPHA-OPERATOR-CONSOLE-PROVIDER-COST-GATE-PANEL-001.md` | UI-ALPHA-OPERATOR-CONSOLE-PROVIDER-COST-GATE-PANEL-001 · Operator Console Provider, Model, and Cost Gate Panel | ✅ `SPEC_OK` |
 | `UI-ALPHA-OPERATOR-CONSOLE-DRY-RUN-PREVIEW-001.md` | UI-ALPHA-OPERATOR-CONSOLE-DRY-RUN-PREVIEW-001 · Operator Console Dry-Run Preview | ✅ `SPEC_OK` |
+| `UI-ALPHA-OPERATOR-CONSOLE-LOCAL-RECEIPT-STORE-001.md` | UI-ALPHA-OPERATOR-CONSOLE-LOCAL-RECEIPT-STORE-001 · Operator Console Local Receipt Store | ✅ `SPEC_OK` |
 | `UI-JOBS-001.md` | UI-JOBS-001 · Dashboard Job History & Metrics (RES_Dash) | ✅ `SPEC_OK` |
 | `UI-PREVIEW-001.md` | UI-PREVIEW-001 · Authenticated Expert Preview UI | ✅ `SPEC_OK` |
 | `UI-PREVIEW-LOADING-STATE-001.md` | UI-PREVIEW-LOADING-STATE-001 · Expert Preview Loading State | ✅ `SPEC_OK` |

--- a/.specs/UI-ALPHA-OPERATOR-CONSOLE-LOCAL-RECEIPT-STORE-001.md
+++ b/.specs/UI-ALPHA-OPERATOR-CONSOLE-LOCAL-RECEIPT-STORE-001.md
@@ -1,0 +1,177 @@
+# UI-ALPHA-OPERATOR-CONSOLE-LOCAL-RECEIPT-STORE-001 · Operator Console Local Receipt Store
+
+## Goal
+
+Add a narrow, protected, local-first receipt store to the Alpha Solver Operator
+Console so an authenticated operator can save a safe local snapshot of the
+current console status and see recent receipt metadata on the console page.
+
+## Motivation
+
+The console can show local status, provider/cost gate state, artifact freshness,
+sequence coherence, and dry-run preview state. Operators need a durable local
+record of what the cockpit showed at a review checkpoint without storing raw
+prompts, outputs, secrets, provider payloads, executable state, or raw artifact
+bodies.
+
+## Scope
+
+- Add one protected POST path under `/dashboard/operator-console` that creates
+  one local receipt snapshot.
+- Add a Local Receipt Store card/subsection to the existing console UI.
+- Add a `local_receipts` status section containing safe recent receipt metadata.
+- Store receipts as JSON under `local/operator_console/receipts/`, or under
+  `<resolved safe artifact root>/receipts/` when the existing inside-repository
+  `ALPHA_OPERATOR_CONSOLE_ARTIFACT_ROOT` override is used.
+- Whitelist the receipt snapshot fields from the already safe console status.
+- List recent receipts as metadata summaries only.
+
+## Non-goals and boundaries
+
+This lane is not a solve lane, provider lane, dry-run execution lane, raw
+artifact archive, general file-writing API, receipt editor, validation lane, or
+readiness lane.
+
+Local-write-only receipt boundary:
+
+- The only new write is creation of one safe local receipt JSON file.
+- No request data may influence the directory, filename, receipt id, or receipt
+  body.
+- Receipts are never edited or deleted in this lane.
+- Receipt files are never uploaded, downloaded, or rendered through a raw viewer.
+
+No-execution/no-solve/no-provider/no-artifact-mutation/no-runtime-output
+boundary:
+
+- Saving a receipt does not run a solve.
+- Saving a receipt does not call `/v1/solve`.
+- Saving a receipt does not call providers, hosted models, local models, MCP,
+  browser automation, network, CLI, or subprocesses.
+- Saving a receipt does not call internal solve functions and does not submit a
+  prompt.
+- Saving a receipt does not generate route, confidence, SAFE-OUT, expert trace,
+  shortlist, diagnostics, answer text, model output, provider result, billing
+  result, benchmark result, or readiness result.
+- Saving a receipt does not create, edit, delete, upload, save, or mutate
+  capture, evidence-packet, anchor-preflight, lift-preflight, or other existing
+  operator artifacts.
+
+No-raw/no-secret/no-readiness/no-validation/no-benchmark/no-superiority
+boundary:
+
+- Receipts do not store raw prompts, raw baseline outputs, raw routed outputs,
+  raw route metadata, system prompts, provider payloads, raw secrets, partial
+  keys, raw environment values, or full artifact JSON.
+- Receipts store safe summaries only.
+- A receipt is not answer-quality proof, validation, production readiness,
+  provider readiness, benchmark evidence, billing accuracy, or superiority
+  evidence.
+- A receipt does not authorize live execution or dry-run execution.
+
+## Code targets
+
+- `alpha/webapp/operator_console_receipts.py` contains receipt-root resolution,
+  schema constants, snapshot whitelisting, safe id generation, digest creation,
+  atomic local write, and recent receipt metadata listing.
+- `alpha/webapp/routes/operator_console.py` wires the protected POST route,
+  status section, and compact UI card.
+- `tests/test_operator_console.py` covers receipt status, route protection,
+  path/body ignore behavior, safe override policy, digest verification,
+  non-leakage, invalid receipt fail-safe handling, newest-first listing, and
+  no-artifact-mutation/no-execution boundaries.
+- `docs/OPERATOR_CONSOLE.md` documents operator-facing behavior and boundaries.
+
+## Receipt schema
+
+Receipt files use schema version `operator_console_receipt_v1` and receipt type
+`status_snapshot`.
+
+Top-level fields:
+
+- `schema_version`
+- `receipt_id`
+- `created_at_utc`
+- `source` (`operator_console`)
+- `receipt_type` (`status_snapshot`)
+- `content_digest`
+- `snapshot`
+
+`content_digest` is a `sha256:<hex>` digest over the safe receipt body with the
+`content_digest` field excluded. It is self-integrity only.
+
+The `snapshot` is a whitelisted subset of current console status:
+
+- `console`: mode, live-provider-call status, claim boundary, boundary notes.
+- `portable_contract`: presence, source path, contract mode, high-level
+  surfaces.
+- `run_setup`: run modes, disabled live-run button flag, note.
+- `route_trace`: placeholder states only.
+- `provider_gate`: configured provider, provider mode label, disabled live
+  provider calls, console-calls-providers flag, emergency stop, live preview
+  surface, categorical key status, required provider key names, provider key
+  status, cap completeness, categorical cap status, cost cap status,
+  token/request cap status, live execution gate, blockers, and gate boundary.
+- `dry_run_preview`: display-only preview mode, dry-run execution status,
+  would-use labels, input/evidence/preflight/freshness statuses, provider-gate
+  summary, preview readiness/blockers, and boundary notes.
+- `local_artifacts`: artifact-root label only; detected flag; status timestamp;
+  capture/evidence/preflight states, schema versions, ids, counts, digests, and
+  freshness/sequence-coherence metadata; boundary texts.
+- `evidence_receipt`: existing placeholder fields and note only.
+
+## Receipt path policy
+
+- Fixed default root: `local/operator_console/receipts/` below the repository
+  root.
+- If `ALPHA_OPERATOR_CONSOLE_ARTIFACT_ROOT` resolves inside the repository root,
+  receipts are written under that safe root's `receipts/` child directory.
+- Outside-root or traversal overrides are rejected by the existing artifact-root
+  policy and cannot redirect receipt writes outside the repository.
+- Receipt ids are generated internally as bounded ids with no path separators.
+- Filenames are derived internally as `<receipt_id>.json`.
+- Collision handling does not overwrite an existing receipt silently.
+- Writes use a temporary file in the receipt directory followed by an atomic
+  rename/replace to the final path.
+- Symlink receipt roots are rejected.
+
+## Test plan
+
+- Verify status JSON includes `local_receipts` with safe labels and zero-count
+  behavior.
+- Verify unauthenticated POST and missing-CSRF POST follow dashboard protection.
+- Verify authenticated POST creates exactly one receipt under the fixed/safe
+  receipt directory.
+- Verify query/body attempts to supply path, filename, receipt id, or receipt
+  body are ignored.
+- Verify outside-root override cannot write outside the repository and inside
+  override writes only below the safe root.
+- Verify receipt id, filename, schema version, and digest shape/verification.
+- Verify receipt snapshots include provider/dry-run/local-artifact summaries but
+  no raw prompts, outputs, raw route metadata, provider payloads, raw secrets,
+  partial keys, or raw env values.
+- Verify recent receipt metadata appears in status/page without exposing full
+  receipt bodies.
+- Verify invalid/corrupt receipt files fail safe.
+- Verify multiple receipts list newest-first with a safe limit.
+- Verify receipt creation does not mutate capture/evidence/preflight artifacts.
+- Verify provider-client constructors patched to raise do not affect page,
+  status, or receipt POST.
+- Verify no provider/network/subprocess/browser/MCP/solve imports are added to
+  the route or helper.
+- Run focused, related, full, lint, and narrative-claim-safety validation.
+
+## Definition of Done
+
+- The protected console exposes a Local Receipt Store card with receipt-root
+  label, recent count, recent metadata summaries, boundary text, and exactly one
+  `Save local receipt snapshot` action.
+- Status JSON exposes `local_receipts` metadata and never exposes full receipt
+  bodies.
+- POST `/dashboard/operator-console/receipts` creates one safe receipt JSON from
+  internally assembled status only.
+- Receipts stay confined to `local/operator_console/receipts/` or the safe
+  override root's `receipts/` child.
+- Existing no-provider, no-runner, no-secret, no-raw, no-readiness, and
+  no-validation boundaries remain intact.
+- Focused and required validation commands pass or any missing evidence is
+  reported exactly.

--- a/alpha/webapp/operator_console_receipts.py
+++ b/alpha/webapp/operator_console_receipts.py
@@ -1,0 +1,339 @@
+"""Local receipt snapshots for the Alpha Solver Operator Console.
+
+This helper is intentionally narrow and local-only. It creates one safe JSON
+receipt under the existing operator-console artifact root and summarizes recent
+receipt metadata. It never accepts request-supplied paths, filenames, ids, or
+receipt bodies, and it never reads or writes capture/evidence/preflight files.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import secrets
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Mapping
+
+from alpha.webapp import operator_console_artifacts as artifacts
+
+__all__ = [
+    "RECEIPT_SCHEMA_VERSION",
+    "RECEIPT_TYPE",
+    "SOURCE",
+    "CREATE_RECEIPT_ENDPOINT",
+    "RECEIPT_BOUNDARY_TEXTS",
+    "build_receipt_store_status",
+    "create_receipt_snapshot",
+    "digest_receipt_body",
+    "receipt_root",
+]
+
+RECEIPT_SCHEMA_VERSION = "operator_console_receipt_v1"
+RECEIPT_TYPE = "status_snapshot"
+SOURCE = "operator_console"
+CREATE_RECEIPT_ENDPOINT = "/dashboard/operator-console/receipts"
+RECENT_LIMIT = 5
+_RECEIPT_ID_RE = re.compile(r"^ocr_[0-9]{8}T[0-9]{6}Z_[0-9a-f]{16}$")
+_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+RECEIPT_BOUNDARY_TEXTS = (
+    "Local receipts are local audit snapshots only.",
+    "Saving a receipt does not run a solve.",
+    "Saving a receipt does not call /v1/solve.",
+    "Saving a receipt does not call providers, models, MCP, browser automation, network, CLI, or subprocesses.",
+    "Saving a receipt does not create, edit, delete, upload, save, or mutate capture/evidence/preflight artifacts.",
+    "Saving a receipt writes only a safe local receipt JSON under the fixed receipt directory.",
+    "Receipts store safe summaries only.",
+    "Receipts do not store raw prompts, raw outputs, raw route metadata, system prompts, provider payloads, raw secrets, partial keys, or raw environment values.",
+    "A receipt is not answer-quality proof, validation, production readiness, provider readiness, benchmark evidence, billing accuracy, or superiority evidence.",
+    "A receipt does not authorize live execution or dry-run execution.",
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _is_within(child: Path, parent: Path) -> bool:
+    try:
+        child.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def receipt_root() -> Path:
+    """Return the fixed receipts directory below the safe artifact root."""
+
+    return artifacts.resolve_artifact_root() / "receipts"
+
+
+def _path_label(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(_REPO_ROOT.resolve()).as_posix()
+    except (OSError, RuntimeError, ValueError):
+        return "local/operator_console/receipts"
+
+
+def _receipt_id(now: datetime) -> str:
+    stamp = now.strftime("%Y%m%dT%H%M%SZ")
+    return f"ocr_{stamp}_{secrets.token_hex(8)}"
+
+
+def _json_bytes(payload: Mapping[str, Any]) -> bytes:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def digest_receipt_body(receipt_body_without_digest: Mapping[str, Any]) -> str:
+    """Return the receipt self-integrity digest over the safe body only."""
+
+    return "sha256:" + hashlib.sha256(_json_bytes(receipt_body_without_digest)).hexdigest()
+
+
+def _copy_map(src: Mapping[str, Any], keys: tuple[str, ...]) -> Dict[str, Any]:
+    return {key: src.get(key) for key in keys if key in src}
+
+
+def safe_snapshot(status: Mapping[str, Any]) -> Dict[str, Any]:
+    """Whitelist the safe console status subset for receipt storage."""
+
+    local = status.get("local_artifacts") or {}
+    freshness = local.get("freshness") or {}
+    provider_gate = status.get("provider_gate") or {}
+    dry_run = status.get("dry_run_preview") or {}
+
+    return {
+        "console": _copy_map(
+            status.get("console") or {},
+            ("mode", "live_provider_calls", "claim_boundary", "boundary_notes"),
+        ),
+        "portable_contract": _copy_map(
+            status.get("portable_contract") or {},
+            ("present", "source_path", "contract_mode", "surfaces"),
+        ),
+        "run_setup": _copy_map(
+            status.get("run_setup") or {},
+            ("run_modes", "live_run_button_enabled", "note"),
+        ),
+        "route_trace": _copy_map(
+            status.get("route_trace") or {},
+            ("route", "confidence", "safe_out_state", "expert_team", "shortlist", "diagnostics", "note"),
+        ),
+        "provider_gate": _copy_map(
+            provider_gate,
+            (
+                "configured_provider",
+                "provider_mode_label",
+                "live_provider_calls",
+                "console_calls_providers",
+                "emergency_stop",
+                "live_preview_surface",
+                "key_status",
+                "required_provider_keys",
+                "provider_key_status",
+                "cap_completeness",
+                "cap_status",
+                "cost_cap_status",
+                "token_request_cap_status",
+                "live_execution_gate",
+                "live_execution_blockers",
+                "gate_boundary",
+            ),
+        ),
+        "dry_run_preview": _copy_map(
+            dry_run,
+            (
+                "preview_mode",
+                "dry_run_execution",
+                "would_use",
+                "input_source_status",
+                "evidence_packet_status",
+                "preflight_status",
+                "freshness_warnings",
+                "provider_gate_summary",
+                "preview_readiness",
+                "preview_blockers",
+                "boundary",
+                "boundary_notes",
+            ),
+        ),
+        "local_artifacts": {
+            "artifact_root": local.get("artifact_root"),
+            "detected": local.get("detected"),
+            "status_generated_at_utc": local.get("status_generated_at_utc"),
+            "capture": _copy_map(
+                local.get("capture") or {},
+                ("state", "schema_version", "packet_id", "counts", "route_metadata_present_count"),
+            ),
+            "evidence_packet": _copy_map(
+                local.get("evidence_packet") or {},
+                ("state", "schema_version", "packet_id", "content_digest", "counts"),
+            ),
+            "anchor_preflight": _copy_map(
+                local.get("anchor_preflight") or {},
+                ("state", "schema_version", "packet_id", "counts", "needs_attention_count"),
+            ),
+            "lift_preflight": _copy_map(
+                local.get("lift_preflight") or {},
+                ("state", "schema_version", "packet_id", "counts", "needs_attention_count"),
+            ),
+            "freshness": {
+                "files": freshness.get("files", {}),
+                "sequence_coherence": freshness.get("sequence_coherence", {}),
+                "boundaries": freshness.get("boundaries", []),
+            },
+            "boundaries": local.get("boundaries", []),
+            "no_artifacts_message": local.get("no_artifacts_message"),
+        },
+        "evidence_receipt": _copy_map(
+            status.get("evidence_receipt") or {},
+            ("receipt_id", "export_digest", "validation_status", "note"),
+        ),
+    }
+
+
+def _build_receipt(status: Mapping[str, Any], now: datetime, receipt_id: str) -> Dict[str, Any]:
+    body = {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "receipt_id": receipt_id,
+        "created_at_utc": now.isoformat().replace("+00:00", "Z"),
+        "source": SOURCE,
+        "receipt_type": RECEIPT_TYPE,
+        "snapshot": safe_snapshot(status),
+    }
+    return {**body, "content_digest": digest_receipt_body(body)}
+
+
+def _safe_receipt_path(root: Path, receipt_id: str) -> Path:
+    if not _RECEIPT_ID_RE.fullmatch(receipt_id):
+        raise ValueError("unsafe receipt id")
+    path = (root / f"{receipt_id}.json").resolve()
+    if not _is_within(path, root.resolve()):
+        raise ValueError("receipt path escaped root")
+    return path
+
+
+def create_receipt_snapshot(status: Mapping[str, Any]) -> Dict[str, Any]:
+    """Create exactly one receipt JSON and return safe metadata."""
+
+    root = receipt_root().resolve()
+    repo_root = _REPO_ROOT.resolve()
+    if not _is_within(root, repo_root):
+        raise ValueError("receipt root must stay inside repository root")
+    if root.exists() and root.is_symlink():
+        raise ValueError("receipt root may not be a symlink")
+    root.mkdir(parents=True, exist_ok=True)
+
+    for _attempt in range(8):
+        now = datetime.now(timezone.utc)
+        rid = _receipt_id(now)
+        final_path = _safe_receipt_path(root, rid)
+        if final_path.exists():
+            continue
+        tmp_path = _safe_receipt_path(root, f"{rid}").with_suffix(".tmp")
+        receipt = _build_receipt(status, now, rid)
+        data = json.dumps(receipt, indent=2, sort_keys=True) + "\n"
+        try:
+            with tmp_path.open("x", encoding="utf-8") as handle:
+                handle.write(data)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.link(tmp_path, final_path)
+        finally:
+            if tmp_path.exists():
+                tmp_path.unlink(missing_ok=True)
+        return _metadata_from_receipt(receipt, final_path, state="created")
+    raise FileExistsError("could not allocate unique receipt id")
+
+
+def _metadata_from_receipt(receipt: Mapping[str, Any], path: Path, *, state: str) -> Dict[str, Any]:
+    snapshot = receipt.get("snapshot") if isinstance(receipt.get("snapshot"), dict) else {}
+    dry_run = snapshot.get("dry_run_preview", {}) if isinstance(snapshot, dict) else {}
+    provider_gate = snapshot.get("provider_gate", {}) if isinstance(snapshot, dict) else {}
+    local = snapshot.get("local_artifacts", {}) if isinstance(snapshot, dict) else {}
+    capture = local.get("capture", {}) if isinstance(local, dict) else {}
+    packet = local.get("evidence_packet", {}) if isinstance(local, dict) else {}
+    return {
+        "receipt_id": receipt.get("receipt_id"),
+        "created_at_utc": receipt.get("created_at_utc"),
+        "schema_version": receipt.get("schema_version"),
+        "receipt_type": receipt.get("receipt_type"),
+        "content_digest": receipt.get("content_digest"),
+        "path_label": _path_label(path),
+        "state": state,
+        "snapshot_summary": {
+            "preview_readiness": dry_run.get("preview_readiness"),
+            "live_execution_gate": provider_gate.get("live_execution_gate"),
+            "capture_state": capture.get("state"),
+            "evidence_packet_state": packet.get("state"),
+        },
+    }
+
+
+def _load_receipt_metadata(path: Path) -> Dict[str, Any]:
+    try:
+        if path.is_symlink() or not path.is_file():
+            raise ValueError("not a regular receipt file")
+        receipt = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(receipt, dict):
+            raise ValueError("receipt is not an object")
+        body = {k: v for k, v in receipt.items() if k != "content_digest"}
+        digest = receipt.get("content_digest")
+        if not isinstance(digest, str) or not _DIGEST_RE.fullmatch(digest):
+            raise ValueError("invalid digest shape")
+        if digest_receipt_body(body) != digest:
+            raise ValueError("digest mismatch")
+        if receipt.get("schema_version") != RECEIPT_SCHEMA_VERSION:
+            raise ValueError("unsupported schema")
+        if not isinstance(receipt.get("receipt_id"), str) or not _RECEIPT_ID_RE.fullmatch(receipt["receipt_id"]):
+            raise ValueError("invalid receipt id")
+        return _metadata_from_receipt(receipt, path, state="present")
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError, TypeError):
+        return {
+            "receipt_id": path.stem[:80],
+            "created_at_utc": None,
+            "schema_version": None,
+            "receipt_type": None,
+            "content_digest": None,
+            "path_label": _path_label(path),
+            "state": "invalid",
+            "snapshot_summary": {},
+        }
+
+
+def _sort_key(item: Mapping[str, Any]) -> tuple[str, str]:
+    return (str(item.get("created_at_utc") or ""), str(item.get("receipt_id") or ""))
+
+
+def list_recent_receipts(limit: int = RECENT_LIMIT) -> List[Dict[str, Any]]:
+    root = receipt_root().resolve()
+    if not _is_within(root, _REPO_ROOT.resolve()) or not root.exists() or root.is_symlink():
+        return []
+    entries = [_load_receipt_metadata(path) for path in root.glob("*.json")]
+    entries.sort(key=_sort_key, reverse=True)
+    return entries[: max(0, limit)]
+
+
+def build_receipt_store_status() -> Dict[str, Any]:
+    root = receipt_root()
+    recent = list_recent_receipts()
+    states: List[str] = []
+    if not root.exists():
+        states.append("missing_dir")
+    elif not recent:
+        states.append("empty")
+    else:
+        states.append("present")
+    if any(item.get("state") == "invalid" for item in recent):
+        states.append("invalid_entries")
+    return {
+        "receipt_root": _path_label(root),
+        "enabled": True,
+        "create_receipt_endpoint": CREATE_RECEIPT_ENDPOINT,
+        "recent": recent,
+        "count": len(recent),
+        "states": states,
+        "boundary": "local receipt snapshots only; safe metadata only; not proof",
+        "boundary_notes": list(RECEIPT_BOUNDARY_TEXTS),
+    }

--- a/alpha/webapp/routes/operator_console.py
+++ b/alpha/webapp/routes/operator_console.py
@@ -28,14 +28,16 @@ from pathlib import Path
 from typing import Any, Dict, List, Mapping, Tuple
 
 from fastapi import APIRouter
-from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 
 from alpha.webapp import operator_console_artifacts as artifacts
+from alpha.webapp import operator_console_receipts as receipts
 
 router = APIRouter()
 
 ROUTE = "/dashboard/operator-console"
 STATUS_ROUTE = "/dashboard/operator-console/status"
+RECEIPTS_ROUTE = receipts.CREATE_RECEIPT_ENDPOINT
 
 # ---------------------------------------------------------------------------
 # Boundary text. These strings are asserted by tests and must appear verbatim
@@ -734,6 +736,7 @@ def build_console_status() -> Dict[str, Any]:
             ),
         },
         "local_artifacts": local_artifacts,
+        "local_receipts": receipts.build_receipt_store_status(),
     }
 
 
@@ -753,6 +756,10 @@ def _list_items(items: List[Any]) -> str:
     return "".join(f"<li>{_escape(item)}</li>" for item in items)
 
 
+def receipts_auth_header() -> str:
+    return "x-alpha-csrf"
+
+
 def _render_page(status: Mapping[str, Any]) -> str:
     console = status["console"]
     contract = status["portable_contract"]
@@ -762,6 +769,7 @@ def _render_page(status: Mapping[str, Any]) -> str:
     dry_run = status["dry_run_preview"]
     capture = status["preflight_capture"]
     receipt = status["evidence_receipt"]
+    receipt_store = status["local_receipts"]
 
     run_mode_rows = "".join(
         '<li class="mode">'
@@ -956,6 +964,25 @@ def _render_page(status: Mapping[str, Any]) -> str:
     )
     dr_gate = dry_run["provider_gate_summary"]
 
+    receipt_items = receipt_store["recent"]
+    receipt_rows = (
+        "".join(
+            "<li>"
+            f"<strong>{_escape(item.get('receipt_id') or 'invalid')}</strong>"
+            f" · {_escape(item.get('created_at_utc') or 'unknown time')}"
+            f" · {_escape(item.get('state'))}"
+            f" · {_escape(item.get('content_digest') or '—')}"
+            f" · {_escape((item.get('snapshot_summary') or {}).get('preview_readiness') or '—')}"
+            "</li>"
+            for item in receipt_items
+        )
+        if receipt_items
+        else "<li>No local receipts saved yet.</li>"
+    )
+    receipt_boundary_html = "".join(
+        f"<li>{_escape(text)}</li>" for text in receipt_store["boundary_notes"]
+    )
+
     return f"""<!doctype html>
 <html lang="en">
   <head>
@@ -995,6 +1022,7 @@ def _render_page(status: Mapping[str, Any]) -> str:
       .disabled-btn {{ margin-top: 0.75rem; border: 0; border-radius: 999px; padding: 0.6rem 1.15rem; font: inherit; font-weight: 700; color: #475569; background: rgba(100, 116, 139, 0.16); cursor: not-allowed; }}
       a.status-link, a.refresh-link {{ display: inline-block; margin-top: 0.75rem; color: #4f46e5; font-weight: 700; }}
       a.refresh-link {{ margin-right: 0.85rem; }}
+      .receipt-btn {{ margin-top: 0.75rem; border: 0; border-radius: 999px; padding: 0.6rem 1.15rem; font: inherit; font-weight: 800; color: #ffffff; background: #4f46e5; cursor: pointer; }}
     </style>
   </head>
   <body>
@@ -1119,6 +1147,24 @@ def _render_page(status: Mapping[str, Any]) -> str:
           {preflight_artifact_html}
         </article>
 
+
+
+        <article class="card" id="card-local-receipt-store">
+          <h2>Local Receipt Store</h2>
+          {_kv_rows({
+              "receipt root": receipt_store["receipt_root"],
+              "recent receipt count": receipt_store["count"],
+              "store state": ", ".join(receipt_store["states"]),
+              "boundary": receipt_store["boundary"],
+          })}
+          <form method="post" action="{RECEIPTS_ROUTE}" data-csrf-header="{_escape(receipts_auth_header())}" onsubmit="event.preventDefault(); fetch(this.action, {{method: 'POST', headers: {{'{_escape(receipts_auth_header())}': document.cookie.split('; ').find(r => r.startsWith('alpha_dashboard_csrf='))?.split('=')[1] || ''}}}}).then(() => window.location.href='{ROUTE}');">
+            <button type="submit" class="receipt-btn">Save local receipt snapshot</button>
+          </form>
+          <p class="note">Recent receipts (safe metadata only):</p>
+          <ul class="surfaces">{receipt_rows}</ul>
+          <ul class="surfaces">{receipt_boundary_html}</ul>
+        </article>
+
         <article class="card" id="card-evidence-receipt">
           <h2>Evidence and Receipt</h2>
           {_kv_rows({
@@ -1154,6 +1200,15 @@ async def operator_console_page() -> HTMLResponse:
     """Render the read-only operator console shell."""
 
     return HTMLResponse(content=_render_page(build_console_status()))
+
+
+@router.post(RECEIPTS_ROUTE)
+async def operator_console_create_receipt() -> RedirectResponse:
+    """Create one safe local receipt snapshot and return to the console."""
+
+    status = build_console_status()
+    receipts.create_receipt_snapshot(status)
+    return RedirectResponse(ROUTE, status_code=303)
 
 
 @router.get(STATUS_ROUTE)

--- a/docs/OPERATOR_CONSOLE.md
+++ b/docs/OPERATOR_CONSOLE.md
@@ -62,7 +62,10 @@ return 404. When mounted, an unauthenticated `GET` redirects to `/login`.
    lift-preflight, init capture, validate capture, export evidence packet) with
    command snippets and a docs pointer. These run from a terminal, not from the
    console.
-8. **Evidence and Receipt** — placeholders for a future receipt id, export
+8. **Local Receipt Store** — a narrow local audit-snapshot store with a
+   receipt-root label, recent receipt count, recent receipt metadata, boundary
+   text, and one `Save local receipt snapshot` action.
+9. **Evidence and Receipt** — placeholders for a future receipt id, export
    digest, and validation status, plus local artifact status and a read-only
    artifact freshness / sequence-coherence subsection (see below).
 
@@ -179,7 +182,9 @@ metadata, not a quality claim).
 
 A "Refresh" affordance on the page is a plain link that reloads the current
 read-only `GET` page. It never POSTs, runs a workflow, calls a provider or
-model, calls a CLI, mutates an artifact, or creates a receipt.
+model, calls a CLI, or mutates an artifact. Receipt creation is available only
+through the separate protected Local Receipt Store action described below, and
+that action writes only a safe receipt JSON.
 
 ### Freshness boundaries
 
@@ -192,6 +197,122 @@ model, calls a CLI, mutates an artifact, or creates a receipt.
   reflects the latest capture file.
 - Copied or restored files can carry misleading modified times, so freshness and
   ordering are hints for the operator, not guarantees about run order.
+
+## Local Receipt Store
+
+Lane: `UI-ALPHA-OPERATOR-CONSOLE-LOCAL-RECEIPT-STORE-001`
+
+The Local Receipt Store card lets an authenticated operator save a safe local
+audit snapshot of the current console status and then see recent receipt
+metadata. A local receipt is a JSON status snapshot for later comparison or
+audit. It is local-only and summary-only; it is not an answer, proof, validation
+result, readiness result, benchmark result, billing result, or superiority
+claim.
+
+### Routes and protection
+
+- Page: `GET /dashboard/operator-console`
+- Read-only status JSON: `GET /dashboard/operator-console/status`
+- Receipt creation: `POST /dashboard/operator-console/receipts`
+
+The receipt creation route is under the same protected `/dashboard` surface as
+the console. Unauthenticated POST requests fail under dashboard protection, and
+authenticated POST requests must satisfy the dashboard CSRF guard. The route
+takes no user-supplied path, filename, receipt id, or receipt body. Query-string
+and request-body attempts to provide any of those values are ignored.
+
+### Receipt root and path policy
+
+Receipts are stored only under the existing safe local artifact root:
+
+- Default: `local/operator_console/receipts/` under the repository root.
+- Safe override: if `ALPHA_OPERATOR_CONSOLE_ARTIFACT_ROOT` resolves inside the
+  repository root, receipts are written under that resolved root's `receipts/`
+  child.
+- Outside-root, traversal, or invalid overrides are rejected by the same safe
+  root policy used for local artifacts, so they cannot redirect receipt writes
+  outside the repository.
+
+Receipt ids are generated internally as bounded safe identifiers with no path
+separators. Filenames are derived internally from the receipt id and end in
+`.json`. Receipt creation writes a temporary file inside the receipt directory
+and then atomically renames it to the final receipt path. It does not overwrite
+an existing receipt silently and does not use a request-supplied path.
+
+### Receipt schema and safe fields
+
+Receipt files use schema version `operator_console_receipt_v1` and receipt type
+`status_snapshot`. Top-level fields are:
+
+- `schema_version`
+- `receipt_id`
+- `created_at_utc`
+- `source` (`operator_console`)
+- `receipt_type` (`status_snapshot`)
+- `content_digest`
+- `snapshot`
+
+`content_digest` is a `sha256:<hex>` digest over the safe receipt body excluding
+the digest field itself. It is self-integrity only. It is not proof that the
+receipt is correct, current, answer-quality evidence, validation evidence, or a
+readiness signal.
+
+The `snapshot` stores only whitelisted safe status summaries:
+
+- Console mode, disabled live-provider-call status, claim boundary, and boundary
+  notes.
+- Portable-contract presence, source path, contract mode, and high-level surface
+  labels.
+- Run modes, disabled live-run button flag, and run-setup note.
+- Route/trace placeholder states only.
+- Provider/cost gate summary: configured provider, provider mode label, disabled
+  live provider calls, console-calls-providers flag, emergency-stop state, live
+  preview surface state, categorical key status (`present` / `missing` only),
+  required provider key names, categorical provider-key status, cap
+  completeness, categorical cap statuses, cost cap status, token/request cap
+  status, live execution gate, blockers, and gate boundary.
+- Dry-run preview summary: display-only preview mode, dry-run execution status,
+  would-use labels, input/evidence/preflight/freshness states, provider-gate
+  summary, preview readiness/blockers, and boundary notes.
+- Local artifact status summaries: artifact-root label only; detected flag;
+  status timestamp; capture/evidence/preflight states, schema versions, packet
+  ids, counts, content digest, route-metadata presence count, freshness metadata,
+  sequence-coherence states/flags, and boundary texts.
+- Existing evidence/receipt placeholder fields and note.
+
+### What receipts do not store
+
+Receipts do **not** store raw prompts, raw baseline outputs, raw routed outputs,
+raw route metadata, system prompts, provider payloads, raw secrets, partial API
+keys, raw environment values, arbitrary request bodies, full artifact JSON, or
+future unsafe status fields. The recent receipt list in the page/status JSON
+shows metadata only: receipt id, creation time, schema version, receipt type,
+content digest, safe path label, state, and a compact snapshot summary. It does
+not return or render the full receipt body by default.
+
+### Receipt boundaries
+
+- Local receipts are local audit snapshots only.
+- Saving a receipt does not run a solve.
+- Saving a receipt does not call `/v1/solve`.
+- Saving a receipt does not call providers, models, MCP, browser automation,
+  network, CLI, or subprocesses.
+- Saving a receipt does not create, edit, delete, upload, save, or mutate
+  capture/evidence/preflight artifacts.
+- Saving a receipt writes only a safe local receipt JSON under the fixed receipt
+  directory.
+- Receipts store safe summaries only.
+- Receipts do not store raw prompts, raw outputs, raw route metadata, system
+  prompts, provider payloads, raw secrets, partial keys, or raw environment
+  values.
+- A receipt is not answer-quality proof, validation, production readiness,
+  provider readiness, benchmark evidence, billing accuracy, or superiority
+  evidence.
+- A receipt does not authorize live execution or dry-run execution.
+
+The Local Receipt Store does not add receipt delete, edit, upload, download, or
+raw-viewer support. Any future receipt management or export behavior requires a
+separate lane.
 
 ## Provider, model, and cost gate panel
 

--- a/tests/test_operator_console.py
+++ b/tests/test_operator_console.py
@@ -29,12 +29,14 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from alpha.webapp import operator_console_artifacts as artifacts  # noqa: E402
+from alpha.webapp import operator_console_receipts as receipts  # noqa: E402
 from alpha.webapp.routes import auth, operator_console  # noqa: E402
 from alpha.eval import operator_run_capture as capture_lib  # noqa: E402
 from service.app import app, _mount_dashboard  # noqa: E402
 
 PAGE_ROUTE = operator_console.ROUTE
 STATUS_ROUTE = operator_console.STATUS_ROUTE
+RECEIPTS_ROUTE = operator_console.RECEIPTS_ROUTE
 
 # A recognizable fake secret. It is placed in the environment and must never
 # appear in any console response (HTML or JSON).
@@ -73,6 +75,8 @@ def test_routes_registered_in_real_app() -> None:
     paths = {getattr(route, "path", None) for route in app.routes}
     assert PAGE_ROUTE in paths
     assert STATUS_ROUTE in paths
+    assert RECEIPTS_ROUTE in paths
+    assert RECEIPTS_ROUTE in paths
 
 
 def test_mount_dashboard_adds_protected_console_routes() -> None:
@@ -100,6 +104,7 @@ def test_unmounted_app_does_not_serve_console() -> None:
     try:
         assert bare_client.get(PAGE_ROUTE).status_code == 404
         assert bare_client.get(STATUS_ROUTE).status_code == 404
+        assert bare_client.post(RECEIPTS_ROUTE).status_code == 404
     finally:
         bare_client.close()
 
@@ -132,6 +137,7 @@ def test_authenticated_page_renders_all_cards(client: TestClient) -> None:
         "card-provider-gate",
         "card-preflight-capture",
         "card-evidence-receipt",
+        "card-local-receipt-store",
     ):
         assert card_id in html
 
@@ -209,6 +215,7 @@ def test_status_json_shape(client: TestClient) -> None:
         "provider_gate",
         "preflight_capture",
         "evidence_receipt",
+        "local_receipts",
     ):
         assert section in payload
 
@@ -1726,21 +1733,25 @@ def test_dry_run_live_run_button_remains_disabled(client: TestClient) -> None:
 
 
 # 5. No POST/action route (or any non-GET route) is added for dry-run preview.
-def test_dry_run_no_post_or_extra_console_routes() -> None:
+def test_dry_run_adds_no_execution_routes_beyond_receipt_post() -> None:
     console_routes = [
         route
         for route in app.routes
         if getattr(route, "path", "").startswith("/dashboard/operator-console")
     ]
+    post_routes = []
     for route in console_routes:
         methods = getattr(route, "methods", set()) or set()
-        assert "POST" not in methods
+        if "POST" in methods:
+            post_routes.append(getattr(route, "path", ""))
         assert "PUT" not in methods
         assert "DELETE" not in methods
         assert "PATCH" not in methods
+    assert post_routes == [RECEIPTS_ROUTE]
     assert {getattr(route, "path", None) for route in console_routes} == {
         PAGE_ROUTE,
         STATUS_ROUTE,
+        RECEIPTS_ROUTE,
     }
 
 
@@ -2136,3 +2147,338 @@ def test_dry_run_preview_coexists_with_existing_sections(client: TestClient) -> 
     html_text = client.get(PAGE_ROUTE).text
     for card_id in ("card-provider-gate", "card-dry-run-preview", "card-evidence-receipt"):
         assert card_id in html_text
+
+# ---------------------------------------------------------------------------
+# Local Receipt Store
+# (AOC-B006-LOCAL-RECEIPT-STORE-001 /
+# UI-ALPHA-OPERATOR-CONSOLE-LOCAL-RECEIPT-STORE-001). Receipts are safe local
+# audit snapshots only: one protected POST creates one JSON receipt under the
+# safe artifact root and stores only whitelisted status summaries.
+# ---------------------------------------------------------------------------
+RAW_SYSTEM_PROMPT = "RAW-SYSTEM-PROMPT-must-not-render-zzz"
+RAW_PROVIDER_PAYLOAD = "RAW-PROVIDER-PAYLOAD-must-not-render-zzz"
+RAW_ENV_SENTINEL = "RAW-ENV-SENTINEL-must-not-render-zzz"
+PARTIAL_KEY = FAKE_SECRET[:12]
+
+
+def _csrf_headers(client: TestClient) -> dict[str, str]:
+    token = client.cookies.get(auth.CSRF_COOKIE_NAME)
+    assert token
+    return {auth.CSRF_HEADER_NAME: token}
+
+
+def _repo_receipt_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    repo_root = Path(artifacts.__file__).resolve().parents[2]
+    rel = Path("local") / f"receipt-tests-{tmp_path.name}"
+    root = repo_root / rel
+    if root.exists():
+        for path in sorted(root.rglob("*"), reverse=True):
+            if path.is_file():
+                path.unlink()
+            elif path.is_dir():
+                path.rmdir()
+        root.rmdir()
+    root.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv(artifacts.ARTIFACT_ROOT_ENV, rel.as_posix())
+    return root / "receipts"
+
+
+def _receipt_files(root: Path) -> list[Path]:
+    return sorted(root.glob("*.json")) if root.exists() else []
+
+
+def _post_receipt(client: TestClient, **kwargs: object):
+    return client.post(
+        RECEIPTS_ROUTE,
+        headers=_csrf_headers(client),
+        follow_redirects=False,
+        **kwargs,
+    )
+
+
+def test_receipt_status_section_empty_and_safe_label(client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _repo_receipt_root(monkeypatch, tmp_path)
+    _login(client)
+    store = client.get(STATUS_ROUTE).json()["local_receipts"]
+    assert store["enabled"] is True
+    assert store["create_receipt_endpoint"] == RECEIPTS_ROUTE
+    assert store["count"] == 0
+    assert "missing_dir" in store["states"] or "empty" in store["states"]
+    assert store["receipt_root"].startswith("local/")
+    assert store["receipt_root"].endswith("/receipts")
+    assert not Path(store["receipt_root"]).is_absolute()
+
+
+def test_receipt_page_empty_renders_normally(client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _repo_receipt_root(monkeypatch, tmp_path)
+    _login(client)
+    html_text = client.get(PAGE_ROUTE).text
+    assert "Local Receipt Store" in html_text
+    assert "Save local receipt snapshot" in html_text
+    assert "No local receipts saved yet." in html_text
+
+
+def test_receipt_post_route_is_protected() -> None:
+    paths = {
+        (getattr(route, "path", None), tuple(sorted(getattr(route, "methods", set()) or set())))
+        for route in app.routes
+    }
+    assert (RECEIPTS_ROUTE, ("POST",)) in paths
+
+
+def test_unauthenticated_receipt_post_matches_protected_behavior(client: TestClient) -> None:
+    response = client.post(RECEIPTS_ROUTE, follow_redirects=False)
+    assert response.status_code == 401
+    assert response.json()["detail"] == "not authenticated"
+
+
+def test_authenticated_receipt_post_requires_csrf(client: TestClient) -> None:
+    _login(client)
+    response = client.post(RECEIPTS_ROUTE, follow_redirects=False)
+    assert response.status_code == 403
+    assert response.json()["detail"] == "missing CSRF token"
+
+
+def test_receipt_post_creates_one_file_with_schema_and_digest(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = _repo_receipt_root(monkeypatch, tmp_path)
+    _login(client)
+    response = _post_receipt(client)
+    assert response.status_code == 303
+    assert response.headers["location"] == PAGE_ROUTE
+    files = _receipt_files(root)
+    assert len(files) == 1
+    receipt = json.loads(files[0].read_text(encoding="utf-8"))
+    assert receipt["schema_version"] == receipts.RECEIPT_SCHEMA_VERSION
+    assert receipt["content_digest"].startswith("sha256:")
+    body = {key: value for key, value in receipt.items() if key != "content_digest"}
+    assert receipts.digest_receipt_body(body) == receipt["content_digest"]
+    assert receipt["receipt_id"] in files[0].name
+    assert files[0].suffix == ".json"
+    assert "/" not in receipt["receipt_id"] and "\\" not in receipt["receipt_id"]
+    assert len(receipt["receipt_id"]) <= 40
+
+
+def test_receipt_post_ignores_user_path_and_body(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = _repo_receipt_root(monkeypatch, tmp_path)
+    _login(client)
+    response = _post_receipt(
+        client,
+        params={"path": "/tmp/evil", "receipt_id": "../evil"},
+        json={"filename": "evil.json", "receipt_id": "evil", "snapshot": {"raw": RAW_PROMPT}},
+    )
+    assert response.status_code == 303
+    files = _receipt_files(root)
+    assert len(files) == 1
+    text = files[0].read_text(encoding="utf-8")
+    assert "evil" not in files[0].name
+    assert "/tmp/evil" not in text
+    assert RAW_PROMPT not in text
+
+
+def test_receipt_outside_root_override_rejected_for_write(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    outside = tmp_path / "outside"
+    monkeypatch.setenv(artifacts.ARTIFACT_ROOT_ENV, str(outside))
+    _login(client)
+    response = _post_receipt(client)
+    assert response.status_code == 303
+    assert not outside.exists()
+    assert receipts.receipt_root() == artifacts.DEFAULT_ARTIFACT_ROOT / "receipts"
+
+
+def test_receipt_inside_root_override_writes_under_safe_root(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = _repo_receipt_root(monkeypatch, tmp_path)
+    _login(client)
+    assert _post_receipt(client).status_code == 303
+    files = _receipt_files(root)
+    assert len(files) == 1
+    assert files[0].resolve().is_relative_to(root.resolve())
+
+
+def test_receipt_snapshot_safe_whitelist_no_raw_or_runtime_output(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = _repo_receipt_root(monkeypatch, tmp_path)
+    capture_root = root.parent
+    _write_all_four(capture_root)
+    monkeypatch.setenv("OPENAI_API_KEY", FAKE_SECRET)
+    monkeypatch.setenv("RAW_ENV_TEST_SENTINEL", RAW_ENV_SENTINEL)
+    monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    _login(client)
+    assert _post_receipt(client).status_code == 303
+    receipt_text = _receipt_files(root)[0].read_text(encoding="utf-8")
+    receipt = json.loads(receipt_text)
+    snapshot = receipt["snapshot"]
+    gate = snapshot["provider_gate"]
+    assert gate["key_status"]["OPENAI_API_KEY"] == "present"
+    assert gate["provider_key_status"] == "present"
+    assert snapshot["dry_run_preview"]["dry_run_execution"] == "not_enabled"
+    assert snapshot["route_trace"]["route"] == "not run yet"
+    assert snapshot["route_trace"]["confidence"] == "not run yet"
+    assert snapshot["route_trace"]["safe_out_state"] == "not run yet"
+    assert snapshot["local_artifacts"]["capture"]["route_metadata_present_count"] == 1
+    assert snapshot["local_artifacts"]["evidence_packet"]["content_digest"].startswith("sha256:")
+    forbidden = (
+        RAW_PROMPT,
+        RAW_BASELINE,
+        RAW_ROUTED,
+        RAW_ROUTE_META,
+        RAW_SYSTEM_PROMPT,
+        RAW_PROVIDER_PAYLOAD,
+        FAKE_SECRET,
+        PARTIAL_KEY,
+        RAW_ENV_SENTINEL,
+        "generated answer",
+    )
+    for token in forbidden:
+        assert token not in receipt_text
+
+
+def test_receipt_save_does_not_leak_raw_in_status_or_html(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = _repo_receipt_root(monkeypatch, tmp_path)
+    _write_all_four(root.parent)
+    monkeypatch.setenv("OPENAI_API_KEY", FAKE_SECRET)
+    _login(client)
+    assert _post_receipt(client).status_code == 303
+    html_text = client.get(PAGE_ROUTE).text
+    status_text = client.get(STATUS_ROUTE).text
+    for token in (RAW_PROMPT, RAW_BASELINE, RAW_ROUTED, RAW_ROUTE_META, RAW_PROVIDER_PAYLOAD, FAKE_SECRET):
+        assert token not in html_text
+        assert token not in status_text
+
+
+def test_recent_receipt_summary_in_status_and_page_without_full_body(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = _repo_receipt_root(monkeypatch, tmp_path)
+    _login(client)
+    assert _post_receipt(client).status_code == 303
+    receipt = json.loads(_receipt_files(root)[0].read_text(encoding="utf-8"))
+    status = client.get(STATUS_ROUTE).json()
+    recent = status["local_receipts"]["recent"]
+    assert status["local_receipts"]["count"] == 1
+    assert recent[0]["receipt_id"] == receipt["receipt_id"]
+    assert "snapshot" not in recent[0]
+    html_text = client.get(PAGE_ROUTE).text
+    assert receipt["receipt_id"] in html_text
+    assert receipt["content_digest"] in html_text
+    assert RAW_PROMPT not in html_text
+    assert RAW_BASELINE not in html_text
+
+
+def test_corrupt_receipt_fails_safe(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = _repo_receipt_root(monkeypatch, tmp_path)
+    root.mkdir(parents=True)
+    (root / "corrupt.json").write_text("{not json", encoding="utf-8")
+    _login(client)
+    assert client.get(STATUS_ROUTE).status_code == 200
+    assert client.get(PAGE_ROUTE).status_code == 200
+    store = client.get(STATUS_ROUTE).json()["local_receipts"]
+    assert "invalid_entries" in store["states"]
+    assert store["recent"][0]["state"] == "invalid"
+
+
+def test_multiple_receipts_newest_first_with_limit(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _repo_receipt_root(monkeypatch, tmp_path)
+    _login(client)
+    for _ in range(7):
+        assert _post_receipt(client).status_code == 303
+    recent = client.get(STATUS_ROUTE).json()["local_receipts"]["recent"]
+    assert len(recent) == 5
+    created = [item["created_at_utc"] for item in recent]
+    assert created == sorted(created, reverse=True)
+
+
+def test_receipt_creation_does_not_mutate_existing_operator_artifacts(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = _repo_receipt_root(monkeypatch, tmp_path)
+    artifact_root = root.parent
+    _write_all_four(artifact_root)
+    names = [
+        "capture.json",
+        "evidence_packet.json",
+        "anchor_preflight_report.json",
+        "lift_preflight_report.json",
+    ]
+    before = {name: (artifact_root / name).read_bytes() for name in names}
+    _login(client)
+    assert _post_receipt(client).status_code == 303
+    after = {name: (artifact_root / name).read_bytes() for name in names}
+    assert after == before
+
+
+def test_provider_client_patched_raise_receipts_ok(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import alpha.providers.openai as openai_provider
+
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("provider client must not be used by receipts")
+
+    monkeypatch.setattr(openai_provider.OpenAIProviderClient, "__init__", _boom)
+    monkeypatch.setattr(openai_provider.OpenAIProviderClient, "execute", _boom)
+    _repo_receipt_root(monkeypatch, tmp_path)
+    _login(client)
+    assert client.get(PAGE_ROUTE).status_code == 200
+    assert client.get(STATUS_ROUTE).status_code == 200
+    assert _post_receipt(client).status_code == 303
+
+
+def test_no_execution_imports_in_receipt_sources() -> None:
+    forbidden = (
+        "ProviderClient",
+        "OpenAIProviderClient",
+        "httpx",
+        "requests.",
+        "import subprocess",
+        "subprocess.",
+        "import socket",
+        "urllib",
+        "playwright",
+        "selenium",
+        "webdriver",
+        "webbrowser",
+        "pexpect",
+        "from alpha.providers",
+        "import alpha.providers",
+        "internal_solve",
+    )
+    for module in (operator_console, receipts):
+        source = Path(module.__file__).read_text(encoding="utf-8")
+        for token in forbidden:
+            assert token not in source, f"{token!r} found in {module.__file__}"
+
+
+def test_receipt_ui_boundary_text_and_no_misleading_receipt_language(client: TestClient) -> None:
+    _login(client)
+    html_text = client.get(PAGE_ROUTE).text
+    for text in receipts.RECEIPT_BOUNDARY_TEXTS:
+        assert text in html_text
+    receipt_card = html_text.split('id="card-local-receipt-store"', 1)[1].split('id="card-evidence-receipt"', 1)[0]
+    for forbidden in (
+        "Run receipt",
+        "Execute",
+        "Solve",
+        "Submit to provider",
+        "Generate answer",
+        "Validate",
+        "Benchmark",
+        "production ready",
+        "winner",
+        "estimated spend",
+    ):
+        assert forbidden not in receipt_card


### PR DESCRIPTION
### Motivation

- Operators need a lightweight, local-only audit snapshot of the operator console state they can save for later comparison without storing raw prompts, outputs, secrets, provider payloads, or mutating existing artifacts.

### Description

- Implements a narrow receipt helper `alpha/webapp/operator_console_receipts.py` that resolves the safe receipts root, whitelists a safe subset of console status, generates bounded receipt ids, computes a `sha256:` content digest over the safe body, and atomically writes receipts under a confined `receipts/` directory.  
- Adds a protected POST route `POST /dashboard/operator-console/receipts` and wires `local_receipts` into the console status and UI in `alpha/webapp/routes/operator_console.py`, exposing a compact “Local Receipt Store” card with receipt-root label, recent count, safe recent metadata, boundary notes, and one action button `Save local receipt snapshot`.  
- Receipt path policy: default receipts path is `local/operator_console/receipts/` under the repo; if `ALPHA_OPERATOR_CONSOLE_ARTIFACT_ROOT` is set and resolves inside the repository it is honored and receipts are written to `<resolved>/receipts/`; outside-root or traversal overrides are rejected; request data never influences path, filename, id, or body.  
- Receipt schema summary: `operator_console_receipt_v1`, `receipt_type: status_snapshot`, top-level fields `schema_version`, `receipt_id`, `created_at_utc`, `source` (`operator_console`), `receipt_type`, `snapshot` (whitelisted safe fields), and `content_digest` (SHA-256 over the safe body excluding the digest field).  
- Boundary confirmation: no provider/model/MCP/network/CLI/subprocess calls; no `/v1/solve`; no artifact mutation; no user-supplied path/id/body; no raw secrets or raw prompts stored or rendered.

### Testing

- Ran focused and suite tests: `python -m pytest tests/test_operator_console.py -q`, `python -m pytest tests/test_operator_console.py tests/test_operator_run_capture.py tests/test_api_endpoints.py -q`, and full `python -m pytest -q` — all executed and passed in this environment.  
- Lint and safety checks: `ruff check alpha/webapp/routes/operator_console.py alpha/webapp/operator_console_receipts.py tests/test_operator_console.py` passed, and `python scripts/check_narrative_claim_safety.py docs/OPERATOR_CONSOLE.md .specs/UI-ALPHA-OPERATOR-CONSOLE-LOCAL-RECEIPT-STORE-001.md` passed.  
- Tests added in `tests/test_operator_console.py` cover status JSON `local_receipts`, empty-state rendering, protected POST route & CSRF behavior, create-only receipt writes under safe root, ignoring user-supplied path/body, outside-root override rejection, inside-root override honoring, receipt id/filename/digest shape and verification, snapshot whitelist (no raw prompts/keys/payloads), recent metadata listing, corrupt-receipt fail-safe handling, newest-first limit, no artifact mutations, provider-client constructor patch isolation, source-scan import checks, and UI boundary text.

Accepted baseline main SHA: `e6f6f5376fe42736afc8091062b3ca38760891a0`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d76596ba483298ca7856b88a5732a)