### PR TITLE
feat: add Manual Next Step Guide (AOC-B008A-OPERATOR-NEXT-STEP-CLARITY-001)

### DIFF
--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -102,6 +102,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `UI-ALPHA-OPERATOR-CONSOLE-DRY-RUN-PREVIEW-001.md` | UI-ALPHA-OPERATOR-CONSOLE-DRY-RUN-PREVIEW-001 · Operator Console Dry-Run Preview | ✅ `SPEC_OK` |
 | `UI-ALPHA-OPERATOR-CONSOLE-LOCAL-RECEIPT-STORE-001.md` | UI-ALPHA-OPERATOR-CONSOLE-LOCAL-RECEIPT-STORE-001 · Operator Console Local Receipt Store | ✅ `SPEC_OK` |
 | `UI-ALPHA-OPERATOR-CONSOLE-CHATGPT-COPY-PASTE-CAPTURE-001.md` | UI-ALPHA-OPERATOR-CONSOLE-CHATGPT-COPY-PASTE-CAPTURE-001 · Operator Console ChatGPT Copy/Paste Capture | ✅ `SPEC_OK` |
+| `UI-ALPHA-OPERATOR-CONSOLE-MANUAL-NEXT-STEP-GUIDE-001.md` | UI-ALPHA-OPERATOR-CONSOLE-MANUAL-NEXT-STEP-GUIDE-001 · Operator Console Manual Next Step Guide | ✅ `SPEC_OK` |
 | `UI-JOBS-001.md` | UI-JOBS-001 · Dashboard Job History & Metrics (RES_Dash) | ✅ `SPEC_OK` |
 | `UI-PREVIEW-001.md` | UI-PREVIEW-001 · Authenticated Expert Preview UI | ✅ `SPEC_OK` |
 | `UI-PREVIEW-LOADING-STATE-001.md` | UI-PREVIEW-LOADING-STATE-001 · Expert Preview Loading State | ✅ `SPEC_OK` |

--- a/.specs/UI-ALPHA-OPERATOR-CONSOLE-MANUAL-NEXT-STEP-GUIDE-001.md
+++ b/.specs/UI-ALPHA-OPERATOR-CONSOLE-MANUAL-NEXT-STEP-GUIDE-001.md
@@ -1,0 +1,89 @@
+# UI-ALPHA-OPERATOR-CONSOLE-MANUAL-NEXT-STEP-GUIDE-001 · Operator Console Manual Next Step Guide
+
+Lane id: `AOC-B008A-OPERATOR-NEXT-STEP-CLARITY-001`
+
+## Goal
+
+Add a compact, protected Operator Console card and status payload section named `manual_next_step_guide` that helps an operator distinguish:
+
+1. what can be reviewed now,
+2. what can only happen manually outside the console, and
+3. what remains blocked inside the console.
+
+This lane is a clarity lane, not an action queue.
+
+## Motivation
+
+The Operator Console already exposes local artifact summaries, freshness metadata, provider/cost gate status, a display-only dry-run preview, local receipt metadata, and manual ChatGPT copy/paste guidance. Operators need a small safety-oriented guide that ties those surfaces together without creating action semantics or execution affordances.
+
+## Scope
+
+- Add a display-only `Manual Next Step Guide` status section.
+- Render a page card under `/dashboard/operator-console`.
+- Use bounded labels only: `label`, `section`, `status`, `description`, `source_surface`, and `boundary`.
+- Include exactly these user-facing sections:
+  - `Available for review`
+  - `Manual-only steps`
+  - `Blocked in this console`
+- Derive meaning only from existing safe surfaces and fixed boundary copy.
+- Keep the existing Local Receipt Store as the only controlled write action.
+
+## Non-goals
+
+- No action queue, task queue, job queue, queue persistence, processor, or workbench behavior.
+- No runner, scheduler, worker, dispatch, approval, retry, or action-control behavior.
+- No dry-run execution, live-provider execution, ChatGPT API integration, browser automation, `/v1/solve` invocation, CLI/subprocess execution, or prompt submission.
+- No paste textarea, paste storage, capture editor, raw prompt viewer, raw output viewer, or raw route metadata viewer.
+- No new POST route, new local persistence model, general-purpose file writing, user-supplied path handling, credential validation, provider ping, or schema migration.
+- No readiness, validation, benchmark, production, scoring, ranking, winner, or superiority claim.
+
+## Code targets
+
+- `alpha/webapp/routes/operator_console.py`
+- `tests/test_operator_console.py`
+- `docs/OPERATOR_CONSOLE.md`
+- `.specs/INDEX.md`
+
+## Tests
+
+Focused tests must prove:
+
+- Status JSON includes `manual_next_step_guide`.
+- The page renders a `Manual Next Step Guide` card.
+- The card includes the three required sections.
+- The card states the display-only and non-executing boundary.
+- The card has no buttons, forms, textareas, or new action controls.
+- No new Operator Console POST route exists beyond the receipt route.
+- The existing receipt route remains the only controlled write action.
+- Raw prompts, raw outputs, raw route metadata, provider payloads, secrets, and pasted model output are not surfaced.
+- Provider/cost gate, dry-run preview, ChatGPT copy/paste capture, live-run disabled state, and route/trace placeholders remain bounded.
+- Process-hardening guards still pass for page and status rendering.
+
+## Definition of done
+
+- `manual_next_step_guide` appears in the status JSON with bounded summary fields only.
+- The protected Operator Console page shows a compact `Manual Next Step Guide` card.
+- The card has no new button and no new write or execution behavior.
+- Focused and broad Operator Console tests pass.
+- Documentation explains the panel and its boundaries.
+
+## Boundary checklist
+
+- [x] Display-only clarity panel.
+- [x] No provider calls.
+- [x] No ChatGPT calls.
+- [x] No `/v1/solve` calls.
+- [x] No browser automation.
+- [x] No CLI, shell, or subprocess execution.
+- [x] No prompt submission.
+- [x] No paste storage.
+- [x] No capture editor.
+- [x] No raw prompt/output display.
+- [x] No new POST route.
+- [x] No new write path.
+- [x] Local Receipt Store remains the only controlled write path.
+- [x] No user-supplied path or filename handling.
+
+## Non-claims
+
+The guide does not claim readiness, validation, benchmark performance, production suitability, scoring, ranking, winner selection, superiority, billing accuracy, provider availability, or output quality.

--- a/alpha/webapp/routes/operator_console.py
+++ b/alpha/webapp/routes/operator_console.py
@@ -101,6 +101,156 @@ GATE_BOUNDARY_TEXTS = (
 )
 
 
+
+# ---------------------------------------------------------------------------
+# Manual next-step guide boundary text. This clarity panel summarizes existing
+# safe surfaces only. It is display-only and non-executing; it adds no controls,
+# routes, persistence, provider calls, ChatGPT calls, or raw artifact views.
+# ---------------------------------------------------------------------------
+MANUAL_NEXT_STEP_TITLE = "Manual Next Step Guide"
+MANUAL_NEXT_STEP_SUBTITLE = (
+    "This console helps you review local evidence and decide what to do manually. "
+    "It does not run providers, call ChatGPT, execute commands, or store pasted "
+    "model output."
+)
+MANUAL_NEXT_STEP_BOUNDARY_TEXTS = (
+    "Manual Next Step Guide is display-only and non-executing.",
+    "Provider calls blocked.",
+    "ChatGPT calls blocked.",
+    "This guide does not call /v1/solve.",
+    "This guide does not run CLI, subprocess, shell, or browser automation.",
+    "This guide does not accept prompt input or store pasted model output.",
+    "This guide does not mutate capture, evidence, preflight, or receipt artifacts.",
+    "This guide adds no write path; the Local Receipt Store remains the only controlled write action.",
+)
+MANUAL_NEXT_STEP_SECTIONS = (
+    "Available for review",
+    "Manual-only steps",
+    "Blocked in this console",
+)
+MANUAL_NEXT_STEP_ITEMS = (
+    {
+        "label": "Local artifact status",
+        "section": "Available for review",
+        "status": "available_for_review",
+        "description": "Review surface only: fixed local artifact summaries, states, counts, ids, and digest labels.",
+        "source_surface": "local_artifacts",
+        "boundary": "summary_metadata_only",
+    },
+    {
+        "label": "Artifact freshness metadata",
+        "section": "Available for review",
+        "status": "available_for_review",
+        "description": "Review surface only: file presence, modified-time labels, age labels, and sequence-coherence metadata.",
+        "source_surface": "local_artifacts.freshness",
+        "boundary": "metadata_only_no_claim",
+    },
+    {
+        "label": "Provider and cost gate status",
+        "section": "Available for review",
+        "status": "available_for_review",
+        "description": "Review surface only: provider mode, categorical key presence, configured cap presence, and blockers.",
+        "source_surface": "provider_gate",
+        "boundary": "display_only_blocked",
+    },
+    {
+        "label": "Display-only dry-run preview",
+        "section": "Available for review",
+        "status": "available_for_review",
+        "description": "Review surface only: a preview of local metadata a future lane would require; it starts nothing.",
+        "source_surface": "dry_run_preview",
+        "boundary": "non_executing_preview",
+    },
+    {
+        "label": "Local receipt metadata",
+        "section": "Available for review",
+        "status": "available_for_review",
+        "description": "Review surface only: recent receipt ids, timestamps, states, and digest labels.",
+        "source_surface": "local_receipts",
+        "boundary": "receipt_metadata_only",
+    },
+    {
+        "label": "Manual ChatGPT copy/paste guidance",
+        "section": "Available for review",
+        "status": "available_for_review",
+        "description": "Review surface only: manual guidance, placeholders, and terminal text snippets; no pasted output is stored.",
+        "source_surface": "chatgpt_copy_paste_capture",
+        "boundary": "manual_guidance_only",
+    },
+    {
+        "label": "Route/trace placeholders",
+        "section": "Available for review",
+        "status": "placeholder_only",
+        "description": "Review surface only: placeholder labels shown until work happens outside this console.",
+        "source_surface": "route_trace",
+        "boundary": "placeholder_only",
+    },
+    {
+        "label": "Review local evidence outside the console",
+        "section": "Manual-only steps",
+        "status": "manual_only",
+        "description": "Manual-only: inspect operator-owned local files and evidence outside this protected page.",
+        "source_surface": "operator_docs",
+        "boundary": "outside_console",
+    },
+    {
+        "label": "Use documented harness commands from a terminal",
+        "section": "Manual-only steps",
+        "status": "manual_only",
+        "description": "Manual-only: follow existing docs and terminal snippets yourself; this guide does not start them.",
+        "source_surface": "preflight_capture",
+        "boundary": "terminal_manual_only",
+    },
+    {
+        "label": "Follow ChatGPT copy/paste guidance outside the console",
+        "section": "Manual-only steps",
+        "status": "manual_only",
+        "description": "Manual-only: collect and paste outputs in the operator-owned local capture workflow outside this page.",
+        "source_surface": "chatgpt_copy_paste_capture",
+        "boundary": "external_manual_capture",
+    },
+    {
+        "label": "Create a local receipt only through the existing receipt-store card",
+        "section": "Manual-only steps",
+        "status": "receipt_only",
+        "description": "Manual-only: use the existing Local Receipt Store card if a safe status snapshot is needed.",
+        "source_surface": "local_receipts",
+        "boundary": "existing_receipt_store_only",
+    },
+    {
+        "label": "Provider calls blocked",
+        "section": "Blocked in this console",
+        "status": "blocked_in_console",
+        "description": "Blocked: provider calls, model SDK calls, and live-provider paths are not available here.",
+        "source_surface": "provider_gate",
+        "boundary": "blocked_non_executable",
+    },
+    {
+        "label": "ChatGPT API calls and browser automation blocked",
+        "section": "Blocked in this console",
+        "status": "blocked_in_console",
+        "description": "Blocked: ChatGPT API calls, browser automation, prompt intake, paste storage, and capture editing are not available here.",
+        "source_surface": "chatgpt_copy_paste_capture",
+        "boundary": "blocked_non_executable",
+    },
+    {
+        "label": "/v1/solve and command paths blocked",
+        "section": "Blocked in this console",
+        "status": "blocked_in_console",
+        "description": "Blocked: /v1/solve, CLI, subprocess, shell, dry-run starts, and live-provider starts are not available here.",
+        "source_surface": "run_setup",
+        "boundary": "blocked_non_executable",
+    },
+    {
+        "label": "Raw prompt/output viewers and claim surfaces blocked",
+        "section": "Blocked in this console",
+        "status": "blocked_in_console",
+        "description": "Blocked: raw prompt viewers, raw output viewers, quality-comparison selectors, and launch-claim surfaces are not available here.",
+        "source_surface": "claim_boundary",
+        "boundary": "blocked_non_claiming",
+    },
+)
+
 # ---------------------------------------------------------------------------
 # ChatGPT copy/paste capture boundary text. This panel is manual guidance only:
 # it summarizes existing safe artifact metadata and never stores pasted content,
@@ -797,6 +947,19 @@ def _build_chatgpt_copy_paste_capture(
     }
 
 
+def _build_manual_next_step_guide() -> Dict[str, Any]:
+    """Assemble bounded display-only next-step clarity labels."""
+
+    return {
+        "title": MANUAL_NEXT_STEP_TITLE,
+        "mode": "display_only",
+        "execution": "non_executing",
+        "sections": list(MANUAL_NEXT_STEP_SECTIONS),
+        "items": [dict(item) for item in MANUAL_NEXT_STEP_ITEMS],
+        "boundary_notes": list(MANUAL_NEXT_STEP_BOUNDARY_TEXTS),
+    }
+
+
 def build_console_status() -> Dict[str, Any]:
     """Assemble the read-only operator console status payload.
 
@@ -853,6 +1016,7 @@ def build_console_status() -> Dict[str, Any]:
     chatgpt_copy_paste_capture = _build_chatgpt_copy_paste_capture(
         local_artifacts, preflight_capture
     )
+    manual_next_step_guide = _build_manual_next_step_guide()
 
     return {
         "console": {
@@ -905,6 +1069,7 @@ def build_console_status() -> Dict[str, Any]:
         "provider_gate": provider_gate,
         "dry_run_preview": dry_run_preview,
         "chatgpt_copy_paste_capture": chatgpt_copy_paste_capture,
+        "manual_next_step_guide": manual_next_step_guide,
         "preflight_capture": preflight_capture,
         "evidence_receipt": {
             "receipt_id": "not generated yet",
@@ -948,6 +1113,7 @@ def _render_page(status: Mapping[str, Any]) -> str:
     gate = status["provider_gate"]
     dry_run = status["dry_run_preview"]
     chatgpt_capture = status["chatgpt_copy_paste_capture"]
+    manual_next_step = status["manual_next_step_guide"]
     capture = status["preflight_capture"]
     receipt = status["evidence_receipt"]
     receipt_store = status["local_receipts"]
@@ -1163,6 +1329,23 @@ def _render_page(status: Mapping[str, Any]) -> str:
     chatgpt_unsafe_html = _list_items(chatgpt_capture["unsafe_actions_blocked"])
     chatgpt_boundary_html = _list_items(chatgpt_capture["boundary_notes"])
 
+    def _manual_items(section: str) -> str:
+        return "".join(
+            "<li>"
+            f"<strong>{_escape(item['label'])}</strong> "
+            f'<span class="badge muted">{_escape(item["status"])}</span>'
+            f"<br />{_escape(item['description'])}"
+            f'<br /><span class="note">source: {_escape(item["source_surface"])} · boundary: {_escape(item["boundary"])}</span>'
+            "</li>"
+            for item in manual_next_step["items"]
+            if item["section"] == section
+        )
+
+    manual_review_html = _manual_items("Available for review")
+    manual_only_html = _manual_items("Manual-only steps")
+    manual_blocked_html = _manual_items("Blocked in this console")
+    manual_boundary_html = _list_items(manual_next_step["boundary_notes"])
+
     receipt_items = receipt_store["recent"]
     receipt_rows = (
         "".join(
@@ -1346,6 +1529,25 @@ def _render_page(status: Mapping[str, Any]) -> str:
           {preflight_artifact_html}
         </article>
 
+
+        <article class="card" id="card-manual-next-step-guide">
+          <h2>{_escape(manual_next_step["title"])}</h2>
+          <p class="note">{_escape(MANUAL_NEXT_STEP_SUBTITLE)}</p>
+          {_kv_rows({
+              "mode": manual_next_step["mode"],
+              "execution": manual_next_step["execution"],
+              "write path": "no new write path",
+              "controlled write": "Local Receipt Store only",
+          })}
+          <h3 class="subhead">Available for review</h3>
+          <ul class="surfaces">{manual_review_html}</ul>
+          <h3 class="subhead">Manual-only steps</h3>
+          <ul class="surfaces">{manual_only_html}</ul>
+          <h3 class="subhead">Blocked in this console</h3>
+          <ul class="surfaces">{manual_blocked_html}</ul>
+          <p class="note">Boundary reminders:</p>
+          <ul class="surfaces">{manual_boundary_html}</ul>
+        </article>
 
 
         <article class="card" id="card-chatgpt-copy-paste-capture">

--- a/docs/OPERATOR_CONSOLE.md
+++ b/docs/OPERATOR_CONSOLE.md
@@ -578,3 +578,15 @@ The card repeats the existing local harness command snippets for anchor prefligh
 ChatGPT copy/paste capture is manual-only. This console does not call ChatGPT. This console does not call providers, models, `/v1/solve`, MCP, browser automation, network, CLI, or subprocesses. This console does not automate a browser. This console does not submit prompts. This console does not store pasted model outputs in this lane. This console does not create, edit, delete, upload, save, or mutate `capture.json`, evidence packets, preflight reports, or receipts from this panel.
 
 The capture harness remains a local lab notebook, not a runner. Receipts may be saved separately through the existing local receipt store, but the ChatGPT Copy/Paste Capture card does not auto-save receipts and does not mutate receipts. Any future paste-storage, capture-editor, browser-automation, or API-automation behavior must be separately authorized.
+
+## Manual Next Step Guide
+
+Lane: `AOC-B008A-OPERATOR-NEXT-STEP-CLARITY-001`
+
+The **Manual Next Step Guide** is a display-only clarity panel in the protected Operator Console. It summarizes safe labels for what the operator can review now, what remains manual-only outside the console, and what is blocked inside the console.
+
+The panel is not a queue, not a runner, and not a workbench. It does not execute anything, call providers, call ChatGPT, call `/v1/solve`, automate a browser, run CLI/subprocess commands, submit prompts, or mutate capture/evidence/preflight artifacts.
+
+The guide does not add write paths. The existing Local Receipt Store remains the only controlled local write action on the Operator Console surface. The guide does not store pasted output and does not add a paste editor, capture editor, raw prompt viewer, raw output viewer, or raw route metadata viewer.
+
+The guide also makes no readiness, validation, benchmark, production, scoring, ranking, winner, or superiority claims. Its labels are operator-safety labels only; they are not evidence of output quality, provider availability, billing accuracy, or launch suitability.

--- a/tests/test_operator_console.py
+++ b/tests/test_operator_console.py
@@ -2877,3 +2877,157 @@ def test_operator_console_no_user_supplied_write_path_parameters() -> None:
     dependant_names = [param.name for param in getattr(route, "dependant").body_params]
     dependant_names += [param.name for param in getattr(route, "dependant").query_params]
     assert dependant_names == []
+
+# ---------------------------------------------------------------------------
+# UI-ALPHA-OPERATOR-CONSOLE-MANUAL-NEXT-STEP-GUIDE-001
+# ---------------------------------------------------------------------------
+def _manual_next_step_card_html(html_text: str) -> str:
+    start = html_text.index('id="card-manual-next-step-guide"')
+    end = html_text.index("</article>", start)
+    return html_text[start:end]
+
+
+def test_manual_next_step_guide_status_payload(client: TestClient) -> None:
+    _login(client)
+    payload = client.get(STATUS_ROUTE).json()
+    assert "manual_next_step_guide" in payload
+    guide = payload["manual_next_step_guide"]
+    assert guide["title"] == "Manual Next Step Guide"
+    assert guide["mode"] == "display_only"
+    assert guide["execution"] == "non_executing"
+    assert guide["sections"] == [
+        "Available for review",
+        "Manual-only steps",
+        "Blocked in this console",
+    ]
+    assert {item["section"] for item in guide["items"]} == set(guide["sections"])
+    assert "Provider calls blocked." in guide["boundary_notes"]
+
+
+def test_manual_next_step_guide_card_copy_and_sections(client: TestClient) -> None:
+    _login(client)
+    card = _manual_next_step_card_html(client.get(PAGE_ROUTE).text)
+    for required in (
+        "Manual Next Step Guide",
+        "Available for review",
+        "Manual-only steps",
+        "Blocked in this console",
+        "display-only",
+        "Provider calls blocked",
+        "Local Receipt Store only",
+    ):
+        assert required in card
+    assert "manual-only" in card.lower()
+    assert "does not run providers" in card
+    assert "does not call /v1/solve" in card
+    assert "does not accept prompt input or store pasted model output" in card
+
+
+def test_manual_next_step_guide_has_no_action_controls(client: TestClient) -> None:
+    _login(client)
+    card = _manual_next_step_card_html(client.get(PAGE_ROUTE).text)
+    assert "<button" not in card
+    assert "<form" not in card
+    assert "<textarea" not in card
+    assert "method=\"post\"" not in card.lower()
+    control_fragments = (
+        "run selected",
+        "dispatch",
+        "submit",
+        "send",
+        "process",
+        "retry",
+        "schedule",
+        "approve",
+    )
+    lowered = card.lower()
+    for word in control_fragments:
+        assert f">{word}<" not in lowered, word
+        assert f'aria-label="{word}"' not in lowered, word
+        assert f'value="{word}"' not in lowered, word
+
+
+def test_manual_next_step_guide_no_new_post_route_and_receipt_only() -> None:
+    post_paths = {
+        getattr(route, "path", None)
+        for route in app.routes
+        if "POST" in getattr(route, "methods", set())
+        and str(getattr(route, "path", "")).startswith("/dashboard/operator-console")
+    }
+    assert post_paths == {RECEIPTS_ROUTE}
+
+
+def test_manual_next_step_guide_no_raw_or_secret_leak(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", FAKE_SECRET)
+    capture = _capture_with_sensitive_metadata()
+    _write(tmp_path, "capture.json", capture)
+    _write(tmp_path, "evidence_packet.json", capture_lib.build_evidence_packet(capture))
+    _use_root(monkeypatch, tmp_path)
+    _login(client)
+    status_text = client.get(STATUS_ROUTE).text
+    card = _manual_next_step_card_html(client.get(PAGE_ROUTE).text)
+    for raw in (
+        RAW_PROMPT,
+        RAW_BASELINE,
+        RAW_ROUTED,
+        RAW_ROUTE_META,
+        RAW_SYS_PROMPT,
+        RAW_PROVIDER_PAYLOAD,
+        FAKE_SECRET,
+        "sk-",
+    ):
+        assert raw not in status_text
+        assert raw not in card
+
+
+def test_manual_next_step_guide_preserves_existing_boundaries(client: TestClient) -> None:
+    _login(client)
+    payload = client.get(STATUS_ROUTE).json()
+    assert payload["provider_gate"]["live_execution_gate"] == "blocked"
+    assert payload["provider_gate"]["live_provider_calls"] == "disabled"
+    assert payload["dry_run_preview"]["preview_mode"] == "display_only"
+    assert payload["dry_run_preview"]["dry_run_execution"] == "not_enabled"
+    assert payload["chatgpt_copy_paste_capture"]["mode"] == "manual_only"
+    assert payload["chatgpt_copy_paste_capture"]["console_stores_pasted_outputs"] is False
+    assert payload["run_setup"]["live_run_button_enabled"] is False
+    assert payload["route_trace"]["note"] == "No solve has run from this console; fields are placeholders."
+
+
+def test_manual_next_step_guide_forbidden_claim_language_absent(client: TestClient) -> None:
+    _login(client)
+    card = _manual_next_step_card_html(client.get(PAGE_ROUTE).text).lower()
+    for forbidden in (
+        "safe action queue",
+        "action queue",
+        "task queue",
+        "job queue",
+        "worker",
+        "run selected",
+        "schedule",
+        "retry",
+        "priority",
+        "winner",
+        "score",
+        "rank",
+        "production-ready",
+        "benchmark passed",
+        "validated output",
+        "readiness",
+        "superiority",
+    ):
+        assert forbidden not in card, forbidden
+
+
+def test_manual_next_step_guide_under_reusable_safety_guard(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _login(client)
+    with operator_console_no_execution_guard(monkeypatch), operator_console_no_get_write_guard(monkeypatch):
+        page = client.get(PAGE_ROUTE)
+        status = client.get(STATUS_ROUTE)
+    assert page.status_code == 200
+    assert status.status_code == 200
+    assert "Manual Next Step Guide" in page.text
+    assert "manual_next_step_guide" in status.json()


### PR DESCRIPTION
### Motivation

- Provide a small, operator-facing clarity lane that ties existing safe Operator Console surfaces together and makes explicit what can be reviewed, what must be done manually, and what is blocked in-console without adding any execution or write semantics. 
- Reduce operator confusion by surfacing bounded, display-only next-step labels so the console remains a local-first cockpit and not a runner or queue.

### Description

- Add a bounded `manual_next_step_guide` status payload and builder `_build_manual_next_step_guide()` in `alpha/webapp/routes/operator_console.py` and register it in `build_console_status()` so the JSON status includes the new section. 
- Render a protected, display-only page card titled `Manual Next Step Guide` in the Operator Console page HTML that shows the three required sections (`Available for review`, `Manual-only steps`, `Blocked in this console`) and contains no buttons, forms, textareas, POST behavior, or action controls. 
- Populate the guide with a fixed set of bounded items derived from existing safe surfaces (`local_artifacts`, `dry_run_preview`, `provider_gate`, `local_receipts`, `chatgpt_copy_paste_capture`, `route_trace`) and include explicit boundary notes; do not read or expose raw prompts, outputs, provider payloads, secrets, or pasted model outputs. 
- Add spec and documentation artifacts by creating `.specs/UI-ALPHA-OPERATOR-CONSOLE-MANUAL-NEXT-STEP-GUIDE-001.md`, updating `.specs/INDEX.md`, and adding a short section to `docs/OPERATOR_CONSOLE.md`. 
- Add focused tests in `tests/test_operator_console.py` validating the presence of `manual_next_step_guide` in status JSON, rendering of the card with the three sections and safe copy, absence of action controls or new POST routes, preservation of existing provider/dry-run/ChatGPT/write boundaries, and that the card does not surface raw secrets or raw artifact content.

### Testing

- Ran focused Operator Console tests with `python -m pytest tests/test_operator_console.py -q` and the updated tests passed. 
- Ran an expanded set with `python -m pytest tests/test_operator_console.py tests/test_operator_run_capture.py tests/test_api_endpoints.py -q` and those tests passed. 
- Ran the full test suite with `python -m pytest -q` and the repository tests completed with the new Operator Console tests passing. 
- Lint and narrative checks passed with `ruff check alpha/webapp/routes/operator_console.py tests/test_operator_console.py` and `python scripts/check_narrative_claim_safety.py docs/OPERATOR_CONSOLE.md .specs/UI-ALPHA-OPERATOR-CONSOLE-MANUAL-NEXT-STEP-GUIDE-001.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4da65914a48329a020bb21ab6592c2)