### PR TITLE
test: harden operator console execution and write boundaries

### DIFF
--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -77,6 +77,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `OUTPUT-DIFF-B1-LIFT-REPORTING-HARDENING-001.md` | OUTPUT-DIFF-B1-LIFT-REPORTING-HARDENING-001 · Output Differentiation Reporting Hardening | ✅ `SPEC_OK` |
 | `OUTPUT-DIFF-MEASUREMENT-HARDENING-001.md` | OUTPUT-DIFF-MEASUREMENT-HARDENING-001 · Output Differentiation Measurement Hardening | ✅ `SPEC_OK` |
 | `PR646-SUBSTANTIVE-LIFT-MANUAL-EVAL-PREP-001.md` | PR646-SUBSTANTIVE-LIFT-MANUAL-EVAL-PREP-001 · Substantive Lift Manual Eval Prep | ✅ `SPEC_OK` |
+| `PROCESS-HARDENING-NO-PROVIDER-CALL-TEST-HELPER-001.md` | PROCESS-HARDENING-NO-PROVIDER-CALL-TEST-HELPER-001 · Operator Console execution-boundary and write-chokepoint hardening | ✅ `SPEC_OK` |
 | `PROVIDER-BUDGET-001.md` | PROVIDER-BUDGET-001 · Post-call Provider Cost Accounting | ✅ `SPEC_OK` |
 | `PROVIDER-EXPERT-PASS-001.md` | PROVIDER-EXPERT-PASS-001 · Opt-in Expert Provider Pass | ✅ `SPEC_OK` |
 | `PROVIDER-OPENAI-001.md` | PROVIDER-OPENAI-001 · Real OpenAI Provider Execution | ✅ `SPEC_OK` |

--- a/.specs/PROCESS-HARDENING-NO-PROVIDER-CALL-TEST-HELPER-001.md
+++ b/.specs/PROCESS-HARDENING-NO-PROVIDER-CALL-TEST-HELPER-001.md
@@ -1,0 +1,30 @@
+# PROCESS-HARDENING-NO-PROVIDER-CALL-TEST-HELPER-001 · Operator Console execution-boundary and write-chokepoint hardening
+
+## Status
+
+`SPEC_OK`
+
+## Scope
+
+This is a process-hardening lane, not a product lane. It adds test-only guard helpers and focused Operator Console regression tests for current execution and write boundaries.
+
+## Boundaries
+
+The lane must not add a new Operator Console panel, Safe Action Queue, Manual Next Step Guide, action controls, run-mode behavior, provider integration, solver execution, browser automation, CLI execution, paste storage, capture editor, schema change, or general-purpose file writing.
+
+The tests enforce only the exercised paths:
+
+- `GET /dashboard/operator-console` must not call providers, model SDKs, ChatGPT APIs, `/v1/solve`, network egress, subprocesses, CLI wrappers, shell commands, browser automation, or unauthorized filesystem writes.
+- `GET /dashboard/operator-console/status` must preserve the same no-execution and no-write boundaries.
+- Importing the Operator Console module tree must not instantiate providers, validate credentials, ping providers, start execution-capable objects, start network connections, start subprocesses, import browser automation, or call `/v1/solve`.
+- The local receipt store remains the only controlled local write chokepoint and must not accept request-supplied paths or filenames.
+
+## Test-helper requirements
+
+The helper is test-only and must block forbidden behavior without performing forbidden behavior. It must include canary tests proving meaningful guards raise on deliberate forbidden actions.
+
+Loopback network access may remain available for in-process/local test infrastructure; outbound/provider network egress must raise before a successful external connection.
+
+## Non-claims
+
+These tests do not prove product completeness, production readiness, provider readiness, answer quality, benchmark validity, value, superiority, scoring, ranking, or winner selection. They only guard specific Operator Console paths against specific forbidden execution and write-boundary regressions.

--- a/tests/operator_console_safety.py
+++ b/tests/operator_console_safety.py
@@ -1,0 +1,100 @@
+"""Reusable test-only guards for Operator Console execution/write boundaries."""
+
+from __future__ import annotations
+
+import builtins
+import socket
+import subprocess
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+
+class OperatorConsoleSafetyViolation(AssertionError):
+    """Raised when a guarded Operator Console path crosses a forbidden boundary."""
+
+
+@contextmanager
+def operator_console_no_execution_guard(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Block execution-capable operations while allowing in-process test clients.
+
+    Network blocking is at the socket layer. Loopback is allowed so FastAPI's
+    in-process TestClient and any existing local-only harness assumptions remain usable,
+    but non-loopback/provider egress raises before a real external connection.
+    """
+
+    original_connect = socket.socket.connect
+    original_connect_ex = socket.socket.connect_ex
+
+    def _is_loopback(address: object) -> bool:
+        host = address[0] if isinstance(address, tuple) and address else address
+        return str(host) in {"127.0.0.1", "::1", "localhost", "testserver"}
+
+    def guarded_connect(self: socket.socket, address: object) -> object:
+        if not _is_loopback(address):
+            raise OperatorConsoleSafetyViolation(f"blocked outbound network egress: {address!r}")
+        return original_connect(self, address)  # pragma: no cover - only if a local socket is used
+
+    def guarded_connect_ex(self: socket.socket, address: object) -> int:
+        if not _is_loopback(address):
+            raise OperatorConsoleSafetyViolation(f"blocked outbound network egress: {address!r}")
+        return original_connect_ex(self, address)  # pragma: no cover - only if a local socket is used
+
+    def _blocked_process(*_args: object, **_kwargs: object) -> None:
+        raise OperatorConsoleSafetyViolation("blocked subprocess/shell/CLI execution")
+
+    monkeypatch.setattr(socket.socket, "connect", guarded_connect)
+    monkeypatch.setattr(socket.socket, "connect_ex", guarded_connect_ex)
+    monkeypatch.setattr(subprocess, "run", _blocked_process)
+    monkeypatch.setattr(subprocess, "Popen", _blocked_process)
+    monkeypatch.setattr(subprocess, "call", _blocked_process)
+    monkeypatch.setattr(subprocess, "check_call", _blocked_process)
+    monkeypatch.setattr(subprocess, "check_output", _blocked_process)
+    yield
+
+
+@contextmanager
+def operator_console_no_get_write_guard(
+    monkeypatch: pytest.MonkeyPatch, *, allowed_write_root: Path | None = None
+) -> Iterator[None]:
+    """Block filesystem writes from Operator Console GET/render/status paths.
+
+    The optional allowlist is for receipt-write canaries or explicit receipt tests only;
+    render/status tests normally pass no allowlist, so any write attempt fails.
+    """
+
+    original_open = builtins.open
+    original_write_text = Path.write_text
+    original_write_bytes = Path.write_bytes
+    write_modes = {"w", "a", "x", "+"}
+
+    def _is_allowed(path: object) -> bool:
+        if allowed_write_root is None:
+            return False
+        try:
+            Path(path).resolve().relative_to(allowed_write_root.resolve())
+            return True
+        except (TypeError, OSError, RuntimeError, ValueError):
+            return False
+
+    def guarded_open(file: object, mode: str = "r", *args: object, **kwargs: object) -> object:
+        if any(flag in mode for flag in write_modes) and not _is_allowed(file):
+            raise OperatorConsoleSafetyViolation(f"blocked unauthorized filesystem write: {file!r}")
+        return original_open(file, mode, *args, **kwargs)
+
+    def guarded_write_text(self: Path, *_args: object, **_kwargs: object) -> int:
+        if not _is_allowed(self):
+            raise OperatorConsoleSafetyViolation(f"blocked unauthorized Path.write_text: {self!s}")
+        return original_write_text(self, *_args, **_kwargs)
+
+    def guarded_write_bytes(self: Path, *_args: object, **_kwargs: object) -> int:
+        if not _is_allowed(self):
+            raise OperatorConsoleSafetyViolation(f"blocked unauthorized Path.write_bytes: {self!s}")
+        return original_write_bytes(self, *_args, **_kwargs)
+
+    monkeypatch.setattr(builtins, "open", guarded_open)
+    monkeypatch.setattr(Path, "write_text", guarded_write_text)
+    monkeypatch.setattr(Path, "write_bytes", guarded_write_bytes)
+    yield

--- a/tests/operator_console_safety.py
+++ b/tests/operator_console_safety.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import builtins
+import os
 import socket
 import subprocess
 from contextlib import contextmanager
@@ -52,6 +53,28 @@ def operator_console_no_execution_guard(monkeypatch: pytest.MonkeyPatch) -> Iter
     monkeypatch.setattr(subprocess, "call", _blocked_process)
     monkeypatch.setattr(subprocess, "check_call", _blocked_process)
     monkeypatch.setattr(subprocess, "check_output", _blocked_process)
+    for name in (
+        "execl",
+        "execle",
+        "execlp",
+        "execlpe",
+        "execv",
+        "execve",
+        "execvp",
+        "execvpe",
+        "popen",
+        "spawnl",
+        "spawnle",
+        "spawnlp",
+        "spawnlpe",
+        "spawnv",
+        "spawnve",
+        "spawnvp",
+        "spawnvpe",
+        "startfile",
+        "system",
+    ):
+        monkeypatch.setattr(os, name, _blocked_process, raising=False)
     yield
 
 
@@ -66,6 +89,7 @@ def operator_console_no_get_write_guard(
     """
 
     original_open = builtins.open
+    original_path_open = Path.open
     original_write_text = Path.write_text
     original_write_bytes = Path.write_bytes
     write_modes = {"w", "a", "x", "+"}
@@ -84,6 +108,11 @@ def operator_console_no_get_write_guard(
             raise OperatorConsoleSafetyViolation(f"blocked unauthorized filesystem write: {file!r}")
         return original_open(file, mode, *args, **kwargs)
 
+    def guarded_path_open(self: Path, mode: str = "r", *args: object, **kwargs: object) -> object:
+        if any(flag in mode for flag in write_modes) and not _is_allowed(self):
+            raise OperatorConsoleSafetyViolation(f"blocked unauthorized Path.open write: {self!s}")
+        return original_path_open(self, mode, *args, **kwargs)
+
     def guarded_write_text(self: Path, *_args: object, **_kwargs: object) -> int:
         if not _is_allowed(self):
             raise OperatorConsoleSafetyViolation(f"blocked unauthorized Path.write_text: {self!s}")
@@ -95,6 +124,7 @@ def operator_console_no_get_write_guard(
         return original_write_bytes(self, *_args, **_kwargs)
 
     monkeypatch.setattr(builtins, "open", guarded_open)
+    monkeypatch.setattr(Path, "open", guarded_path_open)
     monkeypatch.setattr(Path, "write_text", guarded_write_text)
     monkeypatch.setattr(Path, "write_bytes", guarded_write_bytes)
     yield

--- a/tests/test_operator_console.py
+++ b/tests/test_operator_console.py
@@ -2708,12 +2708,20 @@ def test_operator_console_safety_helper_negative_controls(
                 sock.close()
         with pytest.raises(OperatorConsoleSafetyViolation):
             subprocess.run(["python", "-c", "print('must-not-run')"], check=False)
+        with pytest.raises(OperatorConsoleSafetyViolation):
+            os.system("echo must-not-run")
+        with pytest.raises(OperatorConsoleSafetyViolation):
+            os.popen("echo must-not-run")
+        with pytest.raises(OperatorConsoleSafetyViolation):
+            os.spawnv(os.P_WAIT, "/bin/echo", ["echo", "must-not-run"])
 
     with operator_console_no_get_write_guard(monkeypatch):
         with pytest.raises(OperatorConsoleSafetyViolation):
             (tmp_path / "unauthorized.txt").write_text("must-not-write", encoding="utf-8")
         with pytest.raises(OperatorConsoleSafetyViolation):
             open(tmp_path / "unauthorized-open.txt", "w", encoding="utf-8")
+        with pytest.raises(OperatorConsoleSafetyViolation):
+            (tmp_path / "unauthorized-path-open.txt").open("x", encoding="utf-8")
 
 
 def test_operator_console_provider_and_model_canaries_raise(
@@ -2744,11 +2752,22 @@ def test_operator_console_v1_solve_canary_raises(monkeypatch: pytest.MonkeyPatch
     async def _boom(*_args: object, **_kwargs: object) -> None:
         raise OperatorConsoleSafetyViolation("blocked /v1/solve invocation")
 
+    route = next(route for route in app.routes if getattr(route, "path", None) == "/v1/solve")
     monkeypatch.setattr(service_app, "solve", _boom)
+    monkeypatch.setattr(route, "endpoint", _boom)
+    monkeypatch.setattr(route.dependant, "call", _boom)
     with pytest.raises(OperatorConsoleSafetyViolation):
         import anyio
 
         anyio.run(service_app.solve, object(), object())
+    with pytest.raises(OperatorConsoleSafetyViolation):
+        import anyio
+
+        anyio.run(route.endpoint, object(), object())
+    with pytest.raises(OperatorConsoleSafetyViolation):
+        import anyio
+
+        anyio.run(route.dependant.call, object(), object())
 
 
 def test_operator_console_render_status_under_reusable_safety_guard(
@@ -2768,7 +2787,10 @@ def test_operator_console_render_status_under_reusable_safety_guard(
     monkeypatch.setattr(openai_provider.OpenAIProviderClient, "__init__", _blocked)
     monkeypatch.setattr(openai_provider.OpenAIProviderClient, "execute", _blocked)
     monkeypatch.setattr(app.state, "provider_client_factory", _blocked, raising=False)
+    solve_route = next(route for route in app.routes if getattr(route, "path", None) == "/v1/solve")
     monkeypatch.setattr(service_app, "solve", _blocked_solve)
+    monkeypatch.setattr(solve_route, "endpoint", _blocked_solve)
+    monkeypatch.setattr(solve_route.dependant, "call", _blocked_solve)
 
     _login(client)
     with operator_console_no_execution_guard(monkeypatch), operator_console_no_get_write_guard(monkeypatch):
@@ -2799,7 +2821,10 @@ def test_operator_console_import_tree_under_safety_guard(monkeypatch: pytest.Mon
 
     monkeypatch.setattr(openai_provider.OpenAIProviderClient, "__init__", _blocked)
     monkeypatch.setattr(app.state, "provider_client_factory", _blocked, raising=False)
+    solve_route = next(route for route in app.routes if getattr(route, "path", None) == "/v1/solve")
     monkeypatch.setattr(service_app, "solve", _blocked_solve)
+    monkeypatch.setattr(solve_route, "endpoint", _blocked_solve)
+    monkeypatch.setattr(solve_route.dependant, "call", _blocked_solve)
 
     with operator_console_no_execution_guard(monkeypatch), operator_console_no_get_write_guard(monkeypatch):
         importlib.reload(artifacts)
@@ -2813,6 +2838,7 @@ def test_operator_console_write_chokepoint_source_allowlist() -> None:
     modules = (artifacts, operator_console, receipts)
     allowed_write_calls = {
         (Path(receipts.__file__).resolve(), "mkdir"),
+        (Path(receipts.__file__).resolve(), "open"),
         (Path(receipts.__file__).resolve(), "write_text"),
     }
     violations: list[str] = []
@@ -2827,9 +2853,16 @@ def test_operator_console_write_chokepoint_source_allowlist() -> None:
                 elif isinstance(node.func, ast.Name):
                     name = node.func.id
                 if name == "open":
-                    mode = node.args[1].value if len(node.args) > 1 and isinstance(node.args[1], ast.Constant) else "r"
+                    if isinstance(node.func, ast.Attribute):
+                        mode_arg = node.args[0] if node.args else None
+                    else:
+                        mode_arg = node.args[1] if len(node.args) > 1 else None
+                    mode_keyword = next((kw.value for kw in node.keywords if kw.arg == "mode"), None)
+                    mode_node = mode_keyword or mode_arg
+                    mode = mode_node.value if isinstance(mode_node, ast.Constant) else "r"
                     if any(flag in str(mode) for flag in ("w", "a", "x", "+")):
-                        violations.append(f"{module_path}:{node.lineno}: open({mode!r})")
+                        if (module_path, name) not in allowed_write_calls:
+                            violations.append(f"{module_path}:{node.lineno}: open({mode!r})")
                 if name in {"write_text", "write_bytes", "mkdir", "dump"}:
                     if (module_path, name) not in allowed_write_calls:
                         violations.append(f"{module_path}:{node.lineno}: {name}")

--- a/tests/test_operator_console.py
+++ b/tests/test_operator_console.py
@@ -13,9 +13,13 @@ They mirror the wiring/auth style of ``tests/ui/test_expert_preview_real_app.py`
 
 from __future__ import annotations
 
+import ast
 import html
+import importlib
 import json
 import os
+import socket
+import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -25,14 +29,21 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
-if str(PROJECT_ROOT) not in sys.path:
-    sys.path.insert(0, str(PROJECT_ROOT))
+TEST_ROOT = Path(__file__).resolve().parent
+for import_root in (PROJECT_ROOT, TEST_ROOT):
+    if str(import_root) not in sys.path:
+        sys.path.insert(0, str(import_root))
 
 from alpha.webapp import operator_console_artifacts as artifacts  # noqa: E402
 from alpha.webapp import operator_console_receipts as receipts  # noqa: E402
 from alpha.webapp.routes import auth, operator_console  # noqa: E402
 from alpha.eval import operator_run_capture as capture_lib  # noqa: E402
 from service.app import app, _mount_dashboard  # noqa: E402
+from operator_console_safety import (  # noqa: E402
+    OperatorConsoleSafetyViolation,
+    operator_console_no_execution_guard,
+    operator_console_no_get_write_guard,
+)
 
 PAGE_ROUTE = operator_console.ROUTE
 STATUS_ROUTE = operator_console.STATUS_ROUTE
@@ -2679,3 +2690,157 @@ def test_chatgpt_source_scan_no_execution_imports() -> None:
     joined = "\n".join(import_lines).lower()
     for token in ("chatgpt", "provider", "mcp", "httpx", "requests", "subprocess", "socket", "urllib", "playwright", "selenium", "webdriver", "webbrowser", "pexpect", "solve"):
         assert token not in joined, token
+
+# ---------------------------------------------------------------------------
+# PROCESS-HARDENING-NO-PROVIDER-CALL-TEST-HELPER-001
+# ---------------------------------------------------------------------------
+def test_operator_console_safety_helper_negative_controls(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Canaries prove the reusable guard fails on forbidden actions."""
+
+    with operator_console_no_execution_guard(monkeypatch):
+        with pytest.raises(OperatorConsoleSafetyViolation):
+            sock = socket.socket()
+            try:
+                sock.connect(("203.0.113.10", 443))
+            finally:
+                sock.close()
+        with pytest.raises(OperatorConsoleSafetyViolation):
+            subprocess.run(["python", "-c", "print('must-not-run')"], check=False)
+
+    with operator_console_no_get_write_guard(monkeypatch):
+        with pytest.raises(OperatorConsoleSafetyViolation):
+            (tmp_path / "unauthorized.txt").write_text("must-not-write", encoding="utf-8")
+        with pytest.raises(OperatorConsoleSafetyViolation):
+            open(tmp_path / "unauthorized-open.txt", "w", encoding="utf-8")
+
+
+def test_operator_console_provider_and_model_canaries_raise(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Canaries prove provider/model guard patch points are effective."""
+
+    import alpha.providers.openai as openai_provider
+
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise OperatorConsoleSafetyViolation("blocked provider/model invocation")
+
+    monkeypatch.setattr(openai_provider.OpenAIProviderClient, "__init__", _boom)
+    monkeypatch.setattr(openai_provider.OpenAIProviderClient, "execute", _boom)
+    monkeypatch.setattr(app.state, "provider_client_factory", _boom, raising=False)
+
+    with pytest.raises(OperatorConsoleSafetyViolation):
+        app.state.provider_client_factory()
+    with pytest.raises(OperatorConsoleSafetyViolation):
+        openai_provider.OpenAIProviderClient()
+
+
+def test_operator_console_v1_solve_canary_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Canary proves a mocked /v1/solve invocation is observable by guard tests."""
+
+    import service.app as service_app
+
+    async def _boom(*_args: object, **_kwargs: object) -> None:
+        raise OperatorConsoleSafetyViolation("blocked /v1/solve invocation")
+
+    monkeypatch.setattr(service_app, "solve", _boom)
+    with pytest.raises(OperatorConsoleSafetyViolation):
+        import anyio
+
+        anyio.run(service_app.solve, object(), object())
+
+
+def test_operator_console_render_status_under_reusable_safety_guard(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """GET render/status paths stay inside no-execution and no-write guards."""
+
+    import alpha.providers.openai as openai_provider
+    import service.app as service_app
+
+    def _blocked(*_args: object, **_kwargs: object) -> None:
+        raise OperatorConsoleSafetyViolation("blocked execution boundary")
+
+    async def _blocked_solve(*_args: object, **_kwargs: object) -> None:
+        raise OperatorConsoleSafetyViolation("blocked /v1/solve boundary")
+
+    monkeypatch.setattr(openai_provider.OpenAIProviderClient, "__init__", _blocked)
+    monkeypatch.setattr(openai_provider.OpenAIProviderClient, "execute", _blocked)
+    monkeypatch.setattr(app.state, "provider_client_factory", _blocked, raising=False)
+    monkeypatch.setattr(service_app, "solve", _blocked_solve)
+
+    _login(client)
+    with operator_console_no_execution_guard(monkeypatch), operator_console_no_get_write_guard(monkeypatch):
+        page = client.get(PAGE_ROUTE)
+        status = client.get(STATUS_ROUTE)
+
+    assert page.status_code == 200
+    assert status.status_code == 200
+    payload = status.json()
+    assert payload["provider_gate"]["console_calls_providers"] is False
+    assert payload["run_setup"]["live_run_button_enabled"] is False
+    assert payload["provider_gate"]["live_provider_calls"] == "disabled"
+    assert payload["dry_run_preview"]["dry_run_execution"] == "not_enabled"
+    assert payload["chatgpt_copy_paste_capture"]["console_stores_pasted_outputs"] is False
+
+
+def test_operator_console_import_tree_under_safety_guard(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Import/reload of console modules must not start providers, network, solve, or subprocesses."""
+
+    import alpha.providers.openai as openai_provider
+    import service.app as service_app
+
+    def _blocked(*_args: object, **_kwargs: object) -> None:
+        raise OperatorConsoleSafetyViolation("blocked import-time execution boundary")
+
+    async def _blocked_solve(*_args: object, **_kwargs: object) -> None:
+        raise OperatorConsoleSafetyViolation("blocked import-time /v1/solve boundary")
+
+    monkeypatch.setattr(openai_provider.OpenAIProviderClient, "__init__", _blocked)
+    monkeypatch.setattr(app.state, "provider_client_factory", _blocked, raising=False)
+    monkeypatch.setattr(service_app, "solve", _blocked_solve)
+
+    with operator_console_no_execution_guard(monkeypatch), operator_console_no_get_write_guard(monkeypatch):
+        importlib.reload(artifacts)
+        importlib.reload(receipts)
+        importlib.reload(operator_console)
+
+
+def test_operator_console_write_chokepoint_source_allowlist() -> None:
+    """Operator Console writes remain limited to the authorized receipt helper."""
+
+    modules = (artifacts, operator_console, receipts)
+    allowed_write_calls = {
+        (Path(receipts.__file__).resolve(), "mkdir"),
+        (Path(receipts.__file__).resolve(), "write_text"),
+    }
+    violations: list[str] = []
+    for module in modules:
+        module_path = Path(module.__file__).resolve()
+        tree = ast.parse(module_path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                name = ""
+                if isinstance(node.func, ast.Attribute):
+                    name = node.func.attr
+                elif isinstance(node.func, ast.Name):
+                    name = node.func.id
+                if name == "open":
+                    mode = node.args[1].value if len(node.args) > 1 and isinstance(node.args[1], ast.Constant) else "r"
+                    if any(flag in str(mode) for flag in ("w", "a", "x", "+")):
+                        violations.append(f"{module_path}:{node.lineno}: open({mode!r})")
+                if name in {"write_text", "write_bytes", "mkdir", "dump"}:
+                    if (module_path, name) not in allowed_write_calls:
+                        violations.append(f"{module_path}:{node.lineno}: {name}")
+
+    assert violations == []
+
+
+def test_operator_console_no_user_supplied_write_path_parameters() -> None:
+    """Receipt creation remains pathless from the request surface."""
+
+    route = next(route for route in app.routes if getattr(route, "path", None) == RECEIPTS_ROUTE)
+    dependant_names = [param.name for param in getattr(route, "dependant").body_params]
+    dependant_names += [param.name for param in getattr(route, "dependant").query_params]
+    assert dependant_names == []


### PR DESCRIPTION
### Motivation

- Convert the Operator Console no-execution and write-boundary review conventions into CI-enforced tests for `PROCESS-HARDENING-NO-PROVIDER-CALL-TEST-HELPER-001` so future action-adjacent work cannot accidentally introduce provider calls, network egress, subprocesses, `/v1/solve` invocations, or unauthorized filesystem writes. 
- Provide a narrowly scoped, test-only safety helper that enforces execution and write chokepoints for render/status/import paths without changing runtime or UI behavior.

### Description

- Add a reusable test-only helper `tests/operator_console_safety.py` exposing `operator_console_no_execution_guard` (blocks non-loopback socket connects and subprocess/CLI calls) and `operator_console_no_get_write_guard` (blocks `open(..., "w|a|x|+")`, `Path.write_text`, and `Path.write_bytes` outside an allowlisted receipt root). 
- Add a process-hardening spec `.specs/PROCESS-HARDENING-NO-PROVIDER-CALL-TEST-HELPER-001.md` and register it in `.specs/INDEX.md` declaring this is a process-hardening lane (not a product lane). 
- Extend `tests/test_operator_console.py` with focused guarded tests and paired negative-control canaries that verify provider/model patch points, ChatGPT/model SDK paths, `/v1/solve`, outbound network egress, subprocess/CLI execution, import-time instantiation, unauthorized writes, write-chokepoint source allowlist, and request-supplied write-parameter absence are detected and fail as expected. 
- No production code was modified and no new UI, queue, runner, provider path, ChatGPT API path, `/v1/solve` path, CLI/subprocess path, browser automation, paste storage, capture editor, raw prompt/output display, schema change, or general-purpose write path was added. 
- BOUNDARY MAP: `test_operator_console_safety_helper_negative_controls` (blocks network/subprocess/writes), `test_operator_console_provider_and_model_canaries_raise` (provider/model invocation guard), `test_operator_console_v1_solve_canary_raises` (`/v1/solve` guard), `test_operator_console_render_status_under_reusable_safety_guard` (render/status execution/write boundary and provider-gate/run-button/dry-run/chatgpt capture sentinel checks), `test_operator_console_import_tree_under_safety_guard` (import-time guard), `test_operator_console_write_chokepoint_source_allowlist` (write-chokepoint source allowlist), and `test_operator_console_no_user_supplied_write_path_parameters` (no request-supplied write paths). 

### Testing

- Ran focused Operator Console tests with `python -m pytest tests/test_operator_console.py -q`, and the tests passed. 
- Ran an expanded set with `python -m pytest tests/test_operator_console.py tests/test_operator_run_capture.py tests/test_api_endpoints.py -q`, and the tests passed. 
- Ran the full test suite with `python -m pytest -q`, which completed with existing repository skips; the new/changed tests passed as part of that run. 
- Linting: `ruff check tests alpha/webapp service scripts` reported pre-existing lint issues unrelated to the new test files, while `ruff check tests/test_operator_console.py tests/operator_console_safety.py` passed for the changed files; narrative claim safety check `python scripts/check_narrative_claim_safety.py docs/OPERATOR_CONSOLE.md .specs/PROCESS-HARDENING-NO-PROVIDER-CALL-TEST-HELPER-001.md` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d9b131754832998ee446b09d341b8)