### PR TITLE
Progressive disclosure for operator console boundary blocks

### DIFF
--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -105,6 +105,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `UI-ALPHA-OPERATOR-CONSOLE-MANUAL-NEXT-STEP-GUIDE-001.md` | UI-ALPHA-OPERATOR-CONSOLE-MANUAL-NEXT-STEP-GUIDE-001 · Operator Console Manual Next Step Guide | ✅ `SPEC_OK` |
 | `UI-ALPHA-OPERATOR-CONSOLE-FIRST-FIVE-MINUTES-001.md` | UI-ALPHA-OPERATOR-CONSOLE-FIRST-FIVE-MINUTES-001 · Operator Console First 5 Minutes Guide | ✅ `SPEC_OK` |
 | `UI-ALPHA-OPERATOR-CONSOLE-DAILY-USE-WALKTHROUGH-001.md` | UI-ALPHA-OPERATOR-CONSOLE-DAILY-USE-WALKTHROUGH-001 · Operator Console Daily-Use Walkthrough | ✅ `SPEC_OK` |
+| `UI-ALPHA-OPERATOR-CONSOLE-PROGRESSIVE-DISCLOSURE-001.md` | UI-ALPHA-OPERATOR-CONSOLE-PROGRESSIVE-DISCLOSURE-001 · Operator Console Progressive Disclosure | ✅ `SPEC_OK` |
 | `UI-JOBS-001.md` | UI-JOBS-001 · Dashboard Job History & Metrics (RES_Dash) | ✅ `SPEC_OK` |
 | `UI-PREVIEW-001.md` | UI-PREVIEW-001 · Authenticated Expert Preview UI | ✅ `SPEC_OK` |
 | `UI-PREVIEW-LOADING-STATE-001.md` | UI-PREVIEW-LOADING-STATE-001 · Expert Preview Loading State | ✅ `SPEC_OK` |

--- a/.specs/UI-ALPHA-OPERATOR-CONSOLE-PROGRESSIVE-DISCLOSURE-001.md
+++ b/.specs/UI-ALPHA-OPERATOR-CONSOLE-PROGRESSIVE-DISCLOSURE-001.md
@@ -1,0 +1,145 @@
+# UI-ALPHA-OPERATOR-CONSOLE-PROGRESSIVE-DISCLOSURE-001 · Operator Console Progressive Disclosure
+
+Lane id: `AOC-B009-OPERATOR-CONSOLE-PROGRESSIVE-DISCLOSURE-001`
+
+## Goal
+
+Reduce first-glance visual overwhelm on `/dashboard/operator-console` by moving
+long, repeated boundary-note lists and reference-heavy blocks behind
+closed-by-default native HTML `<details>` / `<summary>` elements.
+
+This lane changes default visibility only. It does not remove boundary text and
+does not add execution capability.
+
+## Motivation
+
+A daily operator opened the protected Operator Console in a local preview and
+reported that the local-first and live-provider-disabled signals were clear, but
+that there was "too much text" and "too much everything. no ux." The console's
+safety boundaries are correct; the problem is that every long boundary list and
+reference block renders fully expanded at once, so the operator cannot scan the
+page. Progressive disclosure keeps all the safety information present while
+collapsing the repeated detail so the page becomes scannable.
+
+## Scope
+
+- Add a small `_details(summary, body)` render helper that emits a
+  closed-by-default native `<details class="disclosure"><summary>…</summary>…`
+  element. No `open` attribute, no JavaScript, no frontend dependency.
+- Wrap the following long, repeated boundary/reference blocks in that helper,
+  keeping each card's title and a one-line boundary summary visible:
+  - Dry-Run Preview: "would use" list and the long safety-boundary list.
+  - Provider and Cost Gate: cap/key presence detail tables and the long
+    safety-boundary list.
+  - Preflight and Capture Entry: the terminal workflow command snippets.
+  - Manual Next Step Guide: the boundary-reminder list.
+  - ChatGPT Copy/Paste Capture: would-use, checklist/template, terminal
+    snippets, route-metadata guidance, unsafe-actions list, and the long
+    safety-boundary list.
+  - Local Receipt Store: the receipt-boundary list.
+  - Evidence and Receipt: the local-artifact boundary list and the freshness /
+    sequence-coherence detail.
+- Add minimal CSS for the disclosure summary affordance.
+- Keep the primary header, mode banner, disabled live-run control, and card
+  titles fully visible (never collapsed).
+
+## Non-goals
+
+- No action queue, task queue, job queue, processor, workbench, runner,
+  scheduler, worker, dispatch, approval, retry, or action-control behavior.
+- No provider execution, ChatGPT API integration, browser automation,
+  `/v1/solve` invocation, dry-run execution, or CLI/subprocess/shell execution
+  from the console.
+- No paste storage, capture editor, raw prompt viewer, or raw output viewer.
+- No new POST route, new write path, new status payload field, or new card id.
+- No page-wide layout redesign and no card reordering.
+- No JavaScript accordion or tab framework and no new frontend dependency.
+- No readiness, validation, benchmark, production, scoring, ranking, winner, or
+  superiority claim.
+- No removal, weakening, paraphrase, or badge-replacement of existing boundary
+  text.
+
+## Allowed files
+
+- `alpha/webapp/routes/operator_console.py`
+- `tests/test_operator_console.py`
+- `docs/OPERATOR_CONSOLE.md`
+- `.specs/UI-ALPHA-OPERATOR-CONSOLE-PROGRESSIVE-DISCLOSURE-001.md`
+- `.specs/INDEX.md`
+
+## Implementation notes
+
+- Progressive disclosure is native only: `<details>` / `<summary>` with no
+  `open` attribute renders collapsed by default in the browser and requires no
+  script.
+- Because the collapsed body remains in the served HTML, every existing
+  substring-based safety test continues to pass unchanged; collapse means less
+  visible by default, not removed.
+- The status JSON assembled by `build_console_status` is untouched: this is a
+  render-layer change in `_render_page` only.
+- Card ids, the disabled live-run control, and the single existing receipt form
+  are preserved exactly.
+
+## Definition of done
+
+- The page renders long boundary/reference blocks inside closed-by-default
+  native `<details>` / `<summary>` elements.
+- The mode banner, `Local-first operator console`, `Live provider calls are
+  disabled in this MVP`, `No API keys are displayed`, the claim boundary, the
+  disabled live-run control, and every card title remain visible without
+  expanding anything.
+- All existing boundary text remains present in the served HTML.
+- All existing card ids remain present.
+- Status JSON shape is unchanged.
+- Focused and broad Operator Console tests pass.
+- Documentation notes that detailed boundary reminders may be collapsed on the
+  page but remain available through expandable details.
+
+## Boundary checklist
+
+- [x] Render-only default-visibility change.
+- [x] Native `<details>` / `<summary>` only.
+- [x] Details closed by default (no `open` attribute).
+- [x] No JavaScript and no new frontend dependency.
+- [x] No boundary text removed, weakened, or paraphrased.
+- [x] First-glance safety signals remain visible.
+- [x] No provider calls.
+- [x] No ChatGPT calls.
+- [x] No `/v1/solve` calls.
+- [x] No browser automation.
+- [x] No CLI, shell, or subprocess execution.
+- [x] No prompt submission.
+- [x] No paste storage or capture editor.
+- [x] No raw prompt/output viewer.
+- [x] No new POST route.
+- [x] No new write path.
+- [x] No new status payload field.
+- [x] No new or renamed card id.
+- [x] Local Receipt Store remains the only controlled write path.
+
+## Non-claims
+
+The lane does not claim readiness, validation success, benchmark validity,
+production readiness, scoring, ranking, winner selection, model superiority,
+provider readiness, billing accuracy, or answer quality. It is a presentation
+change that makes existing safety information easier to scan; it does not make
+the console more capable and does not validate the product.
+
+## Test plan
+
+Focused tests must prove:
+
+- The page includes native `<details>` and `<summary>` elements for the long
+  boundary/reference sections.
+- The new details elements are closed by default (no `open` attribute) and no
+  JavaScript accordion/tab framework is introduced.
+- The primary mode/safety banner text stays visible outside any details.
+- All existing safety boundary strings remain present in the served HTML.
+- All existing card ids remain present.
+- The live-run button remains disabled.
+- No new form is added except the existing receipt form.
+- No new POST route is added except the existing receipt route.
+- No raw prompt/output viewer or paste editor is introduced.
+- No queue, runner, scheduler, scoring, ranking, winner, readiness, validation,
+  benchmark, production, or superiority claim is introduced.
+- The status JSON shape is unchanged.

--- a/alpha/webapp/routes/operator_console.py
+++ b/alpha/webapp/routes/operator_console.py
@@ -1101,6 +1101,22 @@ def _list_items(items: List[Any]) -> str:
     return "".join(f"<li>{_escape(item)}</li>" for item in items)
 
 
+def _details(summary: str, body: str) -> str:
+    """Render a closed-by-default native disclosure (no ``open`` attribute, no JS).
+
+    Progressive-disclosure wrapper for long, repeated boundary lists and
+    reference-heavy blocks. The ``body`` always stays in the served HTML — so
+    substring-based safety tests keep passing and no boundary text is removed —
+    but it is collapsed by default to reduce first-glance density. This changes
+    default visibility only; it adds no execution capability and no new control.
+    """
+
+    return (
+        f'<details class="disclosure"><summary>{_escape(summary)}</summary>'
+        f"{body}</details>"
+    )
+
+
 def receipts_auth_header() -> str:
     return "x-alpha-csrf"
 
@@ -1405,6 +1421,9 @@ def _render_page(status: Mapping[str, Any]) -> str:
       a.status-link, a.refresh-link {{ display: inline-block; margin-top: 0.75rem; color: #4f46e5; font-weight: 700; }}
       a.refresh-link {{ margin-right: 0.85rem; }}
       .receipt-btn {{ margin-top: 0.75rem; border: 0; border-radius: 999px; padding: 0.6rem 1.15rem; font: inherit; font-weight: 800; color: #ffffff; background: #4f46e5; cursor: pointer; }}
+      details.disclosure {{ margin-top: 0.6rem; border-top: 1px solid rgba(86, 97, 246, 0.12); padding-top: 0.45rem; }}
+      details.disclosure > summary {{ cursor: pointer; color: #4f46e5; font-weight: 700; font-size: 0.85rem; }}
+      details.disclosure[open] > summary {{ margin-bottom: 0.5rem; }}
     </style>
   </head>
   <body>
@@ -1457,8 +1476,10 @@ def _render_page(status: Mapping[str, Any]) -> str:
               "anchor preflight": dry_run["preflight_status"]["anchor"],
               "lift preflight": dry_run["preflight_status"]["lift"],
           })}
-          <p class="note">Would use (existing local metadata only):</p>
-          <ul class="surfaces">{dr_would_use_html}</ul>
+          {_details(
+              "Would use — existing local metadata (display-only)",
+              f'<ul class="surfaces">{dr_would_use_html}</ul>',
+          )}
           <p class="note">Freshness warnings (local metadata only):</p>
           <ul class="surfaces">{dr_warnings_html}</ul>
 
@@ -1471,7 +1492,10 @@ def _render_page(status: Mapping[str, Any]) -> str:
           <p class="note">Preview blockers (what is missing before a future dry-run lane):</p>
           <ul class="surfaces">{dr_blockers_html}</ul>
           <p class="note">{_escape(dry_run["boundary"])}.</p>
-          <ul class="surfaces">{dr_boundary_html}</ul>
+          {_details(
+              "Dry-Run Preview safety boundaries",
+              f'<ul class="surfaces">{dr_boundary_html}</ul>',
+          )}
         </article>
 
         <article class="card" id="card-route-trace">
@@ -1510,19 +1534,28 @@ def _render_page(status: Mapping[str, Any]) -> str:
           })}
           <p class="note">Blockers (why live execution stays blocked):</p>
           <ul class="surfaces">{blocker_rows}</ul>
-          <p class="note">Cap presence (configured limits only, not billing truth):</p>
-          {cap_rows}
-          <p class="note">Key presence (categorical only):</p>
-          {key_rows}
+          {_details(
+              "Cap and key presence detail (categorical only)",
+              '<p class="note">Cap presence (configured limits only, not billing truth):</p>'
+              f"{cap_rows}"
+              '<p class="note">Key presence (categorical only):</p>'
+              f"{key_rows}",
+          )}
           <p class="note">{_escape(gate["gate_boundary"])}.</p>
-          <ul class="surfaces">{gate_boundary_html}</ul>
+          {_details(
+              "Provider and cost gate safety boundaries",
+              f'<ul class="surfaces">{gate_boundary_html}</ul>',
+          )}
           <p class="note">{_escape(gate["note"])}</p>
         </article>
 
         <article class="card" id="card-preflight-capture">
           <h2>Preflight and Capture Entry</h2>
-          <p class="note">Local workflows (run from a terminal, not from this console):</p>
-          <ul class="workflows">{workflow_rows}</ul>
+          {_details(
+              "Local terminal workflow commands (text only; not executed)",
+              '<p class="note">Local workflows (run from a terminal, not from this console):</p>'
+              f'<ul class="workflows">{workflow_rows}</ul>',
+          )}
           <p class="note">Docs: {_escape(capture["docs"])}</p>
           <p class="note">{_escape(capture["note"])}</p>
           <p class="note">Local preflight report status:</p>
@@ -1545,8 +1578,10 @@ def _render_page(status: Mapping[str, Any]) -> str:
           <ul class="surfaces">{manual_only_html}</ul>
           <h3 class="subhead">Blocked in this console</h3>
           <ul class="surfaces">{manual_blocked_html}</ul>
-          <p class="note">Boundary reminders:</p>
-          <ul class="surfaces">{manual_boundary_html}</ul>
+          {_details(
+              "Boundary reminders",
+              f'<ul class="surfaces">{manual_boundary_html}</ul>',
+          )}
         </article>
 
 
@@ -1564,22 +1599,36 @@ def _render_page(status: Mapping[str, Any]) -> str:
               "console stores pasted outputs": chatgpt_capture["console_stores_pasted_outputs"],
               "current capture stage": chatgpt_capture["current_capture_stage"],
           })}
-          <p class="note">Would use (safe local workflow labels only):</p>
-          <ul class="surfaces">{chatgpt_would_use_html}</ul>
           <p class="note">Next recommended manual steps:</p>
           <ul class="surfaces">{chatgpt_steps_html}</ul>
-          <h3 class="subhead">Copy/paste field checklist</h3>
-          <ul class="surfaces">{chatgpt_checklist_html}</ul>
-          <h3 class="subhead">Placeholder-only capture slot template</h3>
-          {chatgpt_template_html}
-          <h3 class="subhead">Terminal command snippets (text only; not executed)</h3>
-          <ul class="workflows">{chatgpt_commands_html}</ul>
-          <h3 class="subhead">Route metadata guidance</h3>
-          <ul class="surfaces">{chatgpt_route_guidance_html}</ul>
-          <h3 class="subhead">Unsafe actions blocked</h3>
-          <ul class="surfaces">{chatgpt_unsafe_html}</ul>
+          {_details(
+              "Would use — safe local workflow labels only",
+              f'<ul class="surfaces">{chatgpt_would_use_html}</ul>',
+          )}
+          {_details(
+              "Copy/paste field checklist and placeholder capture slot template",
+              '<h3 class="subhead">Copy/paste field checklist</h3>'
+              f'<ul class="surfaces">{chatgpt_checklist_html}</ul>'
+              '<h3 class="subhead">Placeholder-only capture slot template</h3>'
+              f"{chatgpt_template_html}",
+          )}
+          {_details(
+              "Terminal command snippets (text only; not executed)",
+              f'<ul class="workflows">{chatgpt_commands_html}</ul>',
+          )}
+          {_details(
+              "Route metadata guidance",
+              f'<ul class="surfaces">{chatgpt_route_guidance_html}</ul>',
+          )}
+          {_details(
+              "Unsafe actions blocked",
+              f'<ul class="surfaces">{chatgpt_unsafe_html}</ul>',
+          )}
           <p class="note">{_escape(chatgpt_capture["boundary"])}.</p>
-          <ul class="surfaces">{chatgpt_boundary_html}</ul>
+          {_details(
+              "ChatGPT copy/paste safety boundaries",
+              f'<ul class="surfaces">{chatgpt_boundary_html}</ul>',
+          )}
         </article>
 
 
@@ -1596,7 +1645,10 @@ def _render_page(status: Mapping[str, Any]) -> str:
           </form>
           <p class="note">Recent receipts (safe metadata only):</p>
           <ul class="surfaces">{receipt_rows}</ul>
-          <ul class="surfaces">{receipt_boundary_html}</ul>
+          {_details(
+              "Local receipt boundaries",
+              f'<ul class="surfaces">{receipt_boundary_html}</ul>',
+          )}
         </article>
 
         <article class="card" id="card-evidence-receipt">
@@ -1610,15 +1662,21 @@ def _render_page(status: Mapping[str, Any]) -> str:
           <p class="note">Local artifact status:</p>
           {evidence_artifact_html}
           {evidence_no_artifacts}
-          <ul class="surfaces">{boundary_html}</ul>
+          {_details(
+              "Local artifact boundaries",
+              f'<ul class="surfaces">{boundary_html}</ul>',
+          )}
           <p class="note">{_escape(ARTIFACT_BOUNDARY_TEXT)}.</p>
 
           <h3 class="subhead">Artifact Freshness and Sequence Coherence</h3>
           <p class="note">Local filesystem metadata only. Status generated at: {_escape(local["status_generated_at_utc"])}</p>
-          {freshness_files_html}
-          <p class="note">Derived-vs-capture ordering (metadata only):</p>
-          {coherence_html}
-          <ul class="surfaces">{freshness_boundary_html}</ul>
+          {_details(
+              "Freshness and sequence-coherence detail (local metadata only)",
+              f"{freshness_files_html}"
+              '<p class="note">Derived-vs-capture ordering (metadata only):</p>'
+              f"{coherence_html}"
+              f'<ul class="surfaces">{freshness_boundary_html}</ul>',
+          )}
           <a class="refresh-link" href="{ROUTE}">Refresh (reload this read-only page)</a>
         </article>
       </div>

--- a/docs/OPERATOR_CONSOLE.md
+++ b/docs/OPERATOR_CONSOLE.md
@@ -34,6 +34,20 @@ return 404. When mounted, an unauthenticated `GET` redirects to `/login`.
 - Page: `GET /dashboard/operator-console`
 - Read-only status JSON: `GET /dashboard/operator-console/status`
 
+## Reading a dense page (progressive disclosure)
+
+To keep the page scannable, some long boundary-reminder lists and
+reference-heavy blocks are collapsed by default behind native expandable
+`details` controls. Collapsing changes default visibility only: the full
+boundary text remains present in the page HTML/UI and is one click away under
+each `details` summary. Nothing is removed and no text is paraphrased.
+
+The primary mode banner (local-first, live provider calls disabled, no API keys
+displayed, and the claim boundary), the disabled live-run control, each card
+title, and a one-line boundary summary per card stay visible without expanding
+anything. Expanding a `details` section runs nothing; it only reveals text that
+was already loaded with the page.
+
 
 ## Operator Console First 5 Minutes
 

--- a/tests/test_operator_console.py
+++ b/tests/test_operator_console.py
@@ -3031,3 +3031,186 @@ def test_manual_next_step_guide_under_reusable_safety_guard(
     assert status.status_code == 200
     assert "Manual Next Step Guide" in page.text
     assert "manual_next_step_guide" in status.json()
+
+
+# ---------------------------------------------------------------------------
+# UI-ALPHA-OPERATOR-CONSOLE-PROGRESSIVE-DISCLOSURE-001
+# Progressive disclosure collapses long, repeated boundary/reference blocks
+# behind closed-by-default native <details>/<summary>. It changes default
+# visibility only: no boundary text is removed and no execution capability is
+# added. These tests prove the collapse is native, closed by default, and does
+# not weaken any existing safety boundary, card, control, form, or route.
+# ---------------------------------------------------------------------------
+def test_progressive_disclosure_uses_native_details_and_summary(client: TestClient) -> None:
+    _login(client)
+    html_text = client.get(PAGE_ROUTE).text
+    # Several long boundary/reference blocks are now collapsed behind native
+    # <details>/<summary>. Prove both elements are present in useful numbers.
+    assert html_text.count("<details class=\"disclosure\">") >= 8
+    assert html_text.count("<summary>") == html_text.count("<details class=\"disclosure\">")
+    # Each disclosure carries a non-empty <summary> label.
+    assert "<summary></summary>" not in html_text
+
+
+def test_progressive_disclosure_details_are_closed_by_default(client: TestClient) -> None:
+    _login(client)
+    html_text = client.get(PAGE_ROUTE).text
+    # No disclosure may render expanded by default: no ``open`` attribute.
+    assert "<details class=\"disclosure\" open" not in html_text
+    assert "<details open" not in html_text
+    assert " open>" not in html_text
+    # And no JavaScript accordion/tab framework was introduced.
+    assert "<script" not in html_text
+    assert "onclick" not in html_text
+
+
+def test_progressive_disclosure_keeps_first_glance_safety_visible_outside_details(
+    client: TestClient,
+) -> None:
+    """The primary mode/safety banner text must not be hidden inside a disclosure."""
+
+    _login(client)
+    html_text = client.get(PAGE_ROUTE).text
+    # Everything before the first <details> is the always-visible, un-collapsed
+    # region (banner + card headers). The primary safety signals must live there.
+    first_details = html_text.index("<details class=\"disclosure\">")
+    visible_head = html_text[:first_details]
+    assert operator_console.LOCAL_FIRST_TEXT in visible_head
+    assert operator_console.LIVE_DISABLED_TEXT in visible_head
+    assert operator_console.NO_KEYS_TEXT in visible_head
+    assert operator_console.CLAIM_BOUNDARY_TEXT in visible_head
+
+
+def test_progressive_disclosure_retains_all_boundary_text_in_served_html(
+    client: TestClient,
+) -> None:
+    """Collapsing must not remove any boundary text from the served HTML."""
+
+    _login(client)
+    html_text = client.get(PAGE_ROUTE).text
+    for text in (
+        operator_console.LOCAL_FIRST_TEXT,
+        operator_console.LIVE_DISABLED_TEXT,
+        operator_console.NO_KEYS_TEXT,
+        operator_console.CLAIM_BOUNDARY_TEXT,
+        operator_console.ARTIFACT_BOUNDARY_TEXT,
+    ):
+        assert text in html_text
+    for group in (
+        operator_console.GATE_BOUNDARY_TEXTS,
+        operator_console.DRY_RUN_BOUNDARY_TEXTS,
+        operator_console.CHATGPT_CAPTURE_BOUNDARY_TEXTS,
+        operator_console.MANUAL_NEXT_STEP_BOUNDARY_TEXTS,
+    ):
+        for text in group:
+            assert text in html_text
+
+
+def test_progressive_disclosure_preserves_all_card_ids(client: TestClient) -> None:
+    _login(client)
+    html_text = client.get(PAGE_ROUTE).text
+    for card_id in (
+        "card-portable-contract",
+        "card-run-setup",
+        "card-dry-run-preview",
+        "card-route-trace",
+        "card-provider-gate",
+        "card-preflight-capture",
+        "card-manual-next-step-guide",
+        "card-chatgpt-copy-paste-capture",
+        "card-local-receipt-store",
+        "card-evidence-receipt",
+    ):
+        assert card_id in html_text
+
+
+def test_progressive_disclosure_keeps_live_run_button_disabled(client: TestClient) -> None:
+    _login(client)
+    html_text = client.get(PAGE_ROUTE).text
+    assert "Live run (disabled)" in html_text
+    assert "class=\"disabled-btn\" disabled" in html_text
+
+
+def test_progressive_disclosure_adds_no_new_form(client: TestClient) -> None:
+    _login(client)
+    html_text = client.get(PAGE_ROUTE).text
+    # The only form on the page remains the existing receipt-store form.
+    assert html_text.count("<form") == 1
+    assert f'action="{RECEIPTS_ROUTE}"' in html_text
+    # No new interactive text input beyond the pre-existing disabled prompt box.
+    assert html_text.count("<textarea") == 1
+    assert "disabled aria-disabled=\"true\"" in html_text
+
+
+def test_progressive_disclosure_adds_no_new_post_route() -> None:
+    post_paths = {
+        getattr(route, "path", None)
+        for route in app.routes
+        if "POST" in getattr(route, "methods", set())
+        and str(getattr(route, "path", "")).startswith("/dashboard/operator-console")
+    }
+    assert post_paths == {RECEIPTS_ROUTE}
+
+
+def test_progressive_disclosure_adds_no_raw_viewer_or_paste_editor(client: TestClient) -> None:
+    _login(client)
+    html_text = client.get(PAGE_ROUTE).text
+    # No editable/paste surface is introduced by the disclosure change.
+    assert "contenteditable" not in html_text
+    # The status payload still refuses to store pasted output.
+    payload = client.get(STATUS_ROUTE).json()
+    assert payload["chatgpt_copy_paste_capture"]["console_stores_pasted_outputs"] is False
+    assert payload["chatgpt_copy_paste_capture"]["console_writes_capture"] is False
+
+
+def test_progressive_disclosure_introduces_no_claim_language(client: TestClient) -> None:
+    _login(client)
+    html_text = client.get(PAGE_ROUTE).text.lower()
+    for forbidden in (
+        "run now",
+        "execute now",
+        "submit to provider",
+        "generate answer",
+        "solve now",
+        "start solve",
+        "production ready",
+        "ready for production",
+        "estimated spend",
+        "estimated cost",
+        "winner",
+        "leaderboard",
+        "outperforms",
+        "best-in-class",
+        "state-of-the-art",
+        "benchmark passed",
+        "validated output",
+        "readiness confirmed",
+        "queue started",
+        "runner started",
+        "scheduler started",
+    ):
+        assert forbidden not in html_text, forbidden
+
+
+def test_progressive_disclosure_status_payload_shape_unchanged(client: TestClient) -> None:
+    """Progressive disclosure is a render-only change; status JSON is unchanged."""
+
+    _login(client)
+    payload = client.get(STATUS_ROUTE).json()
+    for section in (
+        "console",
+        "portable_contract",
+        "run_setup",
+        "route_trace",
+        "provider_gate",
+        "dry_run_preview",
+        "chatgpt_copy_paste_capture",
+        "manual_next_step_guide",
+        "preflight_capture",
+        "evidence_receipt",
+        "local_artifacts",
+        "local_receipts",
+    ):
+        assert section in payload
+    assert payload["provider_gate"]["live_execution_gate"] == "blocked"
+    assert payload["run_setup"]["live_run_button_enabled"] is False


### PR DESCRIPTION
## Summary

Implements progressive disclosure on the Operator Console by wrapping long, repeated boundary-reminder lists and reference-heavy blocks in native HTML `<details>` / `<summary>` elements. These sections collapse by default (no `open` attribute, no JavaScript) to reduce first-glance visual density while keeping all safety information present and scannable.

This is a render-only change that improves UX without altering safety boundaries, execution capability, or the status JSON shape.

## Changes

### Core Implementation
- Added `_details(summary, body)` helper in `operator_console.py` that emits closed-by-default native disclosure elements
- Wrapped the following sections in progressive disclosure:
  - Dry-Run Preview: "would use" list and safety-boundary list
  - Provider and Cost Gate: cap/key presence detail tables and safety-boundary list
  - Preflight and Capture Entry: terminal workflow command snippets
  - Manual Next Step Guide: boundary-reminder list
  - ChatGPT Copy/Paste Capture: would-use, checklist/template, terminal snippets, route metadata, unsafe actions, and safety-boundary list
  - Local Receipt Store: receipt-boundary list
  - Evidence and Receipt: local-artifact boundaries and freshness/sequence-coherence detail
- Added minimal CSS for disclosure summary affordance (cursor, color, font-weight, spacing)

### Documentation
- Updated `OPERATOR_CONSOLE.md` with "Reading a dense page (progressive disclosure)" section explaining that collapsed sections remain in the HTML and are one click away
- Added comprehensive spec `.specs/UI-ALPHA-OPERATOR-CONSOLE-PROGRESSIVE-DISCLOSURE-001.md` documenting goal, motivation, scope, non-goals, and boundary checklist

### Tests
- Added 11 focused tests proving:
  - Native `<details>` and `<summary>` elements are present in useful numbers (≥8 disclosures)
  - Details are closed by default (no `open` attribute, no JavaScript)
  - Primary safety signals (mode banner, disabled live-run, card titles) remain visible outside disclosures
  - All existing boundary text remains in served HTML
  - All existing card IDs are preserved
  - Live-run button remains disabled
  - No new forms or POST routes added
  - No raw viewer, paste editor, or claim language introduced
  - Status JSON shape is unchanged

## Checklist

- [x] Spec linked: `.specs/UI-ALPHA-OPERATOR-CONSOLE-PROGRESSIVE-DISCLOSURE-001.md`
- [x] Spec sections present: Goal, Motivation, Scope, Non-goals, Allowed files, Implementation notes, Definition of done, Boundary checklist, Non-claims, Test plan
- [x] Tests run: 11 new focused tests added; all existing tests continue to pass (substring-based safety tests unaffected because collapsed text remains in HTML)

## Notes for reviewers

- Progressive disclosure uses native `<details>` / `<summary>` only—no JavaScript, no frontend dependency, no accordion framework
- Because collapsed body content remains in the served HTML, all existing substring-based safety tests pass unchanged
- The status JSON assembled by `build_console_status` is untouched; this is a render-layer change in `_render_page` only
- Card IDs, disabled live-run control, and the single existing receipt form are preserved exactly
- All boundary text remains present; collapse changes default visibility only, not content

https://claude.ai/code/session_01HQw2ZgL8DKnhtbPpy8wFcu