### PR TITLE
Add flow-first orientation band to operator console

### DIFF
--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -106,6 +106,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 | `UI-ALPHA-OPERATOR-CONSOLE-FIRST-FIVE-MINUTES-001.md` | UI-ALPHA-OPERATOR-CONSOLE-FIRST-FIVE-MINUTES-001 · Operator Console First 5 Minutes Guide | ✅ `SPEC_OK` |
 | `UI-ALPHA-OPERATOR-CONSOLE-DAILY-USE-WALKTHROUGH-001.md` | UI-ALPHA-OPERATOR-CONSOLE-DAILY-USE-WALKTHROUGH-001 · Operator Console Daily-Use Walkthrough | ✅ `SPEC_OK` |
 | `UI-ALPHA-OPERATOR-CONSOLE-PROGRESSIVE-DISCLOSURE-001.md` | UI-ALPHA-OPERATOR-CONSOLE-PROGRESSIVE-DISCLOSURE-001 · Operator Console Progressive Disclosure | ✅ `SPEC_OK` |
+| `UI-ALPHA-OPERATOR-CONSOLE-FLOW-FIRST-ORIENTATION-001.md` | UI-ALPHA-OPERATOR-CONSOLE-FLOW-FIRST-ORIENTATION-001 · Operator Console Flow-First Orientation Band | ✅ `SPEC_OK` |
 | `UI-JOBS-001.md` | UI-JOBS-001 · Dashboard Job History & Metrics (RES_Dash) | ✅ `SPEC_OK` |
 | `UI-PREVIEW-001.md` | UI-PREVIEW-001 · Authenticated Expert Preview UI | ✅ `SPEC_OK` |
 | `UI-PREVIEW-LOADING-STATE-001.md` | UI-PREVIEW-LOADING-STATE-001 · Expert Preview Loading State | ✅ `SPEC_OK` |

--- a/.specs/UI-ALPHA-OPERATOR-CONSOLE-FLOW-FIRST-ORIENTATION-001.md
+++ b/.specs/UI-ALPHA-OPERATOR-CONSOLE-FLOW-FIRST-ORIENTATION-001.md
@@ -1,0 +1,212 @@
+# UI-ALPHA-OPERATOR-CONSOLE-FLOW-FIRST-ORIENTATION-001 · Operator Console Flow-First Orientation Band
+
+Lane id: `AOC-B010-OPERATOR-CONSOLE-FLOW-FIRST-ORIENTATION-001`
+
+This lane adds a read-only orientation band. It does not add execution, routes,
+write paths, action controls, or status JSON semantics.
+
+## Goal
+
+Add a read-only flow-first orientation band above the existing
+`/dashboard/operator-console` card grid so a human operator can understand the
+page in the first few seconds:
+
+1. What this page is.
+2. What this page is not.
+3. Whether the console will run anything.
+4. Whether anything needs immediate attention.
+5. What manual next step, if any, happens outside the console.
+
+This is a render-layer UX orientation lane only.
+
+## Motivation
+
+After the progressive-disclosure lane (PR #675), a daily operator opened the
+protected Operator Console and reported that the local-first and
+live-provider-disabled signals were clear, but that the page was still an
+"enormous amount of text," its purpose remained unclear, and the console was
+"still unusable." The operator asked, in effect, what the page is for and how it
+is meant to be used.
+
+The remaining problem is not only text density: the page lacks a flow-first
+mental model. A short, always-visible orientation band at the top answers what
+the page is, what it is not, its current safety posture, whether anything needs
+attention, and what manual step happens outside the console. It makes the
+existing console easier to understand without making it more powerful.
+
+## Scope
+
+- Add a `_render_orientation_band(status)` render helper that emits one
+  always-visible `<section class="orientation-band" id="orientation-band">`
+  containing five elements: a one-line purpose, static non-interactive posture
+  chips, an attention summary, a next-manual-action line, and a details-below
+  pointer.
+- Add two pure summarization helpers over the already-assembled in-memory status
+  dict: `_orientation_attention_items(status)` and
+  `_orientation_next_action(status)`.
+- Render the band near the top of the page, after the existing mode banner and
+  before the existing `<div class="cards">` grid.
+- Add minimal CSS for the band and the static posture chips.
+- Keep the existing card grid, the mode banner, the disabled live-run control,
+  every card title, and all existing boundary text exactly as they are.
+
+### One-line purpose
+
+The band renders exactly:
+
+> This is a local-first status console. It helps you review current local state
+> and decide the next manual step. It does not run, call, or execute anything.
+
+### Static posture chips
+
+Four static, non-interactive `<span>` labels: `Local-first`,
+`Live provider calls: disabled`, `Non-executing / read-only`, and
+`No API keys displayed`. They are not buttons, links, forms, inputs, or toggles;
+they submit nothing and imply no state that can be changed from the console.
+
+### Attention summary
+
+A read-only summary derived only from existing status values already rendered by
+the cards below. The safe default is
+`No immediate attention detected from local metadata.` When existing status data
+indicates a missing/invalid/stale condition, the band summarizes up to three
+bounded items derived from the in-memory status dict:
+
+- `Capture artifact missing.` — from `local_artifacts.capture.state == "missing"`.
+- `Local capture cannot be read.` — from an invalid capture state.
+- `Evidence packet digest needs attention.` — from a `digest_invalid` /
+  `digest_unverifiable` evidence-packet state.
+- `Derived artifacts appear older than capture.` — from an existing
+  `*_older_than_capture` freshness warning in `dry_run_preview.freshness_warnings`.
+
+The summary invents no readiness semantics and never uses "ready", "validated",
+"all clear", "passed", "healthy", "production readiness", "benchmark", "winner",
+or "superiority" wording.
+
+### Next manual action
+
+A read-only line derived from the first existing
+`chatgpt_copy_paste_capture.next_manual_steps` label (underscores rendered as
+spaces), stated plainly as happening outside the console, e.g.
+`Next manual step outside the console: validate capture from terminal.` When no
+step is available the safe default is
+`No manual action required from this console view.` The line is not a button, is
+not clickable, dispatches nothing, and does not say the console performs the
+action.
+
+### Details-below pointer
+
+A quiet pointer: `Details below: review surfaces, manual-only steps, blocked
+behavior, and receipts.` Orientation only.
+
+## Non-goals
+
+- No provider execution, ChatGPT API integration, browser automation,
+  `/v1/solve`, dry-run execution, or CLI/subprocess/shell execution from the
+  console.
+- No paste storage, capture editor, raw prompt viewer, or raw output viewer.
+- No scoring, ranking, winner selection, queue, runner, scheduler, or worker
+  behavior.
+- No action control of any kind, no new route, no new POST route, no new write
+  path, no new status payload field, and no changed status JSON semantics.
+- No removal, weakening, or paraphrase of any existing boundary text.
+- No JavaScript, no full layout redesign, and no card reordering.
+- No readiness, validation, benchmark, production, answer-quality, or
+  superiority claim.
+
+These capabilities are mentioned only as blocked, unavailable, or out of scope.
+
+## Allowed files
+
+- `alpha/webapp/routes/operator_console.py`
+- `tests/test_operator_console.py`
+- `docs/OPERATOR_CONSOLE.md`
+- `.specs/UI-ALPHA-OPERATOR-CONSOLE-FLOW-FIRST-ORIENTATION-001.md`
+- `.specs/INDEX.md`
+
+## Implementation notes
+
+- The band is presentation-only. `build_console_status()` returns the same shape
+  as before; the band is assembled entirely inside `_render_page` from the
+  status dict that function already receives.
+- `_orientation_attention_items` and `_orientation_next_action` are pure
+  summarization helpers over the existing in-memory status dict. They fetch no
+  new data, read no raw artifact content, and add no new state semantics.
+- The posture chips are static `<span>` labels with `cursor: default`; no
+  chip is wrapped in an anchor, button, form, input, or toggle.
+- All band text runs through the shared `_escape` helper, consistent with the
+  rest of the page.
+- The band uses no `<details>` / `<summary>`, so the progressive-disclosure
+  counts and the first-glance-safety-visible assertions are unaffected.
+
+## Definition of done
+
+- The page renders an always-visible orientation band with an `orientation-band`
+  id above the existing `<div class="cards">` grid.
+- The band contains the one-line purpose, the four static posture chips, the
+  attention summary, the next-manual-action line, and the details-below pointer.
+- The posture chips are non-interactive (not buttons, links, forms, or toggles).
+- The attention summary and next-manual-action line are derived only from
+  existing status values, with safe defaults.
+- `Local-first operator console`, `Live provider calls are disabled in this MVP`,
+  `No API keys are displayed`, the existing claim-boundary text, the disabled
+  live-run control, and every existing card id and title remain present.
+- Status JSON shape and semantics are unchanged.
+- Focused Operator Console tests pass.
+- Documentation explains the band, the posture chips, why the attention summary
+  is local-metadata-only, why the next manual action happens outside the console,
+  and what it does not prove.
+
+## Boundary checklist
+
+- [x] Render-only presentation change.
+- [x] Band rendered above the existing card grid; the grid is preserved.
+- [x] Static, non-interactive posture chips (no buttons, links, forms, toggles).
+- [x] Attention summary derived only from existing status values.
+- [x] Next manual action derived only from existing next-step data; happens
+      outside the console.
+- [x] No JavaScript and no new frontend dependency.
+- [x] No boundary text removed, weakened, or paraphrased.
+- [x] First-glance safety signals remain visible.
+- [x] No provider calls, ChatGPT calls, `/v1/solve`, browser automation, CLI,
+      shell, or subprocess execution.
+- [x] No prompt submission, paste storage, capture editor, or raw viewer.
+- [x] No scoring, ranking, winner selection, queue, runner, scheduler, or worker.
+- [x] No action control, new route, new POST route, or new write path.
+- [x] No new status payload field and no changed status JSON semantics.
+- [x] No new or renamed card id.
+- [x] Local Receipt Store remains the only controlled write path.
+
+## Non-claims
+
+This lane does not claim readiness, validation success, benchmark validity,
+production readiness, answer quality, scoring, ranking, winner selection,
+provider readiness, billing accuracy, or model superiority. The band is a
+presentation change that makes existing safety information and manual next steps
+easier to understand; it does not make the console more capable and does not
+validate the product. It is out of scope for the band to prove any of these.
+
+## Test plan
+
+Focused tests must prove:
+
+- The orientation band exists.
+- The band appears before the existing card grid.
+- The band contains the one-line purpose.
+- The band shows the four static posture chips (local-first,
+  live-provider-disabled, non-executing/read-only, no API keys displayed).
+- The posture chips are non-interactive: not buttons, links, forms, or toggles.
+- The band includes an attention summary (both the derived and the safe-default
+  paths).
+- The band includes a next-manual-action line that happens outside the console.
+- The band uses safe, non-readiness language: no "validated", "ready",
+  "all clear", "passed", "healthy", "production readiness", "benchmark",
+  "winner", or "superiority".
+- Existing safety boundary strings remain present in the served HTML.
+- Existing card ids remain present.
+- The live-run button remains disabled.
+- No new form is added except the existing receipt form.
+- No new POST route is added except the existing receipt route.
+- Status JSON shape is unchanged (no orientation field leaks into the payload).
+- No raw prompt/output viewer, paste editor, queue, runner, scheduler, scoring,
+  ranking, winner selection, or action control is introduced.

--- a/alpha/webapp/routes/operator_console.py
+++ b/alpha/webapp/routes/operator_console.py
@@ -57,6 +57,39 @@ CLAIM_BOUNDARY_TEXT = (
 )
 
 # ---------------------------------------------------------------------------
+# Flow-first orientation band text
+# (AOC-B010-OPERATOR-CONSOLE-FLOW-FIRST-ORIENTATION-001). A read-only band
+# rendered above the existing card grid so an operator can understand the page
+# in the first few seconds: what it is, its static safety posture, whether
+# anything needs attention, and what manual step happens outside the console.
+# These are display-only strings. The band adds no control, route, write path,
+# or status payload field, and it derives attention/next-action only by
+# summarizing the already-assembled in-memory status dict.
+# ---------------------------------------------------------------------------
+ORIENTATION_PURPOSE_TEXT = (
+    "This is a local-first status console. It helps you review current local "
+    "state and decide the next manual step. It does not run, call, or execute "
+    "anything."
+)
+ORIENTATION_POSTURE_CHIPS = (
+    "Local-first",
+    "Live provider calls: disabled",
+    "Non-executing / read-only",
+    "No API keys displayed",
+)
+ORIENTATION_ATTENTION_DEFAULT = (
+    "No immediate attention detected from local metadata."
+)
+ORIENTATION_NEXT_ACTION_DEFAULT = (
+    "No manual action required from this console view."
+)
+ORIENTATION_NEXT_ACTION_PREFIX = "Next manual step outside the console: "
+ORIENTATION_DETAILS_POINTER = (
+    "Details below: review surfaces, manual-only steps, blocked behavior, and "
+    "receipts."
+)
+
+# ---------------------------------------------------------------------------
 # Provider and cost gate boundary text. The provider/cost gate panel is a
 # display-only view of configuration and safety-gate state. These strings are
 # asserted by tests and rendered verbatim so an operator sees that gate status
@@ -1121,6 +1154,91 @@ def receipts_auth_header() -> str:
     return "x-alpha-csrf"
 
 
+# ---------------------------------------------------------------------------
+# Flow-first orientation band. Pure render-only summarization over the already
+# assembled in-memory status dict. It fetches nothing, derives no readiness
+# semantics, and adds no field to the status payload. Attention labels restate
+# missing/invalid/stale conditions that are already rendered in the cards below;
+# the next-action line reuses the existing manual copy/paste next-step labels.
+# ---------------------------------------------------------------------------
+def _orientation_attention_items(status: Mapping[str, Any]) -> List[str]:
+    """Return up to three safe attention labels derived from existing status.
+
+    Read-only over the already-assembled status dict. Every label restates a
+    missing/invalid/stale condition already surfaced by a card below. It invents
+    no readiness semantics and uses no "ready"/"validated"/"healthy" wording.
+    """
+
+    local = status.get("local_artifacts") or {}
+    capture = local.get("capture") or {}
+    packet = local.get("evidence_packet") or {}
+    dry_run = status.get("dry_run_preview") or {}
+    warnings = dry_run.get("freshness_warnings") or []
+
+    items: List[str] = []
+    cap_state = capture.get("state")
+    if cap_state == "missing":
+        items.append("Capture artifact missing.")
+    elif cap_state in {"invalid_json", "invalid_structure"}:
+        items.append("Local capture cannot be read.")
+    if packet.get("state") in {"digest_invalid", "digest_unverifiable"}:
+        items.append("Evidence packet digest needs attention.")
+    if any(str(warning).endswith("_older_than_capture") for warning in warnings):
+        items.append("Derived artifacts appear older than capture.")
+    return items[:3]
+
+
+def _orientation_next_action(status: Mapping[str, Any]) -> str:
+    """Return a read-only next-manual-action line from existing capture data.
+
+    Reuses the first existing ``chatgpt_copy_paste_capture.next_manual_steps``
+    label (underscores rendered as spaces) and states plainly that it happens
+    outside the console. Falls back to the safe default when no step exists. It
+    starts nothing, dispatches nothing, and is not a control.
+    """
+
+    steps = (status.get("chatgpt_copy_paste_capture") or {}).get(
+        "next_manual_steps"
+    ) or []
+    if steps:
+        label = str(steps[0]).replace("_", " ")
+        return ORIENTATION_NEXT_ACTION_PREFIX + label + "."
+    return ORIENTATION_NEXT_ACTION_DEFAULT
+
+
+def _render_orientation_band(status: Mapping[str, Any]) -> str:
+    """Render the display-only flow-first orientation band (no controls)."""
+
+    chips_html = "".join(
+        f'<span class="posture-chip">{_escape(chip)}</span>'
+        for chip in ORIENTATION_POSTURE_CHIPS
+    )
+    attention_items = _orientation_attention_items(status)
+    if attention_items:
+        attention_html = "".join(
+            f"<li>{_escape(item)}</li>" for item in attention_items
+        )
+    else:
+        attention_html = f"<li>{_escape(ORIENTATION_ATTENTION_DEFAULT)}</li>"
+    next_action = _orientation_next_action(status)
+
+    return (
+        '<section class="orientation-band" id="orientation-band" '
+        'aria-label="Operator console orientation">'
+        f'<p class="orientation-purpose">{_escape(ORIENTATION_PURPOSE_TEXT)}</p>'
+        '<div class="posture-chips" aria-label="Static console posture">'
+        f"{chips_html}</div>"
+        '<div class="orientation-signals">'
+        '<p class="orientation-label">Attention summary</p>'
+        f'<ul class="orientation-attention">{attention_html}</ul>'
+        '<p class="orientation-label">Next manual action</p>'
+        f'<p class="orientation-next-action">{_escape(next_action)}</p>'
+        "</div>"
+        f'<p class="orientation-pointer note">{_escape(ORIENTATION_DETAILS_POINTER)}</p>'
+        "</section>"
+    )
+
+
 def _render_page(status: Mapping[str, Any]) -> str:
     console = status["console"]
     contract = status["portable_contract"]
@@ -1395,6 +1513,15 @@ def _render_page(status: Mapping[str, Any]) -> str:
       .subtitle {{ color: #565b8f; margin: 0 0 1.25rem; font-weight: 600; }}
       .banner {{ border: 1px solid #c7d2fe; background: rgba(238, 242, 255, 0.9); border-radius: 14px; padding: 1rem 1.15rem; color: #30365f; margin-bottom: 1.5rem; }}
       .banner ul {{ margin: 0.5rem 0 0; padding-left: 1.1rem; }}
+      .orientation-band {{ border: 1px solid #c7d2fe; background: rgba(255, 255, 255, 0.96); border-radius: 14px; padding: 1.1rem 1.25rem; margin-bottom: 1.5rem; box-shadow: 0 12px 40px rgba(31, 35, 71, 0.06); }}
+      .orientation-purpose {{ margin: 0 0 0.85rem; font-size: 1.02rem; font-weight: 700; color: #262a4d; }}
+      .posture-chips {{ display: flex; flex-wrap: wrap; gap: 0.5rem; margin: 0 0 1rem; }}
+      .posture-chip {{ display: inline-block; border-radius: 999px; padding: 0.2rem 0.7rem; font-size: 0.78rem; font-weight: 700; color: #3730a3; background: rgba(99, 102, 241, 0.12); cursor: default; user-select: none; }}
+      .orientation-signals {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 0.35rem 1.5rem; }}
+      .orientation-label {{ margin: 0.35rem 0 0.15rem; font-size: 0.74rem; font-weight: 800; letter-spacing: 0.04em; text-transform: uppercase; color: #565b8f; }}
+      .orientation-attention {{ margin: 0; padding-left: 1.1rem; }}
+      .orientation-next-action {{ margin: 0.1rem 0 0; font-weight: 600; color: #30365f; overflow-wrap: anywhere; }}
+      .orientation-pointer {{ margin-top: 0.9rem; }}
       .cards {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 1.1rem; align-items: start; }}
       .card {{ background: rgba(255, 255, 255, 0.94); border-radius: 16px; padding: 1.15rem 1.25rem; box-shadow: 0 18px 55px rgba(31, 35, 71, 0.08); min-width: 0; }}
       .card h2 {{ margin: 0 0 0.75rem; font-size: 1.08rem; }}
@@ -1441,6 +1568,8 @@ def _render_page(status: Mapping[str, Any]) -> str:
           {boundary_html}
         </ul>
       </section>
+
+      {_render_orientation_band(status)}
 
       <div class="cards">
         <article class="card" id="card-portable-contract">

--- a/docs/OPERATOR_CONSOLE.md
+++ b/docs/OPERATOR_CONSOLE.md
@@ -48,6 +48,51 @@ title, and a one-line boundary summary per card stay visible without expanding
 anything. Expanding a `details` section runs nothing; it only reveals text that
 was already loaded with the page.
 
+## Flow-first orientation band
+
+Lane: `UI-ALPHA-OPERATOR-CONSOLE-FLOW-FIRST-ORIENTATION-001`
+
+Above the card grid, an always-visible **orientation band** gives a flow-first
+answer to "what is this page and how do I use it" before you read any card. It
+is read-only orientation: it starts nothing, changes no state, and adds no
+control. The band has five parts:
+
+- **One-line purpose** — a plain statement that this is a local-first status
+  console that helps you review current local state and decide the next manual
+  step, and that it does not run, call, or execute anything.
+- **Static posture chips** — four non-interactive labels (`Local-first`,
+  `Live provider calls: disabled`, `Non-executing / read-only`,
+  `No API keys displayed`). They are static text, not toggles or buttons: they
+  are not clickable, submit nothing, and do not imply any state can be changed
+  from the console.
+- **Attention summary** — a short read-only summary derived only from local
+  metadata the console already assembles. The safe default is that no immediate
+  attention is detected from local metadata. When existing local metadata shows a
+  missing, unreadable, or stale condition already surfaced by a card below (for
+  example a missing capture artifact or derived files older than capture), the
+  band restates up to three of those items in bounded language. It is
+  local-metadata-only because it summarizes the same in-memory status the cards
+  read; it performs no new fetch and derives no readiness meaning.
+- **Next manual action** — one short line drawn from the existing manual
+  next-step data. It names a step that happens **outside** the console (for
+  example collecting outputs or running a terminal command). The console does not
+  perform the step; there is no button, no queue, and nothing is dispatched. When
+  no step applies, the band says no manual action is required from this console
+  view.
+- **Details-below pointer** — a quiet note that the review surfaces, manual-only
+  steps, blocked behavior, and receipts are detailed in the cards below.
+
+### What the band does not prove
+
+The orientation band is presentation only. It does not add execution, routes,
+write paths, action controls, or status JSON semantics, and it does not prove
+answer quality, route correctness, model superiority, provider readiness,
+billing accuracy, benchmark validity, production readiness, or validation
+success. The posture chips describe the console's fixed local-first, non-executing
+posture; they are not a health check, and a clean attention summary is not a
+readiness signal. It restates existing safety information and manual next steps
+so they are easier to understand; it does not make the console more capable.
+
 
 ## Operator Console First 5 Minutes
 

--- a/tests/test_operator_console.py
+++ b/tests/test_operator_console.py
@@ -3214,3 +3214,258 @@ def test_progressive_disclosure_status_payload_shape_unchanged(client: TestClien
         assert section in payload
     assert payload["provider_gate"]["live_execution_gate"] == "blocked"
     assert payload["run_setup"]["live_run_button_enabled"] is False
+
+
+# ---------------------------------------------------------------------------
+# UI-ALPHA-OPERATOR-CONSOLE-FLOW-FIRST-ORIENTATION-001
+# A read-only flow-first orientation band above the existing card grid answers,
+# in the first few seconds: what the page is, its static safety posture, whether
+# anything needs attention, and what manual step happens outside the console. It
+# is presentation-only: no control, no route, no write path, no status field.
+# ---------------------------------------------------------------------------
+_EXPECTED_STATUS_KEYS = {
+    "console",
+    "portable_contract",
+    "run_setup",
+    "route_trace",
+    "provider_gate",
+    "dry_run_preview",
+    "chatgpt_copy_paste_capture",
+    "manual_next_step_guide",
+    "preflight_capture",
+    "evidence_receipt",
+    "local_artifacts",
+    "local_receipts",
+}
+
+# Non-readiness language guard. The band must not imply readiness, validation,
+# benchmark, winner, or superiority.
+_ORIENTATION_FORBIDDEN_LANGUAGE = (
+    "validated",
+    "ready",
+    "all clear",
+    "passed",
+    "healthy",
+    "production ready",
+    "benchmark",
+    "winner",
+    "superiority",
+)
+
+
+def _orientation_band_html(html_text: str) -> str:
+    start = html_text.index('id="orientation-band"')
+    end = html_text.index("</section>", start)
+    return html_text[start:end]
+
+
+def test_orientation_band_exists(client: TestClient) -> None:
+    _login(client)
+    html_text = client.get(PAGE_ROUTE).text
+    assert 'id="orientation-band"' in html_text
+    assert 'class="orientation-band"' in html_text
+
+
+def test_orientation_band_appears_before_card_grid(client: TestClient) -> None:
+    _login(client)
+    html_text = client.get(PAGE_ROUTE).text
+    assert html_text.index('id="orientation-band"') < html_text.index(
+        '<div class="cards">'
+    )
+
+
+def test_orientation_band_contains_one_line_purpose(client: TestClient) -> None:
+    _login(client)
+    band = _orientation_band_html(client.get(PAGE_ROUTE).text)
+    assert operator_console.ORIENTATION_PURPOSE_TEXT in band
+    # The purpose states plainly that the console does not execute anything.
+    assert "does not run, call, or execute anything" in band
+
+
+def test_orientation_band_shows_static_posture_chips(client: TestClient) -> None:
+    _login(client)
+    band = _orientation_band_html(client.get(PAGE_ROUTE).text)
+    for chip in (
+        "Local-first",
+        "Live provider calls: disabled",
+        "Non-executing / read-only",
+        "No API keys displayed",
+    ):
+        assert f'<span class="posture-chip">{chip}</span>' in band
+
+
+def test_orientation_posture_chips_are_non_interactive(client: TestClient) -> None:
+    _login(client)
+    band = _orientation_band_html(client.get(PAGE_ROUTE).text).lower()
+    # Chips are static labels: not buttons, links, forms, inputs, or toggles.
+    for interactive in (
+        "<button",
+        "<a ",
+        "<a>",
+        "<input",
+        "<select",
+        "<textarea",
+        "<form",
+        "onclick",
+        "onsubmit",
+        "onchange",
+        'role="button"',
+        'type="submit"',
+        'type="checkbox"',
+        "href=",
+        'method="post"',
+    ):
+        assert interactive not in band, interactive
+
+
+def test_orientation_band_includes_attention_summary(client: TestClient) -> None:
+    _login(client)
+    band = _orientation_band_html(client.get(PAGE_ROUTE).text)
+    assert "Attention summary" in band
+    assert '<ul class="orientation-attention">' in band
+    # With no local artifacts present, the band restates a condition already
+    # rendered by the Local Artifact Status card, without inventing readiness.
+    assert "Capture artifact missing." in band
+
+
+def test_orientation_attention_safe_default_when_nothing_needs_attention(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _write_all_four(tmp_path)
+    _use_root(monkeypatch, tmp_path)
+    _login(client)
+    band = _orientation_band_html(client.get(PAGE_ROUTE).text)
+    assert operator_console.ORIENTATION_ATTENTION_DEFAULT in band
+    assert "Capture artifact missing." not in band
+
+
+def test_orientation_band_includes_next_manual_action(client: TestClient) -> None:
+    _login(client)
+    band = _orientation_band_html(client.get(PAGE_ROUTE).text)
+    assert "Next manual action" in band
+    # The line is derived from existing manual next-step data and explicitly
+    # says the step happens outside the console.
+    assert operator_console.ORIENTATION_NEXT_ACTION_PREFIX in band
+    assert "outside the console" in band
+
+
+def test_orientation_band_uses_safe_non_readiness_language(client: TestClient) -> None:
+    _login(client)
+    band_lower = _orientation_band_html(client.get(PAGE_ROUTE).text).lower()
+    for forbidden in _ORIENTATION_FORBIDDEN_LANGUAGE:
+        assert forbidden not in band_lower, forbidden
+
+
+def test_orientation_band_keeps_existing_safety_boundary_strings(
+    client: TestClient,
+) -> None:
+    _login(client)
+    html_text = client.get(PAGE_ROUTE).text
+    for text in (
+        operator_console.LOCAL_FIRST_TEXT,
+        operator_console.LIVE_DISABLED_TEXT,
+        operator_console.NO_KEYS_TEXT,
+        operator_console.CLAIM_BOUNDARY_TEXT,
+        operator_console.ARTIFACT_BOUNDARY_TEXT,
+    ):
+        assert text in html_text
+
+
+def test_orientation_band_preserves_all_card_ids(client: TestClient) -> None:
+    _login(client)
+    html_text = client.get(PAGE_ROUTE).text
+    for card_id in (
+        "card-portable-contract",
+        "card-run-setup",
+        "card-dry-run-preview",
+        "card-route-trace",
+        "card-provider-gate",
+        "card-preflight-capture",
+        "card-manual-next-step-guide",
+        "card-chatgpt-copy-paste-capture",
+        "card-local-receipt-store",
+        "card-evidence-receipt",
+    ):
+        assert card_id in html_text
+
+
+def test_orientation_band_keeps_live_run_button_disabled(client: TestClient) -> None:
+    _login(client)
+    html_text = client.get(PAGE_ROUTE).text
+    assert "Live run (disabled)" in html_text
+    assert 'class="disabled-btn" disabled' in html_text
+
+
+def test_orientation_band_adds_no_new_form(client: TestClient) -> None:
+    _login(client)
+    html_text = client.get(PAGE_ROUTE).text
+    # The only form on the page remains the existing receipt-store form.
+    assert html_text.count("<form") == 1
+    assert f'action="{RECEIPTS_ROUTE}"' in html_text
+    # No new interactive text input beyond the pre-existing disabled prompt box,
+    # and none of it lives in the orientation band.
+    assert html_text.count("<textarea") == 1
+    assert "<textarea" not in _orientation_band_html(html_text)
+
+
+def test_orientation_band_adds_no_new_post_route() -> None:
+    post_paths = {
+        getattr(route, "path", None)
+        for route in app.routes
+        if "POST" in getattr(route, "methods", set())
+        and str(getattr(route, "path", "")).startswith("/dashboard/operator-console")
+    }
+    assert post_paths == {RECEIPTS_ROUTE}
+
+
+def test_orientation_band_status_json_shape_unchanged(client: TestClient) -> None:
+    _login(client)
+    payload = client.get(STATUS_ROUTE).json()
+    # No orientation field leaks into the status payload: the band is render-only.
+    assert set(payload.keys()) == _EXPECTED_STATUS_KEYS
+    assert payload["provider_gate"]["live_execution_gate"] == "blocked"
+    assert payload["provider_gate"]["live_provider_calls"] == "disabled"
+    assert payload["run_setup"]["live_run_button_enabled"] is False
+    for forbidden_field in ("orientation", "orientation_band", "attention_summary"):
+        assert forbidden_field not in payload
+
+
+def test_orientation_band_introduces_no_action_control_or_viewer(
+    client: TestClient,
+) -> None:
+    _login(client)
+    html_text = client.get(PAGE_ROUTE).text
+    band_lower = _orientation_band_html(html_text).lower()
+    for token in (
+        "contenteditable",
+        "<textarea",
+        "queue",
+        "runner",
+        "scheduler",
+        "worker",
+        "scoring",
+        "ranking",
+        "winner",
+        "dispatch",
+        "run selected",
+        "paste",
+        "raw prompt",
+        "raw output",
+    ):
+        assert token not in band_lower, token
+    # The console still refuses to store pasted output or write capture.
+    payload = client.get(STATUS_ROUTE).json()
+    assert payload["chatgpt_copy_paste_capture"]["console_stores_pasted_outputs"] is False
+    assert payload["chatgpt_copy_paste_capture"]["console_writes_capture"] is False
+
+
+def test_orientation_band_under_reusable_safety_guard(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _login(client)
+    with operator_console_no_execution_guard(monkeypatch), operator_console_no_get_write_guard(monkeypatch):
+        page = client.get(PAGE_ROUTE)
+        status = client.get(STATUS_ROUTE)
+    assert page.status_code == 200
+    assert status.status_code == 200
+    assert 'id="orientation-band"' in page.text


### PR DESCRIPTION
## Summary

Adds a read-only orientation band above the operator console card grid to help operators understand the page's purpose, safety posture, and next steps in the first few seconds. The band is presentation-only: it adds no execution, routes, write paths, action controls, or status JSON fields.

## Changes

### Core Implementation
- **`alpha/webapp/routes/operator_console.py`**
  - Added orientation band display constants: `ORIENTATION_PURPOSE_TEXT`, `ORIENTATION_POSTURE_CHIPS`, `ORIENTATION_ATTENTION_DEFAULT`, `ORIENTATION_NEXT_ACTION_DEFAULT`, `ORIENTATION_NEXT_ACTION_PREFIX`, `ORIENTATION_DETAILS_POINTER`
  - Added `_orientation_attention_items(status)`: Pure summarization helper that derives up to three attention labels from existing status values (missing capture, invalid capture, digest issues, stale artifacts)
  - Added `_orientation_next_action(status)`: Pure summarization helper that derives the next manual action from existing `chatgpt_copy_paste_capture.next_manual_steps` data
  - Added `_render_orientation_band(status)`: Renders the complete orientation band HTML with purpose statement, static posture chips, attention summary, next action line, and details pointer
  - Integrated band rendering into `_render_page()` above the existing card grid
  - Added CSS styling for `.orientation-band`, `.orientation-purpose`, `.posture-chips`, `.posture-chip`, `.orientation-signals`, `.orientation-label`, `.orientation-attention`, `.orientation-next-action`, and `.orientation-pointer`

### Documentation
- **`docs/OPERATOR_CONSOLE.md`**: Added "Flow-first orientation band" section explaining the band's five components, what it does not prove, and why it is local-metadata-only
- **`.specs/UI-ALPHA-OPERATOR-CONSOLE-FLOW-FIRST-ORIENTATION-001.md`**: Complete specification including goal, motivation, scope, non-goals, implementation notes, definition of done, boundary checklist, and test plan

### Tests
- **`tests/test_operator_console.py`**: Added 16 focused tests covering:
  - Band existence and placement before card grid
  - Purpose text and safety boundary strings
  - Static posture chips and their non-interactive nature
  - Attention summary (both derived and default paths)
  - Next manual action line
  - Safe language (no readiness/validation/benchmark wording)
  - Preservation of existing card IDs and disabled live-run button
  - No new forms or POST routes
  - Status JSON shape unchanged (no orientation field leaks)
  - No action controls, viewers, or execution semantics
  - Safety guard integration

## Boundary Compliance

✅ Render-only presentation change  
✅ Band rendered above existing card grid; grid preserved  
✅ Static, non-interactive posture chips (no buttons, links, forms, toggles)  
✅ Attention summary derived only from existing status values  
✅ Next manual action derived from existing data; happens outside console  
✅ No JavaScript, no new frontend dependency  
✅ No boundary text removed or weakened  
✅ First-glance safety signals remain visible  
✅ No provider calls, ChatGPT calls, execution, or automation  
✅ No prompt submission, paste storage, or raw viewers  
✅ No scoring, ranking, queue, runner, scheduler, or worker  
✅ No action control, new route, new POST route, or write path  
✅ No new status payload field; JSON semantics unchanged  
✅ No new or renamed card ID  
✅ Local Receipt Store remains only controlled write path  

## Checklist

- [x] Spec linked: `.specs/UI-ALPHA-OPERATOR-CONSOLE-FLOW-FIRST-ORIENTATION-001.md`
- [x] Spec sections present: Goal, Motivation, Scope, Non-goals, Implementation notes, Definition of Done, Boundary checklist, Test plan
- [x] Tests added: 16 focused tests in `test_operator_console.py` covering all band functionality, safety boundaries, and JSON shape preservation

## Notes for reviewers

The orientation band is a pure render-layer

https://claude.ai/code/session_0189pY8anWAXaAxkgsGuVvbB