### PR TITLE
Reduce Alpha-Solver GitHub Actions usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,22 +1,21 @@
 name: ci
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   unit:
+    if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - name: Install deps
-        run: |
-          python -m pip install -U pip
-          pip install -r requirements.txt
       - name: Check local LLM orchestration guardrail suite
         run: |
           make check-local-llm-orchestration-guardrails
-      - name: Run unit tests
-        run: |
-          pytest -q

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,7 +1,6 @@
 name: Docker Publish
 on:
   push:
-    branches: [main]
     tags: ['v*']
 jobs:
   publish:

--- a/.github/workflows/gates.yml
+++ b/.github/workflows/gates.yml
@@ -1,9 +1,15 @@
 name: gates
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   gates:
+    if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -14,24 +20,8 @@ jobs:
       - name: Install deps
         run: |
           python -m pip install -U pip
-          pip install -r requirements.txt pytest-json-report
-
-      - name: "Reliability SLO: run tests"
-        run: |
-          mkdir -p artifacts
-          pytest -q tests/reliability -k "retry or breaker" \
-            --json-report --json-report-file=artifacts/reliability.json || true
-
-      - name: "Reliability SLO: enforce"
-        run: python -m alpha.reliability.slo artifacts/reliability.json
+          pip install -r requirements.txt
 
       - name: "Metrics exporter perf"
         run: |
           pytest -q tests/metrics/test_aggregator.py -q
-
-      - name: Upload reliability artifacts
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: reliability
-          path: artifacts/

--- a/.github/workflows/reliability-slo.yml
+++ b/.github/workflows/reliability-slo.yml
@@ -1,12 +1,19 @@
 name: reliability-slo
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
     paths:
       - "alpha/**"
       - "tests/**"
       - ".github/workflows/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   reliability-slo:
+    if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -19,18 +26,16 @@ jobs:
           pip install -r requirements.txt pytest-json-report
       - name: Start deps
         run: docker run -d --name redis -p 6379:6379 redis:7
-      - name: Run failure-injection suite (placeholder)
+      - name: Run reliability suite
         run: |
           mkdir -p artifacts
-          pytest -q tests/reliability --json-report --json-report-file=artifacts/reliability.json || true
-      - name: Enforce SLOs (placeholder; Codex will upgrade)
-        run: |
-          python - << 'PY'
-          import json, pathlib, sys
-          p = pathlib.Path("artifacts/reliability.json")
-          if not p.exists():
-            print("no report; skipping fail"); sys.exit(0)
-          data = json.loads(p.read_text() or "{}")
-          # Codex will implement p95 checks here
-          print("SLO gate placeholder (pass)")
-          PY
+          pytest -q tests/reliability \
+            --json-report --json-report-file=artifacts/reliability.json
+      - name: Enforce reliability SLOs
+        run: python -m alpha.reliability.slo artifacts/reliability.json
+      - name: Upload reliability artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: reliability
+          path: artifacts/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,10 +3,17 @@ on:
   push:
     branches: [ main ]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 jobs:
   test:
+    if: ${{ github.event_name == 'push' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.specs/ACTIONS-COST-CONTAINMENT-ALPHA-001.md
+++ b/.specs/ACTIONS-COST-CONTAINMENT-ALPHA-001.md
@@ -1,0 +1,40 @@
+# ACTIONS-COST-CONTAINMENT-ALPHA-001 · GitHub Actions Cost Containment
+
+## Objective
+
+Reduce redundant GitHub-hosted runner use without removing any existing
+validation category or changing application behavior.
+
+## Contract
+
+- `.github/workflows/tests.yml` is the sole full-suite `pytest` workflow for
+  pull requests and retains the post-merge `main` run.
+- `.github/workflows/ci.yml` retains the local LLM orchestration guardrail suite
+  under its existing workflow and job status names, without rerunning the full
+  test suite.
+- `.github/workflows/gates.yml` retains the metrics exporter gate.
+- `.github/workflows/reliability-slo.yml` is the sole reliability-suite runner,
+  retains its Redis test dependency, invokes the canonical
+  `alpha.reliability.slo` enforcer, and preserves its report as an artifact.
+- Docker publish builds run only for `v*` tags, matching the publish condition.
+- Pull-request workflows cancel superseded runs for the same PR.
+- Draft pull requests allocate no runners. A `ready_for_review` event must run
+  all applicable checks, and ordinary non-draft PR events must continue to run.
+- Existing workflow and job names remain stable so configured status contexts
+  are not renamed by this change.
+
+## Non-actions
+
+- No application, provider, routing, scoring, budget, or product behavior
+  changes.
+- No external service calls, deployment, release, or registry publication.
+- No reduction in the full test suite, static guardrail, metrics gate, or
+  reliability/SLO validation categories.
+
+## Validation
+
+- Parse every workflow as YAML.
+- Run `tests/test_github_actions_cost_controls.py`.
+- Run the local LLM orchestration guardrail suite.
+- Run the reliability and metrics tests plus the canonical SLO enforcer
+  against a generated local report.

--- a/.specs/INDEX.md
+++ b/.specs/INDEX.md
@@ -6,6 +6,7 @@ Simple registry of the Markdown specs stored in `.specs/`. File names are canoni
 
 | File | Title | Health |
 | --- | --- | --- |
+| `ACTIONS-COST-CONTAINMENT-ALPHA-001.md` | ACTIONS-COST-CONTAINMENT-ALPHA-001 · GitHub Actions Cost Containment | ✅ `SPEC_OK` |
 | `ALPHA-ANSWER-STRUCTURE-V2-001.md` | ALPHA-ANSWER-STRUCTURE-V2-001 | ✅ `SPEC_OK` |
 | `ALPHA-SOLVER-EVAL-FALSE-PREMISE-PERTURBATION-001.md` | ALPHA-SOLVER-EVAL-FALSE-PREMISE-PERTURBATION-001 · False-Premise and Hidden-Constraint Perturbation Case Set | ✅ `SPEC_OK` |
 | `ALPHA-SOLVER-EVAL-HIGHER-HEADROOM-CASESET-001.md` | ALPHA-SOLVER-EVAL-HIGHER-HEADROOM-CASESET-001 · Higher-Headroom Value Read Case Set | ✅ `SPEC_OK` |

--- a/tests/test_github_actions_cost_controls.py
+++ b/tests/test_github_actions_cost_controls.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+PR_WORKFLOWS = ("ci.yml", "tests.yml", "gates.yml", "reliability-slo.yml")
+PR_ACTIVITY_TYPES = {
+    "opened",
+    "synchronize",
+    "reopened",
+    "ready_for_review",
+    "converted_to_draft",
+}
+
+
+def _workflow(name: str) -> dict:
+    # BaseLoader keeps YAML 1.1 words such as `on` as strings, matching the
+    # keys GitHub Actions consumes rather than coercing `on` to True.
+    return yaml.load((WORKFLOWS / name).read_text(), Loader=yaml.BaseLoader)
+
+
+def _run_commands(workflow: dict) -> str:
+    commands = []
+    for job in workflow["jobs"].values():
+        for step in job.get("steps", []):
+            if "run" in step:
+                commands.append(step["run"])
+    return "\n".join(commands)
+
+
+def test_full_suite_runs_once_per_pull_request_revision() -> None:
+    ci_commands = _run_commands(_workflow("ci.yml"))
+    test_commands = _run_commands(_workflow("tests.yml"))
+
+    assert "make check-local-llm-orchestration-guardrails" in ci_commands
+    assert "pytest -q" not in ci_commands
+    assert "python -m pytest -q" in test_commands
+
+
+def test_reliability_and_metrics_gates_have_distinct_ownership() -> None:
+    gates_commands = _run_commands(_workflow("gates.yml"))
+    reliability_commands = _run_commands(_workflow("reliability-slo.yml"))
+
+    assert "tests/metrics/test_aggregator.py" in gates_commands
+    assert "tests/reliability" not in gates_commands
+    assert "alpha.reliability.slo" not in gates_commands
+    assert "tests/reliability" in reliability_commands
+    assert "python -m alpha.reliability.slo" in reliability_commands
+    assert "docker run" in reliability_commands
+
+
+def test_docker_build_is_tag_only() -> None:
+    push = _workflow("docker-publish.yml")["on"]["push"]
+
+    assert push["tags"] == ["v*"]
+    assert "branches" not in push
+
+
+def test_pr_workflows_skip_drafts_and_run_when_ready() -> None:
+    for name in PR_WORKFLOWS:
+        workflow = _workflow(name)
+        pull_request = workflow["on"]["pull_request"]
+        assert PR_ACTIVITY_TYPES.issubset(set(pull_request["types"]))
+
+        concurrency = workflow["concurrency"]
+        assert "github.event.pull_request.number" in concurrency["group"]
+        assert "github.run_id" in concurrency["group"]
+        assert concurrency["cancel-in-progress"] in {
+            "true",
+            "${{ github.event_name == 'pull_request' }}",
+        }
+
+        for job in workflow["jobs"].values():
+            assert "github.event.pull_request.draft == false" in job["if"]


### PR DESCRIPTION
## Summary

- Keep `tests / test` as the sole full-suite pull-request test run.
- Keep `ci / unit` for local-LLM orchestration guardrails without rerunning the full suite.
- Keep `gates / gates` for metrics validation and `reliability-slo / reliability-slo` as the sole reliability/SLO executor.
- Build Docker images only for release tags instead of every `main` push.
- Skip runner allocation for drafts, run on `ready_for_review`, and cancel superseded PR runs.
- Preserve every existing workflow and job name.

## Files changed

- `.github/workflows/ci.yml`
- `.github/workflows/docker-publish.yml`
- `.github/workflows/gates.yml`
- `.github/workflows/reliability-slo.yml`
- `.github/workflows/tests.yml`
- `.specs/ACTIONS-COST-CONTAINMENT-ALPHA-001.md`
- `.specs/INDEX.md`
- `tests/test_github_actions_cost_controls.py`

## Audit ID

`GITHUB_ACTIONS_COST_CONTAINMENT_AUDIT-001`

## Validation

- All seven workflow files parsed successfully as YAML.
- Cost-control regression contract: `4 passed`.
- Local LLM orchestration guardrails: all three checks passed.
- Reliability suite and canonical SLO enforcement passed (`retry_p95=0`, `breaker_open_p95_ms=0`).
- Metrics aggregator validation passed.
- Broad repository run: `1729 passed, 3 skipped, 4 deselected`.
- `git diff --check` passed.

## Known baseline failures

The four deselected tests fail on the unchanged base for local/environmental reasons and are outside this CI-only diff: one local retry-server connection reset, two existing JWT expiry/logging behaviors, and the macOS 1 MB subprocess RSS limit.

## Boundaries preserved

- No application, provider, routing, scoring, budget, runtime, or product behavior changed.
- No provider/model calls, deployment, release, registry publication, issue/comment mutation, or merge occurred.
- All required-check identities were preserved.

## Risk and impact

- Draft checks remain skipped until `ready_for_review`; the latest non-draft head receives the same status contexts.
- Reliability enforcement remains active in one canonical workflow instead of being duplicated.
- Tag-only Docker builds remove the recurring image build on ordinary `main` pushes.